### PR TITLE
fix: YAML syntax error in db-sync workflow

### DIFF
--- a/.github/workflows/db-sync-prod-to-uat.yml
+++ b/.github/workflows/db-sync-prod-to-uat.yml
@@ -148,33 +148,33 @@ jobs:
           echo "🧹 Clearing UAT business data (preserving test tenants)..."
           
           # Create SQL to truncate business tables while preserving test tenant data
-          cat > /tmp/clear_uat.sql <<'SQL'
-          -- Disable triggers to allow truncation
-          SET session_replication_role = 'replica';
-          
-          -- Get list of all tenant-aware tables (those with tenant_id column)
-          DO $$
-          DECLARE
-            r RECORD;
-          BEGIN
-            FOR r IN (
-              SELECT table_schema, table_name
-              FROM information_schema.columns
-              WHERE column_name = 'tenant_id'
-                AND table_schema NOT IN ('pg_catalog', 'information_schema')
-                AND table_name NOT LIKE 'auth_%'
-                AND table_name NOT LIKE 'django_%'
-            ) LOOP
-              -- Delete only non-test tenant data
-              EXECUTE format('DELETE FROM %I.%I WHERE tenant_id NOT IN (SELECT id FROM apps_tenants_tenant WHERE schema_name LIKE ''test_%%'');', 
-                r.table_schema, r.table_name);
-              RAISE NOTICE 'Cleared %', r.table_name;
-            END LOOP;
-          END $$;
-          
-          -- Re-enable triggers
-          SET session_replication_role = 'origin';
-SQL
+          cat > /tmp/clear_uat.sql <<- 'SQL'
+          	-- Disable triggers to allow truncation
+          	SET session_replication_role = 'replica';
+          	
+          	-- Get list of all tenant-aware tables (those with tenant_id column)
+          	DO $$
+          	DECLARE
+          	  r RECORD;
+          	BEGIN
+          	  FOR r IN (
+          	    SELECT table_schema, table_name
+          	    FROM information_schema.columns
+          	    WHERE column_name = 'tenant_id'
+          	      AND table_schema NOT IN ('pg_catalog', 'information_schema')
+          	      AND table_name NOT LIKE 'auth_%'
+          	      AND table_name NOT LIKE 'django_%'
+          	  ) LOOP
+          	    -- Delete only non-test tenant data
+          	    EXECUTE format('DELETE FROM %I.%I WHERE tenant_id NOT IN (SELECT id FROM apps_tenants_tenant WHERE schema_name LIKE ''test_%%'');', 
+          	      r.table_schema, r.table_name);
+          	    RAISE NOTICE 'Cleared %', r.table_name;
+          	  END LOOP;
+          	END $$;
+          	
+          	-- Re-enable triggers
+          	SET session_replication_role = 'origin';
+          	SQL
           
           psql \
             -h localhost \
@@ -227,23 +227,23 @@ SQL
           echo "Found UAT superuser ID: $UAT_SUPERUSER_ID"
           
           # Update all owner_id and created_by_id references
-          cat > /tmp/fixup.sql <<SQL
-          -- Update all owner_id fields
-          UPDATE apps_suppliers_supplier SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
-          UPDATE apps_plants_plant SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
-          UPDATE apps_customers_customer SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
-          
-          -- Update all created_by_id fields
-          UPDATE apps_suppliers_supplier SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
-          UPDATE apps_plants_plant SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
-          UPDATE apps_customers_customer SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
-          UPDATE apps_purchase_orders_purchaseorder SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
-          
-          -- Update any updated_by_id fields
-          UPDATE apps_suppliers_supplier SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
-          UPDATE apps_plants_plant SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
-          UPDATE apps_customers_customer SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
-SQL
+          cat > /tmp/fixup.sql <<- SQL
+          	-- Update all owner_id fields
+          	UPDATE apps_suppliers_supplier SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
+          	UPDATE apps_plants_plant SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
+          	UPDATE apps_customers_customer SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
+          	
+          	-- Update all created_by_id fields
+          	UPDATE apps_suppliers_supplier SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
+          	UPDATE apps_plants_plant SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
+          	UPDATE apps_customers_customer SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
+          	UPDATE apps_purchase_orders_purchaseorder SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
+          	
+          	-- Update any updated_by_id fields
+          	UPDATE apps_suppliers_supplier SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
+          	UPDATE apps_plants_plant SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
+          	UPDATE apps_customers_customer SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
+          	SQL
           
           psql \
             -h localhost \


### PR DESCRIPTION
## Problem

PR #1615 merged with a YAML syntax error that prevents the workflow from running:

```
Invalid workflow file: .github/workflows/db-sync-prod-to-uat.yml#L177
You have an error in your yaml syntax on line 177
```

**Error:** `could not find expected ':'` on line 177

## Root Cause

Heredoc closing delimiters (`SQL`) were placed at column 0 (unindented), which causes YAML parser errors when used inside `run: |` blocks. The YAML parser interprets the unindented delimiter as a new YAML key.

## Solution

Use the `<<-` operator with **tab-indented** closing delimiters:

**Before (❌ YAML error):**
```yaml
run: |
  cat > file.sql <<'SQL'
  content
SQL  # Column 0 - YAML parser error!
```

**After (✅ Works):**
```yaml
run: |
  cat > file.sql <<- 'SQL'
  content
  SQL  # Tab-indented - YAML parser happy!
```

## Changes

- Replace `<<` with `<<-` operator for heredoc blocks
- Indent closing delimiters (`SQL`) with tabs
- Follows proven pattern from `reusable-deploy.yml`

## Validation

✅ YAML syntax validated: `python -c 'import yaml; yaml.safe_load(open(file))'`  
✅ Heredoc syntax validated: `.github/hooks/check-heredoc-syntax.sh`

## Testing

After merge, verify workflow can be manually triggered:
```bash
gh workflow run db-sync-prod-to-uat.yml
```

## Related

- Original PR: #1615
- Follows Golden Standard heredoc pattern from `reusable-deploy.yml`