### PR TITLE
fix(tenants): Remove duplicate invitation email sending

### DIFF
--- a/backend/apps/tenants/admin.py
+++ b/backend/apps/tenants/admin.py
@@ -337,37 +337,9 @@ class TenantAdmin(admin.ModelAdmin):
                         message=f"Welcome {first_name} {last_name}, your new workspace '{tenant.name}' is ready! Click the link to set up your account."
                     )
                     
-                    # Explicitly trigger email send with detailed error logging
-                    try:
-                        logger.info("=" * 80)
-                        logger.info(f"📧 Starting email send for tenant: {tenant.name}")
-                        logger.info(f"   Recipient: {owner_email}")
-                        logger.info(f"   EMAIL_BACKEND: {settings.EMAIL_BACKEND}")
-                        logger.info(f"   SENDGRID_API_KEY: {'✅ SET' if getattr(settings, 'SENDGRID_API_KEY', None) else '❌ NOT SET'}")
-                        logger.info("=" * 80)
-                        
-                        from .signals import send_invitation_email
-                        send_invitation_email(TenantInvitation, invitation, created=True)
-                        
-                        logger.info(f"✅ Email sent successfully to {owner_email}")
-                        
-                    except ConnectionRefusedError as e:
-                        logger.error("=" * 80)
-                        logger.error("❌ CONNECTION REFUSED ERROR (Errno 111)")
-                        logger.error(f"   This indicates SMTP is being attempted instead of Web API!")
-                        logger.error(f"   Error: {str(e)}")
-                        logger.error(f"   Type: {type(e).__name__}")
-                        logger.error("=" * 80)
-                        raise
-                    except Exception as e:
-                        logger.error("=" * 80)
-                        logger.error(f"❌ EMAIL SEND FAILED")
-                        logger.error(f"   Error Type: {type(e).__name__}")
-                        logger.error(f"   Error Message: {str(e)}")
-                        logger.error(f"   Tenant: {tenant.name}")
-                        logger.error(f"   Recipient: {owner_email}")
-                        logger.error("=" * 80)
-                        raise
+                    # Email is automatically sent by post_save signal in signals.py
+                    # No need to manually trigger here (was causing duplicate emails)
+                    logger.info(f"✅ Invitation created for {owner_email}. Email will be sent by post_save signal.")
 
                     self.message_user(
                         request, 

--- a/backend/apps/tenants/signals.py
+++ b/backend/apps/tenants/signals.py
@@ -12,7 +12,7 @@ from .models import TenantInvitation
 logger = logging.getLogger(__name__)
 
 
-@receiver(post_save, sender=TenantInvitation)
+@receiver(post_save, sender=TenantInvitation, dispatch_uid="send_invitation_email_once")
 def send_invitation_email(sender, instance, created, **kwargs):
     """
     Automatically send email when a new invitation is created.
@@ -21,6 +21,8 @@ def send_invitation_email(sender, instance, created, **kwargs):
     - Invitation was just created
     - Status is 'pending'
     - Email address is provided (not a reusable golden ticket)
+    
+    Note: dispatch_uid prevents duplicate signal connections during Django reload.
     """
     if created and instance.status == 'pending' and instance.email:
         # Log configuration status


### PR DESCRIPTION
## 🐛 Critical Bug: Duplicate Invitation Emails

Users receive **TWO identical invitation emails** - unprofessional and confusing.

---

## Root Cause

**Double email send**:
1. **admin.py line 332**:  → triggers post_save signal → Email #1 ✅
2. **admin.py line 349**: Explicit  call → Email #2 ❌

---

## Solution

### 1. Removed Redundant Email Call (admin.py)
**Before** (lines 340-370): 32 lines of explicit email sending with error handling  
**After** (line 341): Simple log message - signal handles everything

### 2. Added dispatch_uid (signals.py)
Prevents duplicate signal connections during Django reload (best practice).

---

## Changes

```diff
backend/apps/tenants/admin.py:  -32 lines, +2 lines
backend/apps/tenants/signals.py: +1 parameter (dispatch_uid)
```

---

## Testing

**Before**: Create invitation → 2 emails sent ❌  
**After**: Create invitation → 1 email sent ✅

---

## Impact

- ✅ Fixes duplicate emails immediately
- ✅ 50% reduction in email sends
- ✅ Cleaner code (-30 lines)
- ✅ Single source of truth (signals.py)

**Status**: Ready for immediate merge  
**Risk**: LOW - Simple, safe fix