### PR TITLE
fix: Make host nginx reload non-fatal in frontend deployment

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -464,7 +464,21 @@ jobs:
               }
           }
           NGINX
-            nginx -t && systemctl reload nginx
+            
+            # Test and reload nginx (non-fatal if service doesn't exist)
+            if nginx -t; then
+              # Try systemctl first (systemd), fall back to service command, or just start nginx
+              if systemctl is-active nginx >/dev/null 2>&1; then
+                systemctl reload nginx
+              elif service nginx status >/dev/null 2>&1; then
+                service nginx reload
+              else
+                # Service not running, try to start it
+                nginx || echo "⚠ Nginx config created but service not running (container will handle traffic)"
+              fi
+            else
+              echo "⚠ Nginx configuration test failed, skipping reload"
+            fi
           fi
           
           # Health check - target container directly on port 8080


### PR DESCRIPTION
Fixes nginx service reload failure. Host nginx is optional since container serves traffic directly.