### PR TITLE
fix(cicd): make promotion workflow labels resilient to missing labels

### DIFF
--- a/.github/workflows/promote-dev-to-uat.yml
+++ b/.github/workflows/promote-dev-to-uat.yml
@@ -43,16 +43,27 @@ jobs:
           fi
           
       - name: Create Pull Request to UAT
+        id: create-pr
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base uat \
             --head development \
             --title "Promote development to UAT" \
             --body "Auto-created PR to promote tested changes from development to UAT environment. Only merges after CI/test checks and review." \
-            --label "auto-promotion,uat-release" \
-            --reviewer Vacilator
+            --reviewer Vacilator)
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "::notice::Created PR: $PR_URL"
+
+      - name: Add labels to PR
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          PR_NUMBER=$(echo "${{ steps.create-pr.outputs.pr_url }}" | grep -oP '\d+$')
+          gh pr edit "$PR_NUMBER" --add-label "auto-promotion,uat-release" || echo "::warning::Could not add labels (they may not exist)"
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/promote-uat-to-main.yml
+++ b/.github/workflows/promote-uat-to-main.yml
@@ -43,16 +43,27 @@ jobs:
           fi
           
       - name: Create Pull Request to Main
+        id: create-pr
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base main \
             --head uat \
             --title "Promote UAT to Main (Production Release)" \
             --body "Auto-created PR to promote reviewed changes from UAT to main. CI must pass and approval is required before merging to production." \
-            --label "auto-promotion,production-release" \
-            --reviewer Vacilator
+            --reviewer Vacilator)
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "::notice::Created PR: $PR_URL"
+
+      - name: Add labels to PR
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          PR_NUMBER=$(echo "${{ steps.create-pr.outputs.pr_url }}" | grep -oP '\d+$')
+          gh pr edit "$PR_NUMBER" --add-label "auto-promotion,production-release" || echo "::warning::Could not add labels (they may not exist)"
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
## Problem
Promotion workflow failing with error:
```
could not add label: 'auto-promotion' not found
```

## Root Cause
The workflow tried to add labels during PR creation, but the labels didn't exist in the repository yet. This caused the entire workflow to fail.

## Solution

### 1. Created Missing Labels
- ✅ `auto-promotion` - Automated promotion PR between environments (green)
- ✅ `uat-release` - Release to UAT environment (blue)
- ✅ `production-release` - Release to production environment (red)

### 2. Made Workflows Resilient
- Split PR creation and label addition into separate steps
- Create PR first without labels (won't fail if labels missing)
- Add labels in separate step with `continue-on-error: true`
- Capture PR URL and extract number for label operations
- Show warning instead of failing if labels can't be added

## Changes
- `promote-dev-to-uat.yml`: Separate PR creation and label addition
- `promote-uat-to-main.yml`: Separate PR creation and label addition

## Benefits
- Workflows won't fail if labels are accidentally deleted
- PR creation always succeeds
- Labels are added when available
- Better error handling and resilience

## Testing
Will be validated on next push to development or UAT branches

## Resolves
https://github.com/Meats-Central/ProjectMeats/actions/runs/19789686093/job/56700949937