### PR TITLE
fix: Add explicit secret passing for UAT and production deployments

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -155,6 +155,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/uat') ||
       (github.event_name == 'workflow_dispatch' && inputs.environment == 'uat')
     needs: []  # Runs independently for push events
+    environment: uat-backend  # Required to access environment-scoped secrets
     uses: ./.github/workflows/reusable-deploy.yml
     with:
       environment: 'uat'
@@ -163,7 +164,21 @@ jobs:
       backend_environment: 'uat-backend'
       frontend_environment: 'uat-frontend'
       api_base_url: 'https://uat.meatscentral.com'
-    secrets: inherit
+    secrets:
+      DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
+      SSH_HOST: ${{ secrets.SSH_HOST }}
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+      DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
+      REACT_APP_API_BASE_URL: ${{ secrets.REACT_APP_API_BASE_URL }}
+      BACKEND_HOST: ${{ secrets.BACKEND_HOST }}
 
   # ==========================================
   # Route to Production
@@ -173,6 +188,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
     needs: []  # Runs independently for push events
+    environment: production-backend  # Required to access environment-scoped secrets
     uses: ./.github/workflows/reusable-deploy.yml
     with:
       environment: 'production'
@@ -181,4 +197,18 @@ jobs:
       backend_environment: 'production-backend'
       frontend_environment: 'production-frontend'
       api_base_url: 'https://meatscentral.com'
-    secrets: inherit
+    secrets:
+      DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
+      SSH_HOST: ${{ secrets.SSH_HOST }}
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+      DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
+      REACT_APP_API_BASE_URL: ${{ secrets.REACT_APP_API_BASE_URL }}
+      BACKEND_HOST: ${{ secrets.BACKEND_HOST }}


### PR DESCRIPTION
## Problem
UAT deployment failed with error:
```
Secret SSH_HOST is required, but not provided while calling.
```

## Root Cause
`secrets: inherit` doesn't work for reusable workflows when the calling job doesn't have an environment context. The called workflow couldn't access environment-scoped secrets.

## Solution
Added two critical elements:

### 1. Environment Context
```yaml
deploy-uat:
  environment: uat-backend  # ← Activates secret scope
  
deploy-prod:
  environment: production-backend
```

### 2. Explicit Secret Passing
Replaced `secrets: inherit` with explicit secret declarations (14 secrets each):

```yaml
secrets:
  DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
  SSH_HOST: ${{ secrets.SSH_HOST }}
  SSH_USER: ${{ secrets.SSH_USER }}
  # ... etc (14 total)
```

This matches the working pattern in `deploy-dev`.

## Changes
- **deploy-uat**: Added environment + 14 explicit secrets
- **deploy-prod**: Added environment + 14 explicit secrets

## Testing
- [ ] Will test on merge (UAT deployment)
- [ ] Verify secrets are accessible

## References
- Failed run: https://github.com/Meats-Central/ProjectMeats/actions/runs/20612519876
- Secrets configured: uat-backend, uat-frontend, production-backend, production-frontend

## Type
- [x] Bug fix (critical)
- [ ] Feature
- [ ] Documentation