### PR TITLE
fix: Route invitation signups to correct endpoint

### DIFF
--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -29,6 +29,8 @@ const SignUp: React.FC = () => {
 
   const { signUp } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
 
   const validateForm = (): string | null => {
     if (!formData.username.trim()) return 'Username is required';
@@ -74,6 +76,7 @@ const SignUp: React.FC = () => {
         firstName: formData.firstName,
         lastName: formData.lastName,
         company: formData.company,
+        token: token || undefined,
       });
 
       // Show success and redirect to dashboard (user is already logged in)

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -19,6 +19,7 @@ export interface SignUpCredentials {
   firstName: string;
   lastName: string;
   company?: string;
+  token?: string;
 }
 
 export interface AuthResponse {
@@ -75,12 +76,18 @@ export class AuthService {
 
   async signUp(credentials: SignUpCredentials): Promise<UserProfile> {
     try {
-      const response = await axios.post(`${API_BASE_URL}/auth/signup/`, {
+      // Determine endpoint based on presence of token
+      const endpoint = credentials.token 
+        ? `${API_BASE_URL}/auth/signup-with-invitation/` 
+        : `${API_BASE_URL}/auth/signup/`;
+
+      const response = await axios.post(endpoint, {
         username: credentials.username,
         email: credentials.email,
         password: credentials.password,
         firstName: credentials.firstName,
         lastName: credentials.lastName,
+        token: credentials.token,
       });
 
       const { token, user } = response.data;


### PR DESCRIPTION
## Problem
Users clicking invitation links were getting **"Open registration is disabled"** error because the frontend was routing all signups to the standard `/api/v1/auth/signup/` endpoint, which is now disabled in favor of invite-only registration.

## Root Cause
The `SignUp` component and `authService` weren't detecting invitation tokens from the URL or routing to the invitation-specific endpoint.

**URL Format**: `/signup?token=abc123...`  
**Expected Endpoint**: `/api/v1/auth/signup-with-invitation/`  
**Actual Endpoint Used**: `/api/v1/auth/signup/` ❌

## Solution
### 1. Updated `authService.ts`
Added optional `token` field to `SignUpCredentials`:
```typescript
export interface SignUpCredentials {
  username: string;
  email: string;
  password: string;
  firstName: string;
  lastName: string;
  company?: string;
  token?: string; // Added
}
```

Updated `signUp` method to route based on token presence:
```typescript
const endpoint = credentials.token 
  ? `${API_BASE_URL}/auth/signup-with-invitation/` 
  : `${API_BASE_URL}/auth/signup/`;
```

### 2. Updated `SignUp.tsx`
Extract token from URL query parameters:
```typescript
import { useSearchParams } from 'react-router-dom';

const [searchParams] = useSearchParams();
const token = searchParams.get('token');
```

Pass token to signup service:
```typescript
await signUp({
  ...formData,
  token: token || undefined,
});
```

## Files Changed
- `frontend/src/services/authService.ts`
- `frontend/src/pages/SignUp.tsx`

## Benefits
✅ Invitation links now work correctly
✅ Routes to proper endpoint based on context
✅ Maintains backward compatibility (no token = standard signup if enabled)
✅ Clean separation between invited and open registration flows

## Testing
- [x] Code changes verified
- [ ] Test invitation link flow: `/signup?token=...`
- [ ] Verify endpoint routing in network tab
- [ ] Confirm successful user creation with invitation
- [ ] Test without token (should use standard endpoint)

## Related
- Complements invite-only registration system
- Works with backend `/api/v1/auth/signup-with-invitation/` endpoint
- Part of guest mode and invitation system implementation