### PR TITLE
fix: add legacy-peer-deps for React 19 + react-table compatibility

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -124,7 +124,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
       - working-directory: ./frontend
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - working-directory: ./frontend
         run: npm run test:ci
       - working-directory: ./frontend

--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -110,7 +110,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
       - working-directory: ./frontend
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - working-directory: ./frontend
         run: npm run test:ci
       - working-directory: ./frontend

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -105,7 +105,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
       - working-directory: ./frontend
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - working-directory: ./frontend
         run: npm run test:ci
       - working-directory: ./frontend

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,3 @@
+# Legacy peer deps required for React 19 compatibility with react-table@7.8.0
+# TODO: Remove this once react-table is replaced with @tanstack/react-table or similar
+legacy-peer-deps=true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "React frontend for ProjectMeats - migrated from PowerApps. For planned upgrades, see docs/ROADMAP.md",
   "private": true,
+  "_comments": {
+    "react-table-migration": "TODO: Replace react-table@7.8.0 with @tanstack/react-table (TanStack Table v8) for React 19 compatibility. See: https://tanstack.com/table/latest"
+  },
   "dependencies": {
     "@ant-design/icons": "^6.0.2",
     "@types/node": "^16.18.0",


### PR DESCRIPTION
## Problem
CI/CD workflow fails with peer dependency conflict:
- Project uses `react@19.2.1`
- `react-table@7.8.0` only supports React ^16.8.3 || ^17.0.0-0 || ^18.0.0
- This causes `npm ci` to fail in GitHub Actions

## Solution
Added `--legacy-peer-deps` flag to handle the temporary incompatibility:

1. **Workflow Updates**: Added `--legacy-peer-deps` to `npm ci` commands in all deployment workflows
2. **Frontend .npmrc**: Created `.npmrc` with `legacy-peer-deps=true` for consistent behavior
3. **Documentation**: Added TODO comment in package.json to track migration to @tanstack/react-table

## Why This Approach?
- **Temporary Fix**: Allows CI/CD to proceed while React 19 is being used
- **Low Risk**: `react-table` still functions with React 19 despite peer dependency warning
- **Future Migration**: Tracked as technical debt to migrate to @tanstack/react-table (TanStack Table v8)

## Changes
- `.github/workflows/11-dev-deployment.yml`: Added `--legacy-peer-deps`
- `.github/workflows/12-uat-deployment.yml`: Added `--legacy-peer-deps`
- `.github/workflows/13-prod-deployment.yml`: Added `--legacy-peer-deps`
- `frontend/.npmrc`: New file with legacy-peer-deps configuration
- `frontend/package.json`: Added TODO comment for future migration

## Testing
- [x] Changes committed and pushed
- [ ] CI/CD pipeline will validate on merge

## Related Issues
- Fixes workflow failure: https://github.com/Meats-Central/ProjectMeats/actions/runs/19928018148/job/57132743812
- Related to PR #1006 (Node.js v20 upgrade)

## Future Work
- [ ] Migrate from `react-table@7.8.0` to `@tanstack/react-table` (React 19 compatible)
- [ ] Remove `--legacy-peer-deps` flag once migration is complete
- [ ] Update all table components to use TanStack Table API

## Checklist
- [x] Minimal changes to fix immediate issue
- [x] All workflows updated consistently  
- [x] Technical debt documented
- [x] No breaking changes

---
**Impact**: Low risk - temporary compatibility fix
**Urgency**: High - blocks CI/CD pipeline