### PR TITLE
Remove 'prod-release' label from promote workflow

### DIFF
--- a/.github/workflows/promote-uat-to-main.yml
+++ b/.github/workflows/promote-uat-to-main.yml
@@ -38,7 +38,6 @@ jobs:
             --head uat \
             --title "Promote UAT to Main (Production Release)" \
             --body "Auto-created PR to promote reviewed changes from UAT to main. CI must pass and approval is required before merging to production." \
-            --label "prod-release,automation" \
             --reviewer Vacilator
 
       - name: PR Already Exists


### PR DESCRIPTION
This pull request contains a minor update to the `.github/workflows/promote-uat-to-main.yml` workflow configuration. The change removes the automatic assignment of the "prod-release,automation" label when creating a pull request to promote changes from UAT to main.