### PR TITLE
HOTFIX: Add fallback URL for smoke tests

### DIFF
--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -408,8 +408,13 @@ jobs:
       
       - name: Run comprehensive smoke tests
         run: |
+          # Use production URL from secrets, fallback to meatscentral.com if not set
+          PROD_URL="${{ secrets.PRODUCTION_URL }}"
+          if [ -z "$PROD_URL" ]; then
+            PROD_URL="https://meatscentral.com"
+          fi
           chmod +x .github/scripts/smoke-tests.sh
-          .github/scripts/smoke-tests.sh "${{ secrets.PRODUCTION_URL }}" 15 5
+          .github/scripts/smoke-tests.sh "$PROD_URL" 15 5
       
       - name: Deployment summary
         if: success()


### PR DESCRIPTION
## Problem
Smoke tests failing due to empty PRODUCTION_URL secret:
```
Error: Base URL not specified
Usage: .github/scripts/smoke-tests.sh <base_url> [max_retries] [retry_delay_seconds]
```

## Root Cause
Calling smoke tests with empty string:
```bash
.github/scripts/smoke-tests.sh "${{ secrets.PRODUCTION_URL }}" 15 5
# Results in: .github/scripts/smoke-tests.sh "" 15 5
```

## Solution
Added fallback logic matching health check fix (PR #822):
```bash
PROD_URL="${{ secrets.PRODUCTION_URL }}"
if [ -z "$PROD_URL" ]; then
  PROD_URL="https://meatscentral.com"
fi
.github/scripts/smoke-tests.sh "$PROD_URL" 15 5
```

## Impact
- Smoke tests will now run successfully
- Validates frontend and backend health post-deployment
- Completes the deployment validation workflow

## Note
This is the final piece! Deploy + health check already working.

## Related
- PR #822 - Health check URL fallback
- PR #823 - This PR (smoke tests URL fallback)