### PR TITLE
feat(ui): Add favicon files (dev/UAT)

### DIFF
--- a/frontend/public/favicon-dev.svg
+++ b/frontend/public/favicon-dev.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#16A34A" rx="8"/>
+  <text x="32" y="44" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">DEV</text>
+</svg>

--- a/frontend/public/favicon-uat.svg
+++ b/frontend/public/favicon-uat.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#EAB308" rx="8"/>
+  <text x="32" y="44" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">UAT</text>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,10 +52,10 @@ const App: React.FC = () => {
       let titlePrefix = '';
 
       if (env === 'development' || env === 'dev') {
-        faviconPath = '/favicon-dev.ico'; // Green DEV
+        faviconPath = '/favicon-dev.svg'; // Green DEV (SVG)
         titlePrefix = '[DEV] ';
       } else if (env === 'uat' || env === 'staging') {
-        faviconPath = '/favicon-uat.ico'; // Yellow UAT
+        faviconPath = '/favicon-uat.svg'; // Yellow UAT (SVG)
         titlePrefix = '[UAT] ';
       }
 


### PR DESCRIPTION
## Completes PR #1767

Previous PR implemented the favicon switching logic but didn't include the actual icon files. This PR adds them.

## Files Added

1. **favicon-dev.svg** - Green with DEV text
2. **favicon-uat.svg** - Yellow with UAT text

## Updated
- App.tsx: Changed to use SVG format

## Why SVG?
- Natively supported by browsers
- Scales perfectly
- Version controlled text files

Completes: #1767