### PR TITLE
Update promote-dev-to-uat.yml

### DIFF
--- a/.github/workflows/promote-dev-to-uat.yml
+++ b/.github/workflows/promote-dev-to-uat.yml
@@ -17,7 +17,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           source-branch: development
-          destination-branch: UAT
+          destination-branch: uat
           title: Promote development to UAT
           body: |
             Auto-created PR to promote tested changes from development to UAT environment.


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow configuration by standardizing the branch name casing.

* Changed the `destination-branch` in `.github/workflows/promote-dev-to-uat.yml` from `UAT` to `uat` to ensure consistency in branch naming conventions.