### PR TITLE
fix: split build and up commands to resolve docker flag parsing errors

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -699,9 +699,13 @@ jobs:
           echo "Current directory contents:"
           ls -la
           
+          # Build frontend image
+          echo "Building frontend image..."
+          docker compose build frontend
+          
           # Start new frontend container using docker compose
           echo "Starting frontend container via docker compose..."
-          docker compose up --detach --build frontend
+          docker compose up -d frontend
           
           echo "✓ Container started successfully"
           


### PR DESCRIPTION
## Changes
- Split `docker compose up --detach --build frontend` into two separate commands:
  1. `docker compose build frontend` - Build image first
  2. `docker compose up -d frontend` - Start container second
- Simplifies flag parsing and avoids SSH heredoc interpretation issues

## Why
- Combined `--detach --build` flags were causing 'unknown flag' errors via SSH
- Splitting into two commands isolates the operations and uses simpler flags
- Build operation doesn't need detach flag (not relevant to build)
- Start operation uses simple `-d` flag without complexity

## Validation
- ✅ Commands run after `cd /root/projectmeats` (line 673)
- ✅ Environment variables exported before execution (lines 687-692)
- ✅ Debug `ls -la` shows directory contents
- ✅ Sequential approach is more explicit and easier to troubleshoot

## Flow
1. Stop old container
2. Build new image
3. Start new container
4. Verify container is running