### PR TITLE
fix: Auto-detect SSL availability in frontend container

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+echo "=== Frontend Container Entrypoint ==="
+echo "Environment: ${ENVIRONMENT:-development}"
+
+# Check if SSL certificates exist
+SSL_CERT="/etc/nginx/ssl/fullchain.pem"
+SSL_KEY="/etc/nginx/ssl/privkey.pem"
+HAS_SSL=false
+
+if [ -f "$SSL_CERT" ] && [ -f "$SSL_KEY" ]; then
+    echo "✓ SSL certificates found"
+    HAS_SSL=true
+else
+    echo "ℹ SSL certificates not found (dev environment)"
+    HAS_SSL=false
+fi
+
+# Choose nginx config based on SSL availability
+if [ "$HAS_SSL" = true ] && [ -f "/etc/nginx/conf.d/frontend-ssl.conf" ]; then
+    echo "→ Using SSL-enabled configuration"
+    cp /etc/nginx/conf.d/frontend-ssl.conf /etc/nginx/conf.d/default.conf
+elif [ -f "/etc/nginx/conf.d/frontend-http.conf" ]; then
+    echo "→ Using HTTP-only configuration"
+    cp /etc/nginx/conf.d/frontend-http.conf /etc/nginx/conf.d/default.conf
+else
+    echo "→ Using default configuration"
+fi
+
+echo "=== Validating nginx configuration ==="
+# Test nginx configuration before starting
+if nginx -t -c /etc/nginx/nginx.conf 2>&1; then
+    echo "✓ Nginx configuration is valid"
+else
+    echo "✗ Nginx configuration validation failed!"
+    echo ""
+    echo "Configuration files:"
+    echo "===================="
+    echo "Main config: /etc/nginx/nginx.conf"
+    echo "Default config: /etc/nginx/conf.d/default.conf"
+    echo ""
+    echo "Content of /etc/nginx/conf.d/default.conf:"
+    cat /etc/nginx/conf.d/default.conf
+    exit 1
+fi
+
+echo "=== Starting nginx ==="
+exec nginx -g 'daemon off;'

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -45,43 +45,22 @@ RUN npm run build
 FROM nginx:alpine
 RUN apk add --no-cache nodejs npm bash  # Install npm, nodejs, and bash here
 
-# Copy SSL-enabled nginx configuration
-COPY deploy/nginx/frontend-ssl.conf /etc/nginx/conf.d/default.conf
+# Copy BOTH nginx configurations (entrypoint will choose based on SSL availability)
+COPY deploy/nginx/frontend.conf /etc/nginx/conf.d/frontend-http.conf
+COPY deploy/nginx/frontend-ssl.conf /etc/nginx/conf.d/frontend-ssl.conf
+
+# Set HTTP-only as default (for environments without SSL)
+COPY deploy/nginx/frontend.conf /etc/nginx/conf.d/default.conf
 
 # Copy the built files from the build stage
 COPY --from=build /project/frontend/build /usr/share/nginx/html
 
-# Create entrypoint script with nginx validation
-# This ensures nginx configuration is valid before starting the server
-RUN cat > /docker-entrypoint.sh <<'EOF'
-#!/bin/bash
-set -e
-
-echo "=== Validating nginx configuration ==="
-# Test nginx configuration before starting
-if nginx -t -c /etc/nginx/nginx.conf; then
-    echo "✓ Nginx configuration is valid"
-else
-    echo "✗ Nginx configuration validation failed!"
-    echo ""
-    echo "Configuration files:"
-    echo "===================="
-    echo "Main config: /etc/nginx/nginx.conf"
-    echo "Default config: /etc/nginx/conf.d/default.conf"
-    echo ""
-    echo "Content of /etc/nginx/conf.d/default.conf:"
-    cat /etc/nginx/conf.d/default.conf
-    exit 1
-fi
-
-echo "=== Starting nginx ==="
-exec nginx -g 'daemon off;'
-EOF
-
+# Copy smart entrypoint that auto-detects SSL availability
+COPY frontend/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 EXPOSE 80 443
 HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://127.0.0.1/ || exit 1
 
-# Use our custom entrypoint that validates config before starting
+# Use our custom entrypoint that auto-selects config based on SSL availability
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Problem

The deployment to dev failed ([workflow run #20615948204](https://github.com/Meats-Central/ProjectMeats/actions/runs/20615948204/job/59208779482)) because:

- PR #1444 enabled `frontend-ssl.conf` which requires SSL certificates at `/etc/nginx/ssl/`
- Dev environment doesn't have SSL certificates installed
- Nginx fails validation on startup because certificate files don't exist
- Container exits immediately, causing health checks to return HTTP 000

**Error from logs:**
```
Health check attempt 1/5 (HTTP 000000), retrying...
Health check attempt 2/5 (HTTP 000000), retrying...
...
✗ Frontend health check failed after 5 attempts
```

## Solution

This PR implements **smart SSL auto-detection** in the frontend container:

### Changes

1. **New `docker-entrypoint.sh`**:
   - Checks if SSL certificates exist at `/etc/nginx/ssl/fullchain.pem` and `privkey.pem`
   - If SSL certs found → activates `frontend-ssl.conf` (HTTPS)
   - If no SSL certs → activates `frontend.conf` (HTTP-only)
   - Logs which configuration is being used
   - Validates nginx config before starting

2. **Updated Dockerfile**:
   - Copies BOTH nginx configs into container
   - Uses `frontend.conf` as default (safe fallback)
   - Replaces inline entrypoint script with external file
   - No changes to exposed ports or health checks

### Benefits

- ✅ **Dev environment works** without SSL certificates
- ✅ **Production automatically enables HTTPS** when SSL certs are mounted
- ✅ **No manual config switching** required
- ✅ **No deployment script changes** needed
- ✅ **Clear logging** shows which config is active
- ✅ **Graceful degradation** ensures service stays up

### How It Works

**Development (no SSL):**
```bash
→ Using HTTP-only configuration
✓ Nginx configuration is valid
=== Starting nginx ===
```

**Production (with SSL):**
```bash
✓ SSL certificates found
→ Using SSL-enabled configuration
✓ Nginx configuration is valid
=== Starting nginx ===
```

### Testing

After deployment, the dev environment should:
- ✅ Container starts successfully
- ✅ Health check passes (HTTP 200)
- ✅ Nginx serves on port 80
- ✅ No SSL errors in logs

Production environment should:
- ✅ Container starts successfully
- ✅ HTTPS works on port 443
- ✅ HTTP redirects to HTTPS
- ✅ SSL certificates loaded correctly

## Fixes

- Fixes #20615948204 (frontend deployment failure)
- Resolves SSL certificate requirement for dev environment
- Maintains SSL support for production environment

## Related PRs

- PR #1444 - Enabled SSL config (caused the issue)
- PR #1441 - Added SSL support infrastructure