### PR TITLE
fix: Map UAT frontend to legacy STAGING_* secrets

### DIFF
--- a/config/env.manifest.json
+++ b/config/env.manifest.json
@@ -1,12 +1,12 @@
 {
   "project": "ProjectMeats",
-  "version": "3.2",
-  "description": "Source of Truth - Fixed Scopes and Mappings",
+  "version": "3.3",
+  "description": "Source of Truth - Legacy Mapping Fix",
   "environments": {
     "dev-backend": { "type": "backend", "prefix": "DEV", "django_settings": "projectmeats.settings.development" },
     "dev-frontend": { "type": "frontend", "prefix": "DEV", "url": "https://dev.meatscentral.com" },
     "uat2-backend": { "type": "backend", "prefix": "UAT", "django_settings": "projectmeats.settings.staging" },
-    "uat2-frontend": { "type": "frontend", "prefix": "UAT", "url": "https://uat.meatscentral.com" },
+    "uat2": { "type": "frontend", "prefix": "STAGING", "url": "https://uat.meatscentral.com" },
     "prod2-backend": { "type": "backend", "prefix": "PROD", "django_settings": "projectmeats.settings.production" },
     "prod2-frontend": { "type": "frontend", "prefix": "PROD", "url": "https://meatscentral.com" }
   },
@@ -18,9 +18,9 @@
           "dev-backend": "DEV_HOST",
           "dev-frontend": "DEV_HOST",
           "uat2-backend": "UAT_HOST",
-          "uat2-frontend": "UAT_HOST",
+          "uat2": "STAGING_HOST",
           "prod2-backend": "PROD_HOST",
-          "prod2-frontend": "PROD_HOST"
+          "prod2-frontend": "PRODUCTION_HOST"
         }
       },
       "BASTION_USER": { 
@@ -29,25 +29,25 @@
           "dev-backend": "DEV_USER",
           "dev-frontend": "DEV_USER",
           "uat2-backend": "UAT_USER",
-          "uat2-frontend": "UAT_USER",
+          "uat2": "STAGING_USER",
           "prod2-backend": "PROD_USER",
-          "prod2-frontend": "PROD_USER"
+          "prod2-frontend": "PRODUCTION_USER"
         }
       },
       "BASTION_SSH_PASSWORD": { 
-        "description": "SSH Password",
+        "description": "SSH Password (Legacy Shared)",
         "ci_secret_mapping": {
           "dev-backend": "DEV_SSH_PASSWORD",
           "dev-frontend": "DEV_SSH_PASSWORD",
           "uat2-backend": "SSH_PASSWORD", 
-          "uat2-frontend": "SSH_PASSWORD",
+          "uat2": "SSH_PASSWORD",
           "prod2-backend": "SSH_PASSWORD",
           "prod2-frontend": "SSH_PASSWORD"
         }
       }
     },
     "application": {
-      "DB_HOST": { "ci_secret_pattern": "{PREFIX}_DB_HOST", "description": "DB Hostname" },
+      "DB_HOST": { "ci_secret_pattern": "{PREFIX}_DB_HOST", "description": "Private DB Host" },
       "DB_PORT": { "ci_secret_pattern": "{PREFIX}_DB_PORT", "default": "5432" },
       "DB_USER": { "ci_secret_pattern": "{PREFIX}_DB_USER", "description": "DB Username" },
       "DB_PASSWORD": { "ci_secret_pattern": "{PREFIX}_DB_PASSWORD", "description": "DB Password" },


### PR DESCRIPTION
## Problem
UAT frontend environment was configured with modern naming conventions that don't match the legacy infrastructure, causing deployment failures and secret resolution issues.

### Mismatch Details:
| Component | Expected (v3.2) | Actual Reality | Impact |
|-----------|----------------|----------------|---------|
| Environment Name | `uat2-frontend` | `uat2` | Workflow can't find environment |
| Secret Prefix | `UAT_*` | `STAGING_*` | Secrets not found |
| SSH Password | `UAT_SSH_PASSWORD` | `SSH_PASSWORD` | Authentication fails |

## Root Cause
The UAT environment was set up before standardization and uses different naming:
- **GitHub Environment**: Named `uat2` (not `uat2-frontend`)
- **Secret Naming**: Uses `STAGING_*` prefix (not `UAT_*`)
- **Shared Secrets**: Uses legacy `SSH_PASSWORD` across UAT/Prod

## Solution

### Manifest Changes (v3.2 → v3.3):

#### 1. Environment Name
```json
// Before
"uat2-frontend": { "type": "frontend", "prefix": "UAT" }

// After
"uat2": { "type": "frontend", "prefix": "STAGING" }
```

#### 2. Infrastructure Secret Mappings
```json
"BASTION_HOST": {
  "ci_secret_mapping": {
    "uat2": "STAGING_HOST"  // was: "uat2-frontend": "UAT_HOST"
  }
}

"BASTION_USER": {
  "ci_secret_mapping": {
    "uat2": "STAGING_USER"  // was: "uat2-frontend": "UAT_USER"
  }
}

"BASTION_SSH_PASSWORD": {
  "ci_secret_mapping": {
    "uat2": "SSH_PASSWORD"  // was: "uat2-frontend": "SSH_PASSWORD"
  }
}
```

#### 3. Production Naming
Also corrected production frontend to use `PRODUCTION_*` (not `PROD_*`) to match actual secret names.

## Benefits

✅ **No Password Resets Required** - Uses existing `SSH_PASSWORD`  
✅ **Matches GitHub Environment Structure** - Targets correct `uat2` environment  
✅ **Resolves Deployment Failures** - Workflows can now find secrets  
✅ **Accurate Audit Results** - No false positives for UAT frontend  
✅ **Backward Compatible** - Maintains legacy infrastructure as-is

## Testing

### Verify Secret Resolution:
```bash
# Check uat2 environment has required secrets
gh secret list --env uat2

# Run audit (should show uat2 correctly)
python3 config/manage_env.py audit
```

### Expected Output:
```
Scanning Environment: uat2...
  ✅ All Clear (X env-specific secrets found)
```

## Migration Path

### Current State:
- `uat2` environment exists with `STAGING_*` secrets
- `uat2-backend` uses `UAT_*` secrets (correct)

### After This PR:
- Manifest correctly maps to both naming schemes
- No infrastructure changes needed
- Deployments work immediately

## Related Issues
- Fixes UAT frontend deployment failures
- Resolves audit false positives
- Part of environment unification effort (v3.x series)

## Future Consideration
Eventually we may want to standardize UAT to use `UAT_*` consistently, but that would require:
1. Creating new secrets in `uat2` environment
2. Updating SSH passwords
3. Coordinated cutover

For now, this fix maintains stability while fixing immediate deployment issues.