### PR TITLE
fix: use heredoc <<- operator to allow tab indentation in YAML

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -519,18 +519,18 @@ jobs:
     steps:
       - name: Create Backend .env File Locally
         run: |
-          cat << 'EOF' > backend.env
-DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
-DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
-ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
-DEBUG=${{ secrets.DEBUG }}
-DB_NAME=${{ secrets.DB_NAME }}
-DB_USER=${{ secrets.DB_USER }}
-DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-DB_HOST=${{ secrets.DB_HOST }}
-DB_PORT=${{ secrets.DB_PORT }}
-DB_ENGINE=django.db.backends.postgresql
-EOF
+          cat <<- 'EOF' > backend.env
+          	DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
+          	DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
+          	ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}
+          	DEBUG=${{ secrets.DEBUG }}
+          	DB_NAME=${{ secrets.DB_NAME }}
+          	DB_USER=${{ secrets.DB_USER }}
+          	DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          	DB_HOST=${{ secrets.DB_HOST }}
+          	DB_PORT=${{ secrets.DB_PORT }}
+          	DB_ENGINE=django.db.backends.postgresql
+          	EOF
           echo "✓ backend.env file created locally"
       
       - name: Transfer .env to Server


### PR DESCRIPTION
## Critical Fix

The main workflow failed with a YAML syntax error on line 523 due to incorrect heredoc indentation.

## Root Cause

When I previously fixed the heredoc EOF delimiter indentation (PR #1591), I removed ALL indentation including from the content lines. This broke the YAML structure because:

1. YAML requires content to be indented under the `run:` block
2. Bash heredoc requires EOF delimiter at column 0 (no indentation)
3. These two requirements conflict when using `<<` operator

## The Solution

Use the `<<-` operator instead of `<<`:
- `<<` requires EOF at column 0 and content can be indented
- `<<-` allows BOTH content AND EOF to be indented with tabs

**Before** (YAML syntax error):
```yaml
run: |
  cat << 'EOF' > backend.env
DJANGO_SECRET_KEY=...  # ❌ Not indented - breaks YAML structure
EOF
```

**After** (Valid YAML + Valid Heredoc):
```yaml
run: |
  cat <<- 'EOF' > backend.env
  DJANGO_SECRET_KEY=...  # ✅ Tab-indented - valid YAML
  EOF  # ✅ Tab-indented - allowed with <<-
```

## Why <<- Works

The `<<-` operator:
- Strips **leading tabs** (not spaces) from heredoc content
- Allows the EOF delimiter to be indented with tabs
- Keeps YAML structure valid
- Produces the same output file content

## Testing

```bash
# Heredoc validation
.github/hooks/check-heredoc-syntax.sh
# Output: ✅ All heredoc syntax is valid

# YAML validation (GitHub will validate on push)
```

## Impact

- ✅ Fixes main pipeline YAML syntax error
- ✅ Maintains heredoc best practices
- ✅ Allows workflow to run again
- ✅ No functional change to backend.env content

## Related

- Fixes: `error parsing called workflow on line 523`
- Addresses validation failure preventing all deployments
- Builds on PR #1591 (heredoc EOF fix)