### PR TITLE
fix: Correct devcontainer build context and dockerfile path

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: .devcontainer
-          file: .devcontainer/Dockerfile
+          context: .
+          file: .devcontainer/Dockerfile.dev
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem
The devcontainer image build was failing with 'failed to read dockerfile' error.

## Root Cause
1. **Filename mismatch**: Workflow looked for `Dockerfile` but file is named `Dockerfile.dev`
2. **Context scope**: Build context was `.devcontainer` which prevented access to `backend/requirements.txt`

## Solution
- Changed `context` from `.devcontainer` to `.` (repo root)
- Changed `file` from `Dockerfile` to `Dockerfile.dev`

## Testing
- Verified changes with `grep -A 5 'docker/build-push-action'`
- Workflow will now correctly build devcontainer image

Resolves workflow failure: https://github.com/Meats-Central/ProjectMeats/actions/runs/20629042099/job/59244137596