### PR TITLE
Add workflow to promote UAT changes to main

### DIFF
--- a/.github/workflows/promote-uat-to-main.yml
+++ b/.github/workflows/promote-uat-to-main.yml
@@ -1,0 +1,26 @@
+name: Promote UAT to Main
+
+on:
+  push:
+    branches:
+      - uat
+  workflow_dispatch:
+
+jobs:
+  create-main-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Pull Request to Main
+        uses: peter-evans/create-pull-request@v5
+        with:
+          source-branch: uat
+          destination-branch: main
+          title: Promote UAT to Main (Production Release)
+          body: |
+            Auto-created PR to promote reviewed changes from UAT to main.
+            CI must pass and approval is required before merging to production.
+          labels: prod-release, automation
+          reviewers: Vacilator


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the process of promoting changes from the `uat` branch to the `main` branch. The workflow triggers on pushes to `uat` or via manual dispatch, and automatically creates a pull request from `uat` to `main` for production releases.

Workflow automation:

* Added `.github/workflows/promote-uat-to-main.yml` to automate creating a pull request from `uat` to `main` when changes are pushed or when manually triggered.
* Configured the workflow to use the `peter-evans/create-pull-request@v5` action, setting up PR metadata including title, body, labels, and reviewers for production releases.