### PR TITLE
HOTFIX: Fix Prod 500 - Correct Middleware Order + Fix read_only_fields String Error

### DIFF
--- a/backend/apps/tenants/invitation_serializers.py
+++ b/backend/apps/tenants/invitation_serializers.py
@@ -80,7 +80,12 @@ class TenantInvitationListSerializer(serializers.ModelSerializer):
             'tenant_name', 'invited_by_username',
             'is_expired_status', 'is_valid_status'
         ]
-        read_only_fields = fields
+        read_only_fields = (
+            'id', 'email', 'role', 'status', 'message',
+            'created_at', 'expires_at', 'accepted_at',
+            'tenant_name', 'invited_by_username',
+            'is_expired_status', 'is_valid_status'
+        )
 
 
 class InvitationSignupSerializer(serializers.Serializer):
@@ -197,4 +202,8 @@ class TenantInvitationDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = TenantInvitation
         fields = '__all__'
-        read_only_fields = fields
+        read_only_fields = (
+            'id', 'token', 'tenant', 'email', 'role', 'invited_by', 
+            'status', 'created_at', 'expires_at', 'accepted_at', 
+            'accepted_by', 'message'
+        )


### PR DESCRIPTION
## Emergency Production Fix

### Problem
Production health check returning HTTP 500 caused by:
1. ~~SessionMiddleware placed after CsrfViewMiddleware when CSRF_USE_SESSIONS=True~~ (Already fixed in production.py)
2. **DRF-Spectacular E001 error**: `read_only_fields` defined as string instead of tuple

### Root Cause  
In `backend/apps/tenants/invitation_serializers.py`:
- `TenantInvitationListSerializer`: Had `read_only_fields = fields` (list variable)
- `TenantInvitationDetailSerializer`: Had `read_only_fields = fields` (string '__all__')

This caused: `TypeError: The read_only_fields option must be a list or tuple. Got str.`

### Solution
✅ Explicitly define `read_only_fields` as tuples in both serializers

### Testing
✅ `python manage.py check --deploy` → 0 errors  
✅ `python manage.py spectacular` → Schema generates cleanly  

### Deployment
- ✅ No migration required
- ✅ Safe to deploy immediately