### PR TITLE
hotfix: Fix UAT migrate job KeyError DB_NAME

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -306,8 +306,20 @@ jobs:
           DATABASE_URL: ${{ secrets.UAT_DB_URL }}
           SECRET_KEY: ${{ secrets.UAT_SECRET_KEY }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.UAT_DJANGO_SETTINGS_MODULE }}
+          DB_ENGINE: django.db.backends.postgresql
         run: |
           echo "=== Running idempotent schema migrations ==="
+          
+          # Parse DATABASE_URL to set individual DB environment variables
+          # Production settings require these vars instead of just DATABASE_URL
+          if [ -n "$DATABASE_URL" ]; then
+            export DB_USER=$(echo "$DATABASE_URL" | sed -n 's|postgresql://\([^:]*\):.*|\1|p')
+            export DB_PASSWORD=$(echo "$DATABASE_URL" | sed -n 's|postgresql://[^:]*:\([^@]*\)@.*|\1|p')
+            export DB_HOST=$(echo "$DATABASE_URL" | sed -n 's|.*@\([^:]*\):.*|\1|p')
+            export DB_PORT=$(echo "$DATABASE_URL" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
+            export DB_NAME=$(echo "$DATABASE_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+            echo "Database config: DB_HOST=$DB_HOST DB_PORT=$DB_PORT DB_NAME=$DB_NAME DB_USER=$DB_USER"
+          fi
           
           # Step 1: Apply shared schema migrations (idempotent with --fake-initial)
           python manage.py migrate_schemas --shared --fake-initial --noinput || {


### PR DESCRIPTION
## 🚨 Critical Hotfix

**Blocks:** PR #868 (UAT→Main promotion)  
**Failing Job:** https://github.com/Meats-Central/ProjectMeats/actions/runs/19839758633/job/56845629446

## Problem
UAT migrate job fails with:
```
KeyError: 'DB_NAME'
File "backend/projectmeats/settings/production.py", line 75
```

**Root Cause:**  
The migrate job only sets `DATABASE_URL` but `DJANGO_SETTINGS_MODULE` points to production settings which require individual DB environment variables.

## Solution
Parse `DATABASE_URL` to extract and export individual DB variables.

## Changes
✅ Add `DB_ENGINE: django.db.backends.postgresql` to env  
✅ Parse `DATABASE_URL` before migrations:
- Extract `DB_USER`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`, `DB_NAME`
- Export as environment variables
- Log configuration (excluding password)

✅ Keeps existing idempotent migration logic unchanged

## Testing
After merge, the failing workflow will be re-run to validate the fix.

## Impact
- **Low risk:** Only adds parsing logic, doesn't change migration commands
- **High value:** Unblocks production release (PR #868)
- **No breaking changes:** Falls back gracefully if DATABASE_URL is empty

---

**Ready to merge immediately after review** ✅