### PR TITLE
fix: preemptive host-level permissions for staticfiles

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -529,6 +529,13 @@ jobs:
           echo "✓ In directory: $(pwd)"
           echo "✓ backend/.env file already transferred"
           
+          # Preemptively create and fix permissions for staticfiles directory on host
+          echo "Creating and fixing permissions for staticfiles directory..."
+          mkdir -p /root/projectmeats/staticfiles
+          chown -R 1000:1000 /root/projectmeats/staticfiles
+          chmod -R 775 /root/projectmeats/staticfiles
+          echo "✓ Host-level permissions fixed"
+          
           # Login to registry
           echo "${{ secrets.DO_ACCESS_TOKEN }}" | docker login registry.digitalocean.com -u "${{ secrets.DO_ACCESS_TOKEN }}" --password-stdin
           
@@ -552,12 +559,6 @@ jobs:
           
           # Wait for container to be ready
           sleep 5
-          
-          # Fix permissions for staticfiles directory
-          echo "Fixing permissions for staticfiles directory..."
-          docker exec -u root pm-backend chown -R 1000:1000 /app/staticfiles
-          docker exec -u root pm-backend chmod -R 775 /app/staticfiles
-          echo "✓ Permissions fixed"
           
           # Collect static files for admin UI
           echo "Collecting static files for Django admin..."


### PR DESCRIPTION
## 🔧 Fix Static File Permission Errors

### Problem
The backend deployment was failing with  because permissions were being fixed AFTER the container started, which was too late for the mounted volume.

### Solution
**Move permission fixes to run BEFORE the container starts:**
- Create  directory on host
- Set ownership to  (Django user)
- Set permissions to 
- Container then mounts this pre-configured directory

### Changes
- Moved  and  commands to execute on host before 
- Removed post-container  permission fixes (no longer needed)
- Ensures staticfiles volume has correct permissions from the start

### Testing
- [x] Permissions set before container creation
- [x] Volume mount inherits correct ownership
- [x] collectstatic can write without errors

### Related Issues
- Fixes backend deployment failures in #1580 and previous attempts
- Resolves Django admin UI styling issues caused by collectstatic failures

---
**Deployment:** This change affects  job in the deployment workflow.