### PR TITLE
fix: Register locations app URLs and implement ViewSet

### DIFF
--- a/backend/projectmeats/urls.py
+++ b/backend/projectmeats/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path("api/v1/", include("tenant_apps.carriers.urls")),
     path("api/v1/", include("tenant_apps.products.urls")),
     path("api/v1/", include("tenant_apps.invoices.urls")),
+    path("api/v1/", include("tenant_apps.locations.urls")),
     path("api/v1/ai-assistant/", include("tenant_apps.ai_assistant.urls")),
     path("api/v1/", include("apps.core.urls")),  # Core shared utilities
     path("api/v1/bug-reports/", include("tenant_apps.bug_reports.urls")),

--- a/backend/tenant_apps/locations/urls.py
+++ b/backend/tenant_apps/locations/urls.py
@@ -1,0 +1,17 @@
+"""
+URL configuration for Locations app.
+"""
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import LocationViewSet
+
+app_name = "locations"
+
+# Create a router and register our viewsets
+router = DefaultRouter()
+router.register(r"locations", LocationViewSet, basename="location")
+
+# The API URLs are now determined automatically by the router
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/backend/tenant_apps/locations/views.py
+++ b/backend/tenant_apps/locations/views.py
@@ -1,3 +1,29 @@
-from django.shortcuts import render
+"""
+ViewSets for Locations app.
+"""
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+from .models import Location
+from .serializers import LocationSerializer, LocationListSerializer
 
-# Create your views here.
+
+class LocationViewSet(viewsets.ModelViewSet):
+    """
+    ViewSet for managing Location instances with tenant isolation.
+    """
+    permission_classes = [IsAuthenticated]
+    serializer_class = LocationSerializer
+    
+    def get_queryset(self):
+        """Filter locations by tenant for isolation."""
+        return Location.objects.filter(tenant=self.request.tenant)
+    
+    def get_serializer_class(self):
+        """Use lightweight serializer for list actions."""
+        if self.action == 'list':
+            return LocationListSerializer
+        return LocationSerializer
+    
+    def perform_create(self, serializer):
+        """Assign tenant automatically on creation."""
+        serializer.save(tenant=self.request.tenant)


### PR DESCRIPTION
## Summary
Fixes the missing `/api/v1/locations/` endpoint by implementing the complete URL routing chain.

## Changes Made
1. **Added locations URL pattern** to `backend/projectmeats/urls.py` (alphabetically placed)
2. **Created `LocationViewSet`** with tenant isolation in `views.py`:
   - Filters by `tenant=request.tenant` for multi-tenancy
   - Uses `LocationListSerializer` for list actions
   - Auto-assigns tenant on creation via `perform_create()`
3. **Created `urls.py`** for locations app with DRF router configuration

## Testing
- Endpoint will be available at `/api/v1/locations/` after deployment
- Follows established patterns from suppliers/customers apps
- Includes proper tenant isolation and authentication

## Related
- Implements Phase 4 logistics features
- Completes locations app setup from recent migrations