### PR TITLE
fix: Add TenantManager to Supplier model

### DIFF
--- a/backend/tenant_apps/suppliers/models.py
+++ b/backend/tenant_apps/suppliers/models.py
@@ -24,6 +24,7 @@ from apps.core.models import (
     Protein,
     ProteinTypeChoices,
     ShippingOfferedChoices,
+    TenantManager,
     TimestampModel,
 )
 from tenant_apps.plants.models import Plant
@@ -31,6 +32,9 @@ from tenant_apps.plants.models import Plant
 
 class Supplier(TimestampModel):
     """Supplier model for managing supplier information."""
+
+    # Use the custom TenantManager to support .for_tenant() queries
+    objects = TenantManager()
 
     # Multi-tenancy
     tenant = models.ForeignKey(


### PR DESCRIPTION
## Problem
The Supplier model was missing the `TenantManager` which provides the `.for_tenant()` query method needed for multi-tenancy support.

## Solution
- Added `TenantManager` to imports from `apps.core.models`
- Added `objects = TenantManager()` to the Supplier class

## Changes
- `backend/tenant_apps/suppliers/models.py`
  - Import `TenantManager`
  - Add `objects = TenantManager()` class attribute

## Benefits
✅ Enables `.for_tenant()` queries on Supplier model
✅ Consistent with other tenant-aware models
✅ Supports multi-tenancy patterns

## Testing
- [x] Python syntax validated
- [ ] Test in dev environment
- [ ] Verify .for_tenant() works correctly