### PR TITLE
fix: Prevent infinite loop in auto-PR workflow

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'development'
+      github.event.workflow_run.head_branch == 'development' &&
+      github.event.workflow_run.event == 'push'
     permissions:
       contents: write
       pull-requests: write
@@ -103,7 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'uat'
+      github.event.workflow_run.head_branch == 'uat' &&
+      github.event.workflow_run.event == 'push'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## 🚨 Critical Bug - Infinite Loop

The auto-PR workflow created 9 duplicate PRs in 3 minutes due to triggering on pull_request events.

**Solution**: Only trigger on push events, not pull_request events.

Fixes infinite loop that created PRs #1393-1402.