### PR TITLE
🛡️ Ensure backend/.env File Exists Before Docker Compose

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -640,6 +640,12 @@ jobs:
           
           echo "✓ In directory: $(pwd)"
           
+          # Ensure backend/.env file exists to prevent Docker Compose parser errors
+          echo "Ensuring backend/.env file exists..."
+          mkdir -p backend
+          touch backend/.env
+          echo "✓ backend/.env file ready"
+          
           # Export environment variables for docker compose
           export REGISTRY="$REG"
           export FRONTEND_IMAGE="$IMG"


### PR DESCRIPTION
## Problem

Docker Compose fails with a parser error if the `backend/.env` file doesn't exist, even though the backend container loads environment variables from a different location.

**Error Without This Fix:**
```
Error: .env file not found: /root/projectmeats/backend/.env
ERROR: Couldn't find env file: /root/projectmeats/backend/.env
```

**Result:** Frontend deployment crashes before the container can start.

---

## Solution

Add a safety check to create an empty `backend/.env` file if it doesn't exist.

---

## Changes Made

**File**: `.github/workflows/reusable-deploy.yml`

**Location**: Lines 643-646 (new step)

**Added After**: `cd /root/projectmeats`

**Added Before**: `docker compose up -d frontend`

```bash
# Ensure backend/.env file exists to prevent Docker Compose parser errors
echo "Ensuring backend/.env file exists..."
mkdir -p backend
touch backend/.env
echo "✓ backend/.env file ready"
```

---

## Why This Matters

### Docker Compose Behavior

1. `docker-compose.yml` may reference `backend/.env` in the `env_file` directive
2. Docker Compose **parser** validates file existence **before** starting containers
3. Missing file causes **immediate failure**, not graceful degradation
4. Parser error prevents **all** containers from starting (including frontend)

### Important Note

- This creates an **empty file** only if it doesn't already exist
- The **backend container** still loads actual environment variables via `--env-file /root/projectmeats/backend/.env` flag in the backend deployment step
- This fix is for Docker Compose **parser** only, not for runtime environment variables

---

## Flow Comparison

### Before (Broken)

```
1. cd /root/projectmeats ✓
2. docker compose up -d frontend ✗ (ERROR: .env file not found)
   → Deployment fails
   → Frontend container not started
   → Manual intervention required
```

### After (Fixed)

```
1. cd /root/projectmeats ✓
2. mkdir -p backend ✓
3. touch backend/.env ✓ (creates empty file if doesn't exist)
4. docker compose up -d frontend ✓
   → Parser validates file exists
   → Frontend container starts successfully
   → Deployment completes
```

---

## Safety Considerations

### What This Does

✅ Creates `backend` directory if it doesn't exist  
✅ Creates empty `.env` file if it doesn't exist  
✅ Idempotent - safe to run multiple times  
✅ Doesn't overwrite existing file

### What This Doesn't Do

❌ Doesn't write any environment variables to the file  
❌ Doesn't expose secrets  
❌ Doesn't affect backend container's actual environment (loaded separately)  
❌ Doesn't modify existing .env file

---

## Impact

### Before (Risky)

- ❌ Deployment fails if .env file missing
- ❌ Parser error prevents all containers from starting
- ❌ Requires manual file creation on server
- ❌ Inconsistent behavior across environments

### After (Robust)

- ✅ Deployment succeeds even if .env file missing
- ✅ Parser validation passes
- ✅ Frontend container starts reliably
- ✅ Consistent behavior across all environments
- ✅ Self-healing deployment

---

## Testing

### After Merge & Deployment

**1. Verify file creation:**
```bash
ssh root@dev-server
ls -la /root/projectmeats/backend/.env
# Should exist and be readable
```

**2. Check GitHub Actions logs:**
```
Ensuring backend/.env file exists...
✓ backend/.env file ready
Starting frontend container via docker compose...
✓ Container started successfully
```

**3. Verify frontend container:**
```bash
docker ps | grep frontend
# Should show running container
```

---

## Related Context

### Why docker-compose.yml Might Reference backend/.env

Docker Compose files can include:
```yaml
services:
  backend:
    env_file:
      - backend/.env
```

Even though we deploy backend separately using `docker run`, Docker Compose **still validates** the file when running `docker compose up -d frontend` because it **parses the entire** `docker-compose.yml` file.

### Backend Container Environment Variables

The backend container loads environment variables from:
- `--env-file /root/projectmeats/backend/.env` (in backend deployment step)
- NOT from the file this fix creates

This fix only satisfies Docker Compose's parser validation.

---

## Verification Checklist

After deployment:

- [ ] Check GitHub Actions logs show "✓ backend/.env file ready"
- [ ] Verify `/root/projectmeats/backend/.env` exists on server
- [ ] Confirm frontend container starts successfully
- [ ] No Docker Compose parser errors in logs
- [ ] Backend container still loads correct environment variables

---

## Priority

**MEDIUM-HIGH** - Prevents deployment failures due to Docker Compose parser validation.

---

**Refs:** #deployment #docker-compose #env-file #parser-fix #robustness