### PR TITLE
fix: Update test_list_staff_users to expect 3 staff users

### DIFF
--- a/backend/apps/tenants/tests_admin_scripts.py
+++ b/backend/apps/tenants/tests_admin_scripts.py
@@ -462,8 +462,8 @@ class TenantQueryTests(TestCase):
     def test_list_staff_users(self):
         """Test listing staff users."""
         staff = User.objects.filter(is_staff=True)
-        # owner and superadmin are staff
-        self.assertEqual(staff.count(), 2)
+        # owner (explicit), superadmin (superuser), and admin (granted via admin role) are staff
+        self.assertEqual(staff.count(), 3)
 
     def test_tenant_owners_query(self):
         """Test finding tenant owners."""


### PR DESCRIPTION
## Problem
The test `test_list_staff_users` was failing in CI with:
```
AssertionError: 3 != 2
```

## Root Cause
When the `admin` user is assigned an admin role to a tenant (line 429-434 in test setup), the tenant signals automatically grant `is_staff=True`. This was not accounted for in the test assertion.

## Solution
Updated the test to expect 3 staff users instead of 2:
1. **owner** - explicitly set `is_staff=True` during user creation
2. **admin** - gets `is_staff=True` via tenant role signal when assigned admin role
3. **superadmin** - superuser with `is_staff=True` by default

## Changes
- Updated test assertion from `self.assertEqual(staff.count(), 2)` to `self.assertEqual(staff.count(), 3)`
- Updated comment to reflect all three staff users

## Testing
This fix aligns the test expectation with the actual behavior of the tenant role permission signals.

Fixes workflow run https://github.com/Meats-Central/ProjectMeats/actions/runs/19816015871