### PR TITLE
fix: Add CSRF token configuration to all Axios instances

### DIFF
--- a/frontend/src/services/aiService.ts
+++ b/frontend/src/services/aiService.ts
@@ -16,6 +16,9 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true, // Allow cookies for authentication
+  xsrfCookieName: 'csrftoken', // Django's CSRF cookie name
+  xsrfHeaderName: 'X-CSRFToken', // Django's expected CSRF header
 });
 
 // Request interceptor for authentication

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -15,6 +15,9 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true, // Allow cookies for authentication
+  xsrfCookieName: 'csrftoken', // Django's CSRF cookie name
+  xsrfHeaderName: 'X-CSRFToken', // Django's expected CSRF header
 });
 
 // Request interceptor for authentication and tenant context

--- a/frontend/src/services/businessApi.ts
+++ b/frontend/src/services/businessApi.ts
@@ -19,6 +19,9 @@ const businessApiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true, // Allow cookies for authentication
+  xsrfCookieName: 'csrftoken', // Django's CSRF cookie name
+  xsrfHeaderName: 'X-CSRFToken', // Django's expected CSRF header
 });
 
 // Request interceptor for authentication

--- a/frontend/src/services/tenantService.ts
+++ b/frontend/src/services/tenantService.ts
@@ -15,6 +15,9 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true, // Allow cookies for authentication
+  xsrfCookieName: 'csrftoken', // Django's CSRF cookie name
+  xsrfHeaderName: 'X-CSRFToken', // Django's expected CSRF header
 });
 
 // Request interceptor for authentication and tenant context


### PR DESCRIPTION
## Problem
POST/PUT/DELETE requests are failing with **403 Forbidden** errors because the `X-CSRFToken` header is missing. Django requires this header for all state-changing requests.

## Root Cause
The Axios instances were not configured to:
1. Send/receive cookies (`withCredentials`)
2. Read Django's CSRF cookie (`csrftoken`)
3. Send the CSRF token in the expected header (`X-CSRFToken`)

## Solution
Updated all Axios instances in the frontend services with Django CSRF configuration:

```typescript
withCredentials: true,        // Allow cookies for authentication
xsrfCookieName: 'csrftoken',  // Django's CSRF cookie name
xsrfHeaderName: 'X-CSRFToken', // Django's expected CSRF header
```

## Files Updated
- `frontend/src/services/apiService.ts`
- `frontend/src/services/tenantService.ts`
- `frontend/src/services/businessApi.ts`
- `frontend/src/services/aiService.ts`

## Testing
After deployment:
1. Login to https://dev.meatscentral.com
2. Create a supplier (POST request)
3. Should succeed with 201 Created (not 403 Forbidden)

## Related
- Follows Django REST Framework CSRF protection standards
- Aligns with unified proxy architecture (same-origin requests)
- Part of fixing dev environment 403 errors

## Checklist
- [x] All Axios instances updated
- [x] Standard Django CSRF configuration
- [x] No breaking changes
- [x] Ready for immediate deployment