### PR TITLE
fix: Use root context for Docker build

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: .devcontainer
+          context: .
           file: .devcontainer/Dockerfile.dev
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
**Problem:** Build fails with 'requirements.txt not found'

**Root Cause:** Dockerfile.dev references `backend/` and `frontend/` directories which exist in repo root, but workflow uses `context: .devcontainer`

**Fix:** Change context to `." (repo root) so Dockerfile can access all required files

**Result:** Build will succeed and push image to GHCR