### PR TITLE
fix: Update email sender to verified identity no-reply@meatscentral.com

### DIFF
--- a/backend/projectmeats/settings/base.py
+++ b/backend/projectmeats/settings/base.py
@@ -284,4 +284,5 @@ EMAIL_PORT = int(os.environ.get('EMAIL_PORT', 587))
 EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', 'True').lower() == 'true'
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', 'apikey')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
-DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'noreply@meatscentral.com')
+DEFAULT_FROM_EMAIL = 'no-reply@meatscentral.com'
+SERVER_EMAIL = 'no-reply@meatscentral.com'

--- a/backend/projectmeats/settings/development.py
+++ b/backend/projectmeats/settings/development.py
@@ -186,8 +186,8 @@ EMAIL_PORT = config("EMAIL_PORT", default=587, cast=int)
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=True, cast=bool)
 EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="apikey")
 EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
-DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="noreply@meatscentral.com")
-SERVER_EMAIL = config("SERVER_EMAIL", default="noreply@meatscentral.com")
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="no-reply@meatscentral.com")
+SERVER_EMAIL = config("SERVER_EMAIL", default="no-reply@meatscentral.com")
 
 # Static files
 STATICFILES_DIRS = [

--- a/backend/projectmeats/settings/production.py
+++ b/backend/projectmeats/settings/production.py
@@ -236,8 +236,8 @@ EMAIL_PORT = config("EMAIL_PORT", default=587, cast=int)
 EMAIL_USE_TLS = True
 EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="apikey")
 EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
-DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="noreply@meatscentral.com")
-SERVER_EMAIL = config("SERVER_EMAIL", default=config("DEFAULT_FROM_EMAIL", default="noreply@meatscentral.com"))
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="no-reply@meatscentral.com")
+SERVER_EMAIL = config("SERVER_EMAIL", default=config("DEFAULT_FROM_EMAIL", default="no-reply@meatscentral.com"))
 
 # -----------------------------------------------------------------------------
 # Static / Media

--- a/backend/projectmeats/settings/staging.py
+++ b/backend/projectmeats/settings/staging.py
@@ -71,8 +71,8 @@ EMAIL_PORT = config("EMAIL_PORT", default=587, cast=int)
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=True, cast=bool)
 EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="apikey")
 EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
-DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="noreply@meatscentral.com")
-SERVER_EMAIL = config("SERVER_EMAIL", default="noreply@meatscentral.com")
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="no-reply@meatscentral.com")
+SERVER_EMAIL = config("SERVER_EMAIL", default="no-reply@meatscentral.com")
 
 # Staging-specific cache (can be less robust)
 CACHES = {


### PR DESCRIPTION
## Summary
Updates all email configurations to use the verified SendGrid sender identity `no-reply@meatscentral.com` instead of `noreply@meatscentral.com`.

## Changes
- Set `DEFAULT_FROM_EMAIL = 'no-reply@meatscentral.com'` in all settings files
- Added `SERVER_EMAIL = 'no-reply@meatscentral.com'` for system emails
- Updated defaults in development.py, production.py, and staging.py

## Why
SendGrid requires emails to be sent from verified sender identities. The previous sender `noreply@meatscentral.com` was not verified, causing email delivery failures. The correct verified identity is `no-reply@meatscentral.com` (with hyphen).

## Impact
- ✅ All tenant onboarding invitations will now send successfully
- ✅ System emails will use verified sender
- ✅ Applies to all environments (dev, staging, production)
- ✅ No code changes required - admin actions already use settings correctly

## Testing
Verified that Django settings load correctly:
```
DEFAULT_FROM_EMAIL: no-reply@meatscentral.com
SERVER_EMAIL: no-reply@meatscentral.com
```

Related to email delivery issues with tenant onboarding workflow.