### PR TITLE
fix(cicd): move DOCR login into build steps to fix authentication expiry

### DIFF
--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -19,12 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Login to DOCR
-        run: echo "${{ secrets.DO_ACCESS_TOKEN }}" | docker login ${{ env.REGISTRY }} -u doctl --password-stdin
-
       - name: Build & Push Frontend
         if: matrix.app == 'frontend'
         run: |
+          echo "${{ secrets.DO_ACCESS_TOKEN }}" | docker login ${{ env.REGISTRY }} -u doctl --password-stdin
           docker build -f frontend/Dockerfile \
             -t $REGISTRY/$FRONTEND_IMAGE:prod-${GITHUB_SHA::7} \
             -t $REGISTRY/$FRONTEND_IMAGE:prod-latest \
@@ -35,6 +33,7 @@ jobs:
       - name: Build & Push Backend (Django)
         if: matrix.app == 'backend'
         run: |
+          echo "${{ secrets.DO_ACCESS_TOKEN }}" | docker login ${{ env.REGISTRY }} -u doctl --password-stdin
           docker build -f backend/Dockerfile \
             -t $REGISTRY/$BACKEND_IMAGE:prod-${GITHUB_SHA::7} \
             -t $REGISTRY/$BACKEND_IMAGE:prod-latest \


### PR DESCRIPTION
## Problem
Workflow run #19788071320 failed with `unauthorized: authentication required` when pushing Docker images to DigitalOcean Container Registry (DOCR).

## Root Cause
Docker login was happening in a separate step before the build-and-push operations. In the matrix strategy, the authentication token was expiring between the login step and the actual push operations.

## Solution
- Move `docker login` command directly into each build-and-push step
- Ensures fresh credentials immediately before each push operation
- Eliminates token expiry issues in matrix jobs

## Changes
- Removed separate "Login to DOCR" step
- Added login command at start of "Build & Push Frontend" step
- Added login command at start of "Build & Push Backend" step

## Testing
This fix will be validated when the workflow runs on this PR merge to main.

Fixes: https://github.com/Meats-Central/ProjectMeats/actions/runs/19788071320/job/56697268843