### PR TITLE
fix: Unindent heredoc closing delimiters in workflows

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -138,7 +138,7 @@ jobs:
           - [ ] Check for any breaking changes
           - [ ] Confirm all tests passed in development
           
-          PRBODY
+PRBODY
           
           if [ "$HAS_CONFLICTS" = "true" ]; then
             cat >> /tmp/pr-body.md <<'CONFLICT'
@@ -152,7 +152,7 @@ jobs:
           
           Please review the conflict resolution before merging.
           
-          CONFLICT
+CONFLICT
           fi
           
           cat >> /tmp/pr-body.md <<'PRBODY'
@@ -161,7 +161,7 @@ jobs:
           
           ---
           _This PR was automatically created after successful development deployment._
-          PRBODY
+PRBODY
           
           echo "" >> /tmp/pr-body.md
           echo "**Commits included:** $COMMIT_COUNT commits" >> /tmp/pr-body.md
@@ -319,7 +319,7 @@ jobs:
           
           **⚠️ PRODUCTION DEPLOYMENT** - Requires additional approval
           
-          PRBODY
+PRBODY
           
           if [ "$HAS_CONFLICTS" = "true" ]; then
             cat >> /tmp/pr-body.md <<'CONFLICT'
@@ -333,7 +333,7 @@ jobs:
           
           Please review the conflict resolution before merging to production.
           
-          CONFLICT
+CONFLICT
           fi
           
           cat >> /tmp/pr-body.md <<'PRBODY'
@@ -342,7 +342,7 @@ jobs:
           
           ---
           _This PR was automatically created after successful UAT deployment._
-          PRBODY
+PRBODY
           
           echo "" >> /tmp/pr-body.md
           echo "**Commits included:** $COMMIT_COUNT commits" >> /tmp/pr-body.md

--- a/.github/workflows/branch-sync-check.yml
+++ b/.github/workflows/branch-sync-check.yml
@@ -89,7 +89,7 @@ jobs:
           
           ### Sync Status
           
-          PRBODY
+PRBODY
           
           echo "- **Commits to sync:** $COMMITS" >> /tmp/sync-pr-body.md
           echo "- **File differences:** ${{ steps.check_drift.outputs.file_diff }} lines" >> /tmp/sync-pr-body.md
@@ -105,7 +105,7 @@ jobs:
           
           ---
           _This PR was automatically created by the branch sync monitor._
-          PRBODY
+PRBODY
           
           gh pr create \
             --base uat \


### PR DESCRIPTION
## 🔧 Fixes Heredoc Validation Failures

Completes the heredoc syntax fixes identified in audit (PR #1475).

### Problem

**Deployments blocked by heredoc validation:**
- Validation script (PR #1478) is now working correctly
- Detecting the 8 indented heredoc closers we found in audit

**Error logs:**
```
❌ ERROR in .github/workflows/auto-pr.yml:
   Line 122: Heredoc 'PRBODY' has INDENTED closing delimiter
❌ ERROR in .github/workflows/branch-sync-check.yml:
   Line 92: Heredoc 'PRBODY' has INDENTED closing delimiter
❌ Heredoc syntax validation FAILED
```

### Issues Fixed

**auto-pr.yml**: 6 indented closers
- Line 122: PRBODY ✅
- Line 136: CONFLICT ✅
- Line 145: PRBODY ✅
- Line 284: PRBODY ✅
- Line 298: CONFLICT ✅
- Line 307: PRBODY ✅

**branch-sync-check.yml**: 2 indented closers
- Line 92: PRBODY ✅
- Line 108: PRBODY ✅

### Root Cause

Heredoc closing delimiters **must** be at column 0 (no spaces/tabs) unless using `<<-` operator.

**Invalid:**
```yaml
run: |
  cat > file.txt << 'EOF'
  content
          EOF  # ❌ 10 spaces of indentation
```

**Valid:**
```yaml
run: |
  cat > file.txt << 'EOF'
  content
EOF  # ✅ NO indentation
```

### Solution

Removed all indentation from PRBODY and CONFLICT closing delimiters.

**Changes:**
```diff
-          PRBODY
+PRBODY

-          CONFLICT
+CONFLICT
```

### Verification

Script validation passes:
```bash
.github/hooks/check-heredoc-syntax.sh
🔍 Checking heredoc syntax in workflow files...
✅ All heredoc syntax is valid
```

### What This Completes

✅ **PR #1475**: Created heredoc validation (Step 4)  
✅ **PR #1478**: Fixed validation script syntax  
✅ **PR #1479 (this)**: Fixed all detected heredoc issues  

**The validation system is now fully operational and protecting against deployment failuresecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*

---

**Fixes**: https://github.com/Meats-Central/ProjectMeats/actions/runs/20626712165