### PR TITLE
fix: Make SSH tunnel verification non-fatal

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -244,9 +244,9 @@ jobs:
           # Wait for tunnel to establish
           sleep 5
           
-          # Verify tunnel is active
+          # Verify tunnel is active (non-fatal check)
           echo "✓ SSH tunnel established"
-          ps aux | grep ssh | grep -v grep | grep 5433
+          ps aux | grep ssh | grep -v grep | grep 5433 || echo "  (Process check skipped - tunnel runs in background)"
       
       - name: Test tunnel connectivity
         env:


### PR DESCRIPTION
## 🐛 Bug Fix: SSH Tunnel Verification Failing

### Problem
The migration job was failing at the tunnel verification step:
```bash
ps aux | grep ssh | grep -v grep | grep 5433
```
This command returns exit code 1 when it doesn't find the process in the expected format, causing the script to exit due to `set -e`.

### Root Cause
- SSH tunnel is created with `-f` flag (fork to background)
- The process may not appear immediately in `ps` output
- The grep chain may not match the process name/args format
- Script exits before migration can run

### Solution
Make the verification non-fatal using the `|| true` pattern:
```bash
ps aux | grep ssh | grep -v grep | grep 5433 || echo "  (Process check skipped - tunnel runs in background)"
```

### Why This is Safe
1. ✅ Tunnel establishment is tested in next step (psql connectivity test)
2. ✅ If tunnel fails, the psql test will catch it
3. ✅ This verification was informational only
4. ✅ Migration will fail gracefully if tunnel is down

### Testing
- Next step will verify with actual database connection
- Migration will proceed only if tunnel works

Related: #1336