### PR TITLE
fix: Construct health check URLs from base URLs

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -434,8 +434,12 @@ jobs:
           MAX_ATTEMPTS=15
           ATTEMPT=1
           
+          # Construct health check URL from STAGING_URL
+          HEALTH_URL="${{ secrets.STAGING_URL }}/api/v1/health/"
+          echo "Health check URL: $HEALTH_URL"
+          
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            if curl -fsS --max-time 10 "${{ secrets.STAGING_BACKEND_HEALTH_URL }}" > /dev/null 2>&1; then
+            if curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null 2>&1; then
               echo "✓ Backend health check passed"
               exit 0
             fi

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -498,8 +498,12 @@ jobs:
           MAX_ATTEMPTS=20
           ATTEMPT=1
           
+          # Construct health check URL from PRODUCTION_URL
+          HEALTH_URL="${{ secrets.PRODUCTION_URL }}/api/v1/health/"
+          echo "Health check URL: $HEALTH_URL"
+          
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            if curl -fsS --max-time 10 "${{ secrets.PRODUCTION_BACKEND_HEALTH_URL }}" > /dev/null; then
+            if curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; then
               echo "✓ Backend health check passed"
               exit 0
             fi


### PR DESCRIPTION
## Issue
Workflow failing due to missing/null secret values for health check URLs:
- `STAGING_BACKEND_HEALTH_URL` (null)
- `PRODUCTION_BACKEND_HEALTH_URL` (not configured)

**Failed Run**: https://github.com/Meats-Central/ProjectMeats/actions/runs/19810530613/job/56752623178

**Error**:
```
secrets.STAGING_BACKEND_HEALTH_URL => null
```

## Root Cause
The hardening changes added health check steps that reference secrets that don't exist in the repository.

## Solution
Construct health check URLs dynamically from existing base URL secrets:

**UAT Deployment:**
```bash
HEALTH_URL="${{ secrets.STAGING_URL }}/api/v1/health/"
```

**Production Deployment:**
```bash
HEALTH_URL="${{ secrets.PRODUCTION_URL }}/api/v1/health/"
```

## Changes
- ✅ UAT workflow: Build health URL from `STAGING_URL`
- ✅ Production workflow: Build health URL from `PRODUCTION_URL`
- ✅ Added URL logging for debugging
- ✅ Removed dependency on non-existent secrets
- ✅ Maintains same functionality

## Benefits
✅ No new secrets required
✅ Uses existing base URL configuration
✅ Fixes deployment workflow failures
✅ Easier to maintain (one URL per environment)
✅ Better debugging with URL logging

## Testing
- Syntax validated
- URL construction verified
- Will apply to next deployment

Fixes the workflow error by using available secrets instead of missing ones.