### PR TITLE
fix: apply UAT backend health check SSH wrapper

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -446,10 +446,13 @@ jobs:
           SSH
 
       - name: Post-deployment health check
+        env:
+          SSHPASS: ${{ secrets.SSH_PASSWORD }}
         run: |
           echo "Waiting for backend to stabilize..."
           sleep 10
           
+          sshpass -e ssh -o StrictHostKeyChecking=yes ${{ secrets.STAGING_USER }}@${{ secrets.STAGING_HOST }} <<'HEALTH_CHECK'
           MAX_ATTEMPTS=15
           ATTEMPT=1
           
@@ -475,6 +478,7 @@ jobs:
             sleep 5
             ATTEMPT=$((ATTEMPT + 1))
           done
+          HEALTH_CHECK
       
       - name: Notify deployment success
         if: success()

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -517,15 +517,44 @@ jobs:
           MAX_ATTEMPTS=20
           ATTEMPT=1
           
+<<<<<<< HEAD
           # Health check using localhost since we're on the deployment server
           HEALTH_URL="http://localhost:8000/api/v1/health/"
           echo "Health check URL: $HEALTH_URL"
           
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+=======
+<<<<<<< HEAD
+          # Construct health check URL from PRODUCTION_URL
+          HEALTH_URL="${{ secrets.PRODUCTION_URL }}/api/v1/health/"
+          echo "Health check URL: $HEALTH_URL"
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+=======
+<<<<<<< HEAD
+          # Health check using localhost since we're on the deployment server
+          HEALTH_URL="http://localhost:8000/api/v1/health/"
+          echo "Health check URL: $HEALTH_URL"
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+>>>>>>> origin/uat
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
             
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✓ Backend health check passed (HTTP $HTTP_CODE)"
+<<<<<<< HEAD
+=======
+=======
+          # Construct health check URL from PRODUCTION_URL
+          HEALTH_URL="${{ secrets.PRODUCTION_URL }}/api/v1/health/"
+          echo "Health check URL: $HEALTH_URL"
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+>>>>>>> a181e8e5d01ce2bf6cee238a3553ffb413c77762
+            if curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; then
+              echo "✓ Backend health check passed"
+>>>>>>> origin/uat
+>>>>>>> origin/uat
               exit 0
             fi
             


### PR DESCRIPTION
## Summary
Direct cherry-pick of the health check fix to UAT branch.

## Problem
The UAT deployment workflow health check was failing with HTTP 000 errors because it runs on the GitHub Actions runner instead of the deployment server where the backend container is running.

## Solution  
Run the health check commands via SSH on the deployment server.

## Changes
- Add SSH wrapper around health check script
- Use SSHPASS environment variable for authentication
- Health check executes on deployment server where container runs

## Original Issue
Resolves: https://github.com/Meats-Central/ProjectMeats/actions/runs/19815158133

## Notes
This is a direct cherry-pick from development (commit 2b30725) to UAT to enable deployment testing.
The database connection issue that blocked automated PR #741 is a separate infrastructure concern.