### PR TITLE
fix(deployment): Use double percent escaping for curl format string

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -735,7 +735,8 @@ jobs:
           
           while [ \$ATTEMPT -le \$MAX_ATTEMPTS ]; do
             # Use localhost since we're on the remote server
-            HTTP_CODE=\$(curl -s -o /dev/null -w '%\{http_code\}' http://localhost:8000/api/v1/health/ 2>/dev/null || echo "000")
+            # Using --write-out with double %% to escape the percent sign in heredoc
+            HTTP_CODE=\$(curl -s -o /dev/null --write-out '%%{http_code}' http://localhost:8000/api/v1/health/ 2>/dev/null || echo "000")
             
             if [ "\$HTTP_CODE" = "200" ]; then
               echo "✓ Backend health check passed (HTTP \$HTTP_CODE)"


### PR DESCRIPTION
The issue persists because bash heredoc interpretsbraces even with single quotes.
Changed to use %%{http_code} which curl will interpret correctly.

Fixes persistent syntax error: 'syntax error near unexpected token (`('
