### PR TITLE
fix: Heredoc validation script bash syntax error

### DIFF
--- a/.github/hooks/check-heredoc-syntax.sh
+++ b/.github/hooks/check-heredoc-syntax.sh
@@ -9,7 +9,8 @@ echo "🔍 Checking heredoc syntax in workflow files..."
 FAILED=0
 
 # Check all YAML workflow files
-for file in .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null; do
+shopt -s nullglob
+for file in .github/workflows/*.yml .github/workflows/*.yaml; do
   if [ ! -f "$file" ]; then
     continue
   fi


### PR DESCRIPTION
## 🔧 Fixes Bash Syntax Error in Validation Script

Resolves heredoc validation script failing with parse error.

### Problem

**Script failing immediately with syntax error:**
```
.github/hooks/check-heredoc-syntax.sh: line 12: syntax error near unexpected token '2'
##[error]Process completed with exit code 2
```

**Affected runs:**
- https://github.com/Meats-Central/ProjectMeats/actions/runs/20626668220
- All deployments after PR #1475

### Root Cause

**Line 12 had invalid bash syntax:**
```bash
for file in .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null; do
```

**Problem**: Bash doesn't allow redirections (`2>/dev/null`) in that position within a `for` loop declaration.

### Solution

Use `shopt -s nullglob` instead - the proper bash way to handle non-matching glob patterns.

**Before:**
```bash
for file in .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null; do
```

**After:**
```bash
shopt -s nullglob
for file in .github/workflows/*.yml .github/workflows/*.yaml; do
```

### How `nullglob` Works

- **Default behavior**: Non-matching glob returns literal pattern string
- **With nullglob**: Non-matching glob expands to nothing (empty list)
- **Result**: Loop body doesn't execute if no files match

### Benefits

✅ **Proper bash syntax** (no parse errors)  
✅ **Cleaner code** (no stderr redirection hacks)  
✅ **Same behavior** (handles missing files correctly)  
✅ **Validation passes** (script can execute)  

### Testing

Script now passes:
```bash
bash -n .github/hooks/check-heredoc-syntax.sh
✅ Script syntax is valid
```

---

**Fixes the validation script so heredoc checking can actually runecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* 🚀