### PR TITLE
fix(cicd): fix $APP_DIR variable expansion in production deployment

### DIFF
--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -256,7 +256,7 @@ jobs:
           sudo mkdir -p "$APP_DIR/env"
 
           # Create runtime env-config.js with production values
-          sudo bash -c "cat > '\$APP_DIR/env/env-config.js' <<'JS'
+          sudo bash -c "cat > \"$APP_DIR/env/env-config.js\" <<'JS'
           window.ENV = {
             API_BASE_URL: \"${{ secrets.REACT_APP_API_BASE_URL }}\",
             ENVIRONMENT: \"production\",


### PR DESCRIPTION
## Problem
Production deployment workflow has been failing with:
```
bash: line 1: /env/env-config.js: No such file or directory
```

## Root Cause
Line 259 uses escaped `\$APP_DIR` inside single quotes in `bash -c`, preventing variable expansion:
```bash
sudo bash -c "cat > '\$APP_DIR/env/env-config.js' <<'JS'
```

This causes `cat` to write to literal `/env/env-config.js` instead of `/opt/pm/frontend/env/env-config.js`.

## Solution
- Change to double quotes around path with proper escaping: `\"\$APP_DIR/env/env-config.js\"`
- Keep heredoc delimiter quoted (`<<'JS'`) to prevent secret interpolation
- Matches the working pattern in dev/UAT workflows

## Impact
- **Severity**: Critical - production deployments have been failing
- **Scope**: Production frontend deployment only
- **Risk**: Low - single-line surgical fix, aligns with working dev/UAT patterns

## Testing
- Verified against dev/UAT workflow patterns
- Resolves error from: https://github.com/Meats-Central/ProjectMeats/actions/runs/19789309134

## Related Issues
Part of addressing branch divergence between main and development.