### PR TITLE
fix: Add heartbeat status-check job to prevent false-positive failures

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -371,3 +371,10 @@ PRBODY
           else
             gh pr edit "$PR_NUMBER" --add-label "release,automated,production" || echo "⚠️  Could not add labels"
           fi
+
+  status-check:
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Validate Workflow Trigger
+        run: echo "✅ Workflow triggered successfully (This job prevents false-positive failures)"

--- a/.github/workflows/branch-sync-check.yml
+++ b/.github/workflows/branch-sync-check.yml
@@ -189,3 +189,10 @@ PRBODY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "_Next check: $(date -u -d '+1 day' +"%Y-%m-%d") 00:00 UTC_" >> $GITHUB_STEP_SUMMARY
+
+  status-check:
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Validate Workflow Trigger
+        run: echo "✅ Workflow triggered successfully (This job prevents false-positive failures)"


### PR DESCRIPTION
## 🩺 Heartbeat Pattern Fix

Implements the **"Keepalive" job pattern** to ensure workflows always report SUCCESS instead of FAILURE when jobs are skipped.

### The Problem (Final Root Cause)

GitHub Actions has this behavior:
- Workflow triggers (either explicitly or via evaluation)
- All jobs have `if:` conditions that don't match
- **0 jobs execute**
- GitHub marks workflow as **FAILURE** ❌

### The Solution (Heartbeat Job)

Add a lightweight `status-check` job that **always runs**:

```yaml
status-check:
  runs-on: ubuntu-latest
  if: always()  # ⬅️ KEY: Runs regardless of other conditions
  steps:
    - run: echo "✅ Workflow triggered successfully"
```

### How It Works

**Before (PR #1484 - Still Failing):**
1. Workflow triggers
2. Main jobs check conditions (`if: github.event.workflow_run.head_branch == 'development'`)
3. Conditions don't match → all jobs skip
4. 0 jobs execute → ❌ FAILURE

**After (This PR - Always Success):**
1. Workflow triggers
2. Main jobs check conditions → skip
3. **status-check job runs** (`if: always()`)
4. 1 job executes successfully → ✅ SUCCESS

### Changes Made

**auto-pr.yml:**
```yaml
jobs:
  draft-uat-pr:
    if: github.event.workflow_run.head_branch == 'development'
    # ... (main logic)
  
  draft-production-pr:
    if: github.event.workflow_run.head_branch == 'uat'
    # ... (main logic)
  
  status-check:  # ⬅️ NEW: Always runs
    runs-on: ubuntu-latest
    if: always()
    steps:
      - run: echo "✅ Workflow triggered successfully"
```

**branch-sync-check.yml:**
```yaml
jobs:
  check-dev-to-uat-sync:
    # ... (main logic)
  
  check-uat-to-prod-sync:
    # ... (main logic)
  
  summary:
    needs: [check-dev-to-uat-sync, check-uat-to-prod-sync]
    if: always()
    # ... (summary logic)
  
  status-check:  # ⬅️ NEW: Always runs
    runs-on: ubuntu-latest
    if: always()
    steps:
      - run: echo "✅ Workflow triggered successfully"
```

### Why This Fix Works

✅ **Guaranteed Execution**: `if: always()` ensures job runs regardless of trigger  
✅ **Minimal Overhead**: Single `echo` command (< 1 second)  
✅ **No Side Effects**: Doesn't interfere with main job logic  
✅ **Clean History**: Workflows show green SUCCESS instead of red FAILURE  
✅ **Industry Standard**: This is the recommended GitHub pattern for this issue  

### Expected Behavior After Merge

**Scenario 1: Push to development**
- Master Pipeline runs → deploys
- Master Pipeline completes → triggers auto-pr.yml
- auto-pr conditions match → draft-uat-pr runs → creates PR ✅
- status-check also runs → SUCCESS ✅

**Scenario 2: Push to feature branch**
- Master Pipeline runs (no deployment for feature branches)
- Master Pipeline completes → triggers auto-pr.yml
- auto-pr conditions DON'T match → main jobs skip
- **status-check runs** → SUCCESS ✅ (instead of FAILURE ❌)

**Scenario 3: Daily schedule trigger (00:00 UTC)**
- branch-sync-check triggers
- Checks run, summary runs
- status-check runs → SUCCESS ✅

**Scenario 4: Random push event (ghost trigger)**
- branch-sync-check evaluated
- Main jobs don't run (wrong trigger)
- **status-check runs** → SUCCESS ✅ (instead of FAILURE ❌)

### Testing Plan

After merge:
1. ✅ Push to development → verify auto-pr creates UAT PR
2. ✅ Push to feature branch → verify workflow shows SUCCESS (not FAILURE)
3. ✅ Check workflow history → no more red failure dots
4. ✅ Wait for daily schedule → verify branch-sync runs successfully

### References

This implements the **Heartbeat Pattern** recommended in the user's prompt:
> "To fix this 'cosmetic' but annoying error, you must ensure at least one job always runs—even if it does nothing."

---

**🎯 This is the REAL fixecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* The previous attempts didn't work because we didn't use `if: always()` - the key to forcing job execution.