### PR TITLE
chore: prevent auto-pr from triggering on pull_request workflows

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   draft-uat-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Optimizes the Auto-PR workflow to prevent redundant runs by filtering out non-push events.

**Changes:**
- Updated the `if` condition to only trigger when the Master Pipeline completes successfully **and** was triggered by a push event
- This prevents the Auto-PR workflow from running when Master Pipeline is triggered by pull_request events

**Benefits:**
- Reduces redundant workflow runs
- Saves CI/CD resources
- Only creates PRs when code is actually pushed to development branch

**Before:** Triggers on any successful Master Pipeline completion
**After:** Only triggers on successful Master Pipeline runs from push events