### PR TITLE
fix: resolve static file permission errors

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -548,6 +548,14 @@ jobs:
           # Wait for container to be ready
           sleep 5
           
+          # Fix permissions for staticfiles directory
+          echo "Fixing permissions for staticfiles directory..."
+          docker exec -u root -T pm-backend chown -R 1000:1000 /app/staticfiles || {
+            echo "⚠ Warning: Could not change ownership, trying chmod instead"
+            docker exec -u root -T pm-backend chmod -R 777 /app/staticfiles
+          }
+          echo "✓ Permissions fixed"
+          
           # Collect static files for admin UI
           echo "Collecting static files for Django admin..."
           docker exec -T pm-backend python manage.py collectstatic --noinput || {


### PR DESCRIPTION
## Problem
The Django collectstatic command was failing with:
```
PermissionError: [Errno 13] Permission denied: '/app/staticfiles/admin'
```

## Solution
Added a permission fix step in the deployment workflow that runs **before** collectstatic:
- First tries: `chown -R 1000:1000 /app/staticfiles` (standard Django/Docker user)
- Falls back to: `chmod -R 777 /app/staticfiles` if chown fails

## Changes
- Updated `.github/workflows/reusable-deploy.yml` to fix permissions before collecting static files
- Ensures the Django container user has write access to /app/staticfiles

## Testing
- [ ] Verify collectstatic runs without permission errors
- [ ] Verify Django admin UI loads correctly with proper CSS styling
- [ ] Verify static files are accessible via nginx

Fixes the permission error blocking admin UI deployment.