### PR TITLE
fix: Store tenant context immediately after signup

### DIFF
--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -94,7 +94,8 @@ export class AuthService {
 
       const response = await axios.post(endpoint, payload);
 
-      const { token, user } = response.data;
+      // EXTRACT TENANT INFO HERE
+      const { token, user, tenant } = response.data;
 
       this.token = token;
       this.user = user;
@@ -102,6 +103,13 @@ export class AuthService {
       // Store in localStorage
       localStorage.setItem('authToken', token);
       localStorage.setItem('user', JSON.stringify(user));
+
+      // CRITICAL FIX: Store the new tenant context immediately
+      if (tenant) {
+        localStorage.setItem('tenantId', tenant.id);
+        localStorage.setItem('tenantName', tenant.name);
+        localStorage.setItem('tenantSlug', tenant.slug);
+      }
 
       return user;
     } catch (error) {


### PR DESCRIPTION
## Critical Data Context Issue

### Problem: The Orphaned Session
Users signing up via invitation were creating data in the wrong tenant due to missing tenant context in localStorage.

### Example Scenario
1. Admin invites user to NA-Meats tenant
2. User clicks invitation link and completes signup
3. Backend creates user linked to NA-Meats
4. Frontend does not store tenant context
5. User creates a Supplier
6. API request lacks X-Tenant-ID header
7. Middleware falls back to domain-based resolution
8. Data saved to Root tenant instead of NA-Meats

### Root Cause
The signUp method was extracting token and user from response but ignoring the tenant object, unlike the login method which properly stores tenant context.

### The Fix
Extract and store tenant context from signup response, matching the login flow pattern.

### Impact

Before:
- Signup creates no tenant context
- API calls default to domain tenant
- Data saved to wrong tenant
- Cross-tenant data leak risk

After:
- Signup stores tenant context immediately
- API calls include X-Tenant-ID header
- Data saved to correct tenant
- Proper tenant isolation maintained

### Files Changed
- frontend/src/services/authService.ts

### Security Impact
HIGH - Without this fix, users can inadvertently create data in wrong tenant, violating multi-tenancy isolation.