### PR TITLE
feat: Configure Nginx with Dynamic Backend Host

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -630,6 +630,8 @@ jobs:
             --restart unless-stopped \
             -p 80:80 \
             -p 443:443 \
+            -e BACKEND_HOST=${BACKEND_HOST} \
+            -e ENVIRONMENT=${ENVIRONMENT} \
             --add-host backend:${BACKEND_HOST} \
             -v /opt/pm/frontend/env/env-config.js:/usr/share/nginx/html/env-config.js:ro"
           

--- a/deploy/nginx/frontend-ssl.conf
+++ b/deploy/nginx/frontend-ssl.conf
@@ -42,7 +42,7 @@ server {
 
     # 1. Backend API Proxy
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://${BACKEND_HOST}:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -54,7 +54,7 @@ server {
 
     # 2. Admin Panel Proxy
     location /admin/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://${BACKEND_HOST}:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -63,7 +63,7 @@ server {
 
     # 3. Static Files Proxy (Admin CSS)
     location /static/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://${BACKEND_HOST}:8000;
         proxy_set_header Host $host;
     }
 

--- a/deploy/nginx/frontend.conf
+++ b/deploy/nginx/frontend.conf
@@ -13,8 +13,9 @@ server {
     index index.html;
 
     # 1. Backend API Proxy
+    # BACKEND_HOST will be substituted by entrypoint script
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://${BACKEND_HOST}:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -26,7 +27,7 @@ server {
 
     # 2. Admin Panel Proxy
     location /admin/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://${BACKEND_HOST}:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -35,7 +36,7 @@ server {
 
     # 3. Static Files Proxy (Admin CSS)
     location /static/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://${BACKEND_HOST}:8000;
         proxy_set_header Host $host;
     }
 

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -43,7 +43,7 @@ RUN npm run build
 
 # Runtime with nginx and npm installed
 FROM nginx:alpine
-RUN apk add --no-cache nodejs npm bash  # Install npm, nodejs, and bash here
+RUN apk add --no-cache nodejs npm bash gettext  # Install npm, nodejs, bash, and gettext (for envsubst)
 
 # Copy configs to 'templates' directory (NOT conf.d) to prevent auto-loading
 # This prevents Nginx from automatically including them


### PR DESCRIPTION
## 🔧 Dynamic Backend Host Configuration

This PR enables the frontend Nginx to proxy API requests to a configurable backend server using the `BACKEND_HOST` environment variable from GitHub Secrets.

### 🎯 Problem
The frontend and backend are deployed on **separate servers**, but Nginx was hardcoded to proxy to `backend:8000`. This doesn't work when:
- Frontend server: 104.131.186.75 (dev-frontend)
- Backend server: Different IP (dev-backend)

### ✅ Solution
Configure Nginx to use a dynamic backend host variable that can be set per environment.

### 🔧 Changes

**1. Nginx Configuration Templates**
- `deploy/nginx/frontend.conf`: Changed `proxy_pass http://backend:8000` → `http://${BACKEND_HOST}:8000`
- `deploy/nginx/frontend-ssl.conf`: Same change for HTTPS config
- Applied to all proxy locations: `/api/`, `/admin/`, `/static/`

**2. Docker Entrypoint**
- `frontend/docker-entrypoint.sh`: Added `envsubst` to substitute `${BACKEND_HOST}` at container startup
- Set fallback value: `BACKEND_HOST=${BACKEND_HOST:-backend}`
- Added logging to show which backend host is being used

**3. Dockerfile**
- `frontend/dockerfile`: Added `gettext` package (provides `envsubst` command)

**4. Deployment Workflow**
- `.github/workflows/reusable-deploy.yml`: Pass `BACKEND_HOST` as environment variable to container
- Uses `-e BACKEND_HOST=${BACKEND_HOST}` in docker run command

### 📋 Configuration

The `BACKEND_HOST` secret should be set in GitHub Secrets for each environment:

```
Environment: dev-frontend
Secret: BACKEND_HOST
Value: <backend-server-ip>  # e.g., 10.0.0.5 or backend.internal
```

### 🧪 Testing

**Before Deployment:**
- Nginx config validation will run during container startup
- Entrypoint will show: "Using backend host: <IP>"

**After Deployment:**
```bash
# Check nginx config
docker exec pm-frontend cat /etc/nginx/conf.d/default.conf | grep proxy_pass

# Should show: proxy_pass http://<BACKEND_IP>:8000;
```

### 🔄 Backwards Compatibility

- **Fallback behavior**: If `BACKEND_HOST` is not set, defaults to `backend`
- **Existing deployments**: Will continue to work with DNS-based `backend` hostname
- **New deployments**: Can specify exact backend server IP

### 📊 Impact

✅ Enables multi-server architecture
✅ Frontend can proxy to remote backend server
✅ Admin panel accessible via frontend (`/admin/`)
✅ API calls routed correctly (`/api/`)
✅ Static files proxied (`/static/`)

### 🎯 Next Steps

After merge:
1. Set `BACKEND_HOST` secret in dev-frontend environment
2. Deploy will automatically use the new configuration
3. Verify admin panel works: http://104.131.186.75/admin
4. Test Golden Ticket feature

### 🔗 Related

- Follows up on deployment diagnostics
- Enables frontend-backend communication across servers
- Required for Golden Ticket feature access via frontend