### PR TITLE
fix: Add gunicorn preload and debug logging

### DIFF
--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -77,11 +77,13 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s \
   CMD curl -fsS http://127.0.0.1:8000/api/v1/health/ || exit 1
 
-# Start Gunicorn with debug logging
+# Start Gunicorn with debug logging and preload
 CMD exec gunicorn projectmeats.wsgi:application \
       --bind 0.0.0.0:8000 \
       --workers ${GUNICORN_WORKERS:-3} \
       --timeout ${GUNICORN_TIMEOUT:-120} \
-      --log-level info \
+      --preload \
+      --log-level debug \
+      --capture-output \
       --access-logfile - \
       --error-logfile -


### PR DESCRIPTION
Add --preload to load Django app before forking workers. This reveals import errors earlier. Also enable debug logging and capture-output.