### PR TITLE
fix: UAT workflow YAML - replace heredoc with echo

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -432,29 +432,25 @@ jobs:
           sudo chown -R 1000:1000 "$MEDIA_DIR" "$STATIC_DIR"
 
           # Configure environment variables (using correct DJANGO_SETTINGS_MODULE for UAT/staging)
-          cat > "$ENV_FILE" <<'ENV_END'
-DJANGO_SETTINGS_MODULE=projectmeats.settings.staging
-ENV_END
-          cat >> "$ENV_FILE" <<ENV_END
-SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}
-CORS_ALLOWED_ORIGINS=${{ secrets.UAT_CORS_ALLOWED_ORIGINS }}
-DATABASE_URL=${{ secrets.UAT_DATABASE_URL }}
-ALLOWED_HOSTS=${{ secrets.UAT_ALLOWED_HOSTS }}
-DEBUG=${{ secrets.DEBUG }}
-LOG_LEVEL=${{ secrets.LOG_LEVEL }}
-CORS_ALLOW_ALL_ORIGINS=${{ secrets.UAT_CORS_ALLOW_ALL_ORIGINS }}
-SESSION_COOKIE_SECURE=${{ secrets.UAT_SESSION_COOKIE_SECURE }}
-CSRF_COOKIE_SECURE=${{ secrets.UAT_CSRF_COOKIE_SECURE }}
-OPENAI_API_KEY=${{ secrets.UAT_OPENAI_API_KEY }}
-STATIC_ROOT=${{ secrets.UAT_STATIC_ROOT }}
-MEDIA_ROOT=${{ secrets.UAT_MEDIA_ROOT }}
-EMAIL_BACKEND=${{ secrets.UAT_EMAIL_BACKEND }}
-EMAIL_HOST=${{ secrets.UAT_EMAIL_HOST }}
-EMAIL_PORT=${{ secrets.UAT_EMAIL_PORT }}
-EMAIL_USE_TLS=${{ secrets.UAT_EMAIL_USE_TLS }}
-EMAIL_HOST_USER=${{ secrets.UAT_EMAIL_HOST_USER }}
-EMAIL_HOST_PASSWORD=${{ secrets.UAT_EMAIL_HOST_PASSWORD }}
-ENV_END
+          echo "DJANGO_SETTINGS_MODULE=projectmeats.settings.staging" | sudo tee "$ENV_FILE" > /dev/null
+          echo "SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "CORS_ALLOWED_ORIGINS=${{ secrets.UAT_CORS_ALLOWED_ORIGINS }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "DATABASE_URL=${{ secrets.UAT_DATABASE_URL }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "ALLOWED_HOSTS=${{ secrets.UAT_ALLOWED_HOSTS }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "DEBUG=${{ secrets.DEBUG }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "LOG_LEVEL=${{ secrets.LOG_LEVEL }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "CORS_ALLOW_ALL_ORIGINS=${{ secrets.UAT_CORS_ALLOW_ALL_ORIGINS }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "SESSION_COOKIE_SECURE=${{ secrets.UAT_SESSION_COOKIE_SECURE }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "CSRF_COOKIE_SECURE=${{ secrets.UAT_CSRF_COOKIE_SECURE }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "OPENAI_API_KEY=${{ secrets.UAT_OPENAI_API_KEY }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "STATIC_ROOT=${{ secrets.UAT_STATIC_ROOT }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "MEDIA_ROOT=${{ secrets.UAT_MEDIA_ROOT }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "EMAIL_BACKEND=${{ secrets.UAT_EMAIL_BACKEND }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "EMAIL_HOST=${{ secrets.UAT_EMAIL_HOST }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "EMAIL_PORT=${{ secrets.UAT_EMAIL_PORT }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "EMAIL_USE_TLS=${{ secrets.UAT_EMAIL_USE_TLS }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "EMAIL_HOST_USER=${{ secrets.UAT_EMAIL_HOST_USER }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          echo "EMAIL_HOST_PASSWORD=${{ secrets.UAT_EMAIL_HOST_PASSWORD }}" | sudo tee -a "$ENV_FILE" > /dev/null
           sudo chown root:root "$ENV_FILE"
           sudo chmod 600 "$ENV_FILE"
 


### PR DESCRIPTION
## Issue
UAT workflow failing with YAML syntax error on line 436.

## Root Cause
GitHub Actions YAML parser doesn't handle heredoc content with leading spaces correctly.

## Solution
Replace heredoc approach with individual echo statements:
- Cleaner YAML parsing
- Each env var written with `echo | sudo tee -a`
- Functionally equivalent to heredoc

## Testing
YAML syntax validated by GitHub Actions on merge.