### PR TITLE
HOTFIX: Disable CSRF_USE_SESSIONS to fix production HTTP 500

### DIFF
--- a/backend/projectmeats/settings/production.py
+++ b/backend/projectmeats/settings/production.py
@@ -140,7 +140,9 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 CSRF_COOKIE_SECURE = True
 CSRF_COOKIE_HTTPONLY = True
 CSRF_COOKIE_SAMESITE = "Strict"
-CSRF_USE_SESSIONS = True  # required by tests
+# CSRF_USE_SESSIONS disabled temporarily due to middleware ordering issue in production
+# TODO: Re-enable after investigating why SessionMiddleware is not being loaded
+# CSRF_USE_SESSIONS = True  # required by tests
 
 # Ensure SessionMiddleware appears BEFORE CsrfViewMiddleware (tests verify order)
 _SESSION = "django.contrib.sessions.middleware.SessionMiddleware"


### PR DESCRIPTION
## Problem
Production backend is returning HTTP 500 with error:
```
django.core.exceptions.ImproperlyConfigured: CSRF_USE_SESSIONS is enabled, 
but request.session is not set. SessionMiddleware must appear before 
CsrfViewMiddleware in MIDDLEWARE.
```

## Root Cause
Despite correct middleware ordering in base.py, Django is somehow not finding SessionMiddleware when CSRF_USE_SESSIONS is enabled in production.

## Solution
Temporarily disable CSRF_USE_SESSIONS to restore production service. This changes CSRF tokens from session-based to cookie-based storage, which is still secure but uses a different mechanism.

## Security Impact
- CSRF protection remains fully active
- Tokens stored in cookies instead of sessions
- Still uses Secure, HttpOnly, and SameSite=Strict flags

## Next Steps
- Deploy this fix immediately to restore production
- Investigate why SessionMiddleware is not being recognized
- Re-enable CSRF_USE_SESSIONS in follow-up after root cause is identified

## Related
- Fixes HTTP 500 errors from previous deployment
- Follow-up to PR #815, #816, #817 (migration fixes)