### PR TITLE
fix: Add TenantManager to all tenant models to prevent 500 errors

### DIFF
--- a/backend/tenant_apps/accounts_receivables/models.py
+++ b/backend/tenant_apps/accounts_receivables/models.py
@@ -5,11 +5,14 @@ Implements tenant ForeignKey field for shared-schema multi-tenancy.
 """
 from decimal import Decimal
 from django.db import models
+from apps.core.models import TenantManager
 from django.contrib.auth.models import User
 from apps.tenants.models import Tenant
 
 
 class AccountsReceivable(models.Model):
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     STATUS_CHOICES = [
         ("pending", "Pending"),
         ("paid", "Paid"),

--- a/backend/tenant_apps/ai_assistant/models.py
+++ b/backend/tenant_apps/ai_assistant/models.py
@@ -12,7 +12,7 @@ from django.core.validators import FileExtensionValidator
 from django.db import models
 from apps.tenants.models import Tenant
 
-from apps.core.models import OwnedModel, StatusModel
+from apps.core.models import OwnedModel, StatusModel, TenantManager
 
 
 class ChatSessionStatusChoices(models.TextChoices):
@@ -124,6 +124,8 @@ class ChatMessage(OwnedModel):
 
 class AIConfiguration(models.Model):
     """Configuration settings for AI providers and models."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     # Multi-tenancy
     tenant = models.ForeignKey(
         Tenant,

--- a/backend/tenant_apps/bug_reports/models.py
+++ b/backend/tenant_apps/bug_reports/models.py
@@ -5,11 +5,14 @@ Provides internal bug tracking and user feedback.
 """
 from django.contrib.auth.models import User
 from django.db import models
+from apps.core.models import TenantManager
 from apps.tenants.models import Tenant
 
 
 class BugReport(models.Model):
     """Bug report submitted by users."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     # Multi-tenancy
     tenant = models.ForeignKey(
         Tenant,

--- a/backend/tenant_apps/carriers/models.py
+++ b/backend/tenant_apps/carriers/models.py
@@ -12,11 +12,14 @@ from apps.core.models import (
     AccountLineOfCreditChoices,
     AppointmentMethodChoices,
     CreditLimitChoices,
+    TenantManager,
 )
 from tenant_apps.contacts.models import Contact
 
 
 class Carrier(models.Model):
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     CARRIER_TYPE_CHOICES = [
         ("truck", "Truck"),
         ("rail", "Rail"),

--- a/backend/tenant_apps/contacts/models.py
+++ b/backend/tenant_apps/contacts/models.py
@@ -7,11 +7,13 @@ Implements tenant ForeignKey field for shared-schema multi-tenancy.
 """
 from django.db import models
 from apps.tenants.models import Tenant
-from apps.core.models import ContactTypeChoices, StatusChoices, TimestampModel
+from apps.core.models import ContactTypeChoices, StatusChoices, TimestampModel, TenantManager
 
 
 class Contact(TimestampModel):
     """Contact model for managing contact information."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     
     # Multi-tenancy
     tenant = models.ForeignKey(

--- a/backend/tenant_apps/customers/models.py
+++ b/backend/tenant_apps/customers/models.py
@@ -19,12 +19,15 @@ from apps.core.models import (
     OriginChoices,
     Protein,
     TimestampModel,
+    TenantManager,
 )
 from tenant_apps.plants.models import Plant
 
 
 class Customer(TimestampModel):
     """Customer model for managing customer information."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
 
     # Multi-tenancy
     tenant = models.ForeignKey(

--- a/backend/tenant_apps/invoices/models.py
+++ b/backend/tenant_apps/invoices/models.py
@@ -12,6 +12,7 @@ from apps.core.models import (
     EdibleInedibleChoices,
     TimestampModel,
     WeightUnitChoices,
+    TenantManager,
 )
 
 
@@ -27,6 +28,8 @@ class InvoiceStatus(models.TextChoices):
 
 class Invoice(TimestampModel):
     """Invoice model for customer invoices."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     # Multi-tenancy
     tenant = models.ForeignKey(
         Tenant,

--- a/backend/tenant_apps/plants/models.py
+++ b/backend/tenant_apps/plants/models.py
@@ -5,11 +5,14 @@ Implements tenant ForeignKey field for shared-schema multi-tenancy.
 """
 
 from django.db import models
+from apps.core.models import TenantManager
 from django.contrib.auth.models import User
 from apps.tenants.models import Tenant
 
 
 class Plant(models.Model):
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     PLANT_TYPE_CHOICES = [
         ("processing", "Processing Plant"),
         ("distribution", "Distribution Center"),

--- a/backend/tenant_apps/products/models.py
+++ b/backend/tenant_apps/products/models.py
@@ -16,11 +16,14 @@ from apps.core.models import (
     PackageTypeChoices,
     ProteinTypeChoices,
     TimestampModel,
+    TenantManager,
 )
 
 
 class Product(TimestampModel):
     """Product model for master product list."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
 
     # Multi-tenancy
     tenant = models.ForeignKey(

--- a/backend/tenant_apps/purchase_orders/models.py
+++ b/backend/tenant_apps/purchase_orders/models.py
@@ -23,6 +23,7 @@ from apps.core.models import (
     ProteinTypeChoices,
     TimestampModel,
     WeightUnitChoices,
+    TenantManager,
 )
 
 
@@ -37,6 +38,8 @@ class PurchaseOrderStatus(models.TextChoices):
 
 class PurchaseOrder(TimestampModel):
     """Purchase Order model for managing purchase orders."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
 
     # Multi-tenancy
     tenant = models.ForeignKey(
@@ -166,6 +169,8 @@ class PurchaseOrder(TimestampModel):
 
 class CarrierPurchaseOrder(TimestampModel):
     """Carrier Purchase Order model for managing carrier-specific purchase orders."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     
     # Multi-tenancy
     tenant = models.ForeignKey(
@@ -346,6 +351,8 @@ class CarrierPurchaseOrder(TimestampModel):
 
 class ColdStorageEntry(TimestampModel):
     """Cold Storage Entry model for tracking boxing and cold storage operations."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
 
     # Multi-tenancy
     tenant = models.ForeignKey(
@@ -465,6 +472,8 @@ class ColdStorageEntry(TimestampModel):
 
 class PurchaseOrderHistory(TimestampModel):
     """Version history for Purchase Order modifications."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
 
     # Multi-tenancy
     tenant = models.ForeignKey(

--- a/backend/tenant_apps/sales_orders/models.py
+++ b/backend/tenant_apps/sales_orders/models.py
@@ -10,6 +10,7 @@ from apps.tenants.models import Tenant
 from apps.core.models import (
     TimestampModel,
     WeightUnitChoices,
+    TenantManager,
 )
 
 
@@ -25,6 +26,8 @@ class SalesOrderStatus(models.TextChoices):
 
 class SalesOrder(TimestampModel):
     """Sales Order model for managing customer sales orders."""
+    # Use custom manager for multi-tenancy
+    objects = TenantManager()
     # Multi-tenancy
     tenant = models.ForeignKey(
         Tenant,


### PR DESCRIPTION
## Problem
Multiple pages (Customers, Carriers, Products, Purchase Orders, Sales Orders, etc.) were returning **500 Internal Server Error** because the models were missing `TenantManager`, but ViewSets were calling `.for_tenant()` queries.

## Root Cause
ViewSets use `.for_tenant(tenant)` to filter querysets, but models were using the default Django `Manager` instead of the custom `TenantManager` that provides this method.

## Solution
Used automated script (`fix_managers.py`) to safely inject `TenantManager` into all tenant-aware models:

### Models Updated (14 total)
- **Customer** (customers)
- **Carrier** (carriers)
- **Contact** (contacts)
- **Plant** (plants)
- **Product** (products)
- **PurchaseOrder** (purchase_orders)
- **CarrierPurchaseOrder** (purchase_orders)
- **ColdStorageEntry** (purchase_orders)
- **PurchaseOrderHistory** (purchase_orders)
- **SalesOrder** (sales_orders)
- **Invoice** (invoices)
- **AccountsReceivable** (accounts_receivables)
- **BugReport** (bug_reports)
- **AIConfiguration** (ai_assistant)

### Changes per Model
1. Added `TenantManager` to imports
2. Added `objects = TenantManager()` class attribute

## Files Changed (11)
```
backend/tenant_apps/accounts_receivables/models.py
backend/tenant_apps/ai_assistant/models.py
backend/tenant_apps/bug_reports/models.py
backend/tenant_apps/carriers/models.py
backend/tenant_apps/contacts/models.py
backend/tenant_apps/customers/models.py
backend/tenant_apps/invoices/models.py
backend/tenant_apps/plants/models.py
backend/tenant_apps/products/models.py
backend/tenant_apps/purchase_orders/models.py
backend/tenant_apps/sales_orders/models.py
```

## Benefits
✅ Fixes 500 errors on all tenant-isolated pages
✅ Enables `.for_tenant()` queries system-wide
✅ Consistent with shared-schema multi-tenancy architecture
✅ Prevents future manager-related errors

## Testing
- [x] Python syntax validated on all models
- [x] Import statements verified
- [ ] Test in dev environment (all pages should load)
- [ ] Verify .for_tenant() queries work correctly

## Related
- Follows pattern established in #1354 (Supplier model)
- Complements #1353 (migration conflict fixes)