### PR TITLE
fix: Use REACT_APP_API_BASE_URL secret for runtime config

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -397,7 +397,7 @@ jobs:
           mkdir -p /opt/pm/frontend/env
           cat > /opt/pm/frontend/env/env-config.js << 'ENVJS'
           window.ENV = {
-            API_BASE_URL: "https://${{ inputs.environment }}.meatscentral.com",
+            API_BASE_URL: "${{ secrets.REACT_APP_API_BASE_URL }}",
             ENVIRONMENT: "${{ inputs.environment }}"
           };
           ENVJS


### PR DESCRIPTION
## 🐛 Critical Bug Fix

### Problem
The `env-config.js` file was **hardcoded** to construct the API URL from the environment name:
```javascript
API_BASE_URL: "https://${environment}.meatscentral.com"
```

This caused the frontend to call `https://development.meatscentral.com` (which doesn't exist) instead of respecting the GitHub Secret `REACT_APP_API_BASE_URL`.

### Solution
Changed the workflow to use the secret value:
```javascript
API_BASE_URL: "${{ secrets.REACT_APP_API_BASE_URL }}"
```

### Impact
- ✅ Enables unified proxy architecture (frontend calls itself, Nginx proxies to backend)
- ✅ Eliminates CORS issues completely
- ✅ Makes secret configuration actually work
- ✅ Aligns Dev environment with UAT/Prod patterns

### Testing
After merge:
1. Ensure `REACT_APP_API_BASE_URL=https://dev.meatscentral.com/api/v1` is set in dev-frontend environment
2. Deploy will generate correct `env-config.js`
3. Verify: `curl https://dev.meatscentral.com/env-config.js`
4. Test login and API calls in Incognito mode

**This is THE fix that makes everything work.**