### PR TITLE
Remove label from UAT promotion workflow

### DIFF
--- a/.github/workflows/promote-dev-to-uat.yml
+++ b/.github/workflows/promote-dev-to-uat.yml
@@ -38,7 +38,6 @@ jobs:
             --head development \
             --title "Promote development to UAT" \
             --body "Auto-created PR to promote tested changes from development to UAT environment. Only merges after CI/test checks and review." \
-            --label "uat-promotion,automation" \
             --reviewer Vacilator
 
       - name: PR Already Exists


### PR DESCRIPTION
This pull request makes a minor adjustment to the workflow for promoting changes from development to UAT. The only change is the removal of the `uat-promotion,automation` label from the auto-created pull requests in the `.github/workflows/promote-dev-to-uat.yml` file.