### PR TITLE
Fix: usage_info format_html error with percentage formatting

### DIFF
--- a/backend/apps/tenants/admin.py
+++ b/backend/apps/tenants/admin.py
@@ -489,8 +489,8 @@ class TenantInvitationAdmin(TenantFilteredAdmin):
             percentage = (obj.usage_count / obj.max_uses * 100) if obj.max_uses > 0 else 0
             color = "#28a745" if percentage < 80 else "#ffc107" if percentage < 100 else "#dc3545"
             return format_html(
-                '<span style="color: {};">{} / {} uses ({:.0f}%)</span>',
-                color, obj.usage_count, obj.max_uses, percentage
+                '<span style="color: {};">{} / {} uses ({}%)</span>',
+                color, obj.usage_count, obj.max_uses, int(percentage)
             )
         return "—"
     usage_info.short_description = "Usage"


### PR DESCRIPTION
## Problem
Admin panel crashes when accessing `/admin/tenants/tenantinvitation/` with error:
```
ValueError: Unknown format code 'f' for object of type 'SafeString'
Exception Location: django/utils/html.py, line 140, in format_html
```

## Root Cause
Line 491-493 in `apps/tenants/admin.py` - `usage_info()` method uses `{:.0f}` format specifier inside `format_html()`:
```python
return format_html(
    '<span style="color: {};">... ({:.0f}%)</span>',
    color, obj.usage_count, obj.max_uses, percentage
)
```

Django's `format_html()` uses `.format()` internally, which doesn't support format specifiers like `{:.0f}` when the value becomes a SafeString during processing.

## Solution
Pre-format the percentage as an integer before passing to `format_html()`:
```python
return format_html(
    '<span style="color: {};">... ({}%)</span>',
    color, obj.usage_count, obj.max_uses, int(percentage)
)
```

## Testing
- [x] Error occurred on production (dev.meatscentral.com)
- [x] Fix applied and tested locally
- [ ] Will verify after deployment

## Related
- Follows PR #1650 which fixed `email_or_type()` method
- Completes admin panel format_html error fixes
- Part of Golden Baseline certification validation

## Impact
- **Before**: Admin panel crashes, cannot view tenant invitations
- **After**: Usage info displays correctly with color-coded percentages

## Checklist
- [x] Single-line fix (minimal surgical change)
- [x] Follows Django format_html() best practices
- [x] No migration required
- [x] No test changes required (display-only fix)
- [x] Maintains XSS protection via format_html()