### PR TITLE
fix: Standardize workflow secrets to be environment-agnostic

### DIFF
--- a/.github/workflows/SECRET_MIGRATION_GUIDE.md
+++ b/.github/workflows/SECRET_MIGRATION_GUIDE.md
@@ -1,0 +1,176 @@
+# GitHub Secrets Migration Guide
+
+## Overview
+This guide documents the standardization of secret names for environment-agnostic workflow design.
+
+## Changes Made
+
+### 1. Reusable Workflow (`reusable-deploy.yml`)
+**Updated `secrets:` section to accept standardized names:**
+
+```yaml
+secrets:
+  DO_ACCESS_TOKEN          # DigitalOcean registry access
+  SSH_HOST                 # Deployment target host
+  SSH_USER                 # SSH username
+  SSH_PASSWORD             # Backend deployment (password auth)
+  SSH_KEY                  # Frontend deployment (key auth)
+  DB_HOST                  # Database host for SSH tunnel
+  DB_PORT                  # Database port (optional, defaults to 5432)
+  DB_NAME                  # Database name
+  DB_USER                  # Database username
+  DB_PASSWORD              # Database password
+  DJANGO_SECRET_KEY        # Django secret key
+  DJANGO_SETTINGS_MODULE   # Django settings module
+  REACT_APP_API_BASE_URL   # Frontend runtime config
+  BACKEND_HOST             # Backend IP for nginx proxy
+```
+
+### 2. Main Pipeline (`main-pipeline.yml`)
+**Updated Development deployment to map environment-specific secrets:**
+
+```yaml
+secrets:
+  DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
+  SSH_HOST: ${{ secrets.DEV_HOST }}
+  SSH_USER: ${{ secrets.DEV_USER }}
+  SSH_PASSWORD: ${{ secrets.DEV_SSH_PASSWORD }}
+  SSH_KEY: ${{ secrets.DEV_FRONTEND_SSH_KEY }}
+  DB_HOST: ${{ secrets.DEV_DB_HOST }}
+  DB_PORT: ${{ secrets.DEV_DB_PORT }}
+  DB_NAME: ${{ secrets.DEV_DB_NAME }}
+  DB_USER: ${{ secrets.DEV_DB_USER }}
+  DB_PASSWORD: ${{ secrets.DEV_DB_PASSWORD }}
+  DJANGO_SECRET_KEY: ${{ secrets.DEV_SECRET_KEY }}
+  DJANGO_SETTINGS_MODULE: ${{ secrets.DEV_DJANGO_SETTINGS_MODULE }}
+  REACT_APP_API_BASE_URL: ${{ secrets.DEV_API_BASE_URL }}
+  BACKEND_HOST: ${{ secrets.DEV_BACKEND_IP }}
+```
+
+## Required Actions for UAT and Production
+
+Since UAT and Production use `secrets: inherit`, you must configure **environment-scoped secrets** in GitHub with the **standardized names** (not environment-prefixed).
+
+### Configure GitHub Environments
+
+#### For `uat-backend` Environment:
+```bash
+gh secret set SSH_HOST --env uat-backend --body "$UAT_HOST"
+gh secret set SSH_USER --env uat-backend --body "$UAT_USER"
+gh secret set SSH_PASSWORD --env uat-backend --body "$UAT_SSH_PASSWORD"
+gh secret set DB_HOST --env uat-backend --body "$UAT_DB_HOST"
+gh secret set DB_PORT --env uat-backend --body "5432"
+gh secret set DB_NAME --env uat-backend --body "$UAT_DB_NAME"
+gh secret set DB_USER --env uat-backend --body "$UAT_DB_USER"
+gh secret set DB_PASSWORD --env uat-backend --body "$UAT_DB_PASSWORD"
+gh secret set DJANGO_SECRET_KEY --env uat-backend --body "$UAT_SECRET_KEY"
+gh secret set DJANGO_SETTINGS_MODULE --env uat-backend --body "projectmeats.settings.production"
+gh secret set BACKEND_HOST --env uat-backend --body "$UAT_BACKEND_IP"
+```
+
+#### For `uat-frontend` Environment:
+```bash
+gh secret set SSH_HOST --env uat-frontend --body "$UAT_HOST"
+gh secret set SSH_USER --env uat-frontend --body "$UAT_USER"
+gh secret set SSH_KEY --env uat-frontend --body "$UAT_FRONTEND_SSH_KEY"
+gh secret set REACT_APP_API_BASE_URL --env uat-frontend --body "https://uat.meatscentral.com"
+gh secret set BACKEND_HOST --env uat-frontend --body "$UAT_BACKEND_IP"
+```
+
+#### For `production-backend` Environment:
+```bash
+gh secret set SSH_HOST --env production-backend --body "$PROD_HOST"
+gh secret set SSH_USER --env production-backend --body "$PROD_USER"
+gh secret set SSH_PASSWORD --env production-backend --body "$PROD_SSH_PASSWORD"
+gh secret set DB_HOST --env production-backend --body "$PROD_DB_HOST"
+gh secret set DB_PORT --env production-backend --body "5432"
+gh secret set DB_NAME --env production-backend --body "$PROD_DB_NAME"
+gh secret set DB_USER --env production-backend --body "$PROD_DB_USER"
+gh secret set DB_PASSWORD --env production-backend --body "$PROD_DB_PASSWORD"
+gh secret set DJANGO_SECRET_KEY --env production-backend --body "$PROD_SECRET_KEY"
+gh secret set DJANGO_SETTINGS_MODULE --env production-backend --body "projectmeats.settings.production"
+gh secret set BACKEND_HOST --env production-backend --body "$PROD_BACKEND_IP"
+```
+
+#### For `production-frontend` Environment:
+```bash
+gh secret set SSH_HOST --env production-frontend --body "$PROD_HOST"
+gh secret set SSH_USER --env production-frontend --body "$PROD_USER"
+gh secret set SSH_KEY --env production-frontend --body "$PROD_FRONTEND_SSH_KEY"
+gh secret set REACT_APP_API_BASE_URL --env production-frontend --body "https://meatscentral.com"
+gh secret set BACKEND_HOST --env production-frontend --body "$PROD_BACKEND_IP"
+```
+
+## Verification
+
+### Check Environment Secrets:
+```bash
+gh secret list --env uat-backend
+gh secret list --env uat-frontend
+gh secret list --env production-backend
+gh secret list --env production-frontend
+```
+
+### Expected Output (Example for uat-backend):
+```
+SSH_HOST                 Updated 2024-12-30
+SSH_USER                 Updated 2024-12-30
+SSH_PASSWORD             Updated 2024-12-30
+DB_HOST                  Updated 2024-12-30
+DB_PORT                  Updated 2024-12-30
+DB_NAME                  Updated 2024-12-30
+DB_USER                  Updated 2024-12-30
+DB_PASSWORD              Updated 2024-12-30
+DJANGO_SECRET_KEY        Updated 2024-12-30
+DJANGO_SETTINGS_MODULE   Updated 2024-12-30
+BACKEND_HOST             Updated 2024-12-30
+```
+
+## Benefits of Standardization
+
+1. **Environment Agnostic**: Reusable workflow doesn't need to know environment prefixes
+2. **Consistency**: Same secret names across all environments
+3. **Maintainability**: Easier to understand and update
+4. **Scalability**: Easy to add new environments without workflow changes
+5. **Security**: Environment-scoped secrets prevent cross-environment access
+
+## Removed Secrets (No Longer Needed)
+
+The following environment-prefixed secrets from `main-pipeline.yml` were removed:
+- `FRONTEND_SSH_KEY` → Now `SSH_KEY`
+- `BACKEND_SSH_PASSWORD` → Now `SSH_PASSWORD`
+- `FRONTEND_HOST` → Removed (not used in reusable workflow)
+- `FRONTEND_USER` → Removed (SSH_USER is shared)
+- `BACKEND_HOST` → Now `SSH_HOST` (for deployment) and `BACKEND_HOST` (for nginx)
+- `BACKEND_USER` → Removed (SSH_USER is shared)
+- `BACKEND_IP` → Now `BACKEND_HOST`
+- `DATABASE_URL` → Removed (constructed from DB_* secrets)
+- `SECRET_KEY` → Now `DJANGO_SECRET_KEY`
+
+## Testing
+
+After configuring secrets, test with:
+```bash
+# Trigger manual deployment to UAT
+gh workflow run main-pipeline.yml --ref uat -f environment=uat
+
+# Monitor workflow
+gh run watch
+```
+
+## Troubleshooting
+
+### "Secret not found" error:
+- Verify secret name matches standardized list
+- Check environment name (e.g., `uat-backend` vs `uat`)
+- Confirm secret is set in correct environment scope
+
+### SSH authentication failures:
+- Backend uses `SSH_PASSWORD` (password auth)
+- Frontend uses `SSH_KEY` (key auth)
+- Ensure correct auth method for each component
+
+### Database connection issues:
+- Verify all DB_* secrets are set
+- Check DB_PORT defaults to 5432 if not specified
+- Confirm SSH tunnel can reach DB_HOST

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -123,22 +123,20 @@ jobs:
       frontend_environment: 'dev-frontend'
       api_base_url: 'https://dev.meatscentral.com'
     secrets:
-      FRONTEND_SSH_KEY: ${{ secrets.DEV_FRONTEND_SSH_KEY }}
-      BACKEND_SSH_PASSWORD: ${{ secrets.DEV_SSH_PASSWORD }}
-      FRONTEND_HOST: ${{ secrets.DEV_FRONTEND_HOST }}
-      FRONTEND_USER: ${{ secrets.DEV_FRONTEND_USER }}
-      BACKEND_HOST: ${{ secrets.DEV_HOST }}
-      BACKEND_USER: ${{ secrets.DEV_USER }}
-      BACKEND_IP: ${{ secrets.DEV_BACKEND_IP }}
-      DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+      DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
+      SSH_HOST: ${{ secrets.DEV_HOST }}
+      SSH_USER: ${{ secrets.DEV_USER }}
+      SSH_PASSWORD: ${{ secrets.DEV_SSH_PASSWORD }}
+      SSH_KEY: ${{ secrets.DEV_FRONTEND_SSH_KEY }}
       DB_HOST: ${{ secrets.DEV_DB_HOST }}
       DB_PORT: ${{ secrets.DEV_DB_PORT }}
+      DB_NAME: ${{ secrets.DEV_DB_NAME }}
       DB_USER: ${{ secrets.DEV_DB_USER }}
       DB_PASSWORD: ${{ secrets.DEV_DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DEV_DB_NAME }}
-      SECRET_KEY: ${{ secrets.DEV_SECRET_KEY }}
+      DJANGO_SECRET_KEY: ${{ secrets.DEV_SECRET_KEY }}
       DJANGO_SETTINGS_MODULE: ${{ secrets.DEV_DJANGO_SETTINGS_MODULE }}
-      DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
+      REACT_APP_API_BASE_URL: ${{ secrets.DEV_API_BASE_URL }}
+      BACKEND_HOST: ${{ secrets.DEV_BACKEND_IP }}
 
   # ==========================================
   # Route to UAT

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -35,6 +35,45 @@ on:
       DO_ACCESS_TOKEN:
         required: true
         description: "DigitalOcean access token (shared across all environments)"
+      SSH_HOST:
+        required: true
+        description: "SSH host for deployment"
+      SSH_USER:
+        required: true
+        description: "SSH username for deployment"
+      SSH_PASSWORD:
+        required: false
+        description: "SSH password for backend deployment (backend uses password auth)"
+      SSH_KEY:
+        required: false
+        description: "SSH private key for frontend deployment (frontend uses key auth)"
+      DB_HOST:
+        required: true
+        description: "Database host (for SSH tunnel)"
+      DB_PORT:
+        required: false
+        description: "Database port (defaults to 5432)"
+      DB_NAME:
+        required: true
+        description: "Database name"
+      DB_USER:
+        required: true
+        description: "Database user"
+      DB_PASSWORD:
+        required: true
+        description: "Database password"
+      DJANGO_SECRET_KEY:
+        required: true
+        description: "Django secret key"
+      DJANGO_SETTINGS_MODULE:
+        required: true
+        description: "Django settings module path"
+      REACT_APP_API_BASE_URL:
+        required: true
+        description: "API base URL for frontend runtime config"
+      BACKEND_HOST:
+        required: true
+        description: "Backend host IP/hostname for nginx proxy and Docker networking"
 
 env:
   REGISTRY: registry.digitalocean.com/meatscentral


### PR DESCRIPTION
## Problem
Secret Name Mismatch between workflows caused pipeline failures. The reusable workflow expected generic secret names, but callers passed environment-prefixed names.

## Solution
- **Reusable Workflow**: Updated `secrets:` section to accept standardized names
- **Main Pipeline**: Updated Development deployment to map repository secrets correctly
- **Standardized Names**: `SSH_HOST`, `SSH_USER`, `SSH_PASSWORD`, `SSH_KEY`, `DB_*`, `DJANGO_*`, etc.

## Key Changes
1. `reusable-deploy.yml`: Added 13 standardized secret definitions (no environment prefixes)
2. `main-pipeline.yml`: Updated development secrets mapping (lines 126-141)
3. Backend uses `SSH_PASSWORD` (password auth), Frontend uses `SSH_KEY` (key auth)
4. UAT/Production use `secrets: inherit` (requires environment-scoped secret configuration)

## Documentation
Added `SECRET_MIGRATION_GUIDE.md` with:
- Complete secret mapping reference
- Commands to configure UAT/Production environment secrets
- Verification steps
- Troubleshooting guide

## Action Required
After merging, configure environment-scoped secrets for UAT/Production using the migration guide.

## Testing
- ✅ YAML syntax validated
- ✅ Development secrets mapping verified
- ⚠️ UAT/Production requires environment secret configuration (see guide)

## Related
- Fixes pipeline failures on development branch
- Prepares for UAT/Production deployments