### PR TITLE
fix: Add Superuser Secrets to Deployment Pipeline

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -61,6 +61,9 @@ jobs:
       DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
       REACT_APP_API_BASE_URL: ${{ secrets.REACT_APP_API_BASE_URL }}
       BACKEND_HOST: ${{ secrets.BACKEND_HOST }}
+      DJANGO_SUPERUSER_USERNAME: ${{ secrets.DJANGO_SUPERUSER_USERNAME }}
+      DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
+      DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
 
   # ==========================================
   # Route to UAT

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -74,6 +74,15 @@ on:
       BACKEND_HOST:
         required: false
         description: "Backend host IP/hostname for nginx proxy and Docker networking (from job environment)"
+      DJANGO_SUPERUSER_USERNAME:
+        required: false
+        description: "Django superuser username (from job environment)"
+      DJANGO_SUPERUSER_PASSWORD:
+        required: false
+        description: "Django superuser password (from job environment)"
+      DJANGO_SUPERUSER_EMAIL:
+        required: false
+        description: "Django superuser email (from job environment)"
 
 env:
   REGISTRY: registry.digitalocean.com/meatscentral


### PR DESCRIPTION
## 🔧 Fix Deployment Issue

This PR fixes a critical issue where the `Setup Superuser` step in the deployment workflow couldn't access required environment variables.

### 🐛 Problem
The superuser management command was failing during deployment because the secrets (`DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_PASSWORD`, `DJANGO_SUPERUSER_EMAIL`) were not declared in the workflow's secret inputs.

### ✅ Solution
- Add `DJANGO_SUPERUSER_USERNAME` to reusable-deploy workflow secrets
- Add `DJANGO_SUPERUSER_PASSWORD` to reusable-deploy workflow secrets
- Add `DJANGO_SUPERUSER_EMAIL` to reusable-deploy workflow secrets
- Pass these secrets from main-pipeline to deploy-dev job

### 📋 Changes
```diff
# reusable-deploy.yml
+ DJANGO_SUPERUSER_USERNAME:
+   required: false
+ DJANGO_SUPERUSER_PASSWORD:
+   required: false
+ DJANGO_SUPERUSER_EMAIL:
+   required: false

# main-pipeline.yml (deploy-dev job)
+ DJANGO_SUPERUSER_USERNAME: ${{ secrets.DJANGO_SUPERUSER_USERNAME }}
+ DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
+ DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
```

### 🧪 Testing
- Changes validated against workflow structure
- Secrets are already set in GitHub environments
- Will be tested on next deployment

### 🎯 Impact
- Fixes superuser creation/update during deployments
- No breaking changes
- UAT/Production already use `secrets: inherit` (will work automatically)

### 📌 Related
- Follows up on Golden Ticket deployment (#1514)
- Ensures admin access is properly configured

Closes: Deployment superuser setup issue