### PR TITLE
hotfix: Use consistent STAGING_* secrets in UAT migrate job

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -284,14 +284,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y sshpass
           mkdir -p ~/.ssh
-          ssh-keyscan -H "${{ secrets.UAT_HOST }}" >> ~/.ssh/known_hosts
+          ssh-keyscan -H "${{ secrets.STAGING_HOST }}" >> ~/.ssh/known_hosts
       
       - name: Run migrations via SSH on deployment server
         env:
-          SSHPASS: ${{ secrets.UAT_SSH_PASSWORD }}
+          SSHPASS: ${{ secrets.SSH_PASSWORD }}
         run: |
           sshpass -e ssh -o StrictHostKeyChecking=yes \
-            ${{ secrets.UAT_USER }}@${{ secrets.UAT_HOST }} << 'SSH_END'
+            ${{ secrets.STAGING_USER }}@${{ secrets.STAGING_HOST }} << 'SSH_END'
           set -euo pipefail
           
           echo "=== Running migrations on deployment server ==="


### PR DESCRIPTION
## Problem

The UAT workflow's `migrate` job was using `UAT_HOST`, `UAT_USER`, and `UAT_SSH_PASSWORD` secrets, but all deployment jobs use `STAGING_HOST`, `STAGING_USER`, and `SSH_PASSWORD`.

This inconsistency caused the migrate job to fail with an empty host value.

**Failed run:** https://github.com/Meats-Central/ProjectMeats/actions/runs/19916475046/job/57096298334

**Error:**
```
ssh-keyscan -H "" >> ~/.ssh/known_hosts
Process completed with exit code 1
```

## Solution

Changed the `migrate` job to use the same secret naming pattern as deployment jobs:
- ✅ `UAT_HOST` → `STAGING_HOST`
- ✅ `UAT_USER` → `STAGING_USER`
- ✅ `UAT_SSH_PASSWORD` → `SSH_PASSWORD`

## Consistency Check

All jobs in UAT workflow now use:
- **deploy-frontend** (env: uat2) → `STAGING_HOST`, `STAGING_USER`, `SSH_PASSWORD`
- **migrate** (env: uat2-backend) → `STAGING_HOST`, `STAGING_USER`, `SSH_PASSWORD` ✅
- **deploy-backend** (env: uat2-backend) → `STAGING_HOST`, `STAGING_USER`, `SSH_PASSWORD`

## Testing

This is a hotfix for UAT deployment. Once merged and promoted to UAT, the workflow will use the correct secrets and deployment should proceed.