### PR TITLE
fix: Wrap conflicting migration operations in SeparateDatabaseAndState

### DIFF
--- a/backend/tenant_apps/contacts/migrations/0002_contact_tenant_and_more.py
+++ b/backend/tenant_apps/contacts/migrations/0002_contact_tenant_and_more.py
@@ -74,19 +74,23 @@ class Migration(migrations.Migration):
 
     operations = [
         # Step 1: Add tenant field via raw SQL (for existing production databases)
-        migrations.RunPython(add_tenant_field_if_not_exists, migrations.RunPython.noop),
-        
-        # Step 2: Register the field with Django's ORM (state-only, no actual DB operation)
-        migrations.AddField(
-            model_name='contact',
-            name='tenant',
-            field=models.ForeignKey(
-                help_text='Tenant this contact belongs to',
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name='contacts',
-                to='tenants.tenant'
-            ),
-            preserve_default=False,
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name='contact',
+                    name='tenant',
+                    field=models.ForeignKey(
+                        help_text='Tenant this contact belongs to',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='contacts',
+                        to='tenants.tenant'
+                    ),
+                    preserve_default=False,
+                ),
+            ],
+            database_operations=[
+                migrations.RunPython(add_tenant_field_if_not_exists, migrations.RunPython.noop),
+            ],
         ),
         
         # Step 3: Add index (now that Django knows the field exists)

--- a/backend/tenant_apps/customers/migrations/0002_customer_tenant_and_more.py
+++ b/backend/tenant_apps/customers/migrations/0002_customer_tenant_and_more.py
@@ -77,19 +77,23 @@ class Migration(migrations.Migration):
 
     operations = [
         # Step 1: Add tenant field via raw SQL (for existing production databases)
-        migrations.RunPython(add_tenant_field_if_not_exists, migrations.RunPython.noop),
-        
-        # Step 2: Register the field with Django's ORM (state-only, no actual DB operation)
-        migrations.AddField(
-            model_name='customer',
-            name='tenant',
-            field=models.ForeignKey(
-                help_text='Tenant this customer belongs to',
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name='customers',
-                to='tenants.tenant'
-            ),
-            preserve_default=False,
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name='customer',
+                    name='tenant',
+                    field=models.ForeignKey(
+                        help_text='Tenant this customer belongs to',
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='customers',
+                        to='tenants.tenant'
+                    ),
+                    preserve_default=False,
+                ),
+            ],
+            database_operations=[
+                migrations.RunPython(add_tenant_field_if_not_exists, migrations.RunPython.noop),
+            ],
         ),
         
         # Step 3: Add index (now that Django knows the field exists)


### PR DESCRIPTION
## Problem
Contacts and Customers migrations had conflicting operations where both `RunPython` (raw SQL) and `AddField` (Django state) were trying to add the same `tenant` field, causing Django to detect the field twice.

## Solution
Wrapped operations in `SeparateDatabaseAndState` to properly separate:
- **state_operations**: `AddField` (tells Django ORM about the field)
- **database_operations**: `RunPython` (adds column via SQL if not exists)

## Files Changed
- `backend/tenant_apps/contacts/migrations/0002_contact_tenant_and_more.py`
- `backend/tenant_apps/customers/migrations/0002_customer_tenant_and_more.py`

## Benefits
✅ **Idempotent**: Safe to run on existing databases (SQL checks if column exists)
✅ **State-aware**: Django ORM knows about the field
✅ **No conflicts**: State and database operations are properly separated
✅ **Syntax verified**: Both migrations pass Python import checks

## Testing
- [x] Migrations pass syntax validation
- [x] Idempotent pattern verified (safe for existing DBs)
- [ ] Test in dev environment
- [ ] Test in UAT before production

## Related Issues
Fixes migration conflicts preventing smooth deployment.