### PR TITLE
fix: Add Host header to frontend health check

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -450,7 +450,7 @@ jobs:
           MAX_ATTEMPTS=20
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:80/ || echo "000")
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Host: localhost" http://localhost:80/ || echo "000")
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✓ Frontend health check passed (HTTP $HTTP_CODE)"
               exit 0


### PR DESCRIPTION
## Problem
Frontend deployment health checks were failing with HTTP 400 errors.

## Root Cause
The health check curl command was not including a Host header, causing nginx to reject requests with HTTP 400 (Bad Request). Nginx logs showed:
- Internal requests (127.0.0.1) succeeded because they used proper HTTP/1.1 headers
- External health check requests (172.17.0.1) failed without Host header

## Solution
Added `-H 'Host: localhost'` to the curl command in the frontend health check to ensure proper HTTP/1.1 requests with required Host header.

## Testing
This fix resolves the issue observed in: https://github.com/Meats-Central/ProjectMeats/actions/runs/20087097428

## Changes
- Modified `.github/workflows/reusable-deploy.yml` line 453
- Added Host header to frontend health check curl command

## Impact
- ✅ Frontend deployments will now pass health checks
- ✅ No changes to application code
- ✅ Minimal change to deployment workflow