### PR TITLE
fix: Move TenantMiddleware after AuthenticationMiddleware

### DIFF
--- a/backend/projectmeats/settings/base.py
+++ b/backend/projectmeats/settings/base.py
@@ -75,13 +75,13 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",  # Must be first for CORS headers
-    "apps.tenants.middleware.TenantMiddleware",  # Custom shared-schema tenant resolution
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",  # Static files middleware
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "apps.tenants.middleware.TenantMiddleware",  # Must be after AuthenticationMiddleware to access request.user
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]


### PR DESCRIPTION
## 🚨 CRITICAL BUG FIX

**Severity**: CRITICAL - Breaks all authenticated requests  
**Environments Affected**: All (dev, uat, prod)

## Problem

Dev environment is broken with this error:
```python
AttributeError: 'WSGIRequest' object has no attribute 'user'
```

## Root Cause

**TenantMiddleware was positioned BEFORE AuthenticationMiddleware** in the MIDDLEWARE list.

When TenantMiddleware tried to access `request.user` for tenant resolution, the user object hadn't been created yet.

### Broken Middleware Order:
```python
MIDDLEWARE = [
    "corsheaders.middleware.CorsMiddleware",
    "apps.tenants.middleware.TenantMiddleware",  # ❌ Tries to access request.user
    # ... other middleware ...
    "django.contrib.auth.middleware.AuthenticationMiddleware",  # Creates request.user
]
```

**Problem**: TenantMiddleware runs → tries to access `request.user` → **AttributeError** (doesn't exist yet)

## Solution

Move TenantMiddleware to **AFTER** AuthenticationMiddleware:

```python
MIDDLEWARE = [
    "corsheaders.middleware.CorsMiddleware",
    # ... other middleware ...
    "django.contrib.auth.middleware.AuthenticationMiddleware",  # Creates request.user
    "apps.tenants.middleware.TenantMiddleware",  # ✅ Now request.user exists
]
```

## Why TenantMiddleware Needs request.user

TenantMiddleware resolves tenant context through multiple strategies:

1. **Domain/subdomain matching** → `TenantDomain` lookup
2. **X-Tenant-ID header** → Explicit tenant selection
3. **Authenticated user's default tenant** → Falls back to `request.user.tenant`

**Without `request.user`**, the middleware crashes before establishing tenant context.

## Django Middleware Execution

Middleware processes requests **top-to-bottom**:

```
Request comes in
  ↓
CorsMiddleware (adds CORS headers)
  ↓
SecurityMiddleware (adds security headers)
  ↓
SessionMiddleware (loads session)
  ↓
AuthenticationMiddleware (creates request.user) ← MUST be before tenant
  ↓
TenantMiddleware (uses request.user to resolve tenant) ← Fixed position
  ↓
View function executes
```

## Changes Made

**File**: `backend/projectmeats/settings/base.py`

```diff
  MIDDLEWARE = [
      "corsheaders.middleware.CorsMiddleware",
-     "apps.tenants.middleware.TenantMiddleware",
      "django.middleware.security.SecurityMiddleware",
      "whitenoise.middleware.WhiteNoiseMiddleware",
      "django.contrib.sessions.middleware.SessionMiddleware",
      "django.middleware.common.CommonMiddleware",
      "django.middleware.csrf.CsrfViewMiddleware",
      "django.contrib.auth.middleware.AuthenticationMiddleware",
+     "apps.tenants.middleware.TenantMiddleware",  # Moved here
      "django.contrib.messages.middleware.MessageMiddleware",
      "django.middleware.clickjacking.XFrameOptionsMiddleware",
  ]
```

**Change**: Moved TenantMiddleware from position 2 to position 8 (immediately after AuthenticationMiddleware)

## Testing

### Before Fix (BROKEN):
```bash
python manage.py runserver
curl http://localhost:8000/api/v1/health/

# Error:
AttributeError: 'WSGIRequest' object has no attribute 'user'
```

### After Fix (WORKS):
```bash
python manage.py runserver
curl http://localhost:8000/api/v1/health/

# Success:
{"status": "healthy"}
```

### Verification Steps:
1. Start dev server
2. Make authenticated request
3. Tenant context should resolve correctly
4. No AttributeError

## Impact

✅ **Dev environment fixed** - Server starts and handles requests  
✅ **Tenant resolution works** - Can access authenticated user  
✅ **Proper isolation** - Tenant context correctly established  
✅ **All environments fixed** - Dev, UAT, Prod all use this settings file  

## Backward Compatibility

✅ **No breaking changes** - This is a bug fix that restores correct behavior  
✅ **No API changes** - Only internal middleware ordering  
✅ **No migration needed** - Pure configuration change  

## Related Documentation

- **Shared-schema multi-tenancy**: docs/GOLDEN_PIPELINE.md
- **Architecture**: docs/ARCHITECTURE.md
- **TenantMiddleware implementation**: apps/tenants/middleware.py

## Golden Pipeline Alignment

This fix aligns with the Golden Pipeline's shared-schema architecture:
- ✅ Row-level security via tenant_id ForeignKey
- ✅ TenantMiddleware for tenant resolution
- ✅ NO schema switching (shared PostgreSQL schema)
- ✅ Standard Django authentication flow

---

**This is a critical production fix and should be merged immediately.**