### PR TITLE
fix: remove duplicate --error-logfile line causing Dockerfile parse error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -102,4 +102,3 @@ CMD ["sh", "-c", "set -x && \
       --capture-output \
       --access-logfile - \
       --error-logfile -"]
-      --error-logfile - || { echo \"Gunicorn failed with exit code $?\"; sleep 300; }"]


### PR DESCRIPTION
## 🔥 Hotfix: Dockerfile Parse Error

**Issue**: Deployment failing with Dockerfile parse error on line 105

```
ERROR: failed to build: failed to solve: dockerfile parse error on line 105: unknown instruction: --error-logfile
```

## Root Cause

Line 105 had a duplicate/stray line that broke Docker's CMD parsing:

```dockerfile
104|       --error-logfile -"]
105|       --error-logfile - || { echo \"Gunicorn failed with exit code $?\"; sleep 300; }"]  ← DUPLICATE
```

After the closing quote of a JSON array (`"]`), Docker interprets any additional text as a Dockerfile instruction, causing the parse error.

## Fix

Removed line 105 (the duplicate). The CMD now correctly ends at line 104:

```dockerfile
104|       --error-logfile -"]
```

## Impact

- ✅ Fixes build failures
- ✅ Allows deployment to proceed
- ✅ No functional changes to Gunicorn configuration

## Related

- Failed run: https://github.com/Meats-Central/ProjectMeats/actions/runs/20689857274/job/59396258212
- Introduced in: #1607