### PR TITLE
fix: add PUBLIC_SCHEMA_URLCONF for health checks

### DIFF
--- a/backend/projectmeats/public_urls.py
+++ b/backend/projectmeats/public_urls.py
@@ -1,0 +1,15 @@
+"""
+Public schema URL configuration for ProjectMeats.
+
+These URLs are accessible without a tenant context (in the public schema).
+Used for health checks, system status, and other non-tenant-specific endpoints.
+"""
+from django.urls import path
+from .health import health_check, health_detailed, ready_check
+
+urlpatterns = [
+    # Health check endpoints (no tenant required)
+    path("api/v1/health/", health_check, name="health-check"),
+    path("api/v1/health/detailed/", health_detailed, name="health-detailed"),
+    path("api/v1/ready/", ready_check, name="ready-check"),
+]

--- a/backend/projectmeats/settings/base.py
+++ b/backend/projectmeats/settings/base.py
@@ -71,6 +71,10 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = "projectmeats.urls"
 
+# Public schema URL configuration (django-tenants)
+# These URLs are accessible without a tenant context  
+PUBLIC_SCHEMA_URLCONF = "projectmeats.public_urls"
+
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",


### PR DESCRIPTION
## 🔧 Fix

Enable health check endpoints to work without tenant context by adding PUBLIC_SCHEMA_URLCONF.

## Issue  

UAT deployment failing with health check 404 errors:
```
Health check attempt 1/15 (HTTP 404)...
Health check attempt 2/15 (HTTP 404)...
...
✗ Backend health check failed after 15 attempts (HTTP 404)
```

**Root Cause**: django-tenants `TenantMainMiddleware` blocks ALL requests that don't have a valid tenant domain. Health check endpoints were unreachable.

## Solution

Created `public_urls.py` with health check routes that work in public schema (no tenant required):

```python
PUBLIC_SCHEMA_URLCONF = "projectmeats.public_urls"
```

## Endpoints Now Working Without Tenant

- ✅ `/api/v1/health/` - Basic health check
- ✅ `/api/v1/health/detailed/` - Detailed system info
- ✅ `/api/v1/ready/` - Readiness check

## Testing

```bash
# Works without Host header or tenant domain
curl http://localhost:8000/api/v1/health/
# Returns: {"status": "healthy", ...}
```

## Impact

- ✅ Fixes UAT deployment health checks
- ✅ Fixes Production deployment health checks
- ✅ Enables monitoring without tenant setup
- ✅ No impact on tenant-scoped URLs

---

**Unblocks**: UAT & Production deployments