### PR TITLE
fix: use global PAT for auto-pr generation to resolve permission errors

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Create Pull Request to UAT
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           # Check if a PR already exists from development -> uat
           EXISTING_PR=$(gh pr list --base uat --head development --json url --jq '.[0].url')


### PR DESCRIPTION
Fixes permission errors in the Auto-PR workflow by switching from GITHUB_TOKEN to the global PAT secret.

**Changes:**
- Updated `.github/workflows/auto-pr.yml` to use `secrets.PAT` instead of `secrets.GITHUB_TOKEN`
- This resolves permission issues when creating PRs across branches

**Testing:**
- Workflow will trigger after merge to development
- Should successfully create PR from development to UAT