### PR TITLE
feat: Add environment-specific wildcard support for ALLOWED_HOSTS

### DIFF
--- a/backend/projectmeats/settings/development.py
+++ b/backend/projectmeats/settings/development.py
@@ -29,6 +29,7 @@ ALLOWED_HOSTS = [
     "127.0.0.1",
     "testserver",
     "0.0.0.0",
+    ".dev.meatscentral.com",  # Wildcard for *.dev.meatscentral.com
     ".meatscentral.com",  # Wildcard for all subdomains
     "dev.meatscentral.com",
     "dev-backend.meatscentral.com",

--- a/backend/projectmeats/settings/staging.py
+++ b/backend/projectmeats/settings/staging.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 DEBUG = config("DEBUG", default=False, cast=bool)
 
 # Staging-specific allowed hosts - read from environment
-env_allowed_hosts = config("ALLOWED_HOSTS", default="localhost,127.0.0.1")
+# Default includes wildcards for UAT subdomain and all meatscentral.com subdomains
+env_allowed_hosts = config("ALLOWED_HOSTS", default="localhost,127.0.0.1,.uat.meatscentral.com,.meatscentral.com")
 ALLOWED_HOSTS = [host.strip() for host in env_allowed_hosts.split(",") if host.strip()]
 
 # Always include localhost for Docker health checks
@@ -26,6 +27,15 @@ if "localhost" not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append("localhost")
 if "127.0.0.1" not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append("127.0.0.1")
+
+# Ensure wildcard patterns are included for UAT
+WILDCARD_HOSTS = [
+    ".uat.meatscentral.com",  # Wildcard for *.uat.meatscentral.com
+    ".meatscentral.com",  # Wildcard for *.meatscentral.com
+]
+for wildcard in WILDCARD_HOSTS:
+    if wildcard not in ALLOWED_HOSTS:
+        ALLOWED_HOSTS.append(wildcard)
 
 # Add UAT hosts (primary) and legacy staging hosts (deprecated)
 STAGING_HOSTS = [

--- a/config/env.manifest.json
+++ b/config/env.manifest.json
@@ -145,11 +145,11 @@
         "required": false,
         "applies_to": ["backend environments"],
         "values": {
-          "dev-backend": "dev.meatscentral.com,.meatscentral.com,157.245.114.182",
-          "uat-backend": "uat.meatscentral.com,.meatscentral.com",
+          "dev-backend": "dev.meatscentral.com,.dev.meatscentral.com,.meatscentral.com,157.245.114.182",
+          "uat-backend": "uat.meatscentral.com,.uat.meatscentral.com,.meatscentral.com",
           "production-backend": "meatscentral.com,.meatscentral.com,www.meatscentral.com"
         },
-        "note": "Include leading dot (.meatscentral.com) for wildcard subdomain support"
+        "note": "Leading dot enables wildcard subdomain matching: .dev.meatscentral.com matches *.dev.meatscentral.com, .meatscentral.com matches *.meatscentral.com"
       },
       "DJANGO_SUPERUSER_USERNAME": {
         "description": "Django superuser username",


### PR DESCRIPTION
## Problem
Multi-tenant subdomains (e.g., `tenant1.dev.meatscentral.com`, `api.uat.meatscentral.com`) were being rejected by Django's ALLOWED_HOSTS validation despite having root wildcards.

## Solution
Added environment-specific wildcard patterns with leading dots for proper subdomain matching:
- **Dev**: `.dev.meatscentral.com` (matches `*.dev.meatscentral.com`)
- **UAT**: `.uat.meatscentral.com` (matches `*.uat.meatscentral.com`)
- **All**: `.meatscentral.com` (matches `*.meatscentral.com`)

## Changes

### 1. config/env.manifest.json (v5.1)
- ✅ Updated **dev-backend**: Added `.dev.meatscentral.com` wildcard
- ✅ Updated **uat-backend**: Added `.uat.meatscentral.com` wildcard
- ✅ Enhanced documentation explaining wildcard behavior

### 2. backend/projectmeats/settings/development.py
- ✅ Added `.dev.meatscentral.com` for dev-specific subdomains
- ✅ Retained `.meatscentral.com` for global wildcard coverage

### 3. backend/projectmeats/settings/staging.py
- ✅ Added `.uat.meatscentral.com` for UAT-specific subdomains
- ✅ Updated default ALLOWED_HOSTS to include wildcards
- ✅ Ensured wildcards are always present even if overridden by environment

## Testing Results

### Development Environment
```
✅ ALLOWED    dev.meatscentral.com
✅ ALLOWED    tenant1.dev.meatscentral.com
✅ ALLOWED    api.dev.meatscentral.com
✅ ALLOWED    uat.meatscentral.com
✅ ALLOWED    tenant2.uat.meatscentral.com
✅ ALLOWED    meatscentral.com
✅ ALLOWED    www.meatscentral.com
✅ ALLOWED    api.meatscentral.com
❌ BLOCKED    invalid.example.com
```

### UAT/Staging Environment
```
✅ ALLOWED    uat.meatscentral.com
✅ ALLOWED    tenant1.uat.meatscentral.com
✅ ALLOWED    api.uat.meatscentral.com
✅ ALLOWED    tenant2.meatscentral.com
❌ BLOCKED    invalid.example.com
```

## Django Wildcard Behavior
Leading dot (`.domain.com`) enables wildcard matching per [Django documentation](https://docs.djangoproject.com/en/stable/ref/settings/#allowed-hosts):

- `.dev.meatscentral.com` matches:
  - ✅ `*.dev.meatscentral.com`
  - ✅ `dev.meatscentral.com`

- `.meatscentral.com` matches:
  - ✅ `*.meatscentral.com`
  - ✅ `meatscentral.com`

## Impact
- ✅ Enables multi-tenant subdomains in dev and UAT
- ✅ Supports dynamic tenant-specific URLs (e.g., `tenant1.dev.meatscentral.com`)
- ✅ Maintains security by blocking non-matching domains
- ✅ Production already has `.meatscentral.com` wildcard

## Manifest Values
```json
{
  "dev-backend": "dev.meatscentral.com,.dev.meatscentral.com,.meatscentral.com,157.245.114.182",
  "uat-backend": "uat.meatscentral.com,.uat.meatscentral.com,.meatscentral.com",
  "production-backend": "meatscentral.com,.meatscentral.com,www.meatscentral.com"
}
```

## Files Changed
- `config/env.manifest.json` - Updated ALLOWED_HOSTS values with wildcards
- `backend/projectmeats/settings/development.py` - Added `.dev.meatscentral.com`
- `backend/projectmeats/settings/staging.py` - Added `.uat.meatscentral.com` and wildcard defaults

Resolves: Wildcard subdomain support for multi-tenant architecture