### PR TITLE
HOTFIX: Exempt health check endpoints from SSL redirect

### DIFF
--- a/backend/projectmeats/settings/production.py
+++ b/backend/projectmeats/settings/production.py
@@ -126,6 +126,8 @@ SECURE_HSTS_SECONDS = 31536000
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
 SECURE_SSL_REDIRECT = True
+# Exempt health check endpoints from SSL redirect for internal monitoring
+SECURE_REDIRECT_EXEMPT = [r'^api/v1/health/$', r'^api/v1/ready/$']
 X_FRAME_OPTIONS = "DENY"
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 


### PR DESCRIPTION
## Problem
Health checks failing with HTTP 301 redirect loop:
```
Health check attempt 1/20 (HTTP 301000)...
```

The `301000` indicates:
- HTTP 301 (redirect to HTTPS)
- Followed by 000 (connection failed)

## Root Cause
`SECURE_SSL_REDIRECT = True` redirects all HTTP requests to HTTPS, but the backend container only listens on HTTP internally (port 8000). The health check from localhost cannot follow the redirect to HTTPS.

## Solution
Added `SECURE_REDIRECT_EXEMPT` to exclude health check endpoints from SSL redirect:
```python
SECURE_REDIRECT_EXEMPT = [r'^api/v1/health/$', r'^api/v1/ready/$']
```

This allows internal health checks to work over HTTP while external traffic still gets redirected to HTTPS via the reverse proxy/load balancer.

## Security Impact
✅ No security impact - external traffic still requires HTTPS via reverse proxy
✅ Only internal localhost health checks can use HTTP
✅ Standard practice for containerized applications

## Related
- Follow-up to PR #819 (Host header fix)
- Part 6 of production deployment restoration