### PR TITLE
fix: remove merge conflict marker from production workflow

### DIFF
--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -517,7 +517,6 @@ jobs:
           MAX_ATTEMPTS=20
           ATTEMPT=1
           
-<<<<<<< HEAD
           # Health check using localhost since we're on the deployment server
           HEALTH_URL="http://localhost:8000/api/v1/health/"
           echo "Health check URL: $HEALTH_URL"
@@ -527,15 +526,6 @@ jobs:
             
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✓ Backend health check passed (HTTP $HTTP_CODE)"
-=======
-          # Construct health check URL from PRODUCTION_URL
-          HEALTH_URL="${{ secrets.PRODUCTION_URL }}/api/v1/health/"
-          echo "Health check URL: $HEALTH_URL"
-          
-          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            if curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; then
-              echo "✓ Backend health check passed"
->>>>>>> origin/uat
               exit 0
             fi
             


### PR DESCRIPTION
## Fix Merge Conflict Marker in Development

Removes unresolved merge conflict marker from production deployment workflow.

### Problem:
- , ,  markers in workflow file
- Blocks proper merges to UAT and production

### Solution:
- Remove conflict markers
- Keep localhost health check (correct approach)

### Impact:
- Unblocks deployment pipeline
- Enables proper development → UAT → production flow