### PR TITLE
HOTFIX: Remove Host header from deployment health check

### DIFF
--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -601,7 +601,8 @@ jobs:
           echo "Health check URL: $HEALTH_URL"
           
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" -H "Host: meatscentral.com" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
+            # Don't send Host header to avoid ALLOWED_HOSTS issues
+            HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
             
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✓ Backend health check passed (HTTP $HTTP_CODE)"
@@ -611,6 +612,9 @@ jobs:
             if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
               echo "✗ Backend health check failed after $MAX_ATTEMPTS attempts (HTTP $HTTP_CODE)"
               echo "Last response code: $HTTP_CODE"
+              # Show last few lines of container logs for debugging
+              echo "=== Last 20 lines of backend logs ==="
+              docker logs pm-backend --tail 20
               exit 1
             fi
             


### PR DESCRIPTION
## Problem
Deployment health check failing with HTTP 400:
```
Health check attempt 1/20 (HTTP 400)...
```

## Root Cause
Health check was sending `Host: meatscentral.com` header but this hostname may not be in ALLOWED_HOSTS environment variable, causing Django to reject the request with HTTP 400.

## Solution
- Remove the Host header from health check curl command
- Let curl use default host (localhost) which is always in ALLOWED_HOSTS via _COMMON_INTERNAL_HOSTS
- Add container log output on failure for better debugging

## Testing
- Health check will use `http://localhost:8000/api/v1/health/` without custom Host header
- localhost is always allowed in production settings

## Related
- Follow-up to PR #818 (CSRF fix)
- Part of production deployment restoration