### PR TITLE
fix: Resolve YAML syntax error in Nginx heredoc (line 358)

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -354,7 +354,7 @@ jobs:
             # Configure host nginx reverse proxy using tee
             # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
-            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'EOF'
+            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'NGINXEOF'
 server {
     listen 80;
     server_name _;
@@ -368,7 +368,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
-EOF
+NGINXEOF
             
             # Validate and reload
             if sudo nginx -t; then

--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -373,7 +373,7 @@ jobs:
             # Configure host nginx reverse proxy using tee
             # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
-            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'EOF'
+            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'NGINXEOF'
 server {
     listen 80;
     server_name _;
@@ -387,7 +387,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
-EOF
+NGINXEOF
             
             # Validate and reload
             if sudo nginx -t; then

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -385,7 +385,7 @@ jobs:
             # Configure host nginx reverse proxy using tee
             # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
-            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'EOF'
+            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'NGINXEOF'
 server {
     listen 80;
     server_name _;
@@ -399,7 +399,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
-EOF
+NGINXEOF
             
             # Validate and reload
             if sudo nginx -t; then


### PR DESCRIPTION
Fixes YAML syntax error by changing heredoc delimiter from EOF to NGINXEOF to avoid conflict with nested heredocs.