### PR TITLE
hotfix: restore correct heredoc syntax in production workflow

### DIFF
--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -257,7 +257,7 @@ jobs:
           sudo mkdir -p "$APP_DIR/env"
 
           # Create runtime env-config.js with production values
-          sudo bash -c 'cat > "$APP_DIR/env/env-config.js" <<JS
+          cat > /tmp/env-config.js <<'ENVJS'
           window.ENV = {
             API_BASE_URL: "${{ secrets.REACT_APP_API_BASE_URL }}",
             ENVIRONMENT: "production",
@@ -269,8 +269,9 @@ jobs:
             ENABLE_DEBUG: "false",
             ENABLE_DEVTOOLS: "false"
           };
-          JS'
+          ENVJS
 
+          sudo mv /tmp/env-config.js "$APP_DIR/env/env-config.js"
           sudo chown root:root "$APP_DIR/env/env-config.js"
           sudo chmod 644 "$APP_DIR/env/env-config.js"
 


### PR DESCRIPTION
## 🚨 Hotfix: Production Frontend Deployment

### Problem
Production frontend deployment failing since PR #608 (e2e test).

**Error**: `bash: line 1: /env/env-config.js: No such file or directory`  
**Failed Run**: https://github.com/Meats-Central/ProjectMeats/actions/runs/19787633149

### Root Cause
During e2e pipeline test, PR #608 conflict resolution accidentally kept the OLD broken heredoc syntax instead of the fixed version from PR #602.

### Fix Applied
Restored the correct heredoc syntax:

**Before (Broken)**:
```yaml
sudo bash -c 'cat > "$APP_DIR/env/env-config.js" <<JS
window.ENV = { ... };
JS'
```

**After (Fixed)**:
```yaml
cat > /tmp/env-config.js <<'ENVJS'
window.ENV = { ... };
ENVJS
sudo mv /tmp/env-config.js "$APP_DIR/env/env-config.js"
```

### Validation
- ✅ YAML syntax validated
- ✅ Matches working dev/UAT workflow syntax
- ✅ Same fix from successful PR #602

### Impact
- **Critical**: Unblocks production frontend deployment
- **Safe**: Only fixes deployment script syntax
- **Tested**: Same pattern works in dev and UAT

### Deployment
Merge will trigger immediate production deployment with corrected workflow.