### PR TITLE
fix: UAT workflow YAML syntax error line 436

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -432,8 +432,10 @@ jobs:
           sudo chown -R 1000:1000 "$MEDIA_DIR" "$STATIC_DIR"
 
           # Configure environment variables (using correct DJANGO_SETTINGS_MODULE for UAT/staging)
-          sudo tee "$ENV_FILE" > /dev/null <<ENV
+          cat > "$ENV_FILE" <<'ENV_END'
 DJANGO_SETTINGS_MODULE=projectmeats.settings.staging
+ENV_END
+          cat >> "$ENV_FILE" <<ENV_END
 SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}
 CORS_ALLOWED_ORIGINS=${{ secrets.UAT_CORS_ALLOWED_ORIGINS }}
 DATABASE_URL=${{ secrets.UAT_DATABASE_URL }}
@@ -452,7 +454,7 @@ EMAIL_PORT=${{ secrets.UAT_EMAIL_PORT }}
 EMAIL_USE_TLS=${{ secrets.UAT_EMAIL_USE_TLS }}
 EMAIL_HOST_USER=${{ secrets.UAT_EMAIL_HOST_USER }}
 EMAIL_HOST_PASSWORD=${{ secrets.UAT_EMAIL_HOST_PASSWORD }}
-ENV
+ENV_END
           sudo chown root:root "$ENV_FILE"
           sudo chmod 600 "$ENV_FILE"
 


### PR DESCRIPTION
## Issue
YAML syntax error in UAT deployment workflow line 436:
```
Invalid workflow file: .github/workflows/12-uat-deployment.yml#L436
You have an error in your yaml syntax on line 436
```

## Root Cause
Heredoc in GitHub Actions YAML causing parser issues with variable substitution.

## Fix
Split heredoc into two parts:
1. Static content with quoted heredoc (no substitution)
2. Dynamic content with unquoted heredoc (variable substitution)

This avoids YAML parser confusion while maintaining functionality.

## Testing
YAML syntax will be validated by GitHub Actions on PR.