### PR TITLE
refactor: Migrate workflows to Split Environment Standard

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -153,26 +153,10 @@ jobs:
       environment: 'uat'
       ref: ${{ github.ref }}
       image_tag: 'uat-${{ github.sha }}'
-      backend_environment: 'uat2-backend'
-      frontend_environment: 'uat2-frontend'
+      backend_environment: 'uat-backend'
+      frontend_environment: 'uat-frontend'
       api_base_url: 'https://uat.meatscentral.com'
-    secrets:
-      FRONTEND_SSH_KEY: ${{ secrets.UAT_FRONTEND_SSH_KEY }}
-      BACKEND_SSH_PASSWORD: ${{ secrets.UAT_SSH_PASSWORD }}
-      FRONTEND_HOST: ${{ secrets.UAT_FRONTEND_HOST }}
-      FRONTEND_USER: ${{ secrets.UAT_FRONTEND_USER }}
-      BACKEND_HOST: ${{ secrets.UAT_HOST }}
-      BACKEND_USER: ${{ secrets.UAT_USER }}
-      BACKEND_IP: ${{ secrets.UAT_BACKEND_IP }}
-      DATABASE_URL: ${{ secrets.UAT_DATABASE_URL }}
-      DB_HOST: ${{ secrets.UAT_DB_HOST }}
-      DB_PORT: ${{ secrets.UAT_DB_PORT }}
-      DB_USER: ${{ secrets.UAT_DB_USER }}
-      DB_PASSWORD: ${{ secrets.UAT_DB_PASSWORD }}
-      DB_NAME: ${{ secrets.UAT_DB_NAME }}
-      SECRET_KEY: ${{ secrets.UAT_SECRET_KEY }}
-      DJANGO_SETTINGS_MODULE: ${{ secrets.UAT_DJANGO_SETTINGS_MODULE }}
-      DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
+    secrets: inherit
 
   # ==========================================
   # Route to Production
@@ -187,23 +171,7 @@ jobs:
       environment: 'production'
       ref: ${{ github.ref }}
       image_tag: 'production-${{ github.sha }}'
-      backend_environment: 'prod2-backend'
-      frontend_environment: 'prod2-frontend'
+      backend_environment: 'production-backend'
+      frontend_environment: 'production-frontend'
       api_base_url: 'https://meatscentral.com'
-    secrets:
-      FRONTEND_SSH_KEY: ${{ secrets.PROD_FRONTEND_SSH_KEY }}
-      BACKEND_SSH_PASSWORD: ${{ secrets.PROD_SSH_PASSWORD }}
-      FRONTEND_HOST: ${{ secrets.PROD_FRONTEND_HOST }}
-      FRONTEND_USER: ${{ secrets.PROD_FRONTEND_USER }}
-      BACKEND_HOST: ${{ secrets.PROD_HOST }}
-      BACKEND_USER: ${{ secrets.PROD_USER }}
-      BACKEND_IP: ${{ secrets.PROD_BACKEND_IP }}
-      DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
-      DB_HOST: ${{ secrets.PROD_DB_HOST }}
-      DB_PORT: ${{ secrets.PROD_DB_PORT }}
-      DB_USER: ${{ secrets.PROD_DB_USER }}
-      DB_PASSWORD: ${{ secrets.PROD_DB_PASSWORD }}
-      DB_NAME: ${{ secrets.PROD_DB_NAME }}
-      SECRET_KEY: ${{ secrets.PROD_SECRET_KEY }}
-      DJANGO_SETTINGS_MODULE: ${{ secrets.PROD_DJANGO_SETTINGS_MODULE }}
-      DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -32,38 +32,9 @@ on:
         description: "API base URL for frontend (optional, for future Build Once Deploy Many pattern)"
         default: ""
     secrets:
-      FRONTEND_SSH_KEY:
-        required: true
-      BACKEND_SSH_PASSWORD:
-        required: true
-      FRONTEND_HOST:
-        required: true
-      FRONTEND_USER:
-        required: true
-      BACKEND_HOST:
-        required: true
-      BACKEND_USER:
-        required: true
-      BACKEND_IP:
-        required: true
-      DATABASE_URL:
-        required: true
-      DB_HOST:
-        required: true
-      DB_PORT:
-        required: false
-      DB_USER:
-        required: true
-      DB_PASSWORD:
-        required: true
-      DB_NAME:
-        required: true
-      SECRET_KEY:
-        required: true
-      DJANGO_SETTINGS_MODULE:
-        required: true
       DO_ACCESS_TOKEN:
         required: true
+        description: "DigitalOcean access token (shared across all environments)"
 
 env:
   REGISTRY: registry.digitalocean.com/meatscentral
@@ -221,11 +192,11 @@ jobs:
       
       - name: Setup SSH tunnel to database
         env:
-          SSHPASS: ${{ secrets.BACKEND_SSH_PASSWORD }}
+          SSHPASS: ${{ secrets.SSH_PASSWORD }}
           DB_HOST: ${{ secrets.DB_HOST }}
           DB_PORT: ${{ secrets.DB_PORT || '5432' }}
-          BASTION_USER: ${{ secrets.BACKEND_USER }}
-          BASTION_HOST: ${{ secrets.BACKEND_HOST }}
+          BASTION_USER: ${{ secrets.SSH_USER }}
+          BASTION_HOST: ${{ secrets.SSH_HOST }}
         run: |
           echo "================================"
           echo "Creating SSH Tunnel"
@@ -274,7 +245,7 @@ jobs:
           DB_USER: ${{ secrets.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           DB_NAME: ${{ secrets.DB_NAME }}
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
         run: |
           echo "================================"
@@ -300,7 +271,7 @@ jobs:
             --network host \
             -e DATABASE_URL="$DATABASE_URL" \
             -e DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" \
-            -e SECRET_KEY="$SECRET_KEY" \
+            -e SECRET_KEY="$DJANGO_SECRET_KEY" \
             -e DB_ENGINE="django.db.backends.postgresql" \
             "$FULL_IMAGE" \
             python manage.py migrate --fake-initial --noinput
@@ -325,9 +296,9 @@ jobs:
     steps:
       - name: Deploy backend container
         env:
-          SSHPASS: ${{ secrets.BACKEND_SSH_PASSWORD }}
+          SSHPASS: ${{ secrets.SSH_PASSWORD }}
         run: |
-          sshpass -e ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${{ secrets.BACKEND_USER }}@${{ secrets.BACKEND_HOST }} << 'SSH'
+          sshpass -e ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'SSH'
           set -euo pipefail
           
           REG="${{ env.REGISTRY }}"
@@ -383,13 +354,13 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          echo "${{ secrets.FRONTEND_SSH_KEY }}" > ~/.ssh/id_ed25519
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ secrets.FRONTEND_HOST }}" >> ~/.ssh/known_hosts 2>&1
+          ssh-keyscan -H "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts 2>&1
 
       - name: Deploy frontend container
         run: |
-          ssh -i ~/.ssh/id_ed25519 ${{ secrets.FRONTEND_USER }}@${{ secrets.FRONTEND_HOST }} << 'SSH'
+          ssh -i ~/.ssh/id_ed25519 ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'SSH'
           set -euo pipefail
           
           REG="${{ env.REGISTRY }}"
@@ -418,7 +389,7 @@ jobs:
           docker run -d --name pm-frontend \
             --restart unless-stopped \
             -p 8080:80 \
-            --add-host backend:${{ secrets.BACKEND_IP }} \
+            --add-host backend:${{ secrets.BACKEND_HOST }} \
             -v /opt/pm/frontend/env/env-config.js:/usr/share/nginx/html/env-config.js:ro \
             "$REG/$IMG:$TAG"
           
@@ -434,7 +405,7 @@ jobs:
               server_name _ localhost;
               
               location ~ ^/(api|admin|static)/ {
-                  proxy_pass http://${{ secrets.BACKEND_IP }}:8000;
+                  proxy_pass http://${{ secrets.BACKEND_HOST }}:8000;
                   proxy_set_header Host \$host;
                   proxy_set_header X-Real-IP \$remote_addr;
                   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 🎯 Summary
Refactors CI/CD workflows to adopt the Split Environment Standard, eliminating environment-specific secret names and enabling environment-agnostic deployment patterns.

## 📋 Changes

### Environment Names
- **UAT**: `uat2-backend/frontend` → `uat-backend/frontend`
- **Production**: `prod2-backend/frontend` → `production-backend/frontend`

### Secret Standardization
All deployment jobs now use standardized secret names:
- `SSH_PASSWORD`, `SSH_USER`, `SSH_HOST` (backend/migration)
- `SSH_KEY`, `SSH_USER`, `SSH_HOST` (frontend)
- `DJANGO_SECRET_KEY` (replaces `SECRET_KEY`)
- `BACKEND_HOST` (replaces `BACKEND_IP`)

### Workflow Architecture
- Replaced explicit secret mappings with `secrets: inherit`
- Removed environment-specific secret declarations from reusable workflow
- Workflows now pull secrets from GitHub Environment scope automatically

## ✅ Benefits
- **Environment Agnostic**: No hardcoded environment prefixes in workflows
- **DRY Principle**: Eliminated ~80 lines of duplicate secret mappings
- **Easier Maintenance**: Secrets managed entirely in GitHub Settings
- **Consistency**: Same secret names across all environments

## ⚠️ Breaking Changes
Requires GitHub Environment secrets to be reconfigured with new standard names:

**Backend Environments** (`uat-backend`, `production-backend`):
- `SSH_PASSWORD`, `SSH_USER`, `SSH_HOST`
- `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `DB_PORT`
- `DJANGO_SECRET_KEY`, `DJANGO_SETTINGS_MODULE`

**Frontend Environments** (`uat-frontend`, `production-frontend`):
- `SSH_KEY`, `SSH_USER`, `SSH_HOST`
- `BACKEND_HOST`, `REACT_APP_API_BASE_URL`

**Shared** (repository-level):
- `DO_ACCESS_TOKEN` (already configured)

## 🧪 Testing Plan
1. Configure new GitHub Environment secrets with standard names
2. Test UAT deployment via manual workflow dispatch
3. Test production deployment after UAT validation
4. Verify migrations run successfully
5. Confirm health checks pass for both backend and frontend

## 📚 Related
- Follows patterns defined in `config/env.manifest.json`
- Aligns with Split Environment Standard documentation
- Prepares for future Build Once Deploy Many pattern