### PR TITLE
hotfix: Use correct DJANGO_SETTINGS_MODULE for UAT deployment

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -431,29 +431,28 @@ jobs:
           # Set permissions for mounted volumes (appuser in container has UID 1000)
           sudo chown -R 1000:1000 "$MEDIA_DIR" "$STATIC_DIR"
 
-          # Same env block as dev. Update values in UAT secrets later.
+          # Configure environment variables (using correct DJANGO_SETTINGS_MODULE for UAT/staging)
           sudo tee "$ENV_FILE" > /dev/null <<ENV
-
-          DJANGO_SETTINGS_MODULE=${{ secrets.UAT_DJANGO_SETTINGS_MODULE }}
-          SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}
-          CORS_ALLOWED_ORIGINS=${{ secrets.UAT_CORS_ALLOWED_ORIGINS }}
-          DATABASE_URL=${{ secrets.UAT_DATABASE_URL }}
-          ALLOWED_HOSTS=${{ secrets.UAT_ALLOWED_HOSTS }}
-          DEBUG=${{ secrets.DEBUG }}
-          LOG_LEVEL=${{ secrets.LOG_LEVEL }}
-          CORS_ALLOW_ALL_ORIGINS=${{ secrets.UAT_CORS_ALLOW_ALL_ORIGINS }}
-          SESSION_COOKIE_SECURE=${{ secrets.UAT_SESSION_COOKIE_SECURE }}
-          CSRF_COOKIE_SECURE=${{ secrets.UAT_CSRF_COOKIE_SECURE }}
-          OPENAI_API_KEY=${{ secrets.UAT_OPENAI_API_KEY }}
-          STATIC_ROOT=${{ secrets.UAT_STATIC_ROOT }}
-          MEDIA_ROOT=${{ secrets.UAT_MEDIA_ROOT }}
-          EMAIL_BACKEND=${{ secrets.UAT_EMAIL_BACKEND }}
-          EMAIL_HOST=${{ secrets.UAT_EMAIL_HOST }}
-          EMAIL_PORT=${{ secrets.UAT_EMAIL_PORT }}
-          EMAIL_USE_TLS=${{ secrets.UAT_EMAIL_USE_TLS }}
-          EMAIL_HOST_USER=${{ secrets.UAT_EMAIL_HOST_USER }}
-          EMAIL_HOST_PASSWORD=${{ secrets.UAT_EMAIL_HOST_PASSWORD }}
-          ENV
+DJANGO_SETTINGS_MODULE=projectmeats.settings.staging
+SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}
+CORS_ALLOWED_ORIGINS=${{ secrets.UAT_CORS_ALLOWED_ORIGINS }}
+DATABASE_URL=${{ secrets.UAT_DATABASE_URL }}
+ALLOWED_HOSTS=${{ secrets.UAT_ALLOWED_HOSTS }}
+DEBUG=${{ secrets.DEBUG }}
+LOG_LEVEL=${{ secrets.LOG_LEVEL }}
+CORS_ALLOW_ALL_ORIGINS=${{ secrets.UAT_CORS_ALLOW_ALL_ORIGINS }}
+SESSION_COOKIE_SECURE=${{ secrets.UAT_SESSION_COOKIE_SECURE }}
+CSRF_COOKIE_SECURE=${{ secrets.UAT_CSRF_COOKIE_SECURE }}
+OPENAI_API_KEY=${{ secrets.UAT_OPENAI_API_KEY }}
+STATIC_ROOT=${{ secrets.UAT_STATIC_ROOT }}
+MEDIA_ROOT=${{ secrets.UAT_MEDIA_ROOT }}
+EMAIL_BACKEND=${{ secrets.UAT_EMAIL_BACKEND }}
+EMAIL_HOST=${{ secrets.UAT_EMAIL_HOST }}
+EMAIL_PORT=${{ secrets.UAT_EMAIL_PORT }}
+EMAIL_USE_TLS=${{ secrets.UAT_EMAIL_USE_TLS }}
+EMAIL_HOST_USER=${{ secrets.UAT_EMAIL_HOST_USER }}
+EMAIL_HOST_PASSWORD=${{ secrets.UAT_EMAIL_HOST_PASSWORD }}
+ENV
           sudo chown root:root "$ENV_FILE"
           sudo chmod 600 "$ENV_FILE"
 
@@ -468,7 +467,9 @@ jobs:
             -v "$MEDIA_DIR:/app/media" \
             -v "$STATIC_DIR:/app/staticfiles" \
             "$REG/$IMG:$TAG" \
-            python manage.py collectstatic --noinput || true
+            python manage.py collectstatic --noinput --clear || {
+              echo "⚠️  collectstatic failed (non-critical, continuing...)"
+            }
 
           sudo docker rm -f pm-backend >/dev/null 2>&1 || true
           sudo docker run -d --name pm-backend --restart unless-stopped \


### PR DESCRIPTION
## Problem

UAT deployment failing with `ModuleNotFoundError: No module named 'config'` because the `UAT_DJANGO_SETTINGS_MODULE` secret contains an incorrect value.

**Failed run:** https://github.com/Meats-Central/ProjectMeats/actions/runs/19916694442/job/57097001238

**Error:**
```
ModuleNotFoundError: No module named 'config'
KeyError: 'collectstatic'
```

## Root Cause

The `UAT_DJANGO_SETTINGS_MODULE` secret is likely set to `config.settings.staging`, but the actual Django project structure uses `projectmeats.settings.staging`.

## Solution

Hardcoded `DJANGO_SETTINGS_MODULE=projectmeats.settings.staging` in the UAT deployment workflow to bypass the incorrect secret value.

Changes:
- ✅ Set correct Django settings module
- ✅ Added `--clear` flag to collectstatic
- ✅ Better error handling for collectstatic failures

## Next Steps

The secret `UAT_DJANGO_SETTINGS_MODULE` should be updated to `projectmeats.settings.staging` in GitHub repository settings, but this hardcoded fix ensures deployment works immediately.