### PR TITLE
fix: follow redirects in UAT health check

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -461,7 +461,7 @@ jobs:
           echo "Health check URL: $HEALTH_URL"
           
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Host: uat.meatscentral.com" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
+            HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" -H "Host: uat.meatscentral.com" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
             
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✓ Backend health check passed (HTTP $HTTP_CODE)"


### PR DESCRIPTION
## Problem
Health check getting HTTP 301 (redirect) instead of HTTP 200.

Backend is likely redirecting HTTP → HTTPS, and curl needs to follow the redirect to get the final response.

## Solution
Add `-L` flag to curl to follow redirects.

## Testing
Previous run showed all 15 attempts returning HTTP 301.
With this fix, curl will follow the redirect and get HTTP 200 from the final destination.

## Related
- Fixes: https://github.com/Meats-Central/ProjectMeats/actions/runs/19816079075
- Part of health check fixes: #742, #747

## Changes
Single character addition: `-L` flag to curl command