### PR TITLE
fix: disable container health check in smoke tests

### DIFF
--- a/.github/scripts/smoke-tests.sh
+++ b/.github/scripts/smoke-tests.sh
@@ -144,33 +144,36 @@ else
     PASSED_TESTS=$((PASSED_TESTS + 1))
 fi
 
-# Test 10: Container Health (if local deployment with docker access)
-# Skip in CI/CD environments where containers run on remote servers
-if command -v docker &> /dev/null && docker ps &>/dev/null 2>&1; then
-    echo -e "\n${BLUE}Test $((TOTAL_TESTS + 1)): Container Health${NC}"
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-    
-    unhealthy=0
-    for container in pm-frontend pm-backend; do
-        if docker ps --filter "name=$container" --format "{{.Status}}" | grep -q "Up"; then
-            echo -e "${GREEN}✓ $container: Running${NC}"
-        else
-            echo -e "${RED}✗ $container: Not running${NC}"
-            unhealthy=$((unhealthy + 1))
-        fi
-    done
-    
-    if [ $unhealthy -eq 0 ]; then
-        PASSED_TESTS=$((PASSED_TESTS + 1))
-    else
-        FAILED_TESTS=$((FAILED_TESTS + 1))
-    fi
-else
-    echo -e "\n${BLUE}Test $((TOTAL_TESTS + 1)): Container Health${NC}"
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-    echo -e "${YELLOW}⊘ SKIPPED (Docker not accessible or not running locally)${NC}"
-    PASSED_TESTS=$((PASSED_TESTS + 1))
-fi
+# Test 10: Container Health - DISABLED
+# This test is not applicable for CI/CD deployments where containers run on remote servers
+# Container health is already verified by the deployment health checks
+# Uncomment for local development testing if needed
+#
+# if command -v docker &> /dev/null && docker ps &>/dev/null 2>&1; then
+#     echo -e "\n${BLUE}Test $((TOTAL_TESTS + 1)): Container Health${NC}"
+#     TOTAL_TESTS=$((TOTAL_TESTS + 1))
+#     
+#     unhealthy=0
+#     for container in pm-frontend pm-backend; do
+#         if docker ps --filter "name=$container" --format "{{.Status}}" | grep -q "Up"; then
+#             echo -e "${GREEN}✓ $container: Running${NC}"
+#         else
+#             echo -e "${RED}✗ $container: Not running${NC}"
+#             unhealthy=$((unhealthy + 1))
+#         fi
+#     done
+#     
+#     if [ $unhealthy -eq 0 ]; then
+#         PASSED_TESTS=$((PASSED_TESTS + 1))
+#     else
+#         FAILED_TESTS=$((FAILED_TESTS + 1))
+#     fi
+# else
+#     echo -e "\n${BLUE}Test $((TOTAL_TESTS + 1)): Container Health${NC}"
+#     TOTAL_TESTS=$((TOTAL_TESTS + 1))
+#     echo -e "${YELLOW}⊘ SKIPPED (Docker not accessible or not running locally)${NC}"
+#     PASSED_TESTS=$((PASSED_TESTS + 1))
+# fi
 
 # Summary
 echo ""


### PR DESCRIPTION
## Problem
UAT deployments continue to fail on Test 10 (Container Health Check) because:
- Smoke tests run on GitHub Actions runner
- Containers run on remote servers (deployed via SSH)
- Runner cannot access remote Docker containers
- Test always fails: `pm-frontend: Not running`

## Why Previous Fix Didn't Work
The check `docker ps &>/dev/null 2>&1` succeeds on GitHub Actions (docker is installed), but then the test looks for containers that don't exist on the runner.

## Solution
**Disabled the container health check test entirely** for CI/CD deployments because:

1. **Not Applicable**: Smoke tests run on GitHub Actions, containers run remotely
2. **Already Verified**: Container health is checked by:
   - Deployment health checks (`/api/v1/health/` returns HTTP 200)
   - Backend/Frontend health checks post-deployment
   - Actual application functionality tests (Tests 1-9)
3. **False Negatives**: Test always fails even when deployment succeeds

## Result
Smoke tests will now show:
```
Total Tests: 9
Passed: 9
Failed: 0
✓ All smoke tests passed
```

Container health check code is commented out and can be re-enabled for local development testing if needed.

## Impact
- ✅ UAT deployments will no longer fail on container checks
- ✅ All relevant functionality still tested (frontend, backend API, health checks, SSL, etc.)
- ✅ No loss of actual deployment validation