### PR TITLE
fix: correct UAT container name in health check

### DIFF
--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -497,7 +497,7 @@ jobs:
           ATTEMPT=1
           
           # First check if container is running
-          if ! sudo docker ps --filter "name=projectmeats-backend-uat" --filter "status=running" | grep -q projectmeats-backend-uat; then
+          if ! sudo docker ps --filter "name=pm-backend" --filter "status=running" | grep -q pm-backend; then
             echo "✗ Backend container is not running"
             exit 1
           fi
@@ -505,7 +505,7 @@ jobs:
           echo "✓ Backend container is running"
           
           # Check container health (if healthcheck is defined in dockerfile)
-          CONTAINER_HEALTH=$(sudo docker inspect --format='{{.State.Health.Status}}' projectmeats-backend-uat 2>/dev/null || echo "none")
+          CONTAINER_HEALTH=$(sudo docker inspect --format='{{.State.Health.Status}}' pm-backend 2>/dev/null || echo "none")
           echo "Container health status: $CONTAINER_HEALTH"
           
           # Health check using localhost since we're on the deployment server
@@ -527,7 +527,7 @@ jobs:
             
             if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
               # If container is running, treat as success despite health check failure
-              if sudo docker ps --filter "name=projectmeats-backend-uat" --filter "status=running" | grep -q projectmeats-backend-uat; then
+              if sudo docker ps --filter "name=pm-backend" --filter "status=running" | grep -q pm-backend; then
                 echo "⚠ Health check failed but container is running (HTTP $HTTP_CODE)"
                 echo "✓ Accepting deployment as successful"
                 exit 0


### PR DESCRIPTION
## 🔧 Infrastructure Fix

**Root Cause Identified**: Container name mismatch blocking UAT deployment

### The Problem
- **Deployment script** creates container named: `pm-backend`
- **Health check** was looking for: `projectmeats-backend-uat`
- **Result**: Container running successfully, but health check fails ❌

### Evidence
```
8bd7dcf014cb   ...   Up Less than a second   0.0.0.0:8000->8000/tcp   pm-backend
```
Container WAS running, health check just couldn't find it!

### The Fix
Updated health check to use correct container name: `pm-backend`

```bash
# Before
docker ps --filter "name=projectmeats-backend-uat"

# After  
docker ps --filter "name=pm-backend"
```

## Impact
✅ UAT deployments will now succeed  
✅ Container properly detected
✅ Health checks will pass

---

**This was the infrastructure issue blocking UATecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*