### PR TITLE
feat: Add reusable invitation tokens for team onboarding

### DIFF
--- a/backend/apps/tenants/management/commands/init_tenant.py
+++ b/backend/apps/tenants/management/commands/init_tenant.py
@@ -386,11 +386,12 @@ class Command(BaseCommand):
 
         invitation = TenantInvitation.objects.create(
             tenant=tenant,
-            email=f"invite@{domain}",
+            email=f"team@{domain}",  # Generic email placeholder
             role="user",
             invited_by=invited_by,
             expires_at=timezone.now() + timedelta(days=days_valid),
             message=f"Welcome to {tenant.name}! Use this link to join our organization.",
+            is_reusable=True,  # ENABLE REUSABILITY
         )
 
         # Generate invitation URL
@@ -400,6 +401,7 @@ class Command(BaseCommand):
         if verbosity >= 1:
             self.stdout.write(self.style.SUCCESS("   ✅ Invitation created"))
             self.stdout.write(f"   📎 URL: {invitation_url}")
+            self.stdout.write(f"   🔄 Reusable: Yes (can be used by multiple team members)")
 
         return invitation, invitation_url
 

--- a/backend/apps/tenants/migrations/0002_invitation_reusability.py
+++ b/backend/apps/tenants/migrations/0002_invitation_reusability.py
@@ -1,0 +1,23 @@
+# Generated migration for reusable invitations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tenants', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='tenantinvitation',
+            name='is_reusable',
+            field=models.BooleanField(default=False, help_text='Allow multiple users to sign up with this token'),
+        ),
+        migrations.AddField(
+            model_name='tenantinvitation',
+            name='usage_count',
+            field=models.PositiveIntegerField(default=0, help_text='Number of times this invitation has been used'),
+        ),
+    ]


### PR DESCRIPTION
## Feature: Reusable Invitation Tokens

Enables **team invitation links** that can be shared with multiple employees, replacing the strict one-invite-one-user limitation.

### Problem
Current implementation: One Invite = One User
- Admin must create separate invitation for each team member
- Time-consuming for large team onboarding
- Cannot share a single link via Slack/email to entire team

### Solution
Upgraded invitation system to support **Reusable Tokens**
- One link can be used by multiple users
- Each user provides their own email during signup
- Tracks usage count for analytics
- Backward compatible with 1:1 invitations

## Changes

### 1. Models (apps/tenants/models.py)
Added fields:
- is_reusable (BooleanField, default=False)
- usage_count (PositiveIntegerField, default=0)

Updated logic:
- is_valid property: reusable invites stay valid until revoked
- accept() method: increments usage_count, keeps status=pending for reusable

### 2. Migration (0002_invitation_reusability.py)
Adds new fields to TenantInvitation table

### 3. Serializer (invitation_serializers.py)
- Added email field (required, user-provided)
- Validation logic:
  * Reusable: accepts any email from form input
  * Non-reusable: enforces invitation email match (security)
- create() uses input email for reusable invites

### 4. Management Command (init_tenant.py)
- Sets is_reusable=True on generated invitations
- Changed placeholder email: invite@ → team@
- Displays reusability status in output

## How It Works

### Reusable Invitation Flow
1. Admin runs: init_tenant --slug=acme
2. Gets team invitation link with token
3. Shares link with entire team (Slack, email, etc)
4. Each employee:
   - Clicks link
   - Enters their own email
   - Completes signup
   - Auto-joins tenant

### Non-Reusable (Traditional) Flow
1. Admin creates invitation for specific email
2. Only that email can use the invitation
3. Invitation closes after one use
4. Security validation enforces email match

## Benefits
✅ Share one link with entire team
✅ Track usage with usage_count field
✅ Backward compatible (default is_reusable=False)
✅ Maintains security for 1:1 invitations
✅ Simplifies team onboarding workflow
✅ No code changes needed in existing invitations

## Testing Checklist
- [ ] Run migration (0002_invitation_reusability)
- [ ] Create reusable invitation via init_tenant
- [ ] Multiple users signup with same token
- [ ] Check usage_count increments
- [ ] Verify invitation stays valid after use
- [ ] Test 1:1 invitation still enforces email match
- [ ] Check expired reusable invites are rejected

## Files Changed (4)
- backend/apps/tenants/models.py
- backend/apps/tenants/migrations/0002_invitation_reusability.py
- backend/apps/tenants/invitation_serializers.py
- backend/apps/tenants/management/commands/init_tenant.py

## Related
- Complements invitation signup flow (#1357, #1358, #1359)
- Enables scalable team onboarding
- Part of invite-only registration system