### PR TITLE
fix: use local script to bypass SSH command mangling

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -699,9 +699,12 @@ jobs:
           echo "Current directory contents:"
           ls -la
           
-          # Start new frontend container using docker compose
+          # Start new frontend container using docker compose via script
           echo "Starting frontend container via docker compose..."
-          docker compose up -d
+          echo "cd /root/projectmeats && docker compose up -d" > deploy_frontend.sh
+          chmod +x deploy_frontend.sh
+          ./deploy_frontend.sh
+          rm deploy_frontend.sh
           
           echo "✓ Container started successfully"
           


### PR DESCRIPTION
## Changes
- Replaced direct `docker compose up -d` command with script-based execution
- Creates temporary `deploy_frontend.sh` script on remote server
- Script contains: `cd /root/projectmeats && docker compose up -d`
- Executes script and cleans up after completion

## Why
- SSH heredoc was mangling docker compose commands regardless of flag format
- Writing command to a script file bypasses SSH command interpretation
- Script execution is a separate shell process without SSH parsing interference
- This pattern isolates the docker compose command from SSH heredoc quirks

## How It Works
1. Create script file: `echo "cd /root/projectmeats && docker compose up -d" > deploy_frontend.sh`
2. Make executable: `chmod +x deploy_frontend.sh`
3. Execute: `./deploy_frontend.sh`
4. Clean up: `rm deploy_frontend.sh`

## Benefits
- Bypasses SSH heredoc command mangling
- Simple docker compose command in script context
- No complex flag parsing through SSH layers
- Script runs in clean shell environment
- Self-cleaning (removes script after execution)

## Testing
- Script creates on remote server in current directory
- Executes with proper environment variables already exported
- Returns to SSH session after completion