### PR TITLE
Refactor: Remove Cockpit and relocate Call Log to Workspace

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,6 @@ import Contacts from './pages/Contacts';
 import Plants from './pages/Plants';
 import Carriers from './pages/Carriers';
 import AIAssistant from './pages/AIAssistant';
-import Cockpit from './pages/Cockpit';
 import CallLog from './pages/Cockpit/CallLog';
 import Claims from './pages/Accounting/Claims';
 import PayablePOs from './pages/Accounting/PayablePOs';
@@ -135,8 +134,7 @@ const App: React.FC = () => {
                 <Route path="carriers" element={<Carriers />} />
                 <Route path="contacts" element={<Contacts />} />
                 <Route path="ai-assistant" element={<AIAssistant />} />
-                <Route path="cockpit" element={<Cockpit />} />
-                <Route path="cockpit/call-log" element={<CallLog />} />
+                <Route path="call-log" element={<CallLog />} />
                 <Route path="processes" element={<Processes />} />
                 <Route path="reports" element={<Reports />} />
                 <Route path="profile" element={<Profile />} />

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -18,18 +18,6 @@ export interface NavigationItem {
 
 export const navigation: NavigationItem[] = [
   {
-    label: 'Cockpit',
-    icon: '🎯',
-    path: '/cockpit',
-    children: [
-      {
-        label: 'Call Log',
-        icon: '📞',
-        path: '/cockpit/call-log',
-      },
-    ],
-  },
-  {
     label: 'Workspace',
     icon: '💼',
     children: [
@@ -37,6 +25,11 @@ export const navigation: NavigationItem[] = [
         label: 'Dashboard',
         icon: '📊',
         path: '/',
+      },
+      {
+        label: 'Call Log',
+        icon: '📞',
+        path: '/call-log',
       },
       {
         label: 'Processes',


### PR DESCRIPTION
## Changes
- **Removed** Cockpit section from main navigation
- **Moved** Call Log feature to Workspace section
- **Updated** Call Log route: `/cockpit/call-log` → `/call-log`
- **Deleted** unused `Cockpit.tsx` component
- **Cleaned** up imports in `App.tsx`

## Files Modified
- `frontend/src/config/navigation.ts` - Navigation structure reorganization
- `frontend/src/App.tsx` - Route updates and import cleanup
- `frontend/src/pages/Cockpit.tsx` - Deleted (unused)

## Testing
- [x] Navigation structure verified
- [x] Call Log accessible at new path
- [x] No broken imports or references
- [x] Simplified navigation hierarchy

## Impact
- **Risk Level**: Low
- **Breaking Changes**: URL change for Call Log (frontend only)
- **Type**: Refactor
- **Benefits**: Cleaner navigation, reduced complexity