### PR TITLE
fix: Fetch all branches to enable git rev-list comparisons

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch all branches
+        run: git fetch --all
+
       - name: Close Existing PR (Force Fresh Release)
         env:
           GH_TOKEN: ${{ secrets.PAT }}
@@ -52,8 +55,8 @@ jobs:
         run: |
           echo "🚀 Creating fresh PR: development -> uat"
           
-          COMMIT_COUNT=$(git rev-list --count uat..development)
-          RECENT_COMMITS=$(git log uat..development --oneline --max-count=10)
+          COMMIT_COUNT=$(git rev-list --count origin/uat..origin/development)
+          RECENT_COMMITS=$(git log origin/uat..origin/development --oneline --max-count=10)
           
           cat > /tmp/pr-body.md <<'PRBODY'
           ## 🚀 Automated Release PR: Development → UAT
@@ -102,6 +105,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch all branches
+        run: git fetch --all
+
       - name: Close Existing PR (Force Fresh Release)
         env:
           GH_TOKEN: ${{ secrets.PAT }}
@@ -130,8 +136,8 @@ jobs:
         run: |
           echo "🚀 Creating fresh PR: uat -> main"
           
-          COMMIT_COUNT=$(git rev-list --count main..uat)
-          RECENT_COMMITS=$(git log main..uat --oneline --max-count=10)
+          COMMIT_COUNT=$(git rev-list --count origin/main..origin/uat)
+          RECENT_COMMITS=$(git log origin/main..origin/uat --oneline --max-count=10)
           
           cat > /tmp/pr-body.md <<'PRBODY'
           ## 🚀 Automated Release PR: UAT → Production


### PR DESCRIPTION
## 🐛 Problem

After fixing the skip condition in PR #1376, the auto-PR workflow **ran** but **failed** when creating the PR with:

```
fatal: ambiguous argument 'uat..development': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
##[error]Process completed with exit code 128.
```

**What happened:**
1. ✅ Workflow triggered (not skipped anymore)
2. ✅ Successfully closed existing PR #1370
3. ❌ Failed when trying to get commit count: `git rev-list --count uat..development`

**Root Cause:**
The `actions/checkout@v4` action with `fetch-depth: 0` fetches **commit history** but doesn't fetch **remote branch refs**. The workflow could see commit history but didn't know about the `uat` branch reference.

## ✅ Solution

### 1. Added "Fetch all branches" step
```yaml
- name: Fetch all branches
  run: git fetch --all
```

### 2. Changed git commands to use remote refs
```bash
# Before (failed)
COMMIT_COUNT=$(git rev-list --count uat..development)
RECENT_COMMITS=$(git log uat..development --oneline)

# After (works)
COMMIT_COUNT=$(git rev-list --count origin/uat..origin/development)
RECENT_COMMITS=$(git log origin/uat..origin/development --oneline)
```

Using `origin/uat` and `origin/development` ensures we're comparing remote branches that were just fetched, not local branches that may not exist.

## 📊 Changes

### For development → UAT job:
- Added: Fetch all branches step
- Changed: `uat..development` → `origin/uat..origin/development`

### For UAT → production job:
- Added: Fetch all branches step  
- Changed: `main..uat` → `origin/main..origin/uat`

## 🎯 Impact

**Before:**
- ✅ Workflow ran (after #1376)
- ✅ Closed existing PR
- ❌ Failed at commit count step
- ❌ No PR created

**After:**
- ✅ Workflow runs
- ✅ Closes existing PR
- ✅ Gets commit count successfully
- ✅ Creates fresh PR with commit info

## 🧪 Testing

- ✅ YAML syntax validated
- ⏳ Will test when this PR merges (should trigger auto-PR to UAT)
- Expected result: Fresh PR created with commit count and recent changes

## 📝 Related

- PR #1375: Added force-fresh PR logic
- PR #1376: Fixed skip condition (event type check)
- This PR: Fixes branch fetching for git comparisons

All three fixes together complete the auto-PR workflow:
1. ✅ Force closes existing PRs
2. ✅ Workflow runs (not skipped)
3. ✅ Can compare branches (this PR)