### PR TITLE
revert: Remove incorrect GitHub Actions expression escaping from all workflows

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -367,7 +367,7 @@ jobs:
             sudo nginx -t && sudo systemctl reload nginx || true
           fi
 
-          sudo docker ps --format "table {{{{.Names}}}}\t{{{{.Image}}}}\t{{{{.Status}}}}\t{{{{.Ports}}}}"
+          sudo docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
           DEPLOY_SCRIPT
 
       - name: Health check (Frontend)
@@ -544,7 +544,7 @@ jobs:
           fi
           
           echo "✓ Container is running"
-          sudo docker ps --format "table {{{{.Names}}}}\t{{{{.Image}}}}\t{{{{.Status}}}}\t{{{{.Ports}}}}"
+          sudo docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
           
           # Perform health checks on the remote server
           echo "=== Performing health checks ==="

--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -386,7 +386,7 @@ jobs:
             sudo nginx -t && sudo systemctl reload nginx || true
           fi
 
-          sudo docker ps --format "table {{{{.Names}}}}\t{{{{.Image}}}}\t{{{{.Status}}}}\t{{{{.Ports}}}}"
+          sudo docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
           DEPLOY_SCRIPT
 
       - name: Health check (Web)
@@ -480,7 +480,7 @@ jobs:
             -v "$STATIC_DIR:/app/staticfiles" \
             "$REG/$IMG:$TAG"
 
-          sudo docker ps --format "table {{{{.Names}}}}\t{{{{.Image}}}}\t{{{{.Status}}}}\t{{{{.Ports}}}}"
+          sudo docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
           SSH
 
       - name: Post-deployment health check

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -398,7 +398,7 @@ jobs:
             sudo nginx -t && sudo systemctl reload nginx || true
           fi
 
-          sudo docker ps --format "table {{{{.Names}}}}\t{{{{.Image}}}}\t{{{{.Status}}}}\t{{{{.Ports}}}}"
+          sudo docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
           DEPLOY_SCRIPT
 
       - name: Health check (Web)
@@ -582,7 +582,7 @@ jobs:
             -v "$STATIC_DIR:/app/staticfiles" \
             "$REG/$IMG:$TAG"
 
-          sudo docker ps --format "table {{{{.Names}}}}\t{{{{.Image}}}}\t{{{{.Status}}}}\t{{{{.Ports}}}}"
+          sudo docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
           SSH
       
       - name: Post-deployment health check


### PR DESCRIPTION
## Revert Incorrect Fix

This reverts the changes from PR #947 which incorrectly escaped Docker format placeholders.

### What Went Wrong
PR #947 escaped {{.Names}} as {{{{.Names}}}} based on incorrect assumption that GitHub Actions would interpret these as expressions. This broke the development workflow which was working fine with unescaped format.

### Analysis
- All three workflows originally had {{.Names}} **unescaped**
- Development workflow was **working correctly** with unescaped format
- The bash syntax error in UAT was **NOT** caused by {{.Names}}
- The actual issue was the semicolon before 'then' (fixed in PR #944)

### This Revert
Restores all three workflows to their original working state:
- ✅ 11-dev-deployment.yml: {{.Names}} (working)
- ✅ 12-uat-deployment.yml: {{.Names}} (matches dev)
- ✅ 13-prod-deployment.yml: {{.Names}} (matches dev)

### Validation
- ✓ YAML syntax valid (all 3)
- ✓ Matches original working format
- ✓ Dev workflow restored

### Related
- PR #944: ✅ Valid fix (semicolon issue)
- PR #947: ❌ Incorrect fix (being reverted)