### PR TITLE
fix: Use localhost for backend health checks in deployment

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -434,22 +434,25 @@ jobs:
           MAX_ATTEMPTS=15
           ATTEMPT=1
           
-          # Construct health check URL from STAGING_URL
-          HEALTH_URL="${{ secrets.STAGING_URL }}/api/v1/health/"
+          # Health check using localhost since we're on the deployment server
+          HEALTH_URL="http://localhost:8000/api/v1/health/"
           echo "Health check URL: $HEALTH_URL"
           
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            if curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null 2>&1; then
-              echo "✓ Backend health check passed"
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
+            
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✓ Backend health check passed (HTTP $HTTP_CODE)"
               exit 0
             fi
             
             if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
-              echo "✗ Backend health check failed"
+              echo "✗ Backend health check failed after $MAX_ATTEMPTS attempts (HTTP $HTTP_CODE)"
+              echo "Last response code: $HTTP_CODE"
               exit 1
             fi
             
-            echo "Health check attempt $ATTEMPT/$MAX_ATTEMPTS..."
+            echo "Health check attempt $ATTEMPT/$MAX_ATTEMPTS (HTTP $HTTP_CODE)..."
             sleep 5
             ATTEMPT=$((ATTEMPT + 1))
           done

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -498,22 +498,25 @@ jobs:
           MAX_ATTEMPTS=20
           ATTEMPT=1
           
-          # Construct health check URL from PRODUCTION_URL
-          HEALTH_URL="${{ secrets.PRODUCTION_URL }}/api/v1/health/"
+          # Health check using localhost since we're on the deployment server
+          HEALTH_URL="http://localhost:8000/api/v1/health/"
           echo "Health check URL: $HEALTH_URL"
           
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            if curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; then
-              echo "✓ Backend health check passed"
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
+            
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✓ Backend health check passed (HTTP $HTTP_CODE)"
               exit 0
             fi
             
             if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
-              echo "✗ Backend health check failed after $MAX_ATTEMPTS attempts"
+              echo "✗ Backend health check failed after $MAX_ATTEMPTS attempts (HTTP $HTTP_CODE)"
+              echo "Last response code: $HTTP_CODE"
               exit 1
             fi
             
-            echo "Health check attempt $ATTEMPT/$MAX_ATTEMPTS..."
+            echo "Health check attempt $ATTEMPT/$MAX_ATTEMPTS (HTTP $HTTP_CODE)..."
             sleep 5
             ATTEMPT=$((ATTEMPT + 1))
           done


### PR DESCRIPTION
## Issue
Health checks failing because `STAGING_URL` and `PRODUCTION_URL` secrets are empty/not configured.

**Failed Run**: https://github.com/Meats-Central/ProjectMeats/actions/runs/19811172978/job/56754222898

**Error Output**:
```
Health check URL: /api/v1/health/
✗ Backend health check failed
```

The URL was just `/api/v1/health/` instead of a full URL because the secret was empty.

## Root Cause
1. Previous fix (#710) tried to construct URLs from `STAGING_URL`/`PRODUCTION_URL` secrets
2. These secrets are not configured or are empty
3. Health checks run **on the deployment server via SSH**, not from GitHub Actions
4. The container runs on `localhost:8000` on the deployment server

## Solution
Use `localhost:8000` directly since we're running the health check **on the deployment server**:

**Before**:
```bash
HEALTH_URL="${{ secrets.STAGING_URL }}/api/v1/health/"  # Empty secret = just "/api/v1/health/"
curl -fsS --max-time 10 "$HEALTH_URL"
```

**After**:
```bash
HEALTH_URL="http://localhost:8000/api/v1/health/"  # Direct localhost on server
HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$HEALTH_URL")
if [ "$HTTP_CODE" = "200" ]; then
  echo "✓ Backend health check passed (HTTP $HTTP_CODE)"
fi
```

## Changes
✅ UAT deployment: Use `http://localhost:8000/api/v1/health/`
✅ Production deployment: Use `http://localhost:8000/api/v1/health/`
✅ Added HTTP status code logging for debugging
✅ More reliable - tests actual running container
✅ No dependency on external URL secrets

## Benefits
✅ Works correctly (tests local container)
✅ No secrets required
✅ Better debugging with HTTP codes
✅ Simpler and more reliable
✅ Tests what's actually deployed

## Technical Note
The health check runs **inside an SSH session on the deployment server**, not from GitHub Actions. Therefore, `localhost:8000` is the correct way to test the deployed container.

Fixes the workflow by using the correct localhost URL instead of relying on empty secrets.