### PR TITLE
fix: Resolve YAML Syntax Error in Deployment Workflows

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -351,48 +351,46 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:dev-${{ github.sha }}
 
           if command -v nginx >/dev/null 2>&1; then
-            # Configure host nginx reverse proxy using tee
-            # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
-            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'NGINXEOF'
-server {
-    listen 80;
-    server_name _;
+            cat <<'EOF' | sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null
+          server {
+              listen 80;
+              server_name _;
 
-    # 1. Backend API (Running on Host Port 8000)
-    location /api/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+              # 1. Backend API (Running on Host Port 8000)
+              location /api/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
 
-    # 2. Django Admin (Running on Host Port 8000)
-    location /admin/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+              # 2. Django Admin (Running on Host Port 8000)
+              location /admin/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
 
-    # 3. Static Files (Running on Host Port 8000 via Whitenoise)
-    location /static/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-    }
+              # 3. Static Files (Running on Host Port 8000 via Whitenoise)
+              location /static/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+              }
 
-    # 4. Frontend (Running on Host Port 8080)
-    location / {
-        proxy_pass http://127.0.0.1:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
-NGINXEOF
+              # 4. Frontend (Running on Host Port 8080)
+              location / {
+                  proxy_pass http://127.0.0.1:8080;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
+          }
+          EOF
             
             # Validate and reload
             if sudo nginx -t; then

--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -370,48 +370,46 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:uat-${{ github.sha }}
 
           if command -v nginx >/dev/null 2>&1; then
-            # Configure host nginx reverse proxy using tee
-            # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
-            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'NGINXEOF'
-server {
-    listen 80;
-    server_name _;
+            cat <<'EOF' | sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null
+          server {
+              listen 80;
+              server_name _;
 
-    # 1. Backend API (Running on Host Port 8000)
-    location /api/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+              # 1. Backend API (Running on Host Port 8000)
+              location /api/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
 
-    # 2. Django Admin (Running on Host Port 8000)
-    location /admin/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+              # 2. Django Admin (Running on Host Port 8000)
+              location /admin/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
 
-    # 3. Static Files (Running on Host Port 8000 via Whitenoise)
-    location /static/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-    }
+              # 3. Static Files (Running on Host Port 8000 via Whitenoise)
+              location /static/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+              }
 
-    # 4. Frontend (Running on Host Port 8080)
-    location / {
-        proxy_pass http://127.0.0.1:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
-NGINXEOF
+              # 4. Frontend (Running on Host Port 8080)
+              location / {
+                  proxy_pass http://127.0.0.1:8080;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
+          }
+          EOF
             
             # Validate and reload
             if sudo nginx -t; then

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -382,48 +382,46 @@ jobs:
             "$REG/$IMG:$TAG"
 
           if command -v nginx >/dev/null 2>&1; then
-            # Configure host nginx reverse proxy using tee
-            # We use a simple forwarding proxy because the container handles the logic
             echo "=== Configuring host nginx reverse proxy ==="
-            sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'NGINXEOF'
-server {
-    listen 80;
-    server_name _;
+            cat <<'EOF' | sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null
+          server {
+              listen 80;
+              server_name _;
 
-    # 1. Backend API (Running on Host Port 8000)
-    location /api/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+              # 1. Backend API (Running on Host Port 8000)
+              location /api/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
 
-    # 2. Django Admin (Running on Host Port 8000)
-    location /admin/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+              # 2. Django Admin (Running on Host Port 8000)
+              location /admin/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
 
-    # 3. Static Files (Running on Host Port 8000 via Whitenoise)
-    location /static/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-    }
+              # 3. Static Files (Running on Host Port 8000 via Whitenoise)
+              location /static/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_set_header Host $host;
+              }
 
-    # 4. Frontend (Running on Host Port 8080)
-    location / {
-        proxy_pass http://127.0.0.1:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
-NGINXEOF
+              # 4. Frontend (Running on Host Port 8080)
+              location / {
+                  proxy_pass http://127.0.0.1:8080;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+              }
+          }
+          EOF
             
             # Validate and reload
             if sudo nginx -t; then


### PR DESCRIPTION
## Problem
The deployment workflows were failing with YAML parse errors:
```
while scanning a simple key
  in ".github/workflows/11-dev-deployment.yml", line 358, column 1
could not find expected ':'
  in ".github/workflows/11-dev-deployment.yml", line 362, column 5
```

The issue was caused by heredoc syntax incompatible with YAML multiline strings.

## Root Cause
Using `sudo tee <<'NGINXEOF'` followed by unindented nginx config blocks caused YAML parser to interpret the nginx config as YAML structure instead of bash script content.

## Solution
Changed heredoc approach from:
```bash
sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null <<'NGINXEOF'
server {
    # unindented content
}
NGINXEOF
```

To pipe-based approach:
```bash
cat <<'EOF' | sudo tee /etc/nginx/conf.d/pm-frontend.conf > /dev/null
          server {
              # properly indented for YAML
          }
          EOF
```

## Changes
- Fixed heredoc syntax in all three deployment workflows
- Properly indented nginx config blocks for YAML compatibility
- Validated all workflows with Python YAML parser
- Maintained complete API routing configuration

## Files Changed
- `.github/workflows/11-dev-deployment.yml`
- `.github/workflows/12-uat-deployment.yml`
- `.github/workflows/13-prod-deployment.yml`

## Validation
✓ All three workflow files validated with Python yaml.safe_load()
✓ Nginx config blocks maintain proper indentation
✓ API routing preserved (/api/, /admin/, /static/, /)

## Testing
Upon merge, workflows will execute without YAML parse errors and properly configure Nginx with backend routing.