### PR TITLE
fix: Update DOCR authentication to use DO_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-buildx-dev-${{ matrix.app }}-
 
       - name: Login to DOCR
-        run: echo "${{ secrets.DO_ACCESS_TOKEN }}" | docker login ${{ env.REGISTRY }} -u doctl --password-stdin
+        run: echo "${{ secrets.DO_ACCESS_TOKEN }}" | docker login ${{ env.REGISTRY }} -u "${{ secrets.DO_ACCESS_TOKEN }}" --password-stdin
 
       - name: Login to GHCR
         run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -346,7 +346,7 @@ jobs:
           # Docker login with retry logic
           MAX_RETRIES=3
           RETRY_COUNT=0
-          until echo "${{ secrets.DO_ACCESS_TOKEN }}" | sudo docker login ${{ env.REGISTRY }} -u doctl --password-stdin; do
+          until echo "${{ secrets.DO_ACCESS_TOKEN }}" | sudo docker login ${{ env.REGISTRY }} -u "${{ secrets.DO_ACCESS_TOKEN }}" --password-stdin; do
             RETRY_COUNT=$((RETRY_COUNT+1))
             if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
               echo "Failed to login after $MAX_RETRIES attempts"
@@ -527,7 +527,7 @@ jobs:
 
           # Docker login with retry logic
           RETRY_COUNT=0
-          until echo "${{ secrets.DO_ACCESS_TOKEN }}" | sudo docker login "$REG" -u doctl --password-stdin; do
+          until echo "${{ secrets.DO_ACCESS_TOKEN }}" | sudo docker login "$REG" -u "${{ secrets.DO_ACCESS_TOKEN }}" --password-stdin; do
             RETRY_COUNT=$((RETRY_COUNT+1))
             if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
               echo "Failed to login after $MAX_RETRIES attempts"


### PR DESCRIPTION
## Summary
Updates DigitalOcean Container Registry authentication to use `DO_ACCESS_TOKEN` as both username and password.

## Changes
- **Build-and-push job**: Changed login from `-u doctl` to `-u ${{ secrets.DO_ACCESS_TOKEN }}`
- **Frontend deployment**: Updated DOCR login with retry logic
- **Backend deployment**: Updated DOCR login with retry logic

## Rationale
DigitalOcean Container Registry authentication requires using the access token as both the username and password for proper authentication. The previous `-u doctl` method was causing authentication failures.

## Testing
- [ ] Verify DOCR login succeeds in build-and-push job
- [ ] Verify frontend deployment can pull images from DOCR
- [ ] Verify backend deployment can pull images from DOCR
- [ ] Monitor workflow logs for authentication errors

## Related Documentation
- DIGITALOCEAN_REGISTRY_FIX.md
- .github/workflows/11-dev-deployment.yml

## Deployment Impact
- **Risk Level**: Low
- **Rollback Plan**: Revert commit if authentication still fails
- **Monitoring**: Check workflow logs and deployment success rate

---
**Type**: Bug Fix  
**Component**: CI/CD  
**Environment**: Development