### PR TITLE
fix: Add Django check before Gunicorn startup for better error visibility

### DIFF
--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -77,9 +77,12 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s \
   CMD curl -fsS http://127.0.0.1:8000/api/v1/health/ || exit 1
 
-CMD exec gunicorn projectmeats.wsgi:application \
-  --bind 0.0.0.0:8000 \
-  --workers ${GUNICORN_WORKERS:-3} \
-  --timeout ${GUNICORN_TIMEOUT:-120} \
-  --access-logfile - \
-  --error-logfile -
+# Add Django check and start Gunicorn with debug logging
+CMD python manage.py check --deploy && \
+    exec gunicorn projectmeats.wsgi:application \
+      --bind 0.0.0.0:8000 \
+      --workers ${GUNICORN_WORKERS:-3} \
+      --timeout ${GUNICORN_TIMEOUT:-120} \
+      --log-level info \
+      --access-logfile - \
+      --error-logfile -


### PR DESCRIPTION
## Problem
Container crashes immediately on startup with no visible error logs.

## Solution  
Added `python manage.py check --deploy` before starting Gunicorn. This will:
- Catch Django configuration errors early
- Provide clear error messages in container logs
- Fail fast if there are deployment issues

## Benefits
- Better debugging when container fails to start
- Validates Django settings before Gunicorn loads
- Error output will be captured in docker logs