### PR TITLE
fix: correct skip import from unittest

### DIFF
--- a/backend/apps/contacts/tests.py
+++ b/backend/apps/contacts/tests.py
@@ -3,7 +3,7 @@ Tests for Contacts API endpoints.
 
 Validates contact creation, validation, and error handling.
 """
-from django.test import skip
+from unittest import skip
 from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework.test import APITestCase

--- a/backend/apps/customers/tests.py
+++ b/backend/apps/customers/tests.py
@@ -3,7 +3,7 @@ Tests for Customers API endpoints.
 
 Validates customer creation, validation, and error handling.
 """
-from django.test import skip
+from unittest import skip
 from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework.test import APITestCase

--- a/backend/apps/purchase_orders/tests.py
+++ b/backend/apps/purchase_orders/tests.py
@@ -2,7 +2,7 @@
 Tests for Purchase Orders app models.
 """
 from decimal import Decimal
-from django.test import skip, TestCase
+from unittest import skip, TestCase
 from django.utils import timezone
 from apps.purchase_orders.models import (
     PurchaseOrder,

--- a/backend/apps/sales_orders/tests.py
+++ b/backend/apps/sales_orders/tests.py
@@ -1,7 +1,7 @@
 """
 Tests for Sales Orders app models.
 """
-from django.test import skip, TestCase
+from unittest import skip, TestCase
 from apps.sales_orders.models import SalesOrder, SalesOrderStatus
 from apps.suppliers.models import Supplier
 from apps.customers.models import Customer

--- a/backend/apps/suppliers/tests.py
+++ b/backend/apps/suppliers/tests.py
@@ -3,7 +3,7 @@ Tests for Suppliers API endpoints.
 
 Validates supplier creation, validation, and error handling.
 """
-from django.test import skip
+from unittest import skip
 from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework.test import APITestCase

--- a/backend/apps/tenants/test_isolation.py
+++ b/backend/apps/tenants/test_isolation.py
@@ -9,7 +9,8 @@ with django-tenants schema creation, which is not feasible in the standard test 
 They serve as documentation for the expected isolation behavior.
 """
 
-from django.test import TestCase, skip
+from django.test import TestCase
+from unittest import skip
 from django_tenants.utils import schema_context
 from django.contrib.auth.models import User
 from apps.tenants.models import Client, Domain

--- a/backend/apps/tenants/tests.py
+++ b/backend/apps/tenants/tests.py
@@ -1,4 +1,4 @@
-from django.test import skip, TestCase
+from unittest import skip, TestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile

--- a/backend/apps/tenants/tests_management_commands.py
+++ b/backend/apps/tenants/tests_management_commands.py
@@ -8,7 +8,8 @@ With django-tenants, tenants are created as Client instances with schemas.
 See SCHEMA_ISOLATION_MIGRATION_COMPLETE.md for new tenant creation approach.
 """
 
-from django.test import TestCase, skip
+from django.test import TestCase
+from unittest import skip
 
 
 @skip("Management command tests need refactoring for schema-based multi-tenancy")


### PR DESCRIPTION
## 🔧 Fix

Correct `@skip` decorator import - it's from `unittest`, not `django.test`.

## Issue
```
ImportError: cannot import name 'skip' from 'django.test'
```

## Solution
Changed all `from django.test import skip` to `from unittest import skip`

## Files Updated
- apps/tenants/tests.py
- apps/tenants/test_isolation.py
- apps/tenants/tests_management_commands.py
- apps/contacts/tests.py
- apps/customers/tests.py
- apps/suppliers/tests.py  
- apps/purchase_orders/tests.py
- apps/sales_orders/tests.py