### PR TITLE
hotfix(cicd): fix YAML indentation in production deployment heredoc

### DIFF
--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -256,20 +256,20 @@ jobs:
           sudo mkdir -p "$APP_DIR/env"
 
           # Create runtime env-config.js with production values
-          sudo bash -c "cat > '$APP_DIR/env/env-config.js' <<'JS'
-window.ENV = {
-  API_BASE_URL: \"${{ secrets.REACT_APP_API_BASE_URL }}\",
-  ENVIRONMENT: \"production\",
-  AI_ASSISTANT_ENABLED: \"${{ secrets.REACT_APP_AI_ASSISTANT_ENABLED }}\",
-  ENABLE_DOCUMENT_UPLOAD: \"${{ secrets.REACT_APP_ENABLE_DOCUMENT_UPLOAD }}\",
-  ENABLE_CHAT_EXPORT: \"${{ secrets.REACT_APP_ENABLE_CHAT_EXPORT }}\",
-  MAX_FILE_SIZE: \"${{ secrets.REACT_APP_MAX_FILE_SIZE }}\",
-  SUPPORTED_FILE_TYPES: \"${{ secrets.REACT_APP_SUPPORTED_FILE_TYPES }}\",
-  ENABLE_DEBUG: \"false\",
-  ENABLE_DEVTOOLS: \"false\"
-};
-JS
-"
+          sudo bash -c "cat > '\$APP_DIR/env/env-config.js' <<'JS'
+          window.ENV = {
+            API_BASE_URL: \"${{ secrets.REACT_APP_API_BASE_URL }}\",
+            ENVIRONMENT: \"production\",
+            AI_ASSISTANT_ENABLED: \"${{ secrets.REACT_APP_AI_ASSISTANT_ENABLED }}\",
+            ENABLE_DOCUMENT_UPLOAD: \"${{ secrets.REACT_APP_ENABLE_DOCUMENT_UPLOAD }}\",
+            ENABLE_CHAT_EXPORT: \"${{ secrets.REACT_APP_ENABLE_CHAT_EXPORT }}\",
+            MAX_FILE_SIZE: \"${{ secrets.REACT_APP_MAX_FILE_SIZE }}\",
+            SUPPORTED_FILE_TYPES: \"${{ secrets.REACT_APP_SUPPORTED_FILE_TYPES }}\",
+            ENABLE_DEBUG: \"false\",
+            ENABLE_DEVTOOLS: \"false\"
+          };
+          JS
+          "
 
           sudo chown root:root "$APP_DIR/env/env-config.js"
           sudo chmod 644 "$APP_DIR/env/env-config.js"


### PR DESCRIPTION
## Problem
Production deployment workflow failing with YAML syntax error:
```
yaml.scanner.ScannerError: while scanning a simple key
  in ".github/workflows/13-prod-deployment.yml", line 260, column 1
could not find expected ':'
```

## Root Cause
Multi-line heredoc content was not properly indented within the YAML `run:` block, breaking YAML structure validation.

## Solution
- Properly indent all heredoc content lines
- Escape `$APP_DIR` with backslash to prevent GitHub Actions variable interpolation
- Maintain proper YAML structure throughout the heredoc

## Testing
- ✅ YAML syntax validated with Python yaml.safe_load()
- Will validate on workflow run after merge

## Resolves
- Workflow run #19789468307 YAML validation failure