### PR TITLE
docs: Update env.manifest to v4.0 with new standard secret names

### DIFF
--- a/config/env.manifest.json
+++ b/config/env.manifest.json
@@ -1,71 +1,59 @@
 {
   "project": "ProjectMeats",
-  "version": "3.3",
-  "description": "Source of Truth - Legacy Mapping Fix",
+  "version": "4.0",
+  "description": "New Standard - Environment-Scoped Secret Names",
   "environments": {
-    "dev-backend": { "type": "backend", "prefix": "DEV", "django_settings": "projectmeats.settings.development" },
-    "dev-frontend": { "type": "frontend", "prefix": "DEV", "url": "https://dev.meatscentral.com" },
-    "uat2-backend": { "type": "backend", "prefix": "UAT", "django_settings": "projectmeats.settings.staging" },
-    "uat2": { "type": "frontend", "prefix": "STAGING", "url": "https://uat.meatscentral.com" },
-    "prod2-backend": { "type": "backend", "prefix": "PROD", "django_settings": "projectmeats.settings.production" },
-    "prod2-frontend": { "type": "frontend", "prefix": "PROD", "url": "https://meatscentral.com" }
+    "dev-backend": { "type": "backend", "django_settings": "projectmeats.settings.development" },
+    "dev-frontend": { "type": "frontend", "url": "https://dev.meatscentral.com" },
+    "uat-backend": { "type": "backend", "django_settings": "projectmeats.settings.staging" },
+    "uat-frontend": { "type": "frontend", "url": "https://uat.meatscentral.com" },
+    "production-backend": { "type": "backend", "django_settings": "projectmeats.settings.production" },
+    "production-frontend": { "type": "frontend", "url": "https://meatscentral.com" }
   },
   "variables": {
     "infrastructure": {
-      "BASTION_HOST": { 
+      "SSH_HOST": { 
         "description": "Droplet IP",
-        "ci_secret_mapping": {
-          "dev-backend": "DEV_HOST",
-          "dev-frontend": "DEV_HOST",
-          "uat2-backend": "UAT_HOST",
-          "uat2": "STAGING_HOST",
-          "prod2-backend": "PROD_HOST",
-          "prod2-frontend": "PRODUCTION_HOST"
-        }
+        "ci_secret_name": "SSH_HOST",
+        "note": "Same name in all environments (environment-scoped)"
       },
-      "BASTION_USER": { 
+      "SSH_USER": { 
         "description": "SSH Username",
-        "ci_secret_mapping": {
-          "dev-backend": "DEV_USER",
-          "dev-frontend": "DEV_USER",
-          "uat2-backend": "UAT_USER",
-          "uat2": "STAGING_USER",
-          "prod2-backend": "PROD_USER",
-          "prod2-frontend": "PRODUCTION_USER"
-        }
+        "ci_secret_name": "SSH_USER",
+        "note": "Same name in all environments (environment-scoped)"
       },
-      "BASTION_SSH_PASSWORD": { 
-        "description": "SSH Password (Legacy Shared)",
-        "ci_secret_mapping": {
-          "dev-backend": "DEV_SSH_PASSWORD",
-          "dev-frontend": "DEV_SSH_PASSWORD",
-          "uat2-backend": "SSH_PASSWORD", 
-          "uat2": "SSH_PASSWORD",
-          "prod2-backend": "SSH_PASSWORD",
-          "prod2-frontend": "SSH_PASSWORD"
-        }
+      "SSH_PASSWORD": { 
+        "description": "SSH Password",
+        "ci_secret_name": "SSH_PASSWORD",
+        "note": "Same name in all environments (environment-scoped)"
+      },
+      "SSH_KEY": {
+        "description": "SSH Private Key (for frontend deployments)",
+        "ci_secret_name": "SSH_KEY",
+        "note": "Optional alternative to SSH_PASSWORD"
+      },
+      "BACKEND_HOST": {
+        "description": "Backend server IP/hostname for nginx routing",
+        "ci_secret_name": "BACKEND_HOST",
+        "note": "Required for frontend deployments"
       }
     },
     "application": {
-      "DB_HOST": { "ci_secret_pattern": "{PREFIX}_DB_HOST", "description": "Private DB Host" },
-      "DB_PORT": { "ci_secret_pattern": "{PREFIX}_DB_PORT", "default": "5432" },
-      "DB_USER": { "ci_secret_pattern": "{PREFIX}_DB_USER", "description": "DB Username" },
-      "DB_PASSWORD": { "ci_secret_pattern": "{PREFIX}_DB_PASSWORD", "description": "DB Password" },
-      "DB_NAME": { "ci_secret_pattern": "{PREFIX}_DB_NAME", "description": "DB Name" },
-      "DATABASE_URL": { 
-        "ci_secret_mapping": {
-            "dev-backend": "DEV_DATABASE_URL",
-            "uat2-backend": "UAT_DATABASE_URL",
-            "prod2-backend": "PROD_DATABASE_URL"
-        }
-      },
-      "SECRET_KEY": { "ci_secret_pattern": "{PREFIX}_SECRET_KEY", "required": true },
-      "DJANGO_SETTINGS_MODULE": { "value_source": "environment_config" }
+      "DB_HOST": { "ci_secret_name": "DB_HOST", "description": "Private DB Host" },
+      "DB_PORT": { "ci_secret_name": "DB_PORT", "default": "5432" },
+      "DB_USER": { "ci_secret_name": "DB_USER", "description": "DB Username" },
+      "DB_PASSWORD": { "ci_secret_name": "DB_PASSWORD", "description": "DB Password" },
+      "DB_NAME": { "ci_secret_name": "DB_NAME", "description": "DB Name" },
+      "DJANGO_SECRET_KEY": { "ci_secret_name": "DJANGO_SECRET_KEY", "required": true },
+      "DJANGO_SETTINGS_MODULE": { "ci_secret_name": "DJANGO_SETTINGS_MODULE", "description": "Django settings path" },
+      "DJANGO_SUPERUSER_USERNAME": { "ci_secret_name": "DJANGO_SUPERUSER_USERNAME", "optional": true },
+      "DJANGO_SUPERUSER_EMAIL": { "ci_secret_name": "DJANGO_SUPERUSER_EMAIL", "optional": true },
+      "DJANGO_SUPERUSER_PASSWORD": { "ci_secret_name": "DJANGO_SUPERUSER_PASSWORD", "optional": true }
     },
     "frontend_runtime": {
-      "REACT_APP_API_BASE_URL": { "ci_secret_pattern": "REACT_APP_API_BASE_URL" },
-      "REACT_APP_ENVIRONMENT": { "ci_secret_pattern": "REACT_APP_ENVIRONMENT" },
-      "REACT_APP_AI_ASSISTANT_ENABLED": { "ci_secret_pattern": "REACT_APP_AI_ASSISTANT_ENABLED" }
+      "REACT_APP_API_BASE_URL": { "ci_secret_name": "REACT_APP_API_BASE_URL" },
+      "REACT_APP_ENVIRONMENT": { "ci_secret_name": "REACT_APP_ENVIRONMENT", "optional": true },
+      "REACT_APP_AI_ASSISTANT_ENABLED": { "ci_secret_name": "REACT_APP_AI_ASSISTANT_ENABLED", "optional": true }
     }
   }
 }


### PR DESCRIPTION
## Summary
Updated env.manifest.json to reflect the **actual** secret naming standard used by workflows.

## Changes

### Version Update
- v3.3 → v4.0
- Description updated to match new standard

### Environment Names (Corrected)
- `uat2-backend` → `uat-backend`
- `uat2` → `uat-frontend`
- `prod2-backend` → `production-backend`
- `prod2-frontend` → `production-frontend`

### Secret Naming (Simplified)
**Before (Prefix-based)**:
- Different names per environment (`DEV_HOST`, `UAT_HOST`, `PROD_HOST`)
- Complex mapping tables

**After (Environment-scoped)**:
- **Same name in all environments** (`SSH_HOST`)
- Simpler: just specify the environment and use the standard name
- Aligns with GitHub's environment-scoped secrets feature

### New Secrets Added
- `SSH_KEY` (for frontend key-based auth)
- `BACKEND_HOST` (for nginx routing)
- `DJANGO_SUPERUSER_USERNAME` (optional)
- `DJANGO_SUPERUSER_EMAIL` (optional)
- `DJANGO_SUPERUSER_PASSWORD` (optional)

### Complete Secret List (v4.0)

**All environments use these exact names:**

#### Infrastructure
- SSH_HOST
- SSH_USER  
- SSH_PASSWORD
- SSH_KEY
- BACKEND_HOST

#### Application (Backend)
- DB_HOST
- DB_PORT
- DB_NAME
- DB_USER
- DB_PASSWORD
- DJANGO_SECRET_KEY
- DJANGO_SETTINGS_MODULE
- DJANGO_SUPERUSER_USERNAME (optional)
- DJANGO_SUPERUSER_EMAIL (optional)
- DJANGO_SUPERUSER_PASSWORD (optional)

#### Frontend Runtime
- REACT_APP_API_BASE_URL
- REACT_APP_ENVIRONMENT (optional)
- REACT_APP_AI_ASSISTANT_ENABLED (optional)

## Why This Matters
This manifest now accurately documents the **actual** secret names used in workflows, eliminating confusion between documentation and implementation.

## Type
- [ ] Bug fix
- [ ] Feature  
- [x] Documentation