### PR TITLE
fix: correct admin button URL for dev environment

### DIFF
--- a/frontend/src/components/ProfileDropdown/ProfileDropdown.tsx
+++ b/frontend/src/components/ProfileDropdown/ProfileDropdown.tsx
@@ -55,13 +55,24 @@ const ProfileDropdown: React.FC<ProfileDropdownProps> = () => {
   };
 
   const handleAdminClick = () => {
-    // Open Django admin in new tab using the API base URL
-    // Remove '/api/v1' from the end to get the base backend URL, then add '/admin/'
-    const baseBackendUrl = config.API_BASE_URL.replace('/api/v1', '');
-    const adminUrl = `${baseBackendUrl}/admin/`;
+    // Open Django admin in new tab
+    // In deployed environments, admin is proxied through the same domain as the frontend
+    // In local dev (localhost), use the API base URL
+    
+    const hostname = window.location.hostname;
+    let adminUrl: string;
+    
+    if (hostname.includes('localhost')) {
+      // Local dev: use backend directly
+      const baseBackendUrl = config.API_BASE_URL.replace('/api/v1', '');
+      adminUrl = `${baseBackendUrl}/admin/`;
+    } else {
+      // Deployed environments: admin is proxied through same domain
+      const protocol = window.location.protocol;
+      adminUrl = `${protocol}//${hostname}/admin/`;
+    }
     
     // Use window.location.href for more reliable navigation
-    // Opens in same tab - more reliable than window.open which can be blocked
     window.location.href = adminUrl;
     setIsOpen(false);
   };


### PR DESCRIPTION
## Problem
The "View as Admin" button in ProfileDropdown was pointing to `http://localhost:8000/admin/` when accessed from `dev.meatscentral.com`.

## Solution
Updated the admin URL logic to:
- **Deployed environments** (dev/uat/prod): Use same-domain proxy path (e.g., `https://dev.meatscentral.com/admin/`)
- **Localhost**: Continue using direct backend connection (e.g., `http://localhost:8000/admin/`)

## Changes
- Modified `ProfileDropdown.tsx` to detect hostname and build appropriate admin URL
- Aligns with unified proxy architecture where nginx proxies both `/api/` and `/admin/` paths

## Testing
- ✅ Test on localhost - should go to `http://localhost:8000/admin/`
- ✅ Test on dev.meatscentral.com - should go to `https://dev.meatscentral.com/admin/`
- ✅ Same logic applies to UAT and Production environments