### PR TITLE
fix: ensure PurchaseOrderHistory inherits tenant from parent

### DIFF
--- a/backend/tenant_apps/purchase_orders/models.py
+++ b/backend/tenant_apps/purchase_orders/models.py
@@ -610,6 +610,7 @@ def create_purchase_order_history(sender, instance, created, **kwargs):
     # Create history entry
     PurchaseOrderHistory.objects.create(
         purchase_order=instance,
+        tenant=instance.tenant,  # Inherit tenant from parent PurchaseOrder
         changed_data=changed_data,
         changed_by=user,
         change_type=change_type,


### PR DESCRIPTION
## 🐛 Bugfix: Missing Tenant in Purchase Order History

**Type**: Critical bugfix for seeding and audit trail

### Problem
`PurchaseOrderHistory` creation in post_save signal didn't set tenant field:
- Caused `IntegrityError` during seeding
- Error: `null value in column tenant_id violates not-null constraint`
- Broke multi-tenancy isolation for audit records

### Solution
Added `tenant=instance.tenant` to history creation (line 612):
```python
PurchaseOrderHistory.objects.create(
    purchase_order=instance,
    tenant=instance.tenant,  # ← FIX: Inherit from parent
    changed_data=changed_data,
    changed_by=user,
    change_type=change_type,
)
```

### Impact
- ✅ Seeding completes successfully (3 tenants created)
- ✅ Audit trail maintains tenant isolation
- ✅ History records inherit correct tenant context

### Validation
```bash
$ python manage.py seed_tenants --count 3 --env development
✅ Created Test Company 1 (Development)
✅ Created Test Company 2 (Development)  
✅ Created Test Company 3 (Development)
```

**Critical for**: Final milestone completion of Golden State Synchronization