### PR TITLE
fix: Update Nginx SSL config to remove deprecation warning

### DIFF
--- a/deploy/nginx/frontend-ssl.conf
+++ b/deploy/nginx/frontend-ssl.conf
@@ -16,7 +16,8 @@ server {
 
 # HTTPS server
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name meatscentral.com www.meatscentral.com;
     
     root /usr/share/nginx/html;


### PR DESCRIPTION
## 🔧 Modernizes Nginx HTTP/2 Configuration

Fixes deprecation warning in Nginx 1.25.1+ by updating SSL configuration syntax.

## Problem

**Nginx deprecation warning in logs:**
```
nginx: [warn] the "listen ... http2" directive is deprecated, use "http2 on;" directive instead
```

The old syntax `listen 443 ssl http2;` is deprecated in favor of separate directives.

## Solution

Updated `deploy/nginx/frontend-ssl.conf`:

### Before (Deprecated):
```nginx
server {
    listen 443 ssl http2;
    server_name meatscentral.com www.meatscentral.com;
    # ...
}
```

### After (Modern):
```nginx
server {
    listen 443 ssl;
    http2 on;
    server_name meatscentral.com www.meatscentral.com;
    # ...
}
```

## Benefits

✅ **Removes deprecation warning** from Nginx logs  
✅ **Future-proofs config** for Nginx 1.25.1+  
✅ **Maintains HTTP/2** functionality (no behavioral change)  
✅ **Follows Nginx best practices**  

## Reference

- [Nginx HTTP/2 Module Documentation](https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2)
- [Nginx 1.25.1 Release Notes](https://nginx.org/en/CHANGES) (deprecation announcement)

## Note on Health Checks

✅ Health check scripts already have `-L` flag from **PR #1455**, so HTTP→HTTPS redirects are properly handled. No additional changes needed for health checks.

## Testing

After merge:
- ✅ HTTP/2 continues to work on HTTPS
- ✅ No deprecation warnings in Nginx logs
- ✅ No functional changes to frontend behavior