### PR TITLE
fix: align frontend deployment syntax with working backend job

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -699,13 +699,9 @@ jobs:
           echo "Current directory contents:"
           ls -la
           
-          # Build frontend image
-          echo "Building frontend image..."
-          docker compose build frontend
-          
           # Start new frontend container using docker compose
           echo "Starting frontend container via docker compose..."
-          docker compose up -d frontend
+          docker compose up -d
           
           echo "✓ Container started successfully"
           


### PR DESCRIPTION
## Changes
- Removed explicit `docker compose build frontend` step
- Simplified start command from `docker compose up -d frontend` to `docker compose up -d`
- Removed service name argument that was causing flag parsing errors

## Why
- Backend deployment uses `docker compose up -d` without service name and succeeds
- Explicit service name argument (`frontend`) was triggering 'unknown command' parsing errors in SSH heredoc
- Standard `docker compose up -d` is more reliable through SSH

## Command Evolution
1. ❌ `docker compose up --detach --build frontend` - Multiple flags confuse parser
2. ❌ `docker compose build frontend && docker compose up -d frontend` - Service name causes issues
3. ✅ `docker compose up -d` - Simple, matches working backend pattern

## Validation
- ✅ Runs in `/root/projectmeats` with docker-compose.yml present
- ✅ Environment variables exported before execution
- ✅ Matches successful backend deployment pattern
- ✅ No service-specific arguments to trigger parsing bugs

## Testing
The backend job successfully uses this exact syntax, so this aligns frontend with proven working approach.