### PR TITLE
fix: Add retry logic for Docker registry push failures

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -367,10 +367,25 @@ jobs:
             -t $GHCR_REGISTRY/$FRONTEND_IMAGE_LC:dev-${GITHUB_SHA::7} \
             -t $GHCR_REGISTRY/$FRONTEND_IMAGE_LC:dev-latest \
             .
-          docker push $REGISTRY/$FRONTEND_IMAGE_LC:dev-${GITHUB_SHA::7}
-          docker push $REGISTRY/$FRONTEND_IMAGE_LC:dev-latest
-          docker push $GHCR_REGISTRY/$FRONTEND_IMAGE_LC:dev-${GITHUB_SHA::7}
-          docker push $GHCR_REGISTRY/$FRONTEND_IMAGE_LC:dev-latest
+          
+          # Push with retry logic for transient registry errors
+          for i in {1..3}; do
+            if docker push $REGISTRY/$FRONTEND_IMAGE_LC:dev-${GITHUB_SHA::7} && \
+               docker push $REGISTRY/$FRONTEND_IMAGE_LC:dev-latest && \
+               docker push $GHCR_REGISTRY/$FRONTEND_IMAGE_LC:dev-${GITHUB_SHA::7} && \
+               docker push $GHCR_REGISTRY/$FRONTEND_IMAGE_LC:dev-latest; then
+              echo "✓ Push succeeded on attempt $i"
+              break
+            else
+              if [ $i -lt 3 ]; then
+                echo "Push failed on attempt $i, retrying in 10s..."
+                sleep 10
+              else
+                echo "Push failed after 3 attempts"
+                exit 1
+              fi
+            fi
+          done
 
       # Build & Push Backend to DOCR and GHCR
       - name: Build & Push Backend to DOCR and GHCR
@@ -383,10 +398,25 @@ jobs:
             -t $GHCR_REGISTRY/$BACKEND_IMAGE_LC:dev-${GITHUB_SHA::7} \
             -t $GHCR_REGISTRY/$BACKEND_IMAGE_LC:dev-latest \
             .
-          docker push $REGISTRY/$BACKEND_IMAGE_LC:dev-${GITHUB_SHA::7}
-          docker push $REGISTRY/$BACKEND_IMAGE_LC:dev-latest
-          docker push $GHCR_REGISTRY/$BACKEND_IMAGE_LC:dev-${GITHUB_SHA::7}
-          docker push $GHCR_REGISTRY/$BACKEND_IMAGE_LC:dev-latest
+          
+          # Push with retry logic for transient registry errors
+          for i in {1..3}; do
+            if docker push $REGISTRY/$BACKEND_IMAGE_LC:dev-${GITHUB_SHA::7} && \
+               docker push $REGISTRY/$BACKEND_IMAGE_LC:dev-latest && \
+               docker push $GHCR_REGISTRY/$BACKEND_IMAGE_LC:dev-${GITHUB_SHA::7} && \
+               docker push $GHCR_REGISTRY/$BACKEND_IMAGE_LC:dev-latest; then
+              echo "✓ Push succeeded on attempt $i"
+              break
+            else
+              if [ $i -lt 3 ]; then
+                echo "Push failed on attempt $i, retrying in 10s..."
+                sleep 10
+              else
+                echo "Push failed after 3 attempts"
+                exit 1
+              fi
+            fi
+          done
 
   test-frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issue
Fixes transient 500 Internal Server Error from Docker registry during image push operations.

## Root Cause
The failed workflow (run #19810530613) encountered:
```
received unexpected HTTP status: 500 Internal Server Error
```

This is a transient registry issue, not a code problem.

## Solution
Added 3-attempt retry logic with 10-second delays for all Docker image pushes:
- Frontend image pushes (DOCR + GHCR)
- Backend image pushes (DOCR + GHCR)

## Changes
- Modified `.github/workflows/11-dev-deployment.yml`
- Added retry loop for `docker push` commands
- Applies to both frontend and backend builds
- Logs attempt number for debugging

## Benefits
✅ Handles transient registry errors automatically
✅ Prevents deployment failures from temporary issues
✅ Improves deployment reliability
✅ No code changes required

## Testing
- Syntax validated
- Retry logic tested with similar patterns
- Will retry failed run automatically

Fixes #19810530613