### PR TITLE
fix: Remove duplicate migration and collectstatic from container CMD

### DIFF
--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -77,13 +77,9 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s \
   CMD curl -fsS http://127.0.0.1:8000/api/v1/health/ || exit 1
 
-CMD /bin/sh -c '\
-  for i in 1 2 3 4 5; do \
-    python manage.py migrate --noinput && break || { echo "migrate retry $i"; sleep 3; }; \
-  done && \
-  python manage.py collectstatic --noinput || true && \
-  exec gunicorn projectmeats.wsgi:application \
-    --bind 0.0.0.0:8000 \
-    --workers ${GUNICORN_WORKERS:-3} \
-    --timeout ${GUNICORN_TIMEOUT:-120} \
-    --access-logfile - --error-logfile -'
+CMD exec gunicorn projectmeats.wsgi:application \
+  --bind 0.0.0.0:8000 \
+  --workers ${GUNICORN_WORKERS:-3} \
+  --timeout ${GUNICORN_TIMEOUT:-120} \
+  --access-logfile - \
+  --error-logfile -


### PR DESCRIPTION
## Problem
The backend container was crashing immediately after starting during deployment:
```
✗ Container is not running
```

## Root Cause
The Dockerfile CMD was running migrations and collectstatic inside the container, but the deployment workflow already runs these operations in pre-deployment tasks using a temporary container. This caused:
- Duplicate migration attempts
- Container crashes when migrations failed or conflicted
- Slower container startup

## Solution
Removed migration and collectstatic operations from the Dockerfile CMD since they're already handled properly in the deployment workflow's pre-deployment phase.

## Changes
- Removed migration retry loop from `backend/dockerfile` CMD
- Removed collectstatic from `backend/dockerfile` CMD  
- Container now only starts Gunicorn directly

## Benefits
- ✅ Migrations run once in controlled pre-deployment phase
- ✅ Container starts faster without redundant operations
- ✅ No risk of migration conflicts or database connection issues
- ✅ Cleaner separation of concerns (deployment vs runtime)

## Testing
- Will be validated by re-running the dev deployment workflow
- Container should start successfully and pass health checks

Fixes: https://github.com/Meats-Central/ProjectMeats/actions/runs/19777069937