### PR TITLE
fix: Handle missing BACKEND_IP secrets in nginx configuration

### DIFF
--- a/.github/workflows/11-dev-deployment.yml
+++ b/.github/workflows/11-dev-deployment.yml
@@ -397,6 +397,12 @@ jobs:
 
           if command -v nginx >/dev/null 2>&1; then
             echo "=== Configuring host nginx reverse proxy ==="
+            # Default to localhost if DEV_BACKEND_IP is not set
+            NGINX_BACKEND_HOST="${{ secrets.DEV_BACKEND_IP }}"
+            if [ -z "$NGINX_BACKEND_HOST" ]; then
+              NGINX_BACKEND_HOST="127.0.0.1"
+              echo "⚠️  DEV_BACKEND_IP not set, using localhost (127.0.0.1) for backend proxy"
+            fi
             {
               echo 'server {'
               echo '    listen 80;'
@@ -404,7 +410,7 @@ jobs:
               echo ''
               echo '    # 1. Route API, Admin, Static to Backend (Port 8000)'
               echo '    location ~ ^/(api|admin|static)/ {'
-              echo '        proxy_pass http://${{ secrets.DEV_BACKEND_IP }}:8000;'
+              echo "        proxy_pass http://$NGINX_BACKEND_HOST:8000;"
               echo '        proxy_set_header Host $host;'
               echo '        proxy_set_header X-Real-IP $remote_addr;'
               echo '        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;'

--- a/.github/workflows/12-uat-deployment.yml
+++ b/.github/workflows/12-uat-deployment.yml
@@ -360,6 +360,12 @@ jobs:
 
           if command -v nginx >/dev/null 2>&1; then
             echo "=== Configuring host nginx reverse proxy ==="
+            # Default to localhost if UAT_BACKEND_IP is not set
+            NGINX_BACKEND_HOST="${{ secrets.UAT_BACKEND_IP }}"
+            if [ -z "$NGINX_BACKEND_HOST" ]; then
+              NGINX_BACKEND_HOST="127.0.0.1"
+              echo "⚠️  UAT_BACKEND_IP not set, using localhost (127.0.0.1) for backend proxy"
+            fi
             {
               echo 'server {'
               echo '    listen 80;'
@@ -367,7 +373,7 @@ jobs:
               echo ''
               echo '    # 1. Route API, Admin, Static to Backend (Port 8000)'
               echo '    location ~ ^/(api|admin|static)/ {'
-              echo '        proxy_pass http://${{ secrets.UAT_BACKEND_IP }}:8000;'
+              echo "        proxy_pass http://$NGINX_BACKEND_HOST:8000;"
               echo '        proxy_set_header Host $host;'
               echo '        proxy_set_header X-Real-IP $remote_addr;'
               echo '        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;'

--- a/.github/workflows/13-prod-deployment.yml
+++ b/.github/workflows/13-prod-deployment.yml
@@ -372,6 +372,12 @@ jobs:
 
           if command -v nginx >/dev/null 2>&1; then
             echo "=== Configuring host nginx reverse proxy ==="
+            # Default to localhost if PROD_BACKEND_IP is not set
+            NGINX_BACKEND_HOST="${{ secrets.PROD_BACKEND_IP }}"
+            if [ -z "$NGINX_BACKEND_HOST" ]; then
+              NGINX_BACKEND_HOST="127.0.0.1"
+              echo "⚠️  PROD_BACKEND_IP not set, using localhost (127.0.0.1) for backend proxy"
+            fi
             {
               echo 'server {'
               echo '    listen 80;'
@@ -379,7 +385,7 @@ jobs:
               echo ''
               echo '    # 1. Route API, Admin, Static to Backend (Port 8000)'
               echo '    location ~ ^/(api|admin|static)/ {'
-              echo '        proxy_pass http://${{ secrets.PROD_BACKEND_IP }}:8000;'
+              echo "        proxy_pass http://$NGINX_BACKEND_HOST:8000;"
               echo '        proxy_set_header Host $host;'
               echo '        proxy_set_header X-Real-IP $remote_addr;'
               echo '        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;'


### PR DESCRIPTION
## Problem

The deployment workflow fails with nginx configuration error when the BACKEND_IP secret (DEV_BACKEND_IP, UAT_BACKEND_IP, or PROD_BACKEND_IP) is not set or is empty:

```
nginx: [emerg] no host in upstream ":8000" in /etc/nginx/conf.d/pm-frontend.conf:7
nginx: configuration file /etc/nginx/nginx.conf test failed
```

This happened because the workflow was directly interpolating the secret into the nginx config:
```bash
echo '        proxy_pass http://${{ secrets.DEV_BACKEND_IP }}:8000;'
# Results in: proxy_pass http://:8000; when secret is empty
```

## Solution

- Added shell variable assignment with default fallback to `127.0.0.1` (localhost)
- Changed from single-quoted to double-quoted echo to allow variable expansion
- Applied consistently across all three deployment workflows (dev, UAT, prod)

```bash
NGINX_BACKEND_HOST="${{ secrets.DEV_BACKEND_IP }}"
if [ -z "$NGINX_BACKEND_HOST" ]; then
  NGINX_BACKEND_HOST="127.0.0.1"
fi
echo "        proxy_pass http://$NGINX_BACKEND_HOST:8000;"
```

## Changes

- ✅ `.github/workflows/11-dev-deployment.yml` - Added localhost fallback for DEV_BACKEND_IP
- ✅ `.github/workflows/12-uat-deployment.yml` - Added localhost fallback for UAT_BACKEND_IP
- ✅ `.github/workflows/13-prod-deployment.yml` - Added localhost fallback for PROD_BACKEND_IP

## Testing

This fix allows the deployment to succeed even when the BACKEND_IP secret is not configured, falling back to localhost which is the correct default for co-located frontend/backend deployments.

## Fixes

- https://github.com/Meats-Central/ProjectMeats/actions/runs/20051812861/job/57509452036

Co-authored-by: GitHub Copilot <noreply@github.com>