### PR TITLE
fix: Prevent false-positive failures in auto-pr and branch-sync workflows

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -13,6 +13,17 @@ on:
       - uat
 
 jobs:
+  # No-op job to prevent "0 jobs = failure" when triggered by non-workflow_run events
+  noop:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_run'
+    steps:
+      - name: Skip - wrong trigger
+        run: |
+          echo "ℹ️  Auto-PR workflow only runs on workflow_run events"
+          echo "Current event: ${{ github.event_name }}"
+          echo "This workflow will skip execution."
+
   draft-uat-pr:
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/branch-sync-check.yml
+++ b/.github/workflows/branch-sync-check.yml
@@ -20,9 +20,21 @@ permissions:
   pull-requests: write
 
 jobs:
+  # No-op job to prevent "0 jobs = failure" when triggered by non-schedule/workflow_dispatch events
+  noop:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Skip - wrong trigger
+        run: |
+          echo "ℹ️  Branch Sync Monitor only runs on schedule or workflow_dispatch events"
+          echo "Current event: ${{ github.event_name }}"
+          echo "This workflow will skip execution."
+
   check-dev-to-uat-sync:
     name: Check Development → UAT Sync
     runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
       - uses: actions/checkout@v4
@@ -117,6 +129,7 @@ PRBODY
   check-uat-to-prod-sync:
     name: Check UAT → Production Sync
     runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
       - uses: actions/checkout@v4
@@ -173,7 +186,7 @@ PRBODY
     name: Sync Status Summary
     runs-on: ubuntu-latest
     needs: [check-dev-to-uat-sync, check-uat-to-prod-sync]
-    if: always()
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && always()
     
     steps:
       - name: Generate summary


### PR DESCRIPTION
## 🔧 Fixes GitHub Actions "0 Jobs = Failure" Issue

Resolves the false-positive workflow failures that occur when workflows are triggered on the wrong event type.

### Problem

**Affected Workflows:**
- `auto-pr.yml` - Expects `workflow_run`, gets `push`
- `branch-sync-check.yml` - Expects `schedule`/`workflow_dispatch`, gets `push`

**Failed Runs:**
- https://github.com/Meats-Central/ProjectMeats/actions/runs/20627198683
- https://github.com/Meats-Central/ProjectMeats/actions/runs/20627198580
- https://github.com/Meats-Central/ProjectMeats/actions/runs/20626857317
- https://github.com/Meats-Central/ProjectMeats/actions/runs/20626857270

**Root Cause:**
GitHub evaluates ALL workflow files on ANY push event. When a workflow's jobs don't match the event conditions, 0 jobs execute, and GitHub marks this as `FAILURE`.

### Solution

Added **lightweight no-op jobs** that execute when the wrong event triggers the workflow:

#### auto-pr.yml
```yaml
jobs:
  noop:
    runs-on: ubuntu-latest
    if: github.event_name != 'workflow_run'
    steps:
      - run: echo "ℹ️  Auto-PR workflow only runs on workflow_run events"
```

#### branch-sync-check.yml
```yaml
jobs:
  noop:
    runs-on: ubuntu-latest
    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
    steps:
      - run: echo "ℹ️  Branch Sync Monitor only runs on schedule/workflow_dispatch"
```

### How It Works

**Before:**
1. Push to development
2. GitHub evaluates auto-pr.yml and branch-sync-check.yml
3. No jobs match conditions (wrong event type)
4. 0 jobs execute → ❌ FAILURE

**After:**
1. Push to development
2. GitHub evaluates auto-pr.yml and branch-sync-check.yml
3. No main jobs match, but noop job runs
4. Noop logs skip message → ✅ SUCCESS

### Benefits

✅ **No more false failures** - workflows succeed with skip message  
✅ **Minimal overhead** - noop jobs only echo a message  
✅ **Clear logging** - explains why workflow skipped  
✅ **No functional changes** - real jobs still run on correct events  
✅ **Cleaner history** - workflow list shows green instead of red  

### Changes Made

**auto-pr.yml:**
- Added noop job when `event_name != 'workflow_run'`

**branch-sync-check.yml:**
- Added noop job when `event_name != 'schedule' && event_name != 'workflow_dispatch'`
- Added event checks to all real jobs (`check-dev-to-uat-sync`, `check-uat-to-prod-sync`, `summary`)

### Testing

After merge:
- Push to any branch will trigger these workflows
- Noop jobs will run and succeed
- No more false-positive failures
- Real jobs still only run on correct triggers

---

**Implements the delegation prompt recommendationecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* 🚀