### PR TITLE
fix: Restore API Routing in Deployment Workflows

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -358,8 +358,32 @@ jobs:
 server {
     listen 80;
     server_name _;
-    
-    # Proxy to frontend container
+
+    # 1. Backend API (Running on Host Port 8000)
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 2. Django Admin (Running on Host Port 8000)
+    location /admin/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 3. Static Files (Running on Host Port 8000 via Whitenoise)
+    location /static/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+    }
+
+    # 4. Frontend (Running on Host Port 8080)
     location / {
         proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
@@ -373,7 +397,7 @@ EOF
             # Validate and reload
             if sudo nginx -t; then
               sudo systemctl reload nginx
-              echo "✓ Nginx reloaded"
+              echo "✓ Nginx reloaded with API routing"
             else
               echo "✗ Nginx config invalid"
               sudo cat /etc/nginx/conf.d/pm-frontend.conf

--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -377,8 +377,32 @@ jobs:
 server {
     listen 80;
     server_name _;
-    
-    # Proxy to frontend container
+
+    # 1. Backend API (Running on Host Port 8000)
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 2. Django Admin (Running on Host Port 8000)
+    location /admin/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 3. Static Files (Running on Host Port 8000 via Whitenoise)
+    location /static/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+    }
+
+    # 4. Frontend (Running on Host Port 8080)
     location / {
         proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
@@ -392,7 +416,7 @@ EOF
             # Validate and reload
             if sudo nginx -t; then
               sudo systemctl reload nginx
-              echo "✓ Nginx reloaded"
+              echo "✓ Nginx reloaded with API routing"
             else
               echo "✗ Nginx config invalid"
               sudo cat /etc/nginx/conf.d/pm-frontend.conf

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -389,8 +389,32 @@ jobs:
 server {
     listen 80;
     server_name _;
-    
-    # Proxy to frontend container
+
+    # 1. Backend API (Running on Host Port 8000)
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 2. Django Admin (Running on Host Port 8000)
+    location /admin/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 3. Static Files (Running on Host Port 8000 via Whitenoise)
+    location /static/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+    }
+
+    # 4. Frontend (Running on Host Port 8080)
     location / {
         proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
@@ -404,7 +428,7 @@ EOF
             # Validate and reload
             if sudo nginx -t; then
               sudo systemctl reload nginx
-              echo "✓ Nginx reloaded"
+              echo "✓ Nginx reloaded with API routing"
             else
               echo "✗ Nginx config invalid"
               sudo cat /etc/nginx/conf.d/pm-frontend.conf


### PR DESCRIPTION
## Problem
The deployment workflows were successfully generating Nginx config, but missing the `/api/` and `/admin/` blocks, severing the connection to the backend.

## Solution
Updated all three deployment workflows (dev, uat, prod) with complete Nginx configuration that includes:

### Routing Blocks Added:
1. **`/api/`** → Backend API (port 8000)
2. **`/admin/`** → Django Admin (port 8000)
3. **`/static/`** → Static files via Whitenoise (port 8000)
4. **`/`** → Frontend (port 8080)

All routes include proper proxy headers (`Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`).

## Files Changed
- `.github/workflows/11-dev-deployment.yml`
- `.github/workflows/12-uat-deployment.yml`
- `.github/workflows/13-prod-deployment.yml`

## Testing
- ✅ Nginx config syntax validated in heredoc
- ✅ All proxy headers properly set
- ✅ Backend routing restored to port 8000
- ✅ Frontend routing maintained on port 8080

## Impact
- Restores full API connectivity in all environments
- Django admin accessible again
- Static files properly served
- No impact on frontend routing

## Deployment
Upon merge to `development`, the dev deployment workflow will automatically deploy with restored API routing.