### PR TITLE
fix: remove pull_request trigger from main-pipeline to reduce noise

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -9,8 +9,6 @@ on:
       - '**.md'
       - 'docs/**'
       - 'archived/**'
-  pull_request:
-    branches: [development, uat, main]
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Issue

The main-pipeline workflow was triggering on PR events and then showing as "skipped" in the workflow runs list, creating unnecessary clutter.

Example skipped runs:
- `🔍 PR Check: Release: Promote development to uat` (main-pipeline on PR)

## Root Cause

The main-pipeline has triggers for both `push` and `pull_request` events. When a PR is opened, the workflow runs but all deploy jobs are skipped (correct behavior due to `if` conditions), resulting in a "skipped" run in the list.

## Solution

We already have a dedicated `pr-validation.yml` workflow that handles PR checks. The main-pipeline should only run on actual pushes (including PR merges) and manual triggers.

**Removed**:
```yaml
pull_request:
  branches: [development, uat, main]
```

**Kept**:
```yaml
on:
  push:              # ✅ Deploys when PR merges (push to branch)
    branches: [development, uat, main]
  workflow_dispatch: # ✅ Manual triggers
```

## Benefits

- ✅ Reduces workflow run list clutter
- ✅ No more confusing "skipped" main-pipeline runs on PRs
- ✅ Cleaner separation: `pr-validation.yml` for PRs, `main-pipeline.yml` for deployments
- ✅ **Deployments still work on PR merge** (push trigger handles this)

## Validation Coverage

PRs are still validated by `pr-validation.yml` which runs:
- Lint Documentation
- Validate Heredoc Syntax  
- Security Scan Documentation
- Check Deployment Configs
- Validate Environment Variables

## Impact

- ✅ No functional changes to deployments
- ✅ PRs still get validated (via pr-validation.yml)
- ✅ Deployments still run when PR is merged (push trigger)
- ✅ Cleaner workflow run history