### PR TITLE
Fix: Django 6.0 format_html compatibility in TenantAdmin

### DIFF
--- a/backend/apps/tenants/admin.py
+++ b/backend/apps/tenants/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin, messages
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.conf import settings
 from django.shortcuts import render, redirect
 from django.urls import path
@@ -385,7 +386,7 @@ class TenantAdmin(admin.ModelAdmin):
         Only displays for test tenants (schema_name starts with 'test_').
         """
         if not obj.schema_name or not obj.schema_name.startswith('test_'):
-            return format_html(
+            return mark_safe(
                 '<div style="background: #f5f5f5; padding: 15px; border-radius: 5px; border: 1px solid #ddd;">'
                 '<p style="color: #666;"><em>Not a test tenant. This section only applies to tenants '
                 'created via the seed_tenants management command.</em></p>'
@@ -413,7 +414,7 @@ class TenantAdmin(admin.ModelAdmin):
                 admin_user.username,
                 admin_user.email
             )
-        return format_html(
+        return mark_safe(
             '<div style="background: #fff3cd; padding: 15px; border-radius: 5px; border: 1px solid #ffc107;">'
             '<p style="margin: 0;">⚠️ No admin user found for this test tenant.</p>'
             '</div>'


### PR DESCRIPTION
## Problem
The Django admin page for Tenant model was throwing a TypeError when viewing tenant details:
```
TypeError at /admin/tenants/tenant/.../change/
args or kwargs must be provided.
```

## Root Cause
Django 6.0 changed `format_html()` behavior to require at least one format argument. The `test_credentials_display()` method had two calls to `format_html()` with HTML strings containing no placeholders.

## Solution
- Replaced `format_html()` with `mark_safe()` for HTML strings without placeholders
- Added `from django.utils.safestring import mark_safe` import
- Maintained `format_html()` where placeholders exist (username and email display)

## Testing
- [x] Admin page loads without errors
- [x] Test credentials display correctly for test tenants
- [x] Non-test tenant message displays correctly
- [x] No admin user warning displays correctly

## Files Changed
- `backend/apps/tenants/admin.py` - Updated `test_credentials_display()` method