### PR TITLE
hotfix: npm install --legacy-peer-deps for TypeScript 5.9

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -30,7 +30,7 @@ WORKDIR /project
 
 # 1) Install deps
 COPY frontend/package*.json ./frontend/
-RUN cd frontend && npm ci
+RUN cd frontend && npm install --legacy-peer-deps
 
 # 2) Copy sources
 COPY frontend ./frontend


### PR DESCRIPTION
## Issue

Frontend Docker build failing with TypeScript 5.9 peer dependency conflict:
```
npm error peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
```

## Fix

Changed `npm ci` to `npm install --legacy-peer-deps` in frontend/dockerfile to bypass peer dependency checks during Docker build.

## Impact

- Allows React 19 + TypeScript 5.9 to build in Docker
- No functional changes
- Workaround until react-scripts@6 upgrade

## Testing

Will validate in deployment workflow.