### PR TITLE
chore: Sync marker to ensure UAT gets workflow updates

### DIFF
--- a/.sync-marker
+++ b/.sync-marker
@@ -1,0 +1,6 @@
+# Sync Marker
+
+This ensures UAT gets the complete CI/CD workflow decoupling from PR #1458.
+
+Date: 2025-12-31 19:57:10 UTC
+


### PR DESCRIPTION
## 🔄 Ensures Complete Branch Synchronization

This adds a sync marker to trigger a fresh promotion to UAT, ensuring it gets the complete workflow decoupling from PR #1458.

### Current Issue

UAT's `main-pipeline.yml` still has the **old version** with `pull_request` trigger:
```yaml
github.event_name == 'pull_request' && format('🔍 PR Check: {0}', github.event.pull_request.title) ||
```

Development has the **correct version** without it (PR #1458 removed it).

### Why This Matters

- UAT and Production must exactly match Development
- The workflow decoupling change needs to be fully propagated
- Without this sync, UAT will still trigger on PRs incorrectly

### What This Does

1. Adds `.sync-marker` file (no functional impact)
2. Triggers fresh deployment to development
3. Auto-PR will create new UAT promotion with ALL changes
4. UAT will get the updated `main-pipeline.yml`
5. Clean path to production after UAT verification

### No Code Changes

- Just a marker file to trigger deployment
- Ensures branch consistency across environments
- Follows proper promotion workflow: dev → uat → prod

---

**This is the correct approach** - going through development first, then auto-promoting to UAT and production. ✅