### PR TITLE
fix: Add sudo to docker commands in health check (CRITICAL FIX)

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -709,18 +709,18 @@ jobs:
           # Check logs immediately to see if there are any startup errors
           echo "=== Checking initial container logs ==="
           sleep 2
-          docker logs pm-backend --tail 50 2>&1 || echo "Could not get initial logs"
+          sudo docker logs pm-backend --tail 50 2>&1 || echo "Could not get initial logs"
           
           # Wait a bit for the application to fully start
           echo "Waiting for application to initialize..."
           sleep 8
           
           # Check if container is running
-          if ! docker ps | grep -q pm-backend; then
+          if ! sudo docker ps | grep -q pm-backend; then
             echo "✗ Container is not running"
             echo "=== Checking container logs (including stopped containers) ==="
-            docker ps -a | grep pm-backend || echo "Container not found in docker ps -a"
-            docker logs pm-backend --tail 100 2>&1 || docker logs $(docker ps -aq --filter name=pm-backend --latest) --tail 100 2>&1 || echo "Failed to get logs"
+            sudo docker ps -a | grep pm-backend || echo "Container not found in docker ps -a"
+            sudo docker logs pm-backend --tail 100 2>&1 || sudo docker logs $(sudo docker ps -aq --filter name=pm-backend --latest) --tail 100 2>&1 || echo "Failed to get logs"
             exit 1
           fi
           
@@ -741,7 +741,7 @@ jobs:
             if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
               echo "✗ Backend health check failed after $MAX_ATTEMPTS attempts (HTTP $HTTP_CODE)"
               echo "=== Checking container logs ==="
-              docker logs pm-backend --tail 100
+              sudo docker logs pm-backend --tail 100
               exit 1
             fi
             


### PR DESCRIPTION
## Root Cause Found!

The deployment uses `sudo docker run` to start containers, but the health check was using `docker` commands without `sudo`. This caused permission issues where the health check couldn't see the running container, making it appear as if the container crashed immediately.

## Changes
- Added `sudo` to all `docker ps` and `docker logs` commands in health check step
- Ensures consistent permissions throughout deployment

## Impact
This should fix the deployment failures that have been occurring!