### PR TITLE
fix: Restore yaml dependency in package-lock.json for Docker build

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21078,6 +21078,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",


### PR DESCRIPTION
## Problem

The merge in #645 inadvertently removed the `yaml 2.8.1` dependency from `tailwindcss` node_modules in package-lock.json, causing `npm ci` to fail in Docker builds.

## Error

```
npm error Missing: yaml@2.8.2 from lock file
```

**Failed workflow**: https://github.com/Meats-Central/ProjectMeats/actions/runs/19807072238

## Solution

Restore the missing yaml dependency entry from the previous commit (ddbf455) to align package-lock.json with package.json requirements.

## Changes

- Restored `node_modules/tailwindcss/node_modules/yaml` entry in package-lock.json
- No functional changes to application code
- Fixes Docker build process

## Testing

- [x] Verified yaml dependency is present in restored package-lock.json
- [ ] CI/CD pipeline will validate Docker build succeeds

---

**Type**: Bug fix  
**Priority**: High (blocks deployment)  
**Risk**: Minimal (only restores missing dependency)