### PR TITLE
fix: Use Dockerfile.dev in build-dev-image workflow

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .devcontainer
-          file: .devcontainer/Dockerfile
+          file: .devcontainer/Dockerfile.dev
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Corrects Phase 2 build - use Dockerfile.dev not Dockerfile