### PR TITLE
fix: Add react-is dependency for recharts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^18.2.0",
         "react-autosuggest": "^10.1.0",
         "react-dom": "^18.2.0",
+        "react-is": "^19.2.1",
         "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "react-table": "^7.8.0",
@@ -18217,8 +18218,7 @@
       "version": "19.2.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.1.tgz",
       "integrity": "sha512-L7BnWgRbMwzMAubQcS7sXdPdNLmKlucPlopgAzx7FtYbksWZgEWiuYM5x9T6UqS2Ne0rsgQTq5kY2SGqpzUkYA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -20978,22 +20978,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "^18.2.0",
     "react-autosuggest": "^10.1.0",
     "react-dom": "^18.2.0",
+    "react-is": "^19.2.1",
     "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "react-table": "^7.8.0",


### PR DESCRIPTION
Fixes: Can't resolve 'react-is' in recharts

Added react-is@^19.2.1 to dependencies.

Error: https://github.com/Meats-Central/ProjectMeats/actions/runs/19920304066/job/57107504814