### PR TITLE
fix: correct heredoc EOF delimiter indentation for validation

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -520,17 +520,17 @@ jobs:
       - name: Create Backend .env File Locally
         run: |
           cat << 'EOF' > backend.env
-          DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
-          DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
-          ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
-          DEBUG=${{ secrets.DEBUG }}
-          DB_NAME=${{ secrets.DB_NAME }}
-          DB_USER=${{ secrets.DB_USER }}
-          DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-          DB_HOST=${{ secrets.DB_HOST }}
-          DB_PORT=${{ secrets.DB_PORT }}
-          DB_ENGINE=django.db.backends.postgresql
-          EOF
+DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
+DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
+ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
+DEBUG=${{ secrets.DEBUG }}
+DB_NAME=${{ secrets.DB_NAME }}
+DB_USER=${{ secrets.DB_USER }}
+DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+DB_HOST=${{ secrets.DB_HOST }}
+DB_PORT=${{ secrets.DB_PORT }}
+DB_ENGINE=django.db.backends.postgresql
+EOF
           echo "✓ backend.env file created locally"
       
       - name: Transfer .env to Server


### PR DESCRIPTION
## Issue

The heredoc validation workflow detected an indented EOF delimiter on line 533 of reusable-deploy.yml, causing the validation check to fail.

## Root Cause

The EOF delimiter in the backend .env file creation heredoc was indented, which is technically incorrect bash syntax:

```yaml
cat << 'EOF' > backend.env
  DJANGO_SECRET_KEY=...
  EOF  # ❌ INDENTED - invalid
```

While bash may tolerate this in some cases, the heredoc validation script correctly flags it as a syntax error.

## Fix

Unindented the EOF delimiter to follow proper heredoc syntax:

```yaml
cat << 'EOF' > backend.env
DJANGO_SECRET_KEY=...
EOF  # ✅ NO INDENTATION - valid
```

## Why This Matters

- ✅ Passes heredoc syntax validation
- ✅ Follows proper bash heredoc standards
- ✅ Prevents potential parsing issues in different shell environments
- ✅ Maintains consistency with other heredocs in the file

## Testing

```bash
.github/hooks/check-heredoc-syntax.sh
# Output: ✅ All heredoc syntax is valid
```

## Impact

- No functional change - the content of backend.env remains identical
- The deployment succeeded with the old syntax, this just corrects the technical issue
- Validation workflow will now pass

## Related

- Addresses validation failure in run https://github.com/Meats-Central/ProjectMeats/actions/runs/20688952972
- Deployment to development completed successfully despite validation failure
- This fix ensures validation passes on future deployments