### PR TITLE
fix: change invitation form button text to 'Proceed'

### DIFF
--- a/backend/templates/admin/form_intermediate.html
+++ b/backend/templates/admin/form_intermediate.html
@@ -33,7 +33,7 @@
     </fieldset>
 
     <div class="submit-row">
-        <input type="submit" value="{% trans 'Send Invite' %}" class="default" />
+        <input type="submit" value="{% trans 'Proceed' %}" class="default" />
     </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## 🎯 Change

Updates the intermediate form submit button text from "Send Invite" to "Proceed" to match specification.

## 📋 Reason

The generic "Proceed" text is more suitable for both:
1. **Onboard Tenant Owner** action (not really "sending invite" in the form - that happens after)
2. **Send Individual Invite** action

"Proceed" better represents the action of moving forward with the form submission.

## 📂 File Changed

- `backend/templates/admin/form_intermediate.html`

## ✅ Verification

After deployment, the form wizards for:
- 🚀 Onboard New Tenant Owner
- 📧 Send Individual Invite

Will display **"Proceed"** button instead of "Send Invite".