### PR TITLE
feat: Add superuser setup and email configuration to deployment pipeline

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -411,6 +411,48 @@ jobs:
           echo ""
           echo "✓ Migrations completed successfully"
       
+      - name: Setup Superuser
+        env:
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+          DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
+          DJANGO_SUPERUSER_USERNAME: ${{ secrets.DJANGO_SUPERUSER_USERNAME }}
+          DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
+          DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
+        run: |
+          echo "================================"
+          echo "Setting up Django Superuser"
+          echo "================================"
+          
+          # Construct DATABASE_URL pointing to tunnel
+          DATABASE_URL="postgresql://$DB_USER:$DB_PASSWORD@127.0.0.1:5433/$DB_NAME"
+          
+          # Use same image as migrations
+          IMAGE_TAG="${{ inputs.environment }}-${{ github.sha }}"
+          FULL_IMAGE="${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${IMAGE_TAG}"
+          
+          echo "Using image: $FULL_IMAGE"
+          echo ""
+          echo "Creating/updating superuser..."
+          
+          # Run setup_superuser management command
+          docker run --rm \
+            --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" \
+            -e SECRET_KEY="$DJANGO_SECRET_KEY" \
+            -e DB_ENGINE="django.db.backends.postgresql" \
+            -e DJANGO_SUPERUSER_USERNAME="$DJANGO_SUPERUSER_USERNAME" \
+            -e DJANGO_SUPERUSER_PASSWORD="$DJANGO_SUPERUSER_PASSWORD" \
+            -e DJANGO_SUPERUSER_EMAIL="$DJANGO_SUPERUSER_EMAIL" \
+            "$FULL_IMAGE" \
+            python manage.py setup_superuser
+          
+          echo ""
+          echo "✓ Superuser setup completed"
+      
       - name: Cleanup SSH tunnel
         if: always()
         run: |

--- a/config/env.manifest.json
+++ b/config/env.manifest.json
@@ -1,8 +1,8 @@
 {
   "project": "ProjectMeats",
-  "version": "5.0",
+  "version": "5.1",
   "description": "Environment-Scoped Secrets (NO prefixes) - Aligned with Working Pipeline",
-  "last_updated": "2025-12-31",
+  "last_updated": "2026-01-02",
   "architecture": "GitHub Environment Secrets with identical names across all environments",
   "environments": {
     "dev-backend": {
@@ -139,6 +139,18 @@
           "production-backend": "projectmeats.settings.production"
         }
       },
+      "ALLOWED_HOSTS": {
+        "description": "Comma-separated list of allowed hosts for Django",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "values": {
+          "dev-backend": "dev.meatscentral.com,.meatscentral.com,157.245.114.182",
+          "uat-backend": "uat.meatscentral.com,.meatscentral.com",
+          "production-backend": "meatscentral.com,.meatscentral.com,www.meatscentral.com"
+        },
+        "note": "Include leading dot (.meatscentral.com) for wildcard subdomain support"
+      },
       "DJANGO_SUPERUSER_USERNAME": {
         "description": "Django superuser username",
         "scope": "environment",
@@ -155,6 +167,57 @@
         "description": "Django superuser password",
         "scope": "environment",
         "required": false,
+        "applies_to": ["backend environments"]
+      },
+      "EMAIL_BACKEND": {
+        "description": "Django email backend class",
+        "scope": "environment",
+        "required": false,
+        "default": "django.core.mail.backends.smtp.EmailBackend",
+        "applies_to": ["backend environments"],
+        "note": "Use console backend for dev, SMTP for production"
+      },
+      "EMAIL_HOST": {
+        "description": "SMTP server hostname",
+        "scope": "environment",
+        "required": false,
+        "default": "smtp.sendgrid.net",
+        "applies_to": ["backend environments"]
+      },
+      "EMAIL_PORT": {
+        "description": "SMTP server port",
+        "scope": "environment",
+        "required": false,
+        "default": "587",
+        "applies_to": ["backend environments"]
+      },
+      "EMAIL_USE_TLS": {
+        "description": "Enable TLS for email",
+        "scope": "environment",
+        "required": false,
+        "default": "True",
+        "applies_to": ["backend environments"]
+      },
+      "EMAIL_HOST_USER": {
+        "description": "SMTP authentication username",
+        "scope": "environment",
+        "required": false,
+        "default": "apikey",
+        "applies_to": ["backend environments"],
+        "note": "For SendGrid, use 'apikey' as username"
+      },
+      "EMAIL_HOST_PASSWORD": {
+        "description": "SMTP authentication password or API key",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "note": "For SendGrid, this is your API key"
+      },
+      "DEFAULT_FROM_EMAIL": {
+        "description": "Default email address for outgoing emails",
+        "scope": "environment",
+        "required": false,
+        "default": "noreply@meatscentral.com",
         "applies_to": ["backend environments"]
       }
     },
@@ -197,8 +260,10 @@
       "BACKEND_HOST", "REACT_APP_API_BASE_URL"
     ],
     "optional_secrets": [
-      "SSH_KEY", "DB_PORT",
+      "SSH_KEY", "DB_PORT", "ALLOWED_HOSTS",
       "DJANGO_SUPERUSER_USERNAME", "DJANGO_SUPERUSER_EMAIL", "DJANGO_SUPERUSER_PASSWORD",
+      "EMAIL_BACKEND", "EMAIL_HOST", "EMAIL_PORT", "EMAIL_USE_TLS", 
+      "EMAIL_HOST_USER", "EMAIL_HOST_PASSWORD", "DEFAULT_FROM_EMAIL",
       "REACT_APP_ENVIRONMENT", "REACT_APP_AI_ASSISTANT_ENABLED"
     ]
   },


### PR DESCRIPTION
## Summary
This PR adds automated superuser management and standardizes email configuration across all deployment environments.

## Changes

### 1. Superuser Automation
- ✅ Added 'Setup Superuser' step to `.github/workflows/reusable-deploy.yml` after migrations
- ✅ Updated `setup_superuser` command to prioritize `DJANGO_SUPERUSER_*` environment variables
- ✅ Maintains backward compatibility with environment-specific variables (`DEVELOPMENT_SUPERUSER_*`, etc.)
- ✅ Runs during every deployment to ensure superuser exists and password is synced

### 2. Email Configuration (env.manifest.json v5.1)
Added comprehensive email backend settings:
- `EMAIL_BACKEND` (default: django.core.mail.backends.smtp.EmailBackend)
- `EMAIL_HOST` (default: smtp.sendgrid.net)
- `EMAIL_PORT` (default: 587)
- `EMAIL_USE_TLS` (default: True)
- `EMAIL_HOST_USER` (default: apikey for SendGrid)
- `EMAIL_HOST_PASSWORD` (SendGrid API key)
- `DEFAULT_FROM_EMAIL` (default: noreply@meatscentral.com)

### 3. ALLOWED_HOSTS Configuration
Added `ALLOWED_HOSTS` to backend_application section with wildcard subdomain support:
- **dev-backend**: `dev.meatscentral.com,.meatscentral.com,157.245.114.182`
- **uat-backend**: `uat.meatscentral.com,.meatscentral.com`
- **production-backend**: `meatscentral.com,.meatscentral.com,www.meatscentral.com`

Note: Leading dot (`.meatscentral.com`) enables wildcard subdomain matching.

## Files Changed
1. `.github/workflows/reusable-deploy.yml` - Added Setup Superuser step
2. `backend/apps/core/management/commands/setup_superuser.py` - Support DJANGO_SUPERUSER_* vars
3. `config/env.manifest.json` - Updated to v5.1 with email and ALLOWED_HOSTS

## Testing
- ✅ Workflow step runs after migrations with correct environment variables
- ✅ setup_superuser command reads DJANGO_SUPERUSER_* variables first
- ✅ Backward compatibility maintained for existing deployments
- ✅ Email configuration follows Django best practices

## Required Secrets
To use these features, ensure the following secrets are set in GitHub Environments:
- `DJANGO_SUPERUSER_USERNAME`
- `DJANGO_SUPERUSER_PASSWORD`
- `DJANGO_SUPERUSER_EMAIL`
- `EMAIL_HOST_PASSWORD` (optional, for SendGrid)
- `ALLOWED_HOSTS` (optional, uses manifest defaults)

## Impact
- Eliminates manual superuser management
- Standardizes email configuration across environments
- Enables proper wildcard subdomain support for multi-tenant architecture

## Next Steps
1. Set required GitHub Environment secrets for dev/uat/production
2. Verify superuser creation on next deployment
3. Configure SendGrid API key for production email

Resolves: Superuser automation, email configuration, and ALLOWED_HOSTS wildcard support