### PR TITLE
fix: Enable SSL nginx configuration for HTTPS support

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -45,8 +45,8 @@ RUN npm run build
 FROM nginx:alpine
 RUN apk add --no-cache nodejs npm bash  # Install npm, nodejs, and bash here
 
-# Copy nginx configuration
-COPY deploy/nginx/frontend.conf /etc/nginx/conf.d/default.conf
+# Copy SSL-enabled nginx configuration
+COPY deploy/nginx/frontend-ssl.conf /etc/nginx/conf.d/default.conf
 
 # Copy the built files from the build stage
 COPY --from=build /project/frontend/build /usr/share/nginx/html


### PR DESCRIPTION
## Enable HTTPS via SSL Nginx Config

Complete the SSL setup by switching to the SSL-enabled nginx configuration.

### Current State
- ✅ SSL certificates installed on production droplet (/etc/nginx/ssl/)
- ✅ Dockerfile exposes port 443  
- ✅ Deployment mounts SSL certificates
- ❌ **Container still uses HTTP-only nginx config** 

### This Fix
Switches from `frontend.conf` to `frontend-ssl.conf`:
- Enables HTTPS on port 443
- HTTP (port 80) automatically redirects to HTTPS
- Full TLS 1.2/1.3 support
- Security headers (HSTS, X-Frame-Options, etc.)

### Testing
After deployment:
```bash
# HTTPS should work
curl -I https://meatscentral.com

# HTTP should redirect to HTTPS
curl -I http://meatscentral.com
```

### Files Changed
- `frontend/dockerfile`: Use frontend-ssl.conf instead of frontend.conf

Part of SSL implementation (PR #1441)