### PR TITLE
fix: remove invalid docker flags and resolve volume permissions

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -550,15 +550,13 @@ jobs:
           
           # Fix permissions for staticfiles directory
           echo "Fixing permissions for staticfiles directory..."
-          docker exec -u root -T pm-backend chown -R 1000:1000 /app/staticfiles || {
-            echo "⚠ Warning: Could not change ownership, trying chmod instead"
-            docker exec -u root -T pm-backend chmod -R 777 /app/staticfiles
-          }
+          docker exec -u root pm-backend chown -R 1000:1000 /app/staticfiles
+          docker exec -u root pm-backend chmod -R 775 /app/staticfiles
           echo "✓ Permissions fixed"
           
           # Collect static files for admin UI
           echo "Collecting static files for Django admin..."
-          docker exec -T pm-backend python manage.py collectstatic --noinput || {
+          docker exec pm-backend python manage.py collectstatic --noinput || {
             echo "⚠ Warning: collectstatic failed, but continuing"
           }
           echo "✓ Static files collected"


### PR DESCRIPTION
## Problem
The backend deployment was failing with two issues:
1. `-T` flag on `docker exec` commands causing "the input device is not a TTY" errors when used with sshpass/SSH
2. Permission denied errors when running `collectstatic` due to incorrect `/app/staticfiles` ownership

## Solution
- **Removed `-T` flag** from all `docker exec` commands in the backend deployment
- **Added proper permission fix sequence**:
  - `chown -R 1000:1000 /app/staticfiles` (set correct ownership)
  - `chmod -R 775 /app/staticfiles` (set secure permissions)
- **Run permission fixes BEFORE collectstatic** to ensure write access

## Technical Details
- The `-T` flag disables pseudo-TTY allocation, which conflicts with SSH sessions
- User ID 1000:1000 is the standard Django/Docker user
- 775 permissions provide secure write access (instead of overly permissive 777)

## Testing
- [ ] Backend deployment completes without TTY errors
- [ ] collectstatic runs successfully
- [ ] Static files (CSS/JS) are served correctly
- [ ] Django admin UI styling loads properly
- [ ] Health check passes

## Related Issues
Fixes deployment failures in #1570 and previous runs