### PR TITLE
fix: Correct function reference in CallLog (CRITICAL)

### DIFF
--- a/frontend/src/pages/Cockpit/CallLog.tsx
+++ b/frontend/src/pages/Cockpit/CallLog.tsx
@@ -433,7 +433,7 @@ export const CallLog: React.FC = () => {
       <ScheduleCallModal
         isOpen={showScheduleModal}
         onClose={() => setShowScheduleModal(false)}
-        onSuccess={fetchCalls}
+        onSuccess={fetchScheduledCalls}
       />
 
       <SplitPaneContainer>


### PR DESCRIPTION
## 🚨 Critical Bug Fix

**Severity:** BLOCKING - CallLog page completely broken  
**Impact:** Users cannot access Call Log page at all

## Problem

**CallLog page showed blank screen** with console error:
```
CallLog.tsx:436 Uncaught ReferenceError: fetchCalls is not defined
```

**Root Cause:**
- Modal callback referenced `fetchCalls`
- Actual function name is `fetchScheduledCalls`
- Function was renamed in PR #1790 (pagination fix)
- PR #1796 (Schedule Call Modal) used old function name
- Build passed but **runtime error broke page completely**

## Solution

**1 line change** (line 436):

```diff
<ScheduleCallModal
  isOpen={showScheduleModal}
  onClose={() => setShowScheduleModal(false)}
- onSuccess={fetchCalls}
+ onSuccess={fetchScheduledCalls}
/>
```

## Impact

### ❌ Before This Fix
```
1. Navigate to /cockpit/call-log
2. Page renders blank ❌
3. Console error: ReferenceError ❌
4. Schedule Call button unusable ❌
5. Call log completely inaccessible ❌
```

### ✅ After This Fix
```
1. Navigate to /cockpit/call-log
2. Page renders correctly ✅
3. No console errors ✅
4. Schedule Call button works ✅
5. Modal success refreshes list ✅
```

## Testing

```bash
# Build verification
cd frontend && npm run build
# ✅ built in 10.41s
```

**Manual Testing:**
- [x] CallLog page loads without errors
- [x] Schedule Call button opens modal
- [x] Modal submit triggers correct function
- [x] Calls list refreshes after success
- [x] No console errors

## Why This Happened

**Timeline:**
1. **PR #1790** (Pagination fix): Function renamed `fetchCalls` → `fetchScheduledCalls`
2. **PR #1796** (Schedule Call Modal): Added modal with `onSuccess={fetchCalls}` (old name)
3. Build passed (no TypeScript error because function name was string in callback)
4. **Deployment broke page completely**

**Lesson:** Always verify function references match after renames, even if build passes.

## Deployment Priority

**⚠️ DEPLOY IMMEDIATELY TO DEV**

This blocks all Call Log functionality. Users cannot:
- View scheduled calls
- Schedule new calls
- Access call log at all

## Files Changed

| File | Change |
|------|--------|
| `CallLog.tsx` | Line 436: `fetchCalls` → `fetchScheduledCalls` |

**Total:** 1 file, 1 line changed

---

**Fixes:** CallLog Blank Page  
**Resolves:** ReferenceError fetchCalls not defined  
**Priority:** CRITICAL - Deploy ASAP 🚨

**Apologies for the oversightecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }* This should have been caught in PR #1796 review.