### PR TITLE
fix: Improve Nginx config formatting and add debug output

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -355,24 +355,28 @@ jobs:
             # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
             sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'EOF'
-            server {
-              listen 80;
-              server_name _;
-              location / {
-                proxy_pass http://127.0.0.1:8080;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-              }
-            }
+server {
+    listen 80;
+    server_name _;
+    
+    # Proxy to frontend container
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
 EOF
             
             # Validate and reload
             if sudo nginx -t; then
               sudo systemctl reload nginx
+              echo "✓ Nginx reloaded"
             else
-              echo "✗ Nginx validation failed"
+              echo "✗ Nginx config invalid"
+              sudo cat /etc/nginx/conf.d/pm-frontend.conf
               exit 1
             fi
           fi

--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -374,24 +374,28 @@ jobs:
             # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
             sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'EOF'
-            server {
-              listen 80;
-              server_name _;
-              location / {
-                proxy_pass http://127.0.0.1:8080;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-              }
-            }
+server {
+    listen 80;
+    server_name _;
+    
+    # Proxy to frontend container
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
 EOF
             
             # Validate and reload
             if sudo nginx -t; then
               sudo systemctl reload nginx
+              echo "✓ Nginx reloaded"
             else
-              echo "✗ Nginx validation failed"
+              echo "✗ Nginx config invalid"
+              sudo cat /etc/nginx/conf.d/pm-frontend.conf
               exit 1
             fi
           fi

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -386,24 +386,28 @@ jobs:
             # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
             sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'EOF'
-            server {
-              listen 80;
-              server_name _;
-              location / {
-                proxy_pass http://127.0.0.1:8080;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-              }
-            }
+server {
+    listen 80;
+    server_name _;
+    
+    # Proxy to frontend container
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
 EOF
             
             # Validate and reload
             if sudo nginx -t; then
               sudo systemctl reload nginx
+              echo "✓ Nginx reloaded"
             else
-              echo "✗ Nginx validation failed"
+              echo "✗ Nginx config invalid"
+              sudo cat /etc/nginx/conf.d/pm-frontend.conf
               exit 1
             fi
           fi


### PR DESCRIPTION
## Nginx Configuration Improvements

**Changes:**
- Clean up Nginx config indentation (4 spaces, proper nesting)
- Add success message: `✓ Nginx reloaded`
- Add debug output on validation failure (`cat config file`)
- Add comment: `# Proxy to frontend container`
- Consistent formatting across dev/uat/prod workflows

**Why:**
- Improves readability of generated Nginx config
- Better debugging when validation fails
- Shows actual config content on error

**Impact:**
- No functional changes
- Only formatting and error messages
- Health checks already correct (GET requests via `curl -w`)

**Testing:**
- Nginx config syntax unchanged (still uses `<<'EOF'`)
- Variable expansion prevented (`` works correctly)
- Validation still runs before reload