### PR TITLE
fix: UAT collectstatic bash syntax error

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -460,14 +460,16 @@ jobs:
           # Note: Migrations now handled by separate 'migrate' job
           # Only collectstatic needs to run here
           echo "=== Collecting static files ==="
-          sudo docker run --rm \
+          if sudo docker run --rm \
             --env-file "$ENV_FILE" \
             -v "$MEDIA_DIR:/app/media" \
             -v "$STATIC_DIR:/app/staticfiles" \
             "$REG/$IMG:$TAG" \
-            python manage.py collectstatic --noinput --clear || {
-              echo "⚠️  collectstatic failed (non-critical, continuing...)"
-            }
+            python manage.py collectstatic --noinput --clear; then
+            echo "✓ collectstatic succeeded"
+          else
+            echo "⚠️  collectstatic failed (non-critical, continuing...)"
+          fi
 
           sudo docker rm -f pm-backend >/dev/null 2>&1 || true
           sudo docker run -d --name pm-backend --restart unless-stopped \


### PR DESCRIPTION
## Issue
UAT deployment failing with bash syntax error:
```
-bash: line 19: syntax error near unexpected token )
```

## Root Cause
Shell brace syntax `|| { ... }` in heredoc SSH script causing parse errors.

## Solution
Replace with standard if-then-else:
```bash
if command; then
  echo "success"
else
  echo "failed (non-critical)"
fi
```

## Testing
Syntax will be validated in deployment workflow.