### PR TITLE
fix: Make frontend nginx config default_server to prevent HTTP 400

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -421,9 +421,13 @@ jobs:
           
           # Configure nginx reverse proxy
           if command -v nginx >/dev/null 2>&1; then
+            # Remove conflicting default Nginx config
+            rm -f /etc/nginx/sites-enabled/default
+            
+            # Create config as default_server to handle all port 80 traffic
             cat > /etc/nginx/conf.d/pm-frontend.conf << 'NGINX'
           server {
-              listen 80;
+              listen 80 default_server;
               server_name _ localhost;
               
               location ~ ^/(api|admin|static)/ {


### PR DESCRIPTION
## Problem
Frontend container is healthy (HTTP 200 on port 8080), but the reverse proxy returns **HTTP 400 on port 80**, causing warnings in deployment logs.

### Current Behavior:
```
✓ Frontend container health check passed (HTTP 200)
Verifying reverse proxy on port 80...
⚠ Reverse proxy returned HTTP 400 (container is healthy, proxy may need attention)
```

## Root Cause

Ubuntu's Nginx ships with a default configuration that conflicts with our app:

1. **Default config exists**: `/etc/nginx/sites-enabled/default`
2. **Both listen on port 80**: Our config + default config
3. **Ambiguous routing**: When `curl localhost:80` executes, Nginx doesn't know which config to use
4. **Wrong handler**: Request may go to "Welcome to Nginx" page instead of our app
5. **Result**: HTTP 400 or unexpected response

### The Conflict:
```
Port 80
  ├─ /etc/nginx/sites-enabled/default  ("Welcome to Nginx")
  └─ /etc/nginx/conf.d/pm-frontend.conf  (Our app) ← Want this!
```

## Solution

### 1. Remove Conflicting Default Config
```bash
rm -f /etc/nginx/sites-enabled/default
```
**Why**: Eliminates the "Welcome to Nginx" page that ships with Ubuntu's nginx package.

### 2. Make Our Config Default Server
```diff
  server {
-     listen 80;
+     listen 80 default_server;
      server_name _ localhost;
      # ...
  }
```

**What `default_server` does:**
- Tells Nginx: "Use THIS config for any request that doesn't match a specific server_name"
- Ensures ALL port 80 traffic routes to our app
- Makes behavior deterministic and explicit

## Changes Made

```yaml
# Configure nginx reverse proxy
if command -v nginx >/dev/null 2>&1; then
  # NEW: Remove conflicting default config
  rm -f /etc/nginx/sites-enabled/default
  
  # NEW: Make our config the default_server
  cat > /etc/nginx/conf.d/pm-frontend.conf << 'NGINX'
server {
    listen 80 default_server;  # ← Added default_server
    server_name _ localhost;
    
    # ... location blocks unchanged ...
}
NGINX
  nginx -t && systemctl reload nginx
fi
```

## Expected Behavior After Fix

### Health Check Output:
```
Checking container health on port 8080...
✓ Frontend container health check passed (HTTP 200)

Verifying reverse proxy on port 80...
✓ Reverse proxy health check passed (HTTP 200)  ← Fixed!
```

### Request Flow:
```
curl http://localhost:80/
  ↓
Nginx (Port 80)
  ↓
Checks server_name: "localhost"
  ↓
Uses default_server config (our app)
  ↓
Proxies to 127.0.0.1:8080 (container)
  ↓
✓ Returns HTTP 200
```

## Benefits

✅ **Eliminates HTTP 400 warnings** - Clean deployment logs  
✅ **Deterministic routing** - No ambiguity in request handling  
✅ **Follows best practices** - Explicit default_server declaration  
✅ **Non-breaking** - Container check still primary (deployment gate)  
✅ **Production-safe** - Removing default config is standard practice  

## Technical Background

### Nginx Config Priority (Without default_server)
1. Try to match request hostname to `server_name` directives
2. If no exact match, use first config file **alphabetically**
3. `default` comes before `pm-frontend.conf` alphabetically
4. **Result**: Wrong config handles the request

### With default_server
1. Explicitly designated config handles unmatched requests
2. Guaranteed to catch `localhost` requests
3. **Result**: Deterministic, correct routing

### Why Safe to Remove Default Config
- Ships with Ubuntu's nginx package as a placeholder
- Contains generic "Welcome to Nginx" static page
- Not needed in production environments
- Standard practice to remove or disable it

## Testing

### Manual Verification:
```bash
# On deployment server after deploy
curl -v http://localhost:80/
# Should return HTTP 200 with our app's response

# Check nginx config
nginx -T | grep "listen 80"
# Should show: listen 80 default_server;
```

### Deployment Flow:
1. Container starts on port 8080
2. Primary health check succeeds (127.0.0.1:8080)
3. Nginx config updated with `default_server`
4. Secondary health check succeeds (localhost:80)
5. **No warnings in logs**

## Related PRs

- PR #1322 - Direct container health checks (primary gate)
- PR #1323 - Reduced retry attempts to 5
- PR #1324 - Golden Pipeline documentation

**This completes the frontend deployment reliability series.**

## Backward Compatibility

✅ No impact on existing deployments  
✅ Container health check logic unchanged (still the deployment gate)  
✅ Proxy check remains informational (non-blocking)  
✅ Only affects nginx config generation on host  

## Golden Pipeline Alignment

This fix aligns with docs/GOLDEN_PIPELINE.md:
- ✅ Frontend health check: Primary on 8080 (container direct)
- ✅ Secondary check: Informational on 80 (proxy status)
- ✅ Non-blocking warnings eliminated
- ✅ Clean deployment logs

---

**Impact**: Deployments will now show clean proxy checks (HTTP 200) instead of HTTP 400 warnings.