### PR TITLE
hotfix: Correct Client model fields in ensure_public_tenant

### DIFF
--- a/backend/apps/tenants/management/commands/ensure_public_tenant.py
+++ b/backend/apps/tenants/management/commands/ensure_public_tenant.py
@@ -28,8 +28,7 @@ class Command(BaseCommand):
                     schema_name='public',
                     defaults={
                         'name': 'Public Schema',
-                        'paid_until': '2099-12-31',
-                        'on_trial': False
+                        'description': 'Public schema for shared tenant resources'
                     }
                 )
                 


### PR DESCRIPTION
## Critical Bug Fix

PR #502 introduced a bug that will cause deployment failures.

## Problem
The `ensure_public_tenant` command uses fields that don't exist:
- ❌ `paid_until` (not in Client model)
- ❌ `on_trial` (not in Client model)

This will cause: `django.db.utils.OperationalError: unknown column`

## Fix
Updated to use actual Client model fields:
- ✅ `schema_name`
- ✅ `name`
- ✅ `description`

## Verification
```bash
# Client model only has these fields
grep -A 10 'class Client' backend/apps/tenants/models.py
```

## Impact
- Prevents deployment failures
- Single line change
- No migration needed (only management command)

**Urgency**: HIGH - Current development branch will fail on next deployment