### PR TITLE
Add workflow to promote development to UAT

### DIFF
--- a/.github/workflows/promote-dev-to-uat.yml
+++ b/.github/workflows/promote-dev-to-uat.yml
@@ -1,0 +1,26 @@
+name: Promote Development to UAT
+
+on:
+  push:
+    branches:
+      - development
+  workflow_dispatch:
+
+jobs:
+  create-uat-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Pull Request to UAT
+        uses: peter-evans/create-pull-request@v5
+        with:
+          source-branch: development
+          destination-branch: UAT
+          title: Promote development to UAT
+          body: |
+            Auto-created PR to promote tested changes from development to UAT environment.
+            - Only merges after CI/test checks and review.
+          labels: uat-promotion, automation
+          reviewers: Vacilator


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the promotion of changes from the `development` branch to the `UAT` branch. The workflow streamlines the process by automatically creating a pull request when changes are pushed to `development` or when manually triggered.

Workflow automation:

* Added `.github/workflows/promote-dev-to-uat.yml` to automate the creation of a pull request from `development` to `UAT`, including labeling and reviewer assignment for UAT promotion.