### PR TITLE
fix: Use environment-scoped secrets in bastion PoC workflow

### DIFF
--- a/.github/workflows/poc-bastion-migration.yml
+++ b/.github/workflows/poc-bastion-migration.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Setup SSH Tunnel to Database
         env:
           SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
         run: |
           # Install sshpass for password-based SSH
           sudo apt-get update -qq
@@ -37,10 +41,10 @@ jobs:
           
           # Create SSH tunnel in background
           # Forward local port 5433 -> remote DB host:port
-          echo "Creating SSH tunnel: localhost:5433 -> ${{ secrets.DATABASE_HOST }}:${{ secrets.DATABASE_PORT }}"
+          echo "Creating SSH tunnel: localhost:5433 -> $DB_HOST:$DB_PORT"
           sshpass -p "$SSH_PASSWORD" ssh -o StrictHostKeyChecking=no -f -N \
-            -L 5433:${{ secrets.DATABASE_HOST }}:${{ secrets.DATABASE_PORT }} \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}
+            -L 5433:$DB_HOST:$DB_PORT \
+            $SSH_USER@$SSH_HOST
           
           # Wait for tunnel to establish
           sleep 5
@@ -49,16 +53,20 @@ jobs:
           ps aux | grep ssh | grep -v grep
       
       - name: Test Database Connectivity
+        env:
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_NAME: ${{ secrets.DB_NAME }}
         run: |
           # Install PostgreSQL client
           sudo apt-get install -y postgresql-client
           
           # Test connection through tunnel
-          PGPASSWORD="${{ secrets.DATABASE_PASSWORD }}" psql \
+          PGPASSWORD="$DB_PASSWORD" psql \
             -h 127.0.0.1 \
             -p 5433 \
-            -U "${{ secrets.DATABASE_USER }}" \
-            -d "${{ secrets.DATABASE_NAME }}" \
+            -U "$DB_USER" \
+            -d "$DB_NAME" \
             -c "SELECT version();"
       
       - name: Setup Python
@@ -77,11 +85,16 @@ jobs:
         working-directory: ./backend
         env:
           # Override DATABASE_URL to use tunnel
-          DATABASE_URL: "postgresql://${{ secrets.DATABASE_USER }}:${{ secrets.DATABASE_PASSWORD }}@127.0.0.1:5433/${{ secrets.DATABASE_NAME }}"
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
         run: |
           echo "Testing database access through SSH tunnel..."
+          
+          # Construct DATABASE_URL for tunnel
+          export DATABASE_URL="postgresql://$DB_USER:$DB_PASSWORD@127.0.0.1:5433/$DB_NAME"
           
           # Read-only check: Show migration status
           python manage.py showmigrations
@@ -92,10 +105,15 @@ jobs:
         if: false  # Disabled for safety - enable manually if needed
         working-directory: ./backend
         env:
-          DATABASE_URL: "postgresql://${{ secrets.DATABASE_USER }}:${{ secrets.DATABASE_PASSWORD }}@127.0.0.1:5433/${{ secrets.DATABASE_NAME }}"
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
         run: |
+          # Construct DATABASE_URL for tunnel
+          export DATABASE_URL="postgresql://$DB_USER:$DB_PASSWORD@127.0.0.1:5433/$DB_NAME"
+          
           # CAUTION: This will actually run migrations
           python manage.py migrate --fake-initial --noinput
       


### PR DESCRIPTION
Fixes the 'Bad local forwarding specification' error by using correct secret names.

## Changes
- Replace `DATABASE_*` secrets with `DB_*` to match environment naming convention
- Use environment variables instead of direct secret interpolation for better security
- Construct DATABASE_URL dynamically from components
- All secrets now properly scoped to dev-backend/uat2-backend/prod2-backend environments

## Testing
Run the PoC workflow manually from Actions tab after merge to validate SSH tunnel works.