### PR TITLE
fix: Add react-refresh dependency to frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "prettier": "^3.6.2",
         "prop-types": "^15.8.1",
         "react-app-rewired": "^2.2.1",
+        "react-refresh": "^0.14.2",
         "serve": "^14.2.0",
         "storybook": "^9.1.5",
         "webpack": "^5.101.3"
@@ -18373,11 +18374,10 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21076,20 +21076,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
       }
     },
     "node_modules/tapable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "prettier": "^3.6.2",
     "prop-types": "^15.8.1",
     "react-app-rewired": "^2.2.1",
+    "react-refresh": "^0.14.2",
     "serve": "^14.2.0",
     "storybook": "^9.1.5",
     "webpack": "^5.101.3"


### PR DESCRIPTION
## Fix: Missing react-refresh Module

**Error:** `Cannot find module 'react-refresh'`  
**Failed Run:** https://github.com/Meats-Central/ProjectMeats/actions/runs/19919726748/job/57105850483

### Root Cause
`@pmmmwh/react-refresh-webpack-plugin` requires `react-refresh` as a peer dependency, but it wasn't explicitly in devDependencies.

### Solution
Added `react-refresh@^0.14.0` to devDependencies.

### Changes
- frontend/package.json: Added react-refresh
- frontend/package-lock.json: Updated

✅ npm install successful  
✅ react-refresh@0.14.2 installed