### PR TITLE
fix: Handle missing DEV_BACKEND_IP in frontend deployment

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -368,12 +368,32 @@ jobs:
             sleep 10
           done
 
+          # Debug: Print deployment variables
+          echo "=== Deployment Variables ==="
+          echo "REGISTRY: ${{ env.REGISTRY }}"
+          echo "FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}"
+          echo "TAG: dev-${{ github.sha }}"
+          echo "BACKEND_IP: ${{ secrets.DEV_BACKEND_IP }}"
+          echo "============================"
+
           sudo docker rm -f pm-frontend >/dev/null 2>&1 || true
-          sudo docker run -d --name pm-frontend --restart unless-stopped \
-            -p 8080:80 \
-            --add-host backend:${{ secrets.DEV_BACKEND_IP }} \
-            -v /opt/pm/frontend/env/env-config.js:/usr/share/nginx/html/env-config.js:ro \
-            ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:dev-${{ github.sha }}
+          
+          # Build docker run command conditionally
+          BACKEND_IP="${{ secrets.DEV_BACKEND_IP }}"
+          if [ -n "$BACKEND_IP" ]; then
+            echo "Adding backend host entry: $BACKEND_IP"
+            sudo docker run -d --name pm-frontend --restart unless-stopped \
+              -p 8080:80 \
+              --add-host backend:"$BACKEND_IP" \
+              -v /opt/pm/frontend/env/env-config.js:/usr/share/nginx/html/env-config.js:ro \
+              ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:dev-${{ github.sha }}
+          else
+            echo "⚠️  DEV_BACKEND_IP not set, skipping --add-host"
+            sudo docker run -d --name pm-frontend --restart unless-stopped \
+              -p 8080:80 \
+              -v /opt/pm/frontend/env/env-config.js:/usr/share/nginx/html/env-config.js:ro \
+              ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:dev-${{ github.sha }}
+          fi
 
           if command -v nginx >/dev/null 2>&1; then
             echo "=== Configuring host nginx reverse proxy ==="


### PR DESCRIPTION
## Problem
Frontend deployment is failing with exit code 125:
```
invalid argument "backend:" for "--add-host" flag: invalid IP address in add-host: ""
```

**Root Cause**: The `DEV_BACKEND_IP` secret is not set, causing the `--add-host backend:` flag to have an empty IP address.

## Solution
This PR implements:

1. **Debug Logging**: Added visibility into deployment variables before docker run
   - Prints REGISTRY, FRONTEND_IMAGE, TAG, BACKEND_IP values
   
2. **Conditional --add-host**: Makes the backend host entry optional
   - If `DEV_BACKEND_IP` is set → uses `--add-host backend:IP`
   - If `DEV_BACKEND_IP` is empty → skips the flag with a warning

3. **Graceful Fallback**: Container starts successfully without backend host entry
   - Frontend can still deploy even if backend IP is not configured
   - Nginx reverse proxy handles backend routing at the host level

## Changes
- Modified `.github/workflows/11-dev-deployment.yml`
- Updated `deploy-frontend` job's docker run command
- Added debug output for troubleshooting

## Testing Checklist
- [x] Verify docker run succeeds when DEV_BACKEND_IP is empty
- [ ] Verify docker run succeeds when DEV_BACKEND_IP is set
- [ ] Confirm frontend container starts successfully
- [ ] Verify nginx routing still works for API calls

## Related Issues
- Fixes: https://github.com/Meats-Central/ProjectMeats/actions/runs/20051654436/job/57509021833

## Next Steps
**Action Required**: Set the `DEV_BACKEND_IP` secret in repository settings:
```
Settings → Secrets and variables → Actions → Repository secrets
Name: DEV_BACKEND_IP
Value: <backend server IP address>
```

## Deployment Impact
- **Risk Level**: Low (adds graceful handling)
- **Rollback Plan**: Revert commit if issues arise
- **Monitoring**: Check workflow logs for debug output

---
**Type**: Bug Fix  
**Component**: CI/CD - Frontend Deployment  
**Environment**: Development