### PR TITLE
fix: Add -L flag to deployment health checks to follow redirects

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -425,7 +425,7 @@ jobs:
           MAX_ATTEMPTS=5
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/health/ || echo "000")
+            HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/health/ || echo "000")
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✓ Backend health check passed (HTTP $HTTP_CODE)"
               exit 0
@@ -570,7 +570,7 @@ jobs:
           MAX_ATTEMPTS=5
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:80/ || echo "000")
+            HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" http://127.0.0.1:80/ || echo "000")
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✓ Frontend health check passed (HTTP $HTTP_CODE)"
               exit 0


### PR DESCRIPTION
## 🔧 Fixes Production Frontend Deployment Health Check

Resolves health check failure in production deployment.

### Problem

**Production frontend deployment failing:**
- Health check receiving HTTP 301 instead of 200
- Frontend container redirects `/` to landing page
- curl wasn't following the redirect
- Deployment failed: https://github.com/Meats-Central/ProjectMeats/actions/runs/20626398333

**Error logs:**
```
Health check attempt 1/5 (HTTP 301), retrying...
Health check attempt 2/5 (HTTP 301), retrying...
...
✗ Frontend health check failed after 5 attempts
```

### Solution

Added `-L` flag to curl commands in deployment workflow:

**Before:**
```bash
curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:80/
```

**After:**
```bash
curl -L -s -o /dev/null -w "%{http_code}" http://127.0.0.1:80/
```

The `-L` flag makes curl:
- Follow HTTP redirects (301, 302, 307, 308)
- Return the FINAL status code after all redirects
- Example: 301 → 200 returns 200 ✅

### Files Changed

`.github/workflows/reusable-deploy.yml`:
- Line 428: Backend health check (added -L)
- Line 573: Frontend health check (added -L)

### Consistency

This matches the fix already applied in PR #1455:
- ✅ `.github/scripts/health-check.sh`
- ✅ `.github/scripts/deployment-health-check.sh`
- ✅ `.github/workflows/reusable-deploy.yml` (this PR)

Now all health check locations use `-L` flag consistently.

### Testing

After merge and deployment:
- ✅ Backend health check will follow redirects
- ✅ Frontend health check will follow redirects
- ✅ Production deployment should succeed
- ✅ HTTP 301 → 200 will be handled correctly

---

**Fixes**: Production deployment health check failure
**Relates to**: PR #1455 (scripts), PR #1469 (production promotion)