### PR TITLE
fix: Handle missing labels gracefully in auto-PR workflow

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -83,13 +83,21 @@ jobs:
           echo "$RECENT_COMMITS" >> /tmp/pr-body.md
           echo '```' >> /tmp/pr-body.md
           
-          gh pr create \
+          # Create PR (without labels first, then add labels separately to handle missing labels gracefully)
+          PR_URL=$(gh pr create \
             --base uat \
             --head development \
             --title "🚀 Release: Promote Development to UAT ($(date +%Y-%m-%d))" \
-            --body-file /tmp/pr-body.md \
-            --label "release,automated" \
-            || echo "⚠️  PR creation failed"
+            --body-file /tmp/pr-body.md) || {
+            echo "⚠️  PR creation failed"
+            exit 1
+          }
+          
+          echo "✅ PR created: $PR_URL"
+          
+          # Add labels (non-fatal if labels don't exist)
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
+          gh pr edit "$PR_NUMBER" --add-label "release,automated" || echo "⚠️  Could not add labels (labels may not exist)"
 
   draft-production-pr:
     runs-on: ubuntu-latest
@@ -167,10 +175,18 @@ jobs:
           echo "$RECENT_COMMITS" >> /tmp/pr-body.md
           echo '```' >> /tmp/pr-body.md
           
-          gh pr create \
+          # Create PR (without labels first, then add labels separately to handle missing labels gracefully)
+          PR_URL=$(gh pr create \
             --base main \
             --head uat \
             --title "🚀 Release: Promote UAT to Production ($(date +%Y-%m-%d))" \
-            --body-file /tmp/pr-body.md \
-            --label "release,automated,production" \
-            || echo "⚠️  PR creation failed"
+            --body-file /tmp/pr-body.md) || {
+            echo "⚠️  PR creation failed"
+            exit 1
+          }
+          
+          echo "✅ PR created: $PR_URL"
+          
+          # Add labels (non-fatal if labels don't exist)
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
+          gh pr edit "$PR_NUMBER" --add-label "release,automated,production" || echo "⚠️  Could not add labels (labels may not exist)"


### PR DESCRIPTION
## Problem
The auto-PR workflow failed when trying to create PR #1384 with error:
```
could not add label: 'release' not found
⚠️  PR creation failed
```

## Root Cause
The workflow used `--label` flag during PR creation, which fails entirely if any label doesn't exist.

## Solution
**Two-step approach:**
1. Create PR first (without labels)
2. Add labels separately with non-fatal error handling

This allows the PR to be created even if labels are missing.

## Changes
- Split PR creation and label addition into separate steps
- Extract PR number from created PR URL
- Use `gh pr edit --add-label` with graceful fallback
- Fail only if PR creation fails, not label addition

## Also Fixed
Created the missing labels in the repository:
- `release` (green #0E8A16)
- `automated` (blue #1D76DB)  
- `production` (red #D93F0B)

## Testing
- [x] PR #1384 was created manually and succeeded
- [ ] Auto-PR workflow will succeed on next development deployment

## References
- Failed workflow: https://github.com/Meats-Central/ProjectMeats/actions/runs/20612239527
- Created PR: #1384

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Documentation