### PR TITLE
🎨 Custom Workflow Display Titles

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -1,5 +1,8 @@
 name: Master Pipeline
 
+run-name: |
+  ${{ github.ref_name == 'development' && '🚀 Deploy to dev' || github.ref_name == 'uat' && '🚀 Deploy to uat' || github.ref_name == 'main' && '🚀 Deploy to prod' || '🚀 Deploy' }}: ${{ github.event.head_commit.message || github.event.pull_request.title || github.event_name }}
+
 on:
   push:
     branches: [development, uat, main]


### PR DESCRIPTION
## Summary

Adds custom display titles to workflows in the Actions tab to improve readability and provide better context.

---

## Problem

Current workflow display in Actions tab:
```
chore: fix deployment triggers and restore clean UI (#1568)
Master Pipeline #341: Commit 86c8409 pushed by Vacilator
development
```

This doesn't clearly show:
- **Which environment** is being deployed to
- **What action** is being performed

---

## Solution

Added `run-name:` property to `main-pipeline.yml` that dynamically sets the workflow display title based on:

1. **Branch/Environment:**
   - `development` → `🚀 Deploy to dev`
   - `uat` → `🚀 Deploy to uat`
   - `main` → `🚀 Deploy to prod`

2. **Commit/PR Title:**
   - Shows commit message for push events
   - Shows PR title for pull_request events
   - Shows event name for workflow_dispatch events

---

## Implementation

```yaml
run-name: |
  ${{ github.ref_name == 'development' && '🚀 Deploy to dev' || github.ref_name == 'uat' && '🚀 Deploy to uat' || github.ref_name == 'main' && '🚀 Deploy to prod' || '🚀 Deploy' }}: ${{ github.event.head_commit.message || github.event.pull_request.title || github.event_name }}
```

**How it works:**
- Checks `github.ref_name` to determine which branch triggered the workflow
- Uses ternary operators to select the appropriate environment label
- Appends the commit message, PR title, or event name as context

---

## Examples

### Before
```
chore: fix deployment triggers and restore clean UI (#1568)
Master Pipeline #341: Commit 86c8409 pushed by Vacilator
development
```

### After

**Push to development:**
```
🚀 Deploy to dev: chore: fix deployment triggers and restore clean UI
Master Pipeline #341
```

**Push to uat:**
```
🚀 Deploy to uat: Release: Promote development to uat (#1558)
Master Pipeline #342
```

**Push to main:**
```
🚀 Deploy to prod: Release: Promote uat to Production (#1557)
Master Pipeline #343
```

**PR merge:**
```
🚀 Deploy to dev: Fix Admin UI styling issue
Master Pipeline #344
```

---

## Benefits

✅ **Instant environment visibility** - No need to read fine print  
✅ **Clear action context** - Know what's being deployed  
✅ **Better filtering** - Easy to find specific deployments  
✅ **Consistent format** - All deployments follow same pattern  
✅ **Visual emoji** - 🚀 makes deployments stand out  

---

## Changes Made

### File: .github/workflows/main-pipeline.yml

```diff
 name: Master Pipeline
 
+run-name: |
+  ${{ github.ref_name == 'development' && '🚀 Deploy to dev' || github.ref_name == 'uat' && '🚀 Deploy to uat' || github.ref_name == 'main' && '🚀 Deploy to prod' || '🚀 Deploy' }}: ${{ github.event.head_commit.message || github.event.pull_request.title || github.event_name }}
+
 on:
   push:
     branches: [development, uat, main]
```

---

## Testing

### Expected Behavior

When this PR is merged to `development`:
```
🚀 Deploy to dev: feat: add custom workflow display titles (#1569)
```

When promoted to `uat`:
```
🚀 Deploy to uat: Release: Promote development to uat
```

When promoted to `main`:
```
🚀 Deploy to prod: Release: Promote uat to Production
```

---

## Compatibility

✅ **Works with existing workflows** - No changes to workflow logic  
✅ **Works with all trigger types** - push, pull_request, workflow_dispatch  
✅ **Works with auto-promote** - Shows correct environment in auto-created PRs  
✅ **No impact on reusable workflow** - Still invisible in UI  

---

## Notes

- The `run-name` property is cosmetic only - it doesn't affect workflow execution
- The reusable workflow (`reusable-deploy.yml`) still has NO `name:` property, so it remains invisible
- This change ONLY affects the display in the Actions tab
- If commit message contains PR number (e.g., `#1568`), it will be included in the display

---

## Priority

**Enhancement** - Improves UX and operational visibility

---

**Refs:** #ux #workflow #cicd #enhancement