### PR TITLE
fix: correct heredoc syntax in backend .env generation

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -509,18 +509,18 @@ jobs:
           mkdir -p backend
           
           # Write environment variables to .env file
-          cat > backend/.env <<'ENVFILE'
-SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
-DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
-ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
-DB_ENGINE=django.db.backends.postgresql
-DB_HOST=${{ secrets.DB_HOST }}
-DB_PORT=${{ secrets.DB_PORT }}
-DB_USER=${{ secrets.DB_USER }}
-DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-DB_NAME=${{ secrets.DB_NAME }}
-DEBUG=${{ secrets.DEBUG }}
-ENVFILE
+          cat > backend/.env <<-'ENVFILE'
+          SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
+          DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
+          ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
+          DB_ENGINE=django.db.backends.postgresql
+          DB_HOST=${{ secrets.DB_HOST }}
+          DB_PORT=${{ secrets.DB_PORT }}
+          DB_USER=${{ secrets.DB_USER }}
+          DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          DB_NAME=${{ secrets.DB_NAME }}
+          DEBUG=${{ secrets.DEBUG }}
+          ENVFILE
           
           echo "✓ backend/.env file created"
           


### PR DESCRIPTION
## Problem
The YAML parser was failing with:
```
yaml.scanner.ScannerError: while scanning a simple key
  in ".github/workflows/reusable-deploy.yml", line 513, column 1
could not find expected ':'
```

This happened because the heredoc content (lines 513-522) started at column 1, which YAML interprets as mapping keys rather than bash script content.

## Solution
Changed `<<'ENVFILE'` to `<<-'ENVFILE'` (with dash) which:
- Allows both content AND delimiter to be indented
- Strips leading tabs from heredoc content (preserving the actual values)
- Keeps content properly within the YAML `run:` block

## Changes
- Updated `.github/workflows/reusable-deploy.yml` line 512
- Indented all heredoc content lines (513-523) to match workflow indentation

## Testing
- [x] YAML syntax validation passes
- [ ] Workflow runs successfully
- [ ] Backend .env file generated correctly

This fix unblocks PR #1570 (static files permissions) from merging.