### PR TITLE
fix: Update frontend deployment to use SSH key authentication

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -312,33 +312,24 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup SSH with password authentication
+      - name: Setup SSH with key authentication
         run: |
-          sudo apt-get update
-          sudo apt-get install -y sshpass netcat-openbsd dnsutils
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          # Use -T timeout to prevent hanging, continue on failure
+          echo "${{ secrets.DEV_FRONTEND_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -T 10 -H "${{ secrets.DEV_FRONTEND_HOST }}" >> ~/.ssh/known_hosts 2>&1 || echo "Warning: ssh-keyscan failed, will try connection anyway"
           chmod 600 ~/.ssh/known_hosts || true
 
-      - name: Test SSH connectivity with retry
-        env:
-          SSHPASS: ${{ secrets.DEV_FRONTEND_PASSWORD }}
-          MAX_SSH_RETRIES: 5
-          SSH_CONNECT_TIMEOUT: 30
+      - name: Test SSH connectivity
         run: |
-          chmod +x .github/scripts/ssh-connect-with-retry.sh
-          ./.github/scripts/ssh-connect-with-retry.sh \
-            "${{ secrets.DEV_FRONTEND_USER }}" \
-            "${{ secrets.DEV_FRONTEND_HOST }}" \
+          ssh -o StrictHostKeyChecking=yes -i ~/.ssh/id_ed25519 \
+            ${{ secrets.DEV_FRONTEND_USER }}@${{ secrets.DEV_FRONTEND_HOST }} \
             "echo 'SSH connection successful'"
 
       - name: Deploy frontend container (8080 behind Nginx)
-        env:
-          SSHPASS: ${{ secrets.DEV_FRONTEND_PASSWORD }}
         run: |
-          sshpass -e ssh -o StrictHostKeyChecking=yes ${{ secrets.DEV_FRONTEND_USER }}@${{ secrets.DEV_FRONTEND_HOST }} <<'DEPLOY_SCRIPT'
+          ssh -o StrictHostKeyChecking=yes -i ~/.ssh/id_ed25519 ${{ secrets.DEV_FRONTEND_USER }}@${{ secrets.DEV_FRONTEND_HOST }} <<'DEPLOY_SCRIPT'
           set -euo pipefail
 
           sudo mkdir -p /opt/pm/frontend/env


### PR DESCRIPTION
## Summary
Replace password authentication with SSH key for dev-frontend deployment.

## Changes
- ✅ Use `DEV_FRONTEND_SSH_KEY` instead of `DEV_FRONTEND_PASSWORD`
- ✅ Remove `sshpass` dependency (cleaner, more secure)
- ✅ Simplify SSH setup steps
- ✅ Improve security by using key-based authentication

## Required Actions
The following secrets must be set in the **`dev-frontend` environment**:

| Secret Name | Value |
|------------|-------|
| `DEV_FRONTEND_HOST` | `104.131.186.75` |
| `DEV_FRONTEND_USER` | `root` |
| `DEV_FRONTEND_SSH_KEY` | Private SSH key content |

### How to Set Secrets
1. Go to: https://github.com/Meats-Central/ProjectMeats/settings/environments
2. Click on **`dev-frontend`** environment
3. Add the three secrets above

## Testing
- [x] SSH key added to droplet (`~/.ssh/authorized_keys`)
- [x] Local SSH connection tested: `ssh root@104.131.186.75`
- [ ] Deploy workflow will test on merge to development

## Security Impact
✅ **Improved** - SSH keys are more secure than passwords
✅ No plaintext passwords in workflow
✅ Keys can be rotated independently