### PR TITLE
fix: Use correct DATABASE_URL secret names in workflows

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -257,12 +257,12 @@ jobs:
       - name: Parse DATABASE_URL and set DB credentials
         id: parse_db
         run: |
-          if [ -n "${{ secrets.DEV_DB_URL }}" ]; then
-            DB_USER=$(echo "${{ secrets.DEV_DB_URL }}" | sed -n 's|postgresql://\([^:]*\):.*|\1|p')
-            DB_PASSWORD=$(echo "${{ secrets.DEV_DB_URL }}" | sed -n 's|postgresql://[^:]*:\([^@]*\)@.*|\1|p')
-            DB_HOST=$(echo "${{ secrets.DEV_DB_URL }}" | sed -n 's|.*@\([^:]*\):.*|\1|p')
-            DB_PORT=$(echo "${{ secrets.DEV_DB_URL }}" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
-            DB_NAME=$(echo "${{ secrets.DEV_DB_URL }}" | sed -n 's|.*/\([^?]*\).*|\1|p')
+          if [ -n "${{ secrets.DEV_DATABASE_URL }}" ]; then
+            DB_USER=$(echo "${{ secrets.DEV_DATABASE_URL }}" | sed -n 's|postgresql://\([^:]*\):.*|\1|p')
+            DB_PASSWORD=$(echo "${{ secrets.DEV_DATABASE_URL }}" | sed -n 's|postgresql://[^:]*:\([^@]*\)@.*|\1|p')
+            DB_HOST=$(echo "${{ secrets.DEV_DATABASE_URL }}" | sed -n 's|.*@\([^:]*\):.*|\1|p')
+            DB_PORT=$(echo "${{ secrets.DEV_DATABASE_URL }}" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
+            DB_NAME=$(echo "${{ secrets.DEV_DATABASE_URL }}" | sed -n 's|.*/\([^?]*\).*|\1|p')
             
             echo "db_user=$DB_USER" >> $GITHUB_OUTPUT
             echo "db_password=$DB_PASSWORD" >> $GITHUB_OUTPUT
@@ -280,7 +280,7 @@ jobs:
       - name: Run idempotent migrations
         working-directory: ./backend
         env:
-          DATABASE_URL: ${{ secrets.DEV_DB_URL }}
+          DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
           SECRET_KEY: ${{ secrets.DEV_SECRET_KEY }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.DEV_DJANGO_SETTINGS_MODULE }}
           DB_ENGINE: django.db.backends.postgresql

--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -303,12 +303,12 @@ jobs:
       - name: Parse DATABASE_URL and set DB credentials
         id: parse_db
         run: |
-          if [ -n "${{ secrets.UAT_DB_URL }}" ]; then
-            DB_USER=$(echo "${{ secrets.UAT_DB_URL }}" | sed -n 's|postgresql://\([^:]*\):.*|\1|p')
-            DB_PASSWORD=$(echo "${{ secrets.UAT_DB_URL }}" | sed -n 's|postgresql://[^:]*:\([^@]*\)@.*|\1|p')
-            DB_HOST=$(echo "${{ secrets.UAT_DB_URL }}" | sed -n 's|.*@\([^:]*\):.*|\1|p')
-            DB_PORT=$(echo "${{ secrets.UAT_DB_URL }}" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
-            DB_NAME=$(echo "${{ secrets.UAT_DB_URL }}" | sed -n 's|.*/\([^?]*\).*|\1|p')
+          if [ -n "${{ secrets.UAT_DATABASE_URL }}" ]; then
+            DB_USER=$(echo "${{ secrets.UAT_DATABASE_URL }}" | sed -n 's|postgresql://\([^:]*\):.*|\1|p')
+            DB_PASSWORD=$(echo "${{ secrets.UAT_DATABASE_URL }}" | sed -n 's|postgresql://[^:]*:\([^@]*\)@.*|\1|p')
+            DB_HOST=$(echo "${{ secrets.UAT_DATABASE_URL }}" | sed -n 's|.*@\([^:]*\):.*|\1|p')
+            DB_PORT=$(echo "${{ secrets.UAT_DATABASE_URL }}" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
+            DB_NAME=$(echo "${{ secrets.UAT_DATABASE_URL }}" | sed -n 's|.*/\([^?]*\).*|\1|p')
             
             echo "db_user=$DB_USER" >> $GITHUB_OUTPUT
             echo "db_password=$DB_PASSWORD" >> $GITHUB_OUTPUT
@@ -326,7 +326,7 @@ jobs:
       - name: Run idempotent migrations
         working-directory: ./backend
         env:
-          DATABASE_URL: ${{ secrets.UAT_DB_URL }}
+          DATABASE_URL: ${{ secrets.UAT_DATABASE_URL }}
           SECRET_KEY: ${{ secrets.UAT_SECRET_KEY }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.UAT_DJANGO_SETTINGS_MODULE }}
           DB_ENGINE: django.db.backends.postgresql

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -297,12 +297,12 @@ jobs:
       - name: Parse DATABASE_URL and set DB credentials
         id: parse_db
         run: |
-          if [ -n "${{ secrets.PROD_DB_URL }}" ]; then
-            DB_USER=$(echo "${{ secrets.PROD_DB_URL }}" | sed -n 's|postgresql://\([^:]*\):.*|\1|p')
-            DB_PASSWORD=$(echo "${{ secrets.PROD_DB_URL }}" | sed -n 's|postgresql://[^:]*:\([^@]*\)@.*|\1|p')
-            DB_HOST=$(echo "${{ secrets.PROD_DB_URL }}" | sed -n 's|.*@\([^:]*\):.*|\1|p')
-            DB_PORT=$(echo "${{ secrets.PROD_DB_URL }}" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
-            DB_NAME=$(echo "${{ secrets.PROD_DB_URL }}" | sed -n 's|.*/\([^?]*\).*|\1|p')
+          if [ -n "${{ secrets.PROD_DATABASE_URL }}" ]; then
+            DB_USER=$(echo "${{ secrets.PROD_DATABASE_URL }}" | sed -n 's|postgresql://\([^:]*\):.*|\1|p')
+            DB_PASSWORD=$(echo "${{ secrets.PROD_DATABASE_URL }}" | sed -n 's|postgresql://[^:]*:\([^@]*\)@.*|\1|p')
+            DB_HOST=$(echo "${{ secrets.PROD_DATABASE_URL }}" | sed -n 's|.*@\([^:]*\):.*|\1|p')
+            DB_PORT=$(echo "${{ secrets.PROD_DATABASE_URL }}" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
+            DB_NAME=$(echo "${{ secrets.PROD_DATABASE_URL }}" | sed -n 's|.*/\([^?]*\).*|\1|p')
             
             echo "db_user=$DB_USER" >> $GITHUB_OUTPUT
             echo "db_password=$DB_PASSWORD" >> $GITHUB_OUTPUT
@@ -320,7 +320,7 @@ jobs:
       - name: Run idempotent migrations
         working-directory: ./backend
         env:
-          DATABASE_URL: ${{ secrets.PROD_DB_URL }}
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
           SECRET_KEY: ${{ secrets.PROD_SECRET_KEY }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.PROD_DJANGO_SETTINGS_MODULE }}
           DB_ENGINE: django.db.backends.postgresql


### PR DESCRIPTION
## Issue
The workflows were looking for secrets with incorrect names:
- Looking for: `DEV_DB_URL`, `UAT_DB_URL`, `PROD_DB_URL`
- Actually configured: `DEV_DATABASE_URL`, `UAT_DATABASE_URL`, `PROD_DATABASE_URL`

This caused the DATABASE_URL to be empty, resulting in migration failures.

## Solution
Updated all three deployment workflows to use the correct secret names:
- `secrets.DEV_DATABASE_URL` (instead of `secrets.DEV_DB_URL`)
- `secrets.UAT_DATABASE_URL` (instead of `secrets.UAT_DB_URL`)
- `secrets.PROD_DATABASE_URL` (instead of `secrets.PROD_DB_URL`)

## Changes
- `.github/workflows/11-dev-deployment.yml` - Updated DEV_DATABASE_URL
- `.github/workflows/12-uat-deployment.yml` - Updated UAT_DATABASE_URL
- `.github/workflows/13-prod-deployment.yml` - Updated PROD_DATABASE_URL

## Testing
Once merged, the next deployment should:
- ✅ Parse DATABASE_URL successfully
- ✅ Extract all DB credentials (USER, PASSWORD, HOST, PORT, NAME)
- ✅ Run migrations without UndefinedValueError
- ✅ Deploy successfully

## Related
- Fixes the issue from PRs #892, #894
- Secrets were already configured, just needed correct names