### PR TITLE
fix(ci): Use secrets inherit for dev deployment

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -41,25 +41,7 @@ jobs:
       backend_environment: 'dev-backend'
       frontend_environment: 'dev-frontend'
       api_base_url: 'https://dev.meatscentral.com'
-    secrets:
-      DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}
-      SSH_HOST: ${{ secrets.SSH_HOST }}
-      SSH_USER: ${{ secrets.SSH_USER }}
-      SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
-      SSH_KEY: ${{ secrets.SSH_KEY }}
-      DB_HOST: ${{ secrets.DB_HOST }}
-      DB_PORT: ${{ secrets.DB_PORT }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
-      DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
-      BACKEND_HOST: ${{ secrets.BACKEND_HOST }}
-      DJANGO_SUPERUSER_USERNAME: ${{ secrets.DJANGO_SUPERUSER_USERNAME }}
-      DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
-      DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
-      DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
-      EMAIL_HOST_PASSWORD: ${{ secrets.EMAIL_HOST_PASSWORD }}
+    secrets: inherit
 
   # ==========================================
   # Route to UAT

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -66,6 +66,9 @@ on:
       DJANGO_SETTINGS_MODULE:
         required: false
         description: "Django settings module path (from job environment)"
+      REACT_APP_API_BASE_URL:
+        required: false
+        description: "API base URL for frontend runtime config (from job environment)"
       BACKEND_HOST:
         required: false
         description: "Backend host IP/hostname for nginx proxy and Docker networking (from job environment)"


### PR DESCRIPTION
## 🛑 Fixes PR #1749 Incomplete Solution

**PR #1749** removed  from the explicit secrets list but didn't account for how  secrets work.

### The Problem with PR #1749

When using explicit  passing (not ), the reusable workflow can **ONLY** access secrets that are explicitly passed. The job's `environment:` context cannot override this at the workflow_call interface level.

**PR #1749 Flow (Broken)**:
```
Main Pipeline (deploy-dev)
├── secrets: [explicit list of 13 secrets]
├── REACT_APP_API_BASE_URL NOT in list ❌
└── Reusable Workflow
    └── deploy-frontend: environment: dev-frontend
        └── secrets.REACT_APP_API_BASE_URL = undefined ❌
```

### The Complete Fix (This PR)

**Change 1: Use `secrets: inherit` in deploy-dev** (matches UAT/Prod pattern)
```yaml
# main-pipeline.yml
deploy-dev:
  secrets: inherit  # ✅ Pass ALL secrets, let jobs filter by environment
```

**Change 2: Re-add secret definition in reusable workflow**
```yaml
# reusable-deploy.yml
secrets:
  REACT_APP_API_BASE_URL:
    required: false
    description: "API base URL for frontend runtime config (from job environment)"
```

### How It Works Now

```
Main Pipeline (deploy-dev)
├── secrets: inherit (all repo + environment secrets available)
└── Reusable Workflow
    ├── deploy-backend
    │   └── environment: dev-backend
    │       └── Reads dev-backend secrets (DB_*, DJANGO_*)
    └── deploy-frontend
        └── environment: dev-frontend
            └── Reads dev-frontend secrets
                └── REACT_APP_API_BASE_URL = https://dev.meatscentral.com ✅
```

## Changes Made

### 1. `.github/workflows/main-pipeline.yml`
- ❌ Removed explicit secrets list (18 lines)
- ✅ Added `secrets: inherit`
- ✅ Now matches UAT/Prod pattern

### 2. `.github/workflows/reusable-deploy.yml`
- ✅ Re-added `REACT_APP_API_BASE_URL` to secrets definition
- ✅ Marked as optional (from job environment)

## Impact

### Before (PR #1749 - Broken)
```javascript
window.ENV = {
  API_BASE_URL: "",  // Empty - secret not accessible
  ENVIRONMENT: "development"
};
```

### After (This PR - Fixed)
```javascript
window.ENV = {
  API_BASE_URL: "https://dev.meatscentral.com",  // ✅ From dev-frontend
  ENVIRONMENT: "development"
};
```

## Benefits

1. ✅ **Consistency**: Dev matches UAT/Prod pattern (all use `secrets: inherit`)
2. ✅ **Correctness**: Frontend reads from correct environment bucket
3. ✅ **Maintainability**: No explicit secret lists to maintain
4. ✅ **Scalability**: New secrets automatically available

## Testing Plan

1. Merge this PR
2. Deploy to dev (automatic on merge to development)
3. Verify `env-config.js` contains correct API URL
4. Verify frontend can call backend APIs successfully

## Related

- **PR #1749** (MERGED): Incomplete fix - removed secret but broke access
- **PR #1747** (MERGED): Locations app URL registration

---

**Priority**: 🔴 **CRITICAL** - Fixes frontend-backend communication broken by PR #1749