### PR TITLE
Change GH_TOKEN to use secrets.PAT

### DIFF
--- a/.github/workflows/promote-uat-to-main.yml
+++ b/.github/workflows/promote-uat-to-main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check if PR already exists
         id: check-pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           PR_COUNT=$(gh pr list --base main --head uat --state open --json number --jq 'length')
           echo "pr_count=${PR_COUNT}" >> "$GITHUB_OUTPUT"
@@ -31,7 +31,7 @@ jobs:
       - name: Create Pull Request to Main
         if: steps.check-pr.outputs.pr_count == '0'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           gh pr create \
             --base main \


### PR DESCRIPTION
This pull request updates the workflow authentication method in the `.github/workflows/promote-uat-to-main.yml` file to improve security and reliability. The most important change is switching from the default `github.token` to a personal access token (`secrets.PAT`) for GitHub CLI operations.

Authentication updates:

* Changed the `GH_TOKEN` environment variable to use `${{ secrets.PAT }}` instead of `${{ github.token }}` for both the "Check if PR already exists" and "Create Pull Request to Main" workflow steps.