### PR TITLE
fix: Remove literal ':latest' string from validation comment

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -88,7 +88,7 @@ jobs:
             FAILED=1
           fi
           
-          # Check for hardcoded :latest in Docker run commands
+          # Check for hardcoded forbidden tag in Docker run commands
           if grep -v '^\s*#' .github/workflows/reusable-deploy.yml | grep -q "docker run.*:${FORBIDDEN_TAG}" 2>/dev/null; then
             echo "❌ ERROR: reusable-deploy.yml uses ':${FORBIDDEN_TAG}' tag in docker run"
             echo "   Deploy steps must use SHA-tagged images only"


### PR DESCRIPTION
## Problem
The Docker Tag Validation job is failing because it's finding the literal string `:latest` in its own comment on line 91 of `main-pipeline.yml`.

## Root Cause
Comment: `# Check for hardcoded :latest in Docker run commands`

When a broader grep search is performed (e.g., `grep -r ':latest'`), this comment matches itself, causing the validation to fail - the classic "detective arresting himself" bug.

## Solution
Changed the comment from:
```bash
# Check for hardcoded :latest in Docker run commands
```

To:
```bash
# Check for hardcoded forbidden tag in Docker run commands
```

Now the comment references the `FORBIDDEN_TAG` variable pattern instead of containing the literal string.

## Testing
✅ Validation script tested locally - passes
✅ No literal `:latest` or `-latest` strings remain in validation logic
✅ YAML syntax validated
✅ grep patterns work correctly

## Impact
- Fixes failing Docker Tag Validation check
- Prevents self-referential validation failures
- Maintains all existing validation logic