### PR TITLE
fix: correct GitHub CLI label syntax to use multiple --label flags

### DIFF
--- a/.github/workflows/ops-release-automation.yml
+++ b/.github/workflows/ops-release-automation.yml
@@ -74,7 +74,8 @@ jobs:
             --head development \
             --title "Sync: Development to UAT ($(date +%Y-%m-%d))" \
             --body "Automated sync. Development is ${{ steps.dev_uat.outputs.commits }} commits ahead." \
-            --label "sync,automated"
+            --label "sync" \
+            --label "automated"
 
   draft-release:
     name: "Draft Release PR"
@@ -162,13 +163,23 @@ jobs:
           SOURCE=${{ steps.context.outputs.SOURCE }}
           TARGET=${{ steps.context.outputs.TARGET }}
           HEAD=${{ steps.conflicts.outputs.HEAD_BRANCH }}
+          LABELS="${{ steps.context.outputs.LABEL }}"
+          
           echo "## Release: ${SOURCE^^} to ${TARGET^^}" > pr_body.md
           if [[ "${{ steps.conflicts.outputs.HAS_CONFLICTS }}" == "true" ]]; then
              echo "**Conflicts Auto-Resolved**: Used 'ours' strategy ($SOURCE)." >> pr_body.md
           fi
-          gh pr create \
-            --base $TARGET \
+          
+          # Convert comma-separated labels to multiple --label flags
+          LABEL_FLAGS=""
+          IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+          for label in "${LABEL_ARRAY[@]}"; do
+            LABEL_FLAGS="$LABEL_FLAGS --label \"$label\""
+          done
+          
+          eval gh pr create \
+            --base "$TARGET" \
             --head "$HEAD" \
             --title "Release: Promote $SOURCE to $TARGET" \
             --body-file pr_body.md \
-            --label "${{ steps.context.outputs.LABEL }}"
+            $LABEL_FLAGS


### PR DESCRIPTION
## 🔧 Fix: GitHub CLI Label Syntax Error

**Issue**: PR creation failing with label not found error:
```
Label 'sync,automated' not found
```

## Root Cause

GitHub CLI expects **multiple `--label` flags** for multiple labels, not comma-separated values:

```bash
# ❌ WRONG (comma-separated)
--label "sync,automated"

# ✅ CORRECT (separate flags)
--label "sync" --label "automated"
```

## Changes Made

### 1. Sync PRs (Line 77)
**Before**:
```yaml
--label "sync,automated"
```

**After**:
```yaml
--label "sync" \
--label "automated"
```

### 2. Draft Release PRs (Lines 158-175)
**Problem**: Context step outputs comma-separated labels (`release,automated` or `release,automated,production`)

**Solution**: Added bash logic to convert comma-separated labels to multiple `--label` flags:

```bash
# Convert comma-separated labels to multiple --label flags
LABEL_FLAGS=""
IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
for label in "${LABEL_ARRAY[@]}"; do
  LABEL_FLAGS="$LABEL_FLAGS --label \"$label\""
done

eval gh pr create ... $LABEL_FLAGS
```

This dynamically generates:
- `--label "release" --label "automated"` for dev→uat
- `--label "release" --label "automated" --label "production"` for uat→main

## Impact

- ✅ Fixes "Label not found" errors in ops-release-automation
- ✅ Works with existing label definitions
- ✅ Supports any number of comma-separated labels
- ✅ No changes needed to label assignment logic

## Testing

The fix handles:
- Single label: `sync` → `--label "sync"`
- Two labels: `release,automated` → `--label "release" --label "automated"`
- Three labels: `release,automated,production` → `--label "release" --label "automated" --label "production"`

## Related

- Failed run: https://github.com/Meats-Central/ProjectMeats/actions/runs/20689877410/job/59396310283
- GitHub CLI docs: Multiple labels require multiple `--label` flags