### PR TITLE
fix(ci): Mount env-config.js to correct container path

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -793,7 +793,7 @@ jobs:
             -e BACKEND_HOST="${BACKEND_HOST}" \
             -e DOMAIN_NAME="${DOMAIN_NAME}" \
             -e ENVIRONMENT="${ENVIRONMENT}" \
-            -v /opt/pm/frontend/env:/usr/share/nginx/html/env:ro \
+            -v /opt/pm/frontend/env/env-config.js:/usr/share/nginx/html/env-config.js:ro \
             "$REG/$IMG:$IMAGE_TAG"
           
           echo "✓ Container started successfully"


### PR DESCRIPTION
## Critical Path Fix

This is a follow-up to PR #1756 that fixes the **actual root cause** of the localhost API connection issue.

## Problem Discovered
After merging #1756 (explicit secret passing), the deployment would still fail because:

1. **Generated file location** (host): `/opt/pm/frontend/env/env-config.js`
2. **Mounted location** (container): `/usr/share/nginx/html/env/env-config.js` (in subdirectory)
3. **HTML loads from**: `/env-config.js` (at root of html directory)
4. **Result**: Browser loaded the baked-in build-time default (localhost) instead of the runtime config

## Root Cause
```bash
# OLD (wrong):
-v /opt/pm/frontend/env:/usr/share/nginx/html/env:ro

# This mounted the DIRECTORY, so file ended up at:
#   /usr/share/nginx/html/env/env-config.js
# But HTML requested:
#   /env-config.js (at root)
```

## Solution
```bash
# NEW (correct):
-v /opt/pm/frontend/env/env-config.js:/usr/share/nginx/html/env-config.js:ro

# This mounts the FILE directly to root, so:
#   /usr/share/nginx/html/env-config.js (correct location)
```

## Impact
- ✅ `window.ENV.API_BASE_URL` will now load correct environment URL
- ✅ Frontend will connect to proper backend (not localhost)
- ✅ **Only 1 line changed** (minimal risk)
- ✅ Zero refactoring required

## Testing
- ✅ Workflow validated with actionlint
- ✅ YAML syntax validated

Fixes: Path mismatch causing localhost fallback
Related: #1756 (explicit secret passing)