### PR TITLE
fix: Run migrations via SSH on deployment server

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -198,32 +198,39 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.backend_environment }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        working-directory: backend
-        run: |
-          pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run migrations
-        working-directory: backend
+      - name: Run migrations via SSH on deployment server
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
+          SSHPASS: ${{ secrets.BACKEND_SSH_PASSWORD }}
         run: |
-          # CRITICAL: Use standard Django migrate (NOT migrate_schemas)
+          # Install sshpass for password authentication
+          sudo apt-get update -qq
+          sudo apt-get install -y sshpass
+          
+          # Run migrations on the deployment server via SSH
+          sshpass -e ssh -o StrictHostKeyChecking=yes \
+            ${{ secrets.BACKEND_USER }}@${{ secrets.BACKEND_HOST }} << 'SSH_END'
+          set -euo pipefail
+          
+          echo "=== Running migrations on deployment server ==="
+          
+          # Navigate to project directory
+          cd /home/django/ProjectMeats/backend || {
+            echo "Error: Project directory not found"
+            exit 1
+          }
+          
+          # Activate virtual environment if it exists
+          if [ -f "../venv/bin/activate" ]; then
+            source ../venv/bin/activate
+          elif [ -f "venv/bin/activate" ]; then
+            source venv/bin/activate
+          fi
+          
+          # Run migrations (standard Django, NOT migrate_schemas)
           python manage.py migrate --fake-initial --noinput
+          
           echo "✓ Migrations completed successfully"
+          SSH_END
 
   # ==========================================
   # Stage 5: Deploy Backend


### PR DESCRIPTION
## Problem

Migrations are failing with database connection timeout:

```
django.db.utils.OperationalError: connection timeout expired
psycopg.errors.ConnectionTimeout: connection timeout expired
```

**Failed Run:** https://github.com/Meats-Central/ProjectMeats/actions/runs/20056901596

## Root Cause

The current workflow runs migrations **on the GitHub Actions runner** (in the cloud):

```yaml
migrate:
  steps:
    - uses: actions/setup-python@v5
    - run: pip install -r requirements.txt
    - run: python manage.py migrate  # ❌ Runs in GitHub cloud
      env:
        DATABASE_URL: ${{ secrets.DATABASE_URL }}
```

**Problem:** The GitHub Actions runner **cannot reach** your DigitalOcean database because:
- Database is behind a firewall
- Only accessible from the deployment server's network
- `DATABASE_URL` points to a private IP or localhost

## Solution

Run migrations **via SSH on the deployment server** (like the old workflow):

```yaml
migrate:
  steps:
    - run: |
        sshpass -e ssh ${{ secrets.BACKEND_USER }}@${{ secrets.BACKEND_HOST }} << 'SSH_END'
        cd /home/django/ProjectMeats/backend
        source ../venv/bin/activate
        python manage.py migrate --fake-initial --noinput
        SSH_END
```

**Why this works:**
- ✅ Runs on the deployment server (same network as database)
- ✅ Uses server's `.env` file with correct `DATABASE_URL`
- ✅ Database is accessible (localhost or private network)
- ✅ Matches the working approach from `11-dev-deployment.yml`

## Network Topology

### Before (Failed) ❌
```
GitHub Runner (Cloud)
    ↓ DATABASE_URL
    ✗ Cannot reach database (firewalled)
DigitalOcean Database (Private)
```

### After (Fixed) ✅
```
GitHub Runner (Cloud)
    ↓ SSH
Deployment Server
    ↓ DATABASE_URL (localhost/private IP)
    ✓ Database accessible
DigitalOcean Database (Private)
```

## Changes

**Removed:**
- Python setup on GitHub runner
- Pip install dependencies
- Direct database connection from GitHub

**Added:**
- SSH connection to deployment server
- Execute migrations on server
- Use server's virtual environment and `.env`

**Before:**
```yaml
- name: Setup Python
  uses: actions/setup-python@v5
- name: Install dependencies
  run: pip install -r requirements.txt
- name: Run migrations
  env:
    DATABASE_URL: ${{ secrets.DATABASE_URL }}  # ❌ Can't reach DB
  run: python manage.py migrate
```

**After:**
```yaml
- name: Run migrations via SSH
  run: |
    sshpass -e ssh ${{ secrets.BACKEND_USER }}@${{ secrets.BACKEND_HOST }} << 'SSH_END'
    cd /home/django/ProjectMeats/backend
    source ../venv/bin/activate
    python manage.py migrate --fake-initial --noinput  # ✅ Runs on server
    SSH_END
```

## Testing

After merge:
1. ✅ Migrations will run on deployment server
2. ✅ Server has database access
3. ✅ No connection timeout
4. ✅ Deployment will proceed

## Impact

- **Fixes:** Database connection timeout
- **Restores:** Working migration approach from old workflow
- **No breaking changes:** Still uses standard Django `migrate` command
- **Security:** No additional secrets needed (uses existing SSH creds)

---

**Merge priority: CRITICAL** - Blocks all deployments