### PR TITLE
HOTFIX: Add fallback URL for health check validation

### DIFF
--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -372,7 +372,11 @@ jobs:
         run: |
           MAX_ATTEMPTS=10
           ATTEMPT=1
+          # Use production URL from secrets, fallback to meatscentral.com if not set
           HEALTH_URL="${{ secrets.PRODUCTION_URL }}/api/v1/health/"
+          if [ -z "${{ secrets.PRODUCTION_URL }}" ]; then
+            HEALTH_URL="https://meatscentral.com/api/v1/health/"
+          fi
           # CURL_FAILURE_CODE represents when curl command itself fails (network error, timeout)
           CURL_FAILURE_CODE="000"
           


### PR DESCRIPTION
## Problem
Post-deployment health check failing with malformed URL:
```
Health check URL: /api/v1/health/
Health check attempt 1/10 (HTTP 000000)...
```

## Root Cause
`PRODUCTION_URL` secret is empty or not set, resulting in:
```bash
HEALTH_URL="${PRODUCTION_URL}/api/v1/health/"
# Results in: "/api/v1/health/" (missing protocol and hostname)
```

## Solution
Added fallback logic:
```bash
if [ -z "${{ secrets.PRODUCTION_URL }}" ]; then
  HEALTH_URL="https://meatscentral.com/api/v1/health/"
fi
```

## Testing
- If `PRODUCTION_URL` secret is set: uses it
- If not set (current state): falls back to `https://meatscentral.com`
- Health check will now have valid URL in both cases

## Related
- PR #822 - Fixes post-deployment validation
- Part of ongoing production deployment fixes (#815-822)