### PR TITLE
fix: Enable Docker tag validation on all PRs

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -59,9 +59,7 @@ jobs:
   check-docker-tags:
     name: Validate Docker Tags
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'pull_request' && 
-      contains(github.event.pull_request.changed_files, '.github/workflows/')
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Problem
The Docker Tag Validation job was **always being skipped** because it used an invalid GitHub Actions condition:

```yaml
if: |
  github.event_name == 'pull_request' && 
  contains(github.event.pull_request.changed_files, '.github/workflows/')
```

**Issue:** `github.event.pull_request.changed_files` doesn't exist in GitHub Actions context, so the condition always evaluated to false, skipping the validation.

## Solution
Simplified the condition to run on **all pull requests**:

```yaml
if: github.event_name == 'pull_request'
```

## Benefits
- ✅ Validation now runs on every PR
- ✅ Catches Docker tag issues before merge
- ✅ No more skipped validation checks
- ✅ Protects against `:latest` tags in deployments

## Testing
✅ Validation script tested locally - passes
✅ No `:latest` strings found in workflow files
✅ Validation logic correctly filters comments
✅ YAML syntax validated

This PR will trigger the validation check on itself, proving it works!