### PR TITLE
fix: Remove push triggers entirely from auto-pr and branch-sync

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -4,10 +4,6 @@ name: 🤖 Auto-Draft Release PR
 run-name: "📋 Draft Promotion: ${{ github.event.workflow_run.head_branch }} → ${{ github.event.workflow_run.head_branch == 'development' && 'UAT' || 'Production' }}"
 
 on:
-  push:
-    # Explicit push trigger to prevent GitHub from treating "no matching jobs" as failure
-    # This ensures the noop job runs when push events occur
-    branches: ['**']
   workflow_run:
     workflows: ["Master Pipeline"]
     types:
@@ -17,17 +13,6 @@ on:
       - uat
 
 jobs:
-  # No-op job to prevent "0 jobs = failure" when triggered by non-workflow_run events
-  noop:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_run'
-    steps:
-      - name: Skip - wrong trigger
-        run: |
-          echo "ℹ️  Auto-PR workflow only runs on workflow_run events"
-          echo "Current event: ${{ github.event_name }}"
-          echo "This workflow will skip execution."
-
   draft-uat-pr:
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/branch-sync-check.yml
+++ b/.github/workflows/branch-sync-check.yml
@@ -4,10 +4,6 @@ name: 🔄 Branch Sync Monitor
 run-name: "🔍 Sync Check: ${{ github.event_name == 'schedule' && 'Daily' || 'Manual' }}"
 
 on:
-  push:
-    # Explicit push trigger to prevent GitHub from treating "no matching jobs" as failure
-    # This ensures the noop job runs when push events occur
-    branches: ['**']
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
@@ -24,21 +20,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  # No-op job to prevent "0 jobs = failure" when triggered by non-schedule/workflow_dispatch events
-  noop:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    steps:
-      - name: Skip - wrong trigger
-        run: |
-          echo "ℹ️  Branch Sync Monitor only runs on schedule or workflow_dispatch events"
-          echo "Current event: ${{ github.event_name }}"
-          echo "This workflow will skip execution."
-
   check-dev-to-uat-sync:
     name: Check Development → UAT Sync
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
       - uses: actions/checkout@v4
@@ -133,7 +117,6 @@ PRBODY
   check-uat-to-prod-sync:
     name: Check UAT → Production Sync
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
       - uses: actions/checkout@v4
@@ -190,7 +173,7 @@ PRBODY
     name: Sync Status Summary
     runs-on: ubuntu-latest
     needs: [check-dev-to-uat-sync, check-uat-to-prod-sync]
-    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && always()
+    if: always()
     
     steps:
       - name: Generate summary


### PR DESCRIPTION
## 🎯 Final Fix: Remove Push Triggers Completely

This reverses the previous two attempts and implements the simplest solution.

### What We Tried (That Didn't Work)

**Attempt 1 (PR #1482):** Added noop jobs
- Result: Jobs didn't execute, still got 0 jobs = failure

**Attempt 2 (PR #1483):** Added explicit push triggers
- Noop jobs ran but workflows still appeared in push history

### The Real Solution

**Remove push triggers entirely** and let these workflows ONLY trigger on their intended events:

**auto-pr.yml:**
- ✅ ONLY triggers on: `workflow_run` (after Master Pipeline completes)
- ❌ NO push trigger

**branch-sync-check.yml:**
- ✅ ONLY triggers on: `schedule` (daily) or `workflow_dispatch` (manual)
- ❌ NO push trigger

### Why This Works

When workflows don't have push in their triggers, GitHub may evaluate the YAML but:
1. Workflow doesn't appear in push event workflow runs
2. Any evaluation failures are internal/hidden
3. Cleaner workflow history (only shows when actually triggered)

### Changes Made

1. **auto-pr.yml:**
   - Removed `push:` trigger block
   - Removed `noop` job
   - Clean: only `workflow_run` trigger

2. **branch-sync-check.yml:**
   - Removed `push:` trigger block
   - Removed `noop` job
   - Removed redundant `if: github.event_name == ...` conditions
   - Clean: only `schedule` and `workflow_dispatch` triggers

### Expected Behavior After Merge

**On push to any branch:**
- ✅ Main Pipeline runs (deploys)
- ✅ PR Validation runs (if PR)
- ❌ Auto-PR workflow: won't appear in workflow list
- ❌ Branch Sync: won't appear in workflow list

**When Master Pipeline completes:**
- ✅ Auto-PR workflow triggers (creates UAT/prod PRs)

**Daily at 00:00 UTC:**
- ✅ Branch Sync workflow triggers (checks drift)

### Benefits

✅ Cleaner workflow history - no noise from unintended triggers  
✅ No false-positive failures  
✅ Workflows only run when they should  
✅ Simpler code - no noop jobs needed  

---

**This is the correct approach recommended by the userecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* 🎯