### PR TITLE
fix: Use heredoc for env vars in UAT/prod to prevent bash parsing of secrets

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -432,25 +432,27 @@ jobs:
           sudo chown -R 1000:1000 "$MEDIA_DIR" "$STATIC_DIR"
 
           # Configure environment variables (using correct DJANGO_SETTINGS_MODULE for UAT/staging)
-          echo "DJANGO_SETTINGS_MODULE=projectmeats.settings.staging" | sudo tee "$ENV_FILE" > /dev/null
-          echo "SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "CORS_ALLOWED_ORIGINS=${{ secrets.UAT_CORS_ALLOWED_ORIGINS }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "DATABASE_URL=${{ secrets.UAT_DATABASE_URL }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "ALLOWED_HOSTS=${{ secrets.UAT_ALLOWED_HOSTS }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "DEBUG=${{ secrets.DEBUG }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "LOG_LEVEL=${{ secrets.LOG_LEVEL }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "CORS_ALLOW_ALL_ORIGINS=${{ secrets.UAT_CORS_ALLOW_ALL_ORIGINS }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "SESSION_COOKIE_SECURE=${{ secrets.UAT_SESSION_COOKIE_SECURE }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "CSRF_COOKIE_SECURE=${{ secrets.UAT_CSRF_COOKIE_SECURE }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "OPENAI_API_KEY=${{ secrets.UAT_OPENAI_API_KEY }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "STATIC_ROOT=${{ secrets.UAT_STATIC_ROOT }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "MEDIA_ROOT=${{ secrets.UAT_MEDIA_ROOT }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "EMAIL_BACKEND=${{ secrets.UAT_EMAIL_BACKEND }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "EMAIL_HOST=${{ secrets.UAT_EMAIL_HOST }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "EMAIL_PORT=${{ secrets.UAT_EMAIL_PORT }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "EMAIL_USE_TLS=${{ secrets.UAT_EMAIL_USE_TLS }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "EMAIL_HOST_USER=${{ secrets.UAT_EMAIL_HOST_USER }}" | sudo tee -a "$ENV_FILE" > /dev/null
-          echo "EMAIL_HOST_PASSWORD=${{ secrets.UAT_EMAIL_HOST_PASSWORD }}" | sudo tee -a "$ENV_FILE" > /dev/null
+          sudo tee "$ENV_FILE" > /dev/null <<ENV
+          DJANGO_SETTINGS_MODULE=projectmeats.settings.staging
+          SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}
+          CORS_ALLOWED_ORIGINS=${{ secrets.UAT_CORS_ALLOWED_ORIGINS }}
+          DATABASE_URL=${{ secrets.UAT_DATABASE_URL }}
+          ALLOWED_HOSTS=${{ secrets.UAT_ALLOWED_HOSTS }}
+          DEBUG=${{ secrets.DEBUG }}
+          LOG_LEVEL=${{ secrets.LOG_LEVEL }}
+          CORS_ALLOW_ALL_ORIGINS=${{ secrets.UAT_CORS_ALLOW_ALL_ORIGINS }}
+          SESSION_COOKIE_SECURE=${{ secrets.UAT_SESSION_COOKIE_SECURE }}
+          CSRF_COOKIE_SECURE=${{ secrets.UAT_CSRF_COOKIE_SECURE }}
+          OPENAI_API_KEY=${{ secrets.UAT_OPENAI_API_KEY }}
+          STATIC_ROOT=${{ secrets.UAT_STATIC_ROOT }}
+          MEDIA_ROOT=${{ secrets.UAT_MEDIA_ROOT }}
+          EMAIL_BACKEND=${{ secrets.UAT_EMAIL_BACKEND }}
+          EMAIL_HOST=${{ secrets.UAT_EMAIL_HOST }}
+          EMAIL_PORT=${{ secrets.UAT_EMAIL_PORT }}
+          EMAIL_USE_TLS=${{ secrets.UAT_EMAIL_USE_TLS }}
+          EMAIL_HOST_USER=${{ secrets.UAT_EMAIL_HOST_USER }}
+          EMAIL_HOST_PASSWORD=${{ secrets.UAT_EMAIL_HOST_PASSWORD }}
+          ENV
           sudo chown root:root "$ENV_FILE"
           sudo chmod 600 "$ENV_FILE"
 


### PR DESCRIPTION
## Fix: Bash Syntax Error from Secret Values

**Error:** `-bash: line 19: syntax error near unexpected token ')'`  
**Failed Run:** https://github.com/Meats-Central/ProjectMeats/actions/runs/19919325537/job/57104835024

### Root Cause
Using `echo | tee` exposes secret values to bash shell parsing:
```bash
echo "SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}" | sudo tee -a "$ENV_FILE"
```

**Problem:** If the secret contains special characters like `)`, `(`, or ```, bash tries to parse them as syntax elements, causing errors.

### Solution
Use heredoc pattern (matches dev workflow):
```bash
sudo tee "$ENV_FILE" > /dev/null <<ENV
SECRET_KEY=${{ secrets.UAT_SECRET_KEY }}
ENV
```

**Why this works:**
- GitHub Actions substitutes secrets into heredoc content BEFORE bash sees it
- Heredoc passes content to tee without shell parsing
- Special characters in secrets treated as literals
- Matches proven working pattern from dev workflow

### Changes
- **12-uat-deployment.yml:** Replace echo commands with heredoc
- **13-prod-deployment.yml:** Already had heredoc, fixed indentation

### Testing
✅ YAML syntax validated (both workflows)  
✅ Pattern matches working dev workflow (line 438)  
✅ Heredoc content properly indented for YAML

---

**This is the REAL fix for the recurring syntax error. Previous fixes addressed different issues.**