### PR TITLE
fix: invoke notification script with bash explicitly

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Notify deployment started
         run: |
           chmod +x .github/scripts/deployment-notifications.sh
-          .github/scripts/deployment-notifications.sh uat started all "UAT deployment initiated"
+          bash .github/scripts/deployment-notifications.sh uat started all "UAT deployment initiated"
       
       - name: Pre-deployment validation
         run: |
@@ -483,7 +483,7 @@ jobs:
       - name: Notify deployment success
         if: success()
         run: |
-          .github/scripts/deployment-notifications.sh uat success backend "Backend deployed successfully"
+          bash .github/scripts/deployment-notifications.sh uat success backend "Backend deployed successfully"
   
   post-deployment-validation:
     runs-on: ubuntu-latest
@@ -503,5 +503,5 @@ jobs:
           echo "=== UAT Deployment Completed ==="
           echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
           echo "Commit: ${{ github.sha }}"
-          .github/scripts/deployment-notifications.sh uat success all "UAT deployment completed"
+          bash .github/scripts/deployment-notifications.sh uat success all "UAT deployment completed"
       


### PR DESCRIPTION
## Problem  
UAT deployment fails at notification step:
```
.github/scripts/deployment-notifications.sh: No such file or directory
Exit code: 127
```

**But health check passesecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* ✅ HTTP 200

## Solution
Explicitly invoke script with bash interpreter:
```bash
bash .github/scripts/deployment-notifications.sh
```

## Changes
Fixed all 3 notification calls in UAT workflow

## Impact
- ✅ UAT deployments will complete fully
- ✅ Health check already working (HTTP 200)
- ✅ Notifications will log properly

Fixes: https://github.com/Meats-Central/ProjectMeats/actions/runs/19817970845