### PR TITLE
refactor: Decouple CI (validation) and CD (deployment) workflows

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -1,9 +1,8 @@
 name: Master Pipeline
 
-# Dynamic run names to distinguish Deploys from PR Checks
+# Dynamic run names for deployments only
 run-name: >-
   ${{ 
-    github.event_name == 'pull_request' && format('🔍 PR Check: {0}', github.event.pull_request.title) || 
     github.event_name == 'workflow_dispatch' && format('🕹️ Manual Deploy: {0}', inputs.environment) || 
     format('🚀 Deploy: {0}', github.ref_name) 
   }}
@@ -15,8 +14,6 @@ on:
       - '**.md'
       - 'docs/**'
       - 'archived/**'
-  pull_request:
-    branches: [development, uat, main]
   workflow_dispatch:
     inputs:
       environment:
@@ -33,96 +30,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ==========================================
-  # Pre-Deployment Validation (Parallel)
-  # ==========================================
-  
-  lint-docs:
-    name: Lint Documentation
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
-
-      - name: Run markdownlint
-        run: |
-          markdownlint '**/*.md' \
-            --ignore 'node_modules/**' \
-            --ignore 'archived/**' \
-            --ignore 'docs/archived/**' \
-            --disable MD013 MD033 MD041 \
-            || echo "::warning::Markdown lint issues found. See above for details."
-  
-  # TEMPORARILY DISABLED: Blocking deployments with false positives
-  # Will re-enable after fixing grep logic to properly exclude archived files
-  check-docker-tags:
-    name: Validate Docker Tags
-    runs-on: ubuntu-latest
-    if: false  # DISABLED - unblocking pipeline
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      
-      - name: Validate immutable tagging in deployment workflows
-        run: |
-          echo "=== Validating immutable Docker image tagging ==="
-          
-          FAILED=0
-          FORBIDDEN_TAG="latest"
-          
-          # Check reusable-deploy.yml for immutable tagging patterns
-          echo "Checking reusable-deploy.yml..."
-          
-          # Deploy jobs must use SHA-tagged images, not the forbidden tag
-          # Exclude comments and this validation file itself from search
-          if grep -v '^\s*#' .github/workflows/reusable-deploy.yml | grep -q "docker pull.*:.*-${FORBIDDEN_TAG}" 2>/dev/null; then
-            echo "❌ ERROR: reusable-deploy.yml uses '-${FORBIDDEN_TAG}' tag in docker pull"
-            echo "   Deploy steps must use SHA-tagged images only"
-            FAILED=1
-          fi
-          
-          # Check for hardcoded forbidden tag in Docker run commands
-          if grep -v '^\s*#' .github/workflows/reusable-deploy.yml | grep -q "docker run.*:${FORBIDDEN_TAG}" 2>/dev/null; then
-            echo "❌ ERROR: reusable-deploy.yml uses ':${FORBIDDEN_TAG}' tag in docker run"
-            echo "   Deploy steps must use SHA-tagged images only"
-            FAILED=1
-          fi
-          
-          # Check main-pipeline.yml for proper tag patterns
-          echo "Checking main-pipeline.yml..."
-          if ! grep -q '\${{ github.sha }}' .github/workflows/main-pipeline.yml 2>/dev/null; then
-            echo "⚠️  WARNING: main-pipeline.yml may not use SHA-based tagging"
-          fi
-          
-          if [ $FAILED -eq 1 ]; then
-            echo ""
-            echo "=== VALIDATION FAILED ==="
-            echo "Deploy steps must pull images using SHA tags only."
-            echo "Example: \${{ env.REGISTRY }}/\${{ env.BACKEND_IMAGE }}:prod-\${{ github.sha }}"
-            echo ""
-            echo "Build steps can push both SHA and -${FORBIDDEN_TAG} tags for caching:"
-            echo "  - \${{ env.REGISTRY }}/\${{ env.BACKEND_IMAGE }}:prod-\${{ github.sha }}"
-            echo "  - \${{ env.REGISTRY }}/\${{ env.BACKEND_IMAGE }}:prod-${FORBIDDEN_TAG}"
-            exit 1
-          fi
-          
-          echo "✓ All deployment workflows use immutable tagging"
-
   # ==========================================
   # Route to Development
   # ==========================================

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,102 @@
+name: PR Validation
+
+# Dynamic run name to show PR title
+run-name: "🔍 PR Check: ${{ github.event.pull_request.title }}"
+
+on:
+  pull_request:
+    branches: [development, uat, main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ==========================================
+  # Pre-Deployment Validation (Parallel)
+  # ==========================================
+  
+  lint-docs:
+    name: Lint Documentation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install markdownlint-cli
+        run: npm install -g markdownlint-cli
+
+      - name: Run markdownlint
+        run: |
+          markdownlint '**/*.md' \
+            --ignore 'node_modules/**' \
+            --ignore 'archived/**' \
+            --ignore 'docs/archived/**' \
+            --disable MD013 MD033 MD041 \
+            || echo "::warning::Markdown lint issues found. See above for details."
+  
+  # TEMPORARILY DISABLED: Blocking deployments with false positives
+  # Will re-enable after fixing grep logic to properly exclude archived files
+  check-docker-tags:
+    name: Validate Docker Tags
+    runs-on: ubuntu-latest
+    if: false  # DISABLED - unblocking pipeline
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      
+      - name: Validate immutable tagging in deployment workflows
+        run: |
+          echo "=== Validating immutable Docker image tagging ==="
+          
+          FAILED=0
+          FORBIDDEN_TAG="latest"
+          
+          # Check reusable-deploy.yml for immutable tagging patterns
+          echo "Checking reusable-deploy.yml..."
+          
+          # Deploy jobs must use SHA-tagged images, not the forbidden tag
+          # Exclude comments and this validation file itself from search
+          if grep -v '^\s*#' .github/workflows/reusable-deploy.yml | grep -q "docker pull.*:.*-${FORBIDDEN_TAG}" 2>/dev/null; then
+            echo "❌ ERROR: reusable-deploy.yml uses '-${FORBIDDEN_TAG}' tag in docker pull"
+            echo "   Deploy steps must use SHA-tagged images only"
+            FAILED=1
+          fi
+          
+          # Check for hardcoded forbidden tag in Docker run commands
+          if grep -v '^\s*#' .github/workflows/reusable-deploy.yml | grep -q "docker run.*:${FORBIDDEN_TAG}" 2>/dev/null; then
+            echo "❌ ERROR: reusable-deploy.yml uses ':${FORBIDDEN_TAG}' tag in docker run"
+            echo "   Deploy steps must use SHA-tagged images only"
+            FAILED=1
+          fi
+          
+          # Check main-pipeline.yml for proper tag patterns
+          echo "Checking main-pipeline.yml..."
+          if ! grep -q '\${{ github.sha }}' .github/workflows/main-pipeline.yml 2>/dev/null; then
+            echo "⚠️  WARNING: main-pipeline.yml may not use SHA-based tagging"
+          fi
+          
+          if [ $FAILED -eq 1 ]; then
+            echo ""
+            echo "=== VALIDATION FAILED ==="
+            echo "Deploy steps must pull images using SHA tags only."
+            echo "Example: \${{ env.REGISTRY }}/\${{ env.BACKEND_IMAGE }}:prod-\${{ github.sha }}"
+            echo ""
+            echo "Build steps can push both SHA and -${FORBIDDEN_TAG} tags for caching:"
+            echo "  - \${{ env.REGISTRY }}/\${{ env.BACKEND_IMAGE }}:prod-\${{ github.sha }}"
+            echo "  - \${{ env.REGISTRY }}/\${{ env.BACKEND_IMAGE }}:prod-${FORBIDDEN_TAG}"
+            exit 1
+          fi
+          
+          echo "✓ All deployment workflows use immutable tagging"


### PR DESCRIPTION
## 🎯 Separates PR Validation from Deployment Pipeline

Fixes noisy Auto-PR workflow triggers by decoupling CI validation from CD deployment.

## Problem

**Master Pipeline triggered on both PRs and deployments:**
- ❌ Auto-PR workflow triggered on every PR check
- ❌ Workflow history cluttered with validation + deployment runs
- ❌ PR checks ran unnecessary deployment job logic
- ❌ Confusing mix of CI validation and CD deployment

## Solution

### 1. Created `pr-validation.yml` (NEW)
**Purpose**: Handle all PR validation checks
- Triggers: `pull_request` only
- Jobs: `lint-docs`, `check-docker-tags`
- Run name: `🔍 PR Check: [PR title]`
- Independent from deployments

### 2. Updated `main-pipeline.yml`
**Purpose**: Pure deployment pipeline
- **REMOVED**: `pull_request` trigger
- **REMOVED**: `lint-docs` job
- **REMOVED**: `check-docker-tags` job
- **KEPT**: `deploy-dev`, `deploy-uat`, `deploy-prod` jobs
- Triggers: `push` (dev/uat/main) + `workflow_dispatch`
- Run name: `🚀 Deploy: [branch]`

## Workflow Routing

```mermaid
graph LR
    A[PR Opened/Updated] --> B[pr-validation.yml]
    B --> C[Lint Docs + Validate Tags]
    
    D[Push to dev/uat/main] --> E[main-pipeline.yml]
    E --> F[Build + Deploy]
    
    G[Manual Trigger] --> E
```

## Benefits

✅ **Clear separation** of CI validation vs CD deployment  
✅ **Auto-PR workflow** only triggers on actual deployments  
✅ **Faster PR checks** (no deployment job overhead)  
✅ **Cleaner history** - no more mixing validation with deployment  
✅ **No duplicate triggers** on PR checks  

## Before vs After

**Before:**
```
Master Pipeline (PR check on #1450)
Master Pipeline (Deploy to development)  
Master Pipeline (PR check on #1453)
Master Pipeline (Deploy to development)
```

**After:**
```
🔍 PR Check: fix: Isolate nginx configs...
🚀 Deploy: development
🔍 PR Check: feat: Add dynamic workflow names...
🚀 Deploy: development
```

## Testing

After merge:
1. **Open PR** → Should trigger `pr-validation.yml` only
2. **Merge to dev** → Should trigger `main-pipeline.yml` only
3. **Auto-PR workflow** should NOT trigger on PR checks

## Impact

- ✅ Existing PRs will use new `pr-validation.yml`
- ✅ Deployments continue using `main-pipeline.yml`
- ✅ No breaking changes to deployment logic
- ✅ Auto-PR workflow immediately cleaner