### PR TITLE
fix: Remove event type check causing auto-PR workflow to skip

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -13,8 +13,7 @@ jobs:
   draft-uat-pr:
     runs-on: ubuntu-latest
     if: |
-      github.event.workflow_run.conclusion == 'success' && 
-      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'development'
     permissions:
       contents: write
@@ -92,8 +91,7 @@ jobs:
   draft-production-pr:
     runs-on: ubuntu-latest
     if: |
-      github.event.workflow_run.conclusion == 'success' && 
-      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'uat'
     permissions:
       contents: write


### PR DESCRIPTION
## 🐛 Problem

The auto-PR workflow was being **skipped** (not running at all), preventing PRs from being created.

**Root Cause:** The job-level `if` condition was too restrictive:
```yaml
if: |
  github.event.workflow_run.conclusion == 'success' && 
  github.event.workflow_run.event == 'push' &&  # ❌ THIS WAS THE PROBLEM
  github.event.workflow_run.head_branch == 'development'
```

**What happened:**
1. PR #1375 was merged to development
2. Master Pipeline ran successfully on development branch
3. Auto-PR workflow was triggered
4. Job condition checked `github.event.workflow_run.event`
5. Event type was `pull_request` (from the PR merge), not `push`
6. Condition evaluated to `false` → Job skipped (0s runtime)
7. No PR created to UAT

## ✅ Solution

Removed the `event == 'push'` check from both job conditions.

**New condition:**
```yaml
if: |
  github.event.workflow_run.conclusion == 'success' &&
  github.event.workflow_run.head_branch == 'development'
```

**Why this works:**
- We only care that Master Pipeline **succeeded on the target branch**
- Whether it was triggered by `push` or `pull_request` doesn't matter
- The `head_branch` check is sufficient to determine which job should run
- Jobs will no longer skip when PRs are merged

## 📊 Evidence

Recent auto-PR workflow runs showing "skipped" status:
```bash
$ gh run list --workflow=auto-pr.yml --limit 5
conclusion: skipped  # ❌ Not running at all
conclusion: skipped
conclusion: skipped
conclusion: skipped
```

Recent Master Pipeline run that triggered it:
```bash
event: pull_request  # ← This was the issue
headBranch: development
conclusion: success
```

## 🎯 Impact

**Before:** Auto-PR workflow skipped → No release PRs created
**After:** Auto-PR workflow runs → Fresh PRs created automatically

Affects both promotion paths:
- ✅ Development → UAT
- ✅ UAT → Production

## 🧪 Testing

- ✅ YAML syntax validated
- ⏳ Will test when this PR is merged (should trigger auto-PR to UAT)
- Expected: New PR created with label `release,automated`

## 📝 Related

- Original PR that added force-fresh logic: #1375
- That PR worked correctly, but this event check was preventing it from running