### PR TITLE
fix: Make security scanning non-blocking for V1.1

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -135,11 +135,12 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   # ==========================================
-  # Stage 1.5: Security Scan
+  # Stage 1.5: Security Scan (Non-Blocking)
   # ==========================================
   security-scan:
     needs: [build-and-push]
     runs-on: ubuntu-latest
+    continue-on-error: true  # Don't block deployment on vulnerabilities
     strategy:
       matrix:
         app: [frontend, backend]
@@ -155,7 +156,7 @@ jobs:
           output: 'trivy-results-${{ matrix.app }}.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '1'
+          exit-code: '0'  # Don't fail the job, just report
         env:
           TRIVY_USERNAME: ${{ secrets.DO_ACCESS_TOKEN }}
           TRIVY_PASSWORD: ${{ secrets.DO_ACCESS_TOKEN }}

--- a/docs/GOLDEN_PIPELINE.md
+++ b/docs/GOLDEN_PIPELINE.md
@@ -114,9 +114,11 @@ python manage.py migrate --fake-initial --noinput
 
 ### Security Scanning
 - **Trivy Integration**: Scans images for CRITICAL and HIGH vulnerabilities
-- **Fail-Fast**: Deployment blocked if critical CVEs found
+- **Non-Blocking**: Reports CVEs to GitHub Security but allows deployment to proceed
 - **Unfixed Exclusion**: Ignores vulnerabilities without patches (reduces false positives)
-- **SARIF Upload**: Results visible in GitHub Security tab
+- **SARIF Upload**: Results visible in GitHub Security tab for review
+
+**Rationale**: Security scanning is informational in V1.1. Future versions will implement blocking policies after baseline vulnerability remediation.
 
 ### Frontend Stack
 - **TypeScript 5.7.2**: Latest stable with React 19 support


### PR DESCRIPTION
## 🎯 Problem
PR #1500 added Trivy security scanning with exit-code: 1, which blocks deployments when CVEs are found.

## 🔧 Solution
Make security scanning informational for V1.1:
- Set continue-on-error: true on security-scan job
- Change Trivy exit-code from 1 to 0 (report only)
- CVE reports still uploaded to GitHub Security tab

## 📊 Impact
- Deployments proceed even with inherited vulnerabilities
- Security team can review SARIF reports in GitHub Security
- Gradual hardening: V1.1 (scan+report) → V1.2 (block new CVEs) → V1.3 (block all CVEs)