### PR TITLE
feat: Auto-close existing release PRs to force fresh PRs

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -7,32 +7,166 @@ on:
       - completed
     branches:
       - development
+      - uat
 
 jobs:
   draft-uat-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    if: |
+      github.event.workflow_run.conclusion == 'success' && 
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'development'
     permissions:
       contents: write
       pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Create Pull Request to UAT
+      - name: Close Existing PR (Force Fresh Release)
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
-          # Check if a PR already exists from development -> uat
-          EXISTING_PR=$(gh pr list --base uat --head development --json url --jq '.[0].url')
+          echo "🔍 Checking for existing PR: development -> uat"
           
-          if [ -z "$EXISTING_PR" ]; then
-            echo "🚀 Creating new PR: Development -> UAT"
-            gh pr create \
-              --base uat \
-              --head development \
-              --title "🚀 Promote Dev to UAT" \
-              --body "Automated PR created after successful deployment to Development. Review changes and merge to deploy to UAT."
+          EXISTING_PR=$(gh pr list --base uat --head development --state open --json number,url --jq '.[0]')
+          
+          if [ -n "$EXISTING_PR" ]; then
+            PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number')
+            PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
+            
+            echo "🗑️  Found existing PR #$PR_NUMBER: $PR_URL"
+            echo "🔄 Closing to create fresh PR with latest changes..."
+            
+            gh pr close "$PR_NUMBER" --comment "🔄 Auto-closing to create fresh release PR with all accumulated changes from development."
+            
+            echo "✅ Closed PR #$PR_NUMBER"
           else
-            echo "✅ PR already exists: $EXISTING_PR"
+            echo "✅ No existing PR found - will create new one"
           fi
+
+      - name: Create Fresh Pull Request to UAT
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          echo "🚀 Creating fresh PR: development -> uat"
+          
+          COMMIT_COUNT=$(git rev-list --count uat..development)
+          RECENT_COMMITS=$(git log uat..development --oneline --max-count=10)
+          
+          cat > /tmp/pr-body.md <<'PRBODY'
+          ## 🚀 Automated Release PR: Development → UAT
+          
+          **Triggered by:** Successful deployment to Development
+          
+          ### Review Checklist
+          - [ ] Review all changes since last UAT deployment
+          - [ ] Verify dev environment is stable
+          - [ ] Check for any breaking changes
+          - [ ] Confirm all tests passed in development
+          
+          **Note:** This is a fresh PR containing all accumulated changes. Previous PR was auto-closed to ensure this is the single source of truth.
+          
+          ---
+          _This PR was automatically created after successful development deployment._
+          PRBODY
+          
+          echo "" >> /tmp/pr-body.md
+          echo "**Commits included:** $COMMIT_COUNT commits" >> /tmp/pr-body.md
+          echo "" >> /tmp/pr-body.md
+          echo "### Recent Changes" >> /tmp/pr-body.md
+          echo '```' >> /tmp/pr-body.md
+          echo "$RECENT_COMMITS" >> /tmp/pr-body.md
+          echo '```' >> /tmp/pr-body.md
+          
+          gh pr create \
+            --base uat \
+            --head development \
+            --title "🚀 Release: Promote Development to UAT ($(date +%Y-%m-%d))" \
+            --body-file /tmp/pr-body.md \
+            --label "release,automated" \
+            || echo "⚠️  PR creation failed"
+
+  draft-production-pr:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.conclusion == 'success' && 
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'uat'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Close Existing PR (Force Fresh Release)
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          echo "🔍 Checking for existing PR: uat -> main"
+          
+          EXISTING_PR=$(gh pr list --base main --head uat --state open --json number,url --jq '.[0]')
+          
+          if [ -n "$EXISTING_PR" ]; then
+            PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number')
+            PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
+            
+            echo "🗑️  Found existing PR #$PR_NUMBER: $PR_URL"
+            echo "🔄 Closing to create fresh PR with latest changes..."
+            
+            gh pr close "$PR_NUMBER" --comment "🔄 Auto-closing to create fresh release PR with all accumulated changes from UAT."
+            
+            echo "✅ Closed PR #$PR_NUMBER"
+          else
+            echo "✅ No existing PR found - will create new one"
+          fi
+
+      - name: Create Fresh Pull Request to Production
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          echo "🚀 Creating fresh PR: uat -> main"
+          
+          COMMIT_COUNT=$(git rev-list --count main..uat)
+          RECENT_COMMITS=$(git log main..uat --oneline --max-count=10)
+          
+          cat > /tmp/pr-body.md <<'PRBODY'
+          ## 🚀 Automated Release PR: UAT → Production
+          
+          **Triggered by:** Successful deployment to UAT
+          
+          ### Production Release Checklist
+          - [ ] UAT environment verified and stable
+          - [ ] All acceptance tests passed
+          - [ ] Stakeholder sign-off obtained
+          - [ ] Rollback plan confirmed
+          - [ ] On-call engineer notified
+          
+          **⚠️ PRODUCTION DEPLOYMENT** - Requires additional approval
+          
+          **Note:** This is a fresh PR containing all accumulated changes. Previous PR was auto-closed to ensure this is the single source of truth.
+          
+          ---
+          _This PR was automatically created after successful UAT deployment._
+          PRBODY
+          
+          echo "" >> /tmp/pr-body.md
+          echo "**Commits included:** $COMMIT_COUNT commits" >> /tmp/pr-body.md
+          echo "" >> /tmp/pr-body.md
+          echo "### Recent Changes" >> /tmp/pr-body.md
+          echo '```' >> /tmp/pr-body.md
+          echo "$RECENT_COMMITS" >> /tmp/pr-body.md
+          echo '```' >> /tmp/pr-body.md
+          
+          gh pr create \
+            --base main \
+            --head uat \
+            --title "🚀 Release: Promote UAT to Production ($(date +%Y-%m-%d))" \
+            --body-file /tmp/pr-body.md \
+            --label "release,automated,production" \
+            || echo "⚠️  PR creation failed"


### PR DESCRIPTION
## Problem
When multiple commits are merged to development, the existing auto-PR workflow would skip creating a new PR if one already existed. This meant the PR wouldn't reflect the latest accumulated changes, creating confusion about what was actually being promoted.

## Solution
Modified the auto-draft release PR workflow to **force fresh PRs** by:
1. **Checking for existing open PRs** (development → uat or uat → main)
2. **Auto-closing existing PRs** with explanatory comment
3. **Creating fresh PR** with ALL current changes

## Key Changes

### 1. Close Existing PRs (Force Fresh)
```bash
# Find open PR
EXISTING_PR=$(gh pr list --base uat --head development --state open)

# Close it with comment
gh pr close "$PR_NUMBER" --comment "Auto-closing to create fresh release PR..."
```

### 2. Enhanced PR Bodies
- Shows commit count (`git rev-list --count`)
- Lists recent commits (`git log --oneline --max-count=10`)
- Includes environment-specific checklists
- Uses `--body-file` to avoid shell quoting issues

### 3. Added UAT → Production Workflow
Previously missing! Now both promotion paths are automated:
- ✅ Development → UAT (triggered on dev deployments)
- ✅ UAT → Production (triggered on UAT deployments)

## Workflow Behavior

### Development → UAT
**Trigger:** Successful deployment to development
**Actions:**
1. Close any existing dev→uat PR
2. Create fresh PR with:
   - All commits since last UAT deployment
   - Development checklist
   - Labels: `release`, `automated`

### UAT → Production
**Trigger:** Successful deployment to UAT
**Actions:**
1. Close any existing uat→main PR
2. Create fresh PR with:
   - All commits since last production deployment
   - Production release checklist (stricter)
   - Labels: `release`, `automated`, `production`

## Benefits

✅ **Single Source of Truth**: Fresh PR always shows complete diff
✅ **No Stale PRs**: Old PRs auto-closed with clear explanation
✅ **Full Automation**: Complete development → UAT → production flow
✅ **Clear Audit Trail**: Auto-close comments explain why PR was replaced
✅ **Better Context**: Commit counts and recent changes in PR body

## Example PR Body
```markdown
## 🚀 Automated Release PR: Development → UAT

**Triggered by:** Successful deployment to Development
**Commits included:** 42 commits

### Recent Changes
\`\`\`
a1b2c3d fix: Secret standardization
e4f5g6h feat: Add feature X
\`\`\`

### Review Checklist
- [ ] Review all changes since last UAT deployment
- [ ] Verify dev environment is stable
...
```

## Testing

- ✅ YAML syntax validated
- ⚠️ Will test in practice when next dev deployment completes
- Manual test: Run workflow with `workflow_dispatch` once merged

## Notes

- Existing open PRs will be auto-closed on next successful deployment
- Closed PRs remain in history with explanatory comments
- Works for both development→uat and uat→main promotions