### PR TITLE
fix: Restore frontend dockerfile to use npm ci

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -30,7 +30,7 @@ WORKDIR /project
 
 # 1) Install deps
 COPY frontend/package*.json ./frontend/
-RUN cd frontend && npm install --legacy-peer-deps
+RUN cd frontend && npm ci
 
 # 2) Copy sources
 COPY frontend ./frontend


### PR DESCRIPTION
## Issue
Frontend Docker build failing with legacy-peer-deps flag.

## Solution
Restore original dockerfile that uses `npm ci` with React 18 + TS 4.9 stable versions.

## Testing
This matches last successful deployment (commit 7c1fdb0).