### PR TITLE
fix: Add explicit push triggers to make noop jobs execute

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -4,6 +4,10 @@ name: 🤖 Auto-Draft Release PR
 run-name: "📋 Draft Promotion: ${{ github.event.workflow_run.head_branch }} → ${{ github.event.workflow_run.head_branch == 'development' && 'UAT' || 'Production' }}"
 
 on:
+  push:
+    # Explicit push trigger to prevent GitHub from treating "no matching jobs" as failure
+    # This ensures the noop job runs when push events occur
+    branches: ['**']
   workflow_run:
     workflows: ["Master Pipeline"]
     types:

--- a/.github/workflows/branch-sync-check.yml
+++ b/.github/workflows/branch-sync-check.yml
@@ -4,6 +4,10 @@ name: 🔄 Branch Sync Monitor
 run-name: "🔍 Sync Check: ${{ github.event_name == 'schedule' && 'Daily' || 'Manual' }}"
 
 on:
+  push:
+    # Explicit push trigger to prevent GitHub from treating "no matching jobs" as failure
+    # This ensures the noop job runs when push events occur
+    branches: ['**']
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'


### PR DESCRIPTION
## 🔧 Fixes Noop Jobs Not Executing

Completes the fix from PR #1482.

### Problem

PR #1482 added noop jobs, but they're not executing:
- Workflows still failing with 0 jobs
- Noop jobs never run
- Same failure pattern continues

**Why:**
GitHub workflows WITHOUT explicit `push` triggers are evaluated differently. The workflow file is checked, but jobs may not execute.

### Solution

Add explicit `push` trigger to both workflows:

```yaml
on:
  push:
    branches: ['**']  # Match all branches
  workflow_run: ...  # Original triggers remain
```

### How This Works

**Before (PR #1482):**
```yaml
on:
  workflow_run: ...  # No explicit push
jobs:
  noop:
    if: github.event_name != 'workflow_run'
```
- Push occurs
- GitHub checks workflow file
- No explicit push trigger → special evaluation
- Jobs don't execute → 0 jobs → FAILURE ❌

**After (This PR):**
```yaml
on:
  push:
    branches: ['**']  # Explicit push trigger
  workflow_run: ...
jobs:
  noop:
    if: github.event_name != 'workflow_run'
```
- Push occurs
- Explicit push trigger → normal evaluation
- Noop job condition matches → executes
- Job succeeds → SUCCESS ✅

### Changes

**auto-pr.yml:**
```yaml
on:
  push:
    branches: ['**']
  workflow_run: ...
```

**branch-sync-check.yml:**
```yaml
on:
  push:
    branches: ['**']
  schedule: ...
  workflow_dispatch: ...
```

### Testing

After merge:
1. Push to any branch
2. Both workflows will trigger
3. Noop jobs will execute and log skip messages
4. Workflows will show SUCCESS status
5. No more false-positive failures

---

**This should finally fix the false-positive failuresecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* 🚀