### PR TITLE
fix: correct arithmetic expansion syntax in dev deployment workflow

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -753,6 +753,6 @@ jobs:
             
             echo "Health check attempt \$ATTEMPT/\$MAX_ATTEMPTS failed (HTTP \$HTTP_CODE), retrying..."
             sleep 5
-            ATTEMPT=\$((ATTEMPT + 1))
+            ATTEMPT=\$((\$ATTEMPT + 1))
           done
           SSH


### PR DESCRIPTION
## Problem
The dev deployment workflow was failing with a bash syntax error on line 162:
```
-bash: line 162: syntax error near unexpected token '('
```

## Root Cause
In the health check retry loop, the arithmetic expansion had incorrect escaping:
```bash
ATTEMPT=\$((ATTEMPT + 1))  # Wrong - missing backslash on inner variable
```

Inside the quoted heredoc (`<<'SSH'`), the variable inside the arithmetic expansion also needs to be escaped.

## Solution
Fixed the arithmetic expansion syntax:
```bash
ATTEMPT=\$((\$ATTEMPT + 1))  # Correct - both dollars escaped
```

## Testing
- ✅ YAML syntax validated with Python yaml parser
- ✅ Similar patterns checked in other workflow files (none found)

## References
- Failed job: https://github.com/Meats-Central/ProjectMeats/actions/runs/19782587934/job/56684903462
- Error location: Line 756 in `.github/workflows/11-dev-deployment.yml`

## Checklist
- [x] Fix applied to the deployment workflow
- [x] YAML syntax validated
- [x] Similar issues checked in other workflows
- [x] Commit message follows conventional commits format