### PR TITLE
fix: correct heredoc delimiter indentation in deployment workflow

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -509,18 +509,18 @@ jobs:
           mkdir -p backend
           
           # Write environment variables to .env file
-          cat > backend/.env <<-'ENVFILE'
-          SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
-          DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
-          ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
-          DB_ENGINE=django.db.backends.postgresql
-          DB_HOST=${{ secrets.DB_HOST }}
-          DB_PORT=${{ secrets.DB_PORT }}
-          DB_USER=${{ secrets.DB_USER }}
-          DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-          DB_NAME=${{ secrets.DB_NAME }}
-          DEBUG=${{ secrets.DEBUG }}
-          ENVFILE
+          cat > backend/.env <<'ENVFILE'
+SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
+DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
+ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
+DB_ENGINE=django.db.backends.postgresql
+DB_HOST=${{ secrets.DB_HOST }}
+DB_PORT=${{ secrets.DB_PORT }}
+DB_USER=${{ secrets.DB_USER }}
+DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+DB_NAME=${{ secrets.DB_NAME }}
+DEBUG=${{ secrets.DEBUG }}
+ENVFILE
           
           echo "✓ backend/.env file created"
           


### PR DESCRIPTION
## Problem
The heredoc closing delimiter `ENVFILE` was indented, causing YAML/Bash syntax errors during workflow execution.

## Solution
- Moved `ENVFILE` closing delimiter to column 0 (no indentation)
- Removed `<<-` operator and unindented content for proper heredoc syntax
- Fixes deployment workflow failures in `deploy-backend` job

## Testing
- [x] YAML syntax validation
- [x] Heredoc syntax follows Bash standards
- [ ] Deploy to dev environment

Fixes #1573