### PR TITLE
Fix: Admin panel format_html error in TenantInvitation display

### DIFF
--- a/backend/apps/tenants/admin.py
+++ b/backend/apps/tenants/admin.py
@@ -480,7 +480,7 @@ class TenantInvitationAdmin(TenantFilteredAdmin):
     
     def email_or_type(self, obj):
         if obj.is_reusable:
-            return format_html('<strong style="color: #0066cc;">🔗 Reusable Link</strong>')
+            return format_html('<strong style="color: #0066cc;">{}</strong>', '🔗 Reusable Link')
         return obj.email or "—"
     email_or_type.short_description = "Email / Type"
     


### PR DESCRIPTION
## Problem
Admin panel crashes when accessing  with error:
```
TypeError: args or kwargs must be provided
```

## Root Cause
Line 483 in `apps/tenants/admin.py` - `email_or_type()` method calls `format_html()` without required format arguments:
```python
return format_html('<strong style="color: #0066cc;">🔗 Reusable Link</strong>')
```

## Solution
Changed to properly pass format arguments per Django's `format_html()` API:
```python
return format_html('<strong style="color: #0066cc;">{}</strong>', '🔗 Reusable Link')
```

## Testing
- [ ] Verified fix resolves admin panel crash
- [ ] Reusable invitation links display correctly with blue styling
- [ ] XSS protection maintained via proper format_html usage

## Related
- Discovered during Golden Baseline certification (Phase 2)
- Part of post-tenant-seeding admin panel validation

## Checklist
- [x] Single-line fix (minimal surgical change)
- [x] Follows Django format_html() best practices
- [x] Maintains XSS protection
- [x] No migration required
- [x] No test changes required (display-only fix)