### PR TITLE
fix: resolve workflow syntax errors and restore pipeline stability

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -1,8 +1,5 @@
 name: Master Pipeline
 
-run-name: |
-  ${{ github.ref_name == 'development' && '🚀 Deploy to dev' || github.ref_name == 'uat' && '🚀 Deploy to uat' || github.ref_name == 'main' && '🚀 Deploy to prod' || '🚀 Deploy' }}: ${{ github.event.head_commit.message || github.event.pull_request.title || github.event_name }}
-
 on:
   push:
     branches: [development, uat, main]

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -508,19 +508,17 @@ jobs:
           echo "Creating backend/.env file from secrets..."
           mkdir -p backend
           
-          # Write environment variables to .env file
-          cat > backend/.env <<'ENVFILE'
-SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
-DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
-ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
-DB_ENGINE=django.db.backends.postgresql
-DB_HOST=${{ secrets.DB_HOST }}
-DB_PORT=${{ secrets.DB_PORT }}
-DB_USER=${{ secrets.DB_USER }}
-DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-DB_NAME=${{ secrets.DB_NAME }}
-DEBUG=${{ secrets.DEBUG }}
-ENVFILE
+          # Write environment variables to .env file using echo commands
+          echo "SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}" > backend/.env
+          echo "DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}" >> backend/.env
+          echo "ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}" >> backend/.env
+          echo "DB_ENGINE=django.db.backends.postgresql" >> backend/.env
+          echo "DB_HOST=${{ secrets.DB_HOST }}" >> backend/.env
+          echo "DB_PORT=${{ secrets.DB_PORT }}" >> backend/.env
+          echo "DB_USER=${{ secrets.DB_USER }}" >> backend/.env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> backend/.env
+          echo "DB_NAME=${{ secrets.DB_NAME }}" >> backend/.env
+          echo "DEBUG=${{ secrets.DEBUG }}" >> backend/.env
           
           echo "✓ backend/.env file created"
           


### PR DESCRIPTION
## Summary
This PR fixes the recurring YAML syntax errors and restores clean workflow titles.

## Changes Made

### 1. Fixed Heredoc Syntax Error
- **Problem**: The heredoc closing delimiter was indented, causing YAML validation failures
- **Solution**: Replaced  with individual  commands
- **Benefit**: Eliminates all heredoc-related syntax errors permanently

### 2. Restored Clean Workflow Titles  
- **Problem**: Custom `run-name` was creating duplicate/confusing titles in Actions UI
- **Solution**: Removed `run-name` from `main-pipeline.yml`
- **Benefit**: Workflow runs now display as clean commit messages (e.g., "fix: resolve static file permission errors")

### 3. Maintained Critical Fixes
- ✅ Backend `.env` generation from GitHub Secrets
- ✅ Staticfiles permission fix (`chown -R 1000:1000`)
- ✅ Health check logic
- ✅ Proper deployment triggers on `development` branch

## Testing
- [ ] PR validation check passes (no YAML errors)
- [ ] Deployment to dev completes successfully
- [ ] Backend container starts and serves traffic
- [ ] Admin UI styling works (collectstatic runs)
- [ ] Workflow title displays as commit message

## Related Issues
Fixes recurring deployment failures from PRs #1570, #1572, #1573, #1574