### PR TITLE
fix: Automatically Sync Superuser on Container Start

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -508,11 +508,14 @@ jobs:
           # Stop old container
           docker rm -f pm-backend || true
           
-          # Start new container
+          # Start new container with superuser credentials from secrets
           docker run -d --name pm-backend \
             --restart unless-stopped \
             -p 8000:8000 \
             --env-file /home/django/ProjectMeats/backend/.env \
+            -e DJANGO_SUPERUSER_USERNAME="${{ secrets.DJANGO_SUPERUSER_USERNAME }}" \
+            -e DJANGO_SUPERUSER_EMAIL="${{ secrets.DJANGO_SUPERUSER_EMAIL }}" \
+            -e DJANGO_SUPERUSER_PASSWORD="${{ secrets.DJANGO_SUPERUSER_PASSWORD }}" \
             -v /home/django/ProjectMeats/media:/app/media \
             -v /home/django/ProjectMeats/staticfiles:/app/staticfiles \
             "$REG/$IMG:$TAG"

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -79,10 +79,14 @@ HEALTHCHECK --interval=30s --timeout=5s \
 
 # Start Gunicorn with debug logging, preload, and error handling
 # Use exec form for proper signal handling
+# CRITICAL: setup_superuser runs on EVERY container start to sync credentials
 CMD ["sh", "-c", "set -x && \
     echo \"Starting container at $(date)\" && \
     python manage.py check && \
     echo \"Django check passed\" && \
+    echo \"Setting up superuser...\" && \
+    python manage.py setup_superuser && \
+    echo \"Superuser setup complete\" && \
     exec gunicorn projectmeats.wsgi:application \
       --bind 0.0.0.0:8000 \
       --workers ${GUNICORN_WORKERS:-3} \


### PR DESCRIPTION
## 🔧 AUTOMATED SUPERUSER FIX

This PR ensures superuser credentials are **automatically synchronized** with GitHub Secrets on every container start.

### 🐛 Problem

**Current Behavior:**
- Superuser created during migration step (has secrets)
- Backend container starts with .env file (no superuser vars)
- Credentials in database don't match current secrets
- **Login fails even with correct GitHub Secret values**

**User Experience:**
```
User: *types correct username/password from secrets*
Django: "Invalid credentials"
User: 😠
```

### 🎯 Root Cause

1. **Migration step** (runs in CI):
   - Has access to `DJANGO_SUPERUSER_*` secrets
   - Runs `setup_superuser`
   - Creates/updates superuser in database

2. **Backend container** (runs on server):
   - Uses `--env-file .env` (no superuser vars)
   - Never runs `setup_superuser` again
   - Superuser password never updates

3. **Result:**
   - If secrets change → login breaks
   - If database state drifts → login breaks
   - Manual SSH intervention required

### ✅ Solution

**Automatic Synchronization on Every Container Start:**

1. **Pass secrets to container:**
   ```bash
   docker run -d      -e DJANGO_SUPERUSER_USERNAME="$SECRET"      -e DJANGO_SUPERUSER_EMAIL="$SECRET"      -e DJANGO_SUPERUSER_PASSWORD="$SECRET"
   ```

2. **Run setup_superuser in dockerfile CMD:**
   ```dockerfile
   CMD ["sh", "-c", "
     python manage.py check &&
     python manage.py setup_superuser &&  # ← NEW!
     exec gunicorn ...
   "]
   ```

3. **Benefits:**
   - ✅ Runs on **every** container start
   - ✅ Syncs password with **current** secrets
   - ✅ Updates existing user or creates new one
   - ✅ Logs credentials for verification
   - ✅ **Zero manual intervention**

### 🔧 Changes

**File 1: `backend/dockerfile`**
- Added `python manage.py setup_superuser` to CMD
- Runs after Django check, before gunicorn
- Logs: "Setting up superuser..." and "Superuser setup complete"

**File 2: `.github/workflows/reusable-deploy.yml`**
- Added `-e DJANGO_SUPERUSER_USERNAME` to docker run
- Added `-e DJANGO_SUPERUSER_EMAIL` to docker run  
- Added `-e DJANGO_SUPERUSER_PASSWORD` to docker run
- Secrets now passed directly to container

### 📋 How It Works

**On Every Container Start:**
```
1. Container starts
2. Django check ✅
3. setup_superuser runs:
   • Checks for existing user
   • Updates password to match secrets
   • Promotes to superuser if needed
   • Logs credentials (username, email)
4. Gunicorn starts ✅
5. Login works! 🎉
```

**Container Logs Will Show:**
```
Starting container at ...
Django check passed
Setting up superuser...
Target superuser credentials:
  Username: admin
  Email: admin@example.com
✅ Superuser updated: admin (admin@example.com)
✅ Login test passed for: admin
============================================================
🎉 Superuser ready to use!
   Username: admin
   Email: admin@example.com
   Superuser: Yes
   Staff: Yes
   Active: Yes
============================================================
Superuser setup complete
[gunicorn starts...]
```

### 🧪 Testing

**After deployment:**
```bash
# 1. Check container logs
docker logs pm-backend | grep "Superuser"

# 2. Verify credentials match secrets
# Go to: https://dev.meatscentral.com/admin/
# Username: (from DJANGO_SUPERUSER_USERNAME secret)
# Password: (from DJANGO_SUPERUSER_PASSWORD secret)

# 3. Should login successfully!
```

**Update password test:**
```bash
# 1. Change DJANGO_SUPERUSER_PASSWORD secret
# 2. Redeploy or restart container
# 3. Password automatically updates
# 4. Login with new password works immediately
```

### 📊 Impact

✅ **Automatic password sync** - no more manual fixes
✅ **Works across all environments** - dev, UAT, prod
✅ **Idempotent** - safe to run multiple times
✅ **Zero downtime** - runs during startup
✅ **Credential verification** - logs show actual values
✅ **Future-proof** - handles secret changes gracefully

### 🎯 Use Cases Solved

**Case 1: Password Changed in Secrets**
- Before: Login breaks, manual SSH required
- After: Container restart syncs automatically

**Case 2: Database Corruption**
- Before: Manual user recreation required
- After: setup_superuser fixes automatically

**Case 3: Fresh Deployment**
- Before: Superuser created but might drift
- After: Always synced with secrets

**Case 4: Multiple Deployments**
- Before: Password could be out of sync
- After: Every deployment syncs credentials

### 🚀 Deployment

**Will affect:**
- ✅ dev-backend (immediate fix for login issue)
- ✅ uat-backend (when promoted)
- ✅ prod-backend (when promoted)

**Container restart behavior:**
- Takes ~1-2 seconds longer to start (setup_superuser runs)
- No downtime (health check waits for completion)
- Logs show sync status

**Monitoring:**
```bash
# Watch container start
docker logs -f pm-backend

# Look for:
# "Setting up superuser..."
# "Superuser setup complete"
```

### 🔗 Related Issues

- Fixes: Login failure despite correct secrets
- Follows: PR #1524 (superuser email lookup)
- Follows: PR #1525 (multiple users handling)
- **FINAL FIX** for persistent login issues

---

**This is the PERMANENT solution. No more manual SSH intervention neededecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* 🎉