### PR TITLE
fix: resolve UAT deployment health check merge conflict

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -453,7 +453,6 @@ jobs:
           MAX_ATTEMPTS=15
           ATTEMPT=1
           
-<<<<<<< HEAD
           # Health check using localhost since we're on the deployment server
           HEALTH_URL="http://localhost:8000/api/v1/health/"
           echo "Health check URL: $HEALTH_URL"
@@ -463,15 +462,6 @@ jobs:
             
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✓ Backend health check passed (HTTP $HTTP_CODE)"
-=======
-          # Construct health check URL from STAGING_URL
-          HEALTH_URL="${{ secrets.STAGING_URL }}/api/v1/health/"
-          echo "Health check URL: $HEALTH_URL"
-          
-          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            if curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null 2>&1; then
-              echo "✓ Backend health check passed"
->>>>>>> origin/uat
               exit 0
             fi
             


### PR DESCRIPTION
## Problem
Merge conflict in UAT deployment workflow preventing successful deployments.

The conflict was between:
- PR #715 fix (localhost health check)  
- Previous STAGING_URL approach

## Solution
- Resolved conflict by keeping the localhost approach from PR #715
- Uses `http://localhost:8000/api/v1/health/` for health checks
- SSH deployment runs on the same server, so localhost is correct

## Testing
- Resolves failing health checks in PR #722 (UAT → Main)
- Will allow PR #724 (dev → UAT) to merge successfully

## Related
- Fixes deployment pipeline blockage
- Related to PR #715, #722, #723, #724