### PR TITLE
fix: update test to accept django-tenants backend

### DIFF
--- a/backend/apps/core/tests/test_database.py
+++ b/backend/apps/core/tests/test_database.py
@@ -29,10 +29,15 @@ class DatabaseConnectivityTest(TestCase):
     def test_database_engine_configured(self):
         """Test that database engine is properly configured."""
         engine = connection.settings_dict['ENGINE']
-        self.assertEqual(
-            engine,
+        # Accept both django-tenants backend and standard PostgreSQL backend
+        valid_engines = [
             'django.db.backends.postgresql',
-            f"Database engine must be PostgreSQL, got: {engine}"
+            'django_tenants.postgresql_backend',
+        ]
+        self.assertIn(
+            engine,
+            valid_engines,
+            f"Database engine must be PostgreSQL (standard or django-tenants), got: {engine}"
         )
 
     def test_database_write_operations(self):


### PR DESCRIPTION
## 🔧 Fix

Update `test_database_engine_configured` test to accept both:
- `django.db.backends.postgresql` (standard)
- `django_tenants.postgresql_backend` (schema-based multi-tenancy)

## Issue
The test was failing after schema-based multi-tenancy migration because it only checked for the standard PostgreSQL backend.

## Solution
Modified assertion to accept both valid backends.

## Testing
```bash
python manage.py test apps.core.tests.test_database.DatabaseConnectivityTest.test_database_engine_configured
```

Related to PR #1013