### PR TITLE
feat(admin): Field Registry Service & Admin API - Phase 2

### DIFF
--- a/backend/tenant_apps/workflows/services/__init__.py
+++ b/backend/tenant_apps/workflows/services/__init__.py
@@ -1,0 +1,4 @@
+# Workflow services
+from .field_registry import FieldRegistry, get_entity_fields, get_available_entities
+
+__all__ = ['FieldRegistry', 'get_entity_fields', 'get_available_entities']

--- a/backend/tenant_apps/workflows/services/field_registry.py
+++ b/backend/tenant_apps/workflows/services/field_registry.py
@@ -1,0 +1,288 @@
+"""
+Field Registry Service
+
+Maps entity types to their available fields for the form builder.
+Provides metadata about fields including type, label, and validation.
+"""
+
+from django.apps import apps
+from django.db import models
+from typing import Dict, List, Any, Optional
+
+
+# Entity type to Django model mapping
+ENTITY_MODEL_MAP = {
+    'supplier': ('suppliers', 'Supplier'),
+    'customer': ('customers', 'Customer'),
+    'contact': ('contacts', 'Contact'),
+    'carrier': ('carriers', 'Carrier'),
+    'purchase_order': ('purchase_orders', 'PurchaseOrder'),
+    'sales_order': ('sales_orders', 'SalesOrder'),
+    'invoice': ('invoices', 'Invoice'),
+    'product': ('products', 'Product'),
+    'plant': ('plants', 'Plant'),
+    'location': ('locations', 'Location'),
+}
+
+# Fields to exclude from form builder (internal/system fields)
+EXCLUDED_FIELDS = {
+    'id', 'pk', 'created_on', 'modified_on', 'created_at', 'updated_at',
+    'created_by', 'modified_by', 'tenant', 'custom_data', 'uuid',
+}
+
+# Django field type to form field type mapping
+FIELD_TYPE_MAP = {
+    'CharField': 'text',
+    'TextField': 'textarea',
+    'EmailField': 'email',
+    'URLField': 'url',
+    'IntegerField': 'number',
+    'DecimalField': 'decimal',
+    'FloatField': 'number',
+    'BooleanField': 'checkbox',
+    'NullBooleanField': 'checkbox',
+    'DateField': 'date',
+    'DateTimeField': 'datetime',
+    'TimeField': 'time',
+    'FileField': 'file',
+    'ImageField': 'image',
+    'ForeignKey': 'select',
+    'OneToOneField': 'select',
+    'ManyToManyField': 'multiselect',
+    'JSONField': 'json',
+    'UUIDField': 'text',
+    'SlugField': 'text',
+    'PositiveIntegerField': 'number',
+    'PositiveSmallIntegerField': 'number',
+    'BigIntegerField': 'number',
+    'SmallIntegerField': 'number',
+}
+
+
+class FieldRegistry:
+    """
+    Registry service for entity field metadata.
+    
+    Used by the form builder to provide field selection and configuration.
+    """
+    
+    @classmethod
+    def get_entity_types(cls) -> List[Dict[str, str]]:
+        """Get list of available entity types."""
+        available = []
+        for entity_type, (app_label, model_name) in ENTITY_MODEL_MAP.items():
+            try:
+                apps.get_model(app_label, model_name)
+                available.append({
+                    'key': entity_type,
+                    'label': entity_type.replace('_', ' ').title(),
+                    'app': app_label,
+                    'model': model_name,
+                })
+            except LookupError:
+                # Model not installed, skip
+                continue
+        return available
+    
+    @classmethod
+    def get_model_for_entity(cls, entity_type: str) -> Optional[type]:
+        """Get Django model class for an entity type."""
+        if entity_type not in ENTITY_MODEL_MAP:
+            return None
+        
+        app_label, model_name = ENTITY_MODEL_MAP[entity_type]
+        try:
+            return apps.get_model(app_label, model_name)
+        except LookupError:
+            return None
+    
+    @classmethod
+    def get_fields_for_entity(cls, entity_type: str) -> List[Dict[str, Any]]:
+        """
+        Get all available fields for an entity type.
+        
+        Returns a list of field metadata suitable for the form builder.
+        """
+        model = cls.get_model_for_entity(entity_type)
+        if not model:
+            return []
+        
+        fields = []
+        for field in model._meta.get_fields():
+            # Skip fields without a name attribute
+            if not hasattr(field, 'name'):
+                continue
+            
+            # Skip reverse relations
+            field_type = type(field).__name__
+            if field_type.endswith('Rel'):
+                continue
+            
+            # Skip non-editable fields
+            if not getattr(field, 'editable', True):
+                continue
+            
+            # Skip excluded fields
+            if field.name in EXCLUDED_FIELDS:
+                continue
+            
+            # Build field metadata
+            field_meta = cls._build_field_metadata(field)
+            if field_meta:
+                fields.append(field_meta)
+        
+        # Sort by label
+        fields.sort(key=lambda f: f['label'].lower())
+        return fields
+    
+    @classmethod
+    def _build_field_metadata(cls, field) -> Optional[Dict[str, Any]]:
+        """Build metadata dictionary for a single field."""
+        field_type = type(field).__name__
+        
+        # Map to form field type
+        form_type = FIELD_TYPE_MAP.get(field_type, 'text')
+        
+        # Get field label
+        verbose_name = getattr(field, 'verbose_name', field.name)
+        if verbose_name:
+            label = str(verbose_name).replace('_', ' ').title()
+        else:
+            label = field.name.replace('_', ' ').title()
+        
+        # Determine if required
+        is_required = not getattr(field, 'blank', True) and not getattr(field, 'null', True)
+        
+        # Get max length for text fields
+        max_length = getattr(field, 'max_length', None)
+        
+        # Get choices if available
+        choices = getattr(field, 'choices', None)
+        choice_list = None
+        if choices:
+            choice_list = [{'value': c[0], 'label': c[1]} for c in choices]
+            form_type = 'select'  # Override to select if has choices
+        
+        # Get help text
+        help_text = str(getattr(field, 'help_text', '') or '')
+        
+        # Get default value
+        default = getattr(field, 'default', models.NOT_PROVIDED)
+        default_value = None
+        if default is not models.NOT_PROVIDED and not callable(default):
+            default_value = default
+        
+        # Build metadata
+        metadata = {
+            'key': field.name,
+            'label': label,
+            'type': form_type,
+            'django_type': field_type,
+            'required': is_required,
+            'help_text': help_text,
+        }
+        
+        # Optional fields
+        if max_length:
+            metadata['max_length'] = max_length
+        if choice_list:
+            metadata['choices'] = choice_list
+        if default_value is not None:
+            metadata['default'] = default_value
+        
+        # Related model info for foreign keys
+        if field_type in ('ForeignKey', 'OneToOneField', 'ManyToManyField'):
+            related_model = field.related_model
+            if related_model:
+                metadata['related_model'] = {
+                    'app': related_model._meta.app_label,
+                    'model': related_model._meta.model_name,
+                    'label': related_model._meta.verbose_name.title(),
+                }
+        
+        return metadata
+    
+    @classmethod
+    def get_field_metadata(cls, entity_type: str, field_key: str) -> Optional[Dict[str, Any]]:
+        """Get metadata for a specific field."""
+        fields = cls.get_fields_for_entity(entity_type)
+        for field in fields:
+            if field['key'] == field_key:
+                return field
+        return None
+    
+    @classmethod
+    def find_matching_fields(
+        cls, 
+        source_field: Dict[str, Any], 
+        target_entity_type: str
+    ) -> List[Dict[str, Any]]:
+        """
+        Find fields in target entity that match source field.
+        
+        Used for smart auto-population suggestions.
+        Matching criteria:
+        1. Exact name match (highest confidence)
+        2. Similar name (contains common substring)
+        3. Same type (lower confidence)
+        """
+        target_fields = cls.get_fields_for_entity(target_entity_type)
+        matches = []
+        
+        source_key = source_field['key'].lower()
+        source_type = source_field['type']
+        
+        for target in target_fields:
+            target_key = target['key'].lower()
+            score = 0
+            match_reason = []
+            
+            # Exact name match
+            if source_key == target_key:
+                score = 100
+                match_reason.append('exact_name')
+            # Name contains match
+            elif source_key in target_key or target_key in source_key:
+                score = 70
+                match_reason.append('partial_name')
+            # Common suffix/prefix (e.g., supplier_email vs contact_email)
+            elif cls._has_common_suffix(source_key, target_key):
+                score = 60
+                match_reason.append('common_suffix')
+            
+            # Type match bonus
+            if source_type == target['type']:
+                score += 20
+                match_reason.append('same_type')
+            
+            if score > 0:
+                matches.append({
+                    'field': target,
+                    'score': min(score, 100),
+                    'reasons': match_reason,
+                })
+        
+        # Sort by score descending
+        matches.sort(key=lambda m: m['score'], reverse=True)
+        return matches[:5]  # Return top 5 matches
+    
+    @staticmethod
+    def _has_common_suffix(key1: str, key2: str) -> bool:
+        """Check if two keys share a common suffix."""
+        # Common field suffixes
+        suffixes = ['_id', '_name', '_email', '_phone', '_address', '_date', '_type']
+        for suffix in suffixes:
+            if key1.endswith(suffix) and key2.endswith(suffix):
+                return True
+        return False
+
+
+# Convenience functions
+def get_entity_fields(entity_type: str) -> List[Dict[str, Any]]:
+    """Get all fields for an entity type."""
+    return FieldRegistry.get_fields_for_entity(entity_type)
+
+
+def get_available_entities() -> List[Dict[str, str]]:
+    """Get list of available entity types."""
+    return FieldRegistry.get_entity_types()

--- a/backend/tenant_apps/workflows/static/admin/workflows/js/form_builder.js
+++ b/backend/tenant_apps/workflows/static/admin/workflows/js/form_builder.js
@@ -106,10 +106,42 @@ function formBuilder() {
             // Update hidden form fields for Django
             this.updateInlineOrder(newOrder);
             
-            // Optionally save via AJAX
-            // await this.saveStepOrder(newOrder);
+            // Save via AJAX
+            await this.saveStepOrder(newOrder);
             
             console.log('Steps reordered:', newOrder);
+        },
+        
+        async saveStepOrder(newOrder) {
+            // Get form ID from URL
+            const pathParts = window.location.pathname.split('/');
+            const formIdIndex = pathParts.findIndex(p => p === 'tenantform') + 1;
+            const formId = pathParts[formIdIndex];
+            
+            if (!formId || formId === 'add') {
+                console.log('New form - order will be saved with form submission');
+                return;
+            }
+            
+            try {
+                const response = await fetch(`/api/v1/workflows/admin/forms/${formId}/reorder/`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': getCsrfToken(),
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ step_order: newOrder.map(s => s.id) })
+                });
+                
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                
+                console.log('Step order saved');
+            } catch (error) {
+                console.error('Error saving step order:', error);
+            }
         },
         
         // Update Django inline form order fields
@@ -143,13 +175,13 @@ function formBuilder() {
         
         // ==================== FIELD EDITOR ====================
         
-        openFieldEditor(stepId) {
+        async openFieldEditor(stepId) {
             this.currentStepId = stepId;
             const step = this.formSteps.find(s => s.id === stepId);
             this.currentStepName = step ? step.name : 'Unknown Step';
             
-            // Load fields for this step's entity type
-            this.loadFieldsForEntity(step?.entityType || 'supplier');
+            // Load fields from API
+            await this.loadFieldsFromAPI(stepId);
             
             this.showFieldModal = true;
         },
@@ -160,8 +192,42 @@ function formBuilder() {
             this.fieldSearch = '';
         },
         
+        async loadFieldsFromAPI(stepId) {
+            try {
+                const response = await fetch(`/api/v1/workflows/admin/steps/${stepId}/fields/`, {
+                    headers: {
+                        'X-CSRFToken': getCsrfToken(),
+                    },
+                    credentials: 'same-origin'
+                });
+                
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                
+                const data = await response.json();
+                
+                this.selectedFields = data.selected_fields || [];
+                this.availableFields = data.available_fields || [];
+                this.filteredAvailableFields = [...this.availableFields];
+                this.currentStepName = data.step_name;
+                
+                console.log('Loaded fields:', {
+                    selected: this.selectedFields.length,
+                    available: this.availableFields.length
+                });
+            } catch (error) {
+                console.error('Error loading fields:', error);
+                // Fallback to showing empty state
+                this.selectedFields = [];
+                this.availableFields = [];
+                this.filteredAvailableFields = [];
+            }
+        },
+        
+        // Fallback for when API is not available (during development)
         loadFieldsForEntity(entityType) {
-            // Entity field definitions (will be fetched from API in production)
+            // Entity field definitions (fallback - will be fetched from API in production)
             const entityFields = {
                 supplier: [
                     { key: 'name', label: 'Name', type: 'text', required: true },
@@ -304,15 +370,77 @@ function formBuilder() {
         },
         
         async saveFieldSelection() {
-            // TODO: Save via AJAX to backend
-            console.log('Saving field selection for step:', this.currentStepId);
-            console.log('Selected fields:', this.selectedFields.map(f => f.key));
+            if (!this.currentStepId) {
+                console.error('No step ID set');
+                return;
+            }
             
-            // For now, close the modal
-            this.closeFieldModal();
+            try {
+                // Prepare field data
+                const fieldsData = this.selectedFields.map((f, index) => ({
+                    key: f.key,
+                    visible: true,
+                    required: f.required || false,
+                    custom_label: '',
+                    help_text: '',
+                }));
+                
+                const response = await fetch(`/api/v1/workflows/admin/steps/${this.currentStepId}/fields/`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': getCsrfToken(),
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ fields: fieldsData })
+                });
+                
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                
+                const result = await response.json();
+                console.log('Saved field selection:', result);
+                
+                // Update the step card to show new field count
+                const stepCard = document.querySelector(`.step-card[data-step-id="${this.currentStepId}"]`);
+                if (stepCard) {
+                    const fieldCountEl = stepCard.querySelector('.stat strong');
+                    if (fieldCountEl) {
+                        fieldCountEl.textContent = this.selectedFields.length;
+                    }
+                }
+                
+                // Close modal
+                this.closeFieldModal();
+                
+                // Show success feedback
+                this.showNotification('Fields saved successfully!', 'success');
+                
+            } catch (error) {
+                console.error('Error saving fields:', error);
+                this.showNotification('Error saving fields. Please try again.', 'error');
+            }
+        },
+        
+        showNotification(message, type = 'info') {
+            // Simple notification using Django admin style
+            const container = document.querySelector('.messagelist') || this.createMessageList();
+            const li = document.createElement('li');
+            li.className = type === 'error' ? 'error' : 'success';
+            li.textContent = message;
+            container.appendChild(li);
             
-            // Show success message
-            alert('Field selection saved! (AJAX save coming soon)');
+            // Auto-remove after 5 seconds
+            setTimeout(() => li.remove(), 5000);
+        },
+        
+        createMessageList() {
+            const container = document.createElement('ul');
+            container.className = 'messagelist';
+            const content = document.querySelector('#content') || document.body;
+            content.insertBefore(container, content.firstChild);
+            return container;
         },
         
         // ==================== RULE EDITOR ====================

--- a/backend/tenant_apps/workflows/tests_admin_api.py
+++ b/backend/tenant_apps/workflows/tests_admin_api.py
@@ -1,0 +1,226 @@
+"""
+Tests for Field Registry Service and Admin API endpoints.
+"""
+from django.test import TestCase
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.contrib.auth import get_user_model
+
+from apps.tenants.models import Tenant
+from tenant_apps.workflows.models import TenantForm, TenantFormEntity, TenantFormField
+from tenant_apps.workflows.services import FieldRegistry, get_entity_fields, get_available_entities
+
+
+User = get_user_model()
+
+
+class FieldRegistryTests(TestCase):
+    """Tests for the Field Registry service."""
+    
+    def test_get_available_entities(self):
+        """Test getting list of available entity types."""
+        entities = get_available_entities()
+        
+        self.assertIsInstance(entities, list)
+        self.assertGreater(len(entities), 0)
+        
+        # Check structure
+        for entity in entities:
+            self.assertIn('key', entity)
+            self.assertIn('label', entity)
+            self.assertIn('app', entity)
+            self.assertIn('model', entity)
+    
+    def test_get_entity_fields_supplier(self):
+        """Test getting fields for supplier entity."""
+        fields = get_entity_fields('supplier')
+        
+        self.assertIsInstance(fields, list)
+        self.assertGreater(len(fields), 0)
+        
+        # Check field structure
+        for field in fields:
+            self.assertIn('key', field)
+            self.assertIn('label', field)
+            self.assertIn('type', field)
+            self.assertIn('required', field)
+        
+        # Should have common supplier fields
+        field_keys = [f['key'] for f in fields]
+        self.assertIn('name', field_keys)
+        self.assertIn('email', field_keys)
+    
+    def test_get_entity_fields_unknown_entity(self):
+        """Test getting fields for unknown entity returns empty list."""
+        fields = get_entity_fields('unknown_entity_type')
+        self.assertEqual(fields, [])
+    
+    def test_find_matching_fields(self):
+        """Test smart field matching algorithm."""
+        source_field = {'key': 'email', 'type': 'email'}
+        matches = FieldRegistry.find_matching_fields(source_field, 'contact')
+        
+        self.assertIsInstance(matches, list)
+        
+        if matches:
+            # First match should be the exact match
+            first_match = matches[0]
+            self.assertIn('field', first_match)
+            self.assertIn('score', first_match)
+            self.assertIn('reasons', first_match)
+            
+            # Exact name match should have high score
+            if first_match['field']['key'] == 'email':
+                self.assertGreaterEqual(first_match['score'], 100)
+
+
+class AdminAPITests(APITestCase):
+    """Tests for the Admin Form Builder API endpoints."""
+    
+    @classmethod
+    def setUpTestData(cls):
+        # Create admin user
+        cls.admin_user = User.objects.create_superuser(
+            username='testadmin',
+            email='admin@test.com',
+            password='testpass123'
+        )
+        
+        # Create tenant
+        cls.tenant = Tenant.objects.create(
+            name='Test Tenant',
+            slug='test-tenant'
+        )
+        
+        # Create test form
+        cls.form = TenantForm.objects.create(
+            tenant=cls.tenant,
+            name='Test Form',
+            description='A test form',
+            status='draft'
+        )
+        
+        # Create test entity/step
+        cls.step = TenantFormEntity.objects.create(
+            form=cls.form,
+            entity_type='supplier',
+            step_name='Supplier Info',
+            order=0
+        )
+    
+    def setUp(self):
+        self.client.force_authenticate(user=self.admin_user)
+    
+    def test_get_available_entities_api(self):
+        """Test the available entities API endpoint."""
+        response = self.client.get('/api/v1/workflows/admin/entities/')
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('entities', response.data)
+        self.assertIn('count', response.data)
+        self.assertGreater(response.data['count'], 0)
+    
+    def test_get_entity_fields_api(self):
+        """Test the entity fields API endpoint."""
+        response = self.client.get('/api/v1/workflows/admin/entities/supplier/fields/')
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('entity_type', response.data)
+        self.assertIn('fields', response.data)
+        self.assertEqual(response.data['entity_type'], 'supplier')
+        self.assertGreater(len(response.data['fields']), 0)
+    
+    def test_get_entity_fields_api_unknown_entity(self):
+        """Test the entity fields API with unknown entity type."""
+        response = self.client.get('/api/v1/workflows/admin/entities/unknown_type/fields/')
+        
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+    
+    def test_get_step_fields_api(self):
+        """Test getting fields for a form step."""
+        response = self.client.get(f'/api/v1/workflows/admin/steps/{self.step.id}/fields/')
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('step_id', response.data)
+        self.assertIn('step_name', response.data)
+        self.assertIn('entity_type', response.data)
+        self.assertIn('selected_fields', response.data)
+        self.assertIn('available_fields', response.data)
+    
+    def test_save_step_fields_api(self):
+        """Test saving field selection for a form step."""
+        fields_data = {
+            'fields': [
+                {'key': 'name', 'visible': True, 'required': True},
+                {'key': 'email', 'visible': True, 'required': False},
+            ]
+        }
+        
+        response = self.client.post(
+            f'/api/v1/workflows/admin/steps/{self.step.id}/fields/',
+            fields_data,
+            format='json'
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status'], 'success')
+        
+        # Verify fields were created
+        self.assertEqual(self.step.fields.count(), 2)
+        
+        # Verify field data
+        name_field = self.step.fields.get(field_key='name')
+        self.assertTrue(name_field.is_required)
+        
+        email_field = self.step.fields.get(field_key='email')
+        self.assertFalse(email_field.is_required)
+    
+    def test_reorder_steps_api(self):
+        """Test reordering form steps."""
+        # Create second step
+        step2 = TenantFormEntity.objects.create(
+            form=self.form,
+            entity_type='contact',
+            step_name='Contact Info',
+            order=1
+        )
+        
+        # Reorder: step2 first, then step1
+        response = self.client.post(
+            f'/api/v1/workflows/admin/forms/{self.form.id}/reorder/',
+            {'step_order': [str(step2.id), str(self.step.id)]},
+            format='json'
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Verify order changed
+        step2.refresh_from_db()
+        self.step.refresh_from_db()
+        
+        self.assertEqual(step2.order, 0)
+        self.assertEqual(self.step.order, 1)
+    
+    def test_smart_match_api(self):
+        """Test the smart field matching API."""
+        response = self.client.post(
+            '/api/v1/workflows/admin/smart-match/',
+            {
+                'source_field': {'key': 'email', 'type': 'email'},
+                'target_entity_type': 'contact'
+            },
+            format='json'
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('source_field', response.data)
+        self.assertIn('target_entity_type', response.data)
+        self.assertIn('matches', response.data)
+    
+    def test_unauthenticated_access(self):
+        """Test that unauthenticated users cannot access admin APIs."""
+        self.client.logout()
+        
+        response = self.client.get('/api/v1/workflows/admin/entities/')
+        # Should be 401 or 403
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])

--- a/backend/tenant_apps/workflows/urls.py
+++ b/backend/tenant_apps/workflows/urls.py
@@ -11,7 +11,10 @@ from .views import (
     TenantFormViewSet, TenantFormEntityViewSet, 
     TenantFormFieldViewSet, TenantFormRuleViewSet,
     TenantWorkflowViewSet, TenantWorkflowConditionViewSet,
-    TenantWorkflowActionViewSet, WorkflowExecutionLogViewSet
+    TenantWorkflowActionViewSet, WorkflowExecutionLogViewSet,
+    # Admin Form Builder API Views
+    EntityFieldsAPIView, AvailableEntitiesAPIView,
+    FormStepFieldsAPIView, FormStepReorderAPIView, SmartFieldMatchAPIView
 )
 
 app_name = 'workflows'
@@ -35,4 +38,11 @@ router.register(r'execution-logs', WorkflowExecutionLogViewSet, basename='workfl
 
 urlpatterns = [
     path('', include(router.urls)),
+    
+    # Admin Form Builder API endpoints
+    path('admin/entities/', AvailableEntitiesAPIView.as_view(), name='admin-available-entities'),
+    path('admin/entities/<str:entity_type>/fields/', EntityFieldsAPIView.as_view(), name='admin-entity-fields'),
+    path('admin/steps/<uuid:step_id>/fields/', FormStepFieldsAPIView.as_view(), name='admin-step-fields'),
+    path('admin/forms/<uuid:form_id>/reorder/', FormStepReorderAPIView.as_view(), name='admin-form-reorder'),
+    path('admin/smart-match/', SmartFieldMatchAPIView.as_view(), name='admin-smart-match'),
 ]

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -7,9 +7,11 @@ Provides REST API endpoints for Forms, Workflows, and Lists.
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.views import APIView
 from django.db.models import Count, Prefetch
 from django.utils import timezone
+from django.db import transaction
 
 from .models import (
     TenantList, TenantForm, TenantFormEntity, TenantFormField, TenantFormRule,
@@ -24,6 +26,205 @@ from .serializers import (
     TenantWorkflowConditionSerializer, TenantWorkflowActionSerializer,
     WorkflowExecutionLogSerializer
 )
+from .services import FieldRegistry, get_entity_fields, get_available_entities
+
+
+# =============================================================================
+# ADMIN FORM BUILDER API VIEWS
+# =============================================================================
+
+class EntityFieldsAPIView(APIView):
+    """
+    API endpoint for getting available fields for an entity type.
+    Used by the form builder admin interface.
+    """
+    permission_classes = [IsAdminUser]
+    
+    def get(self, request, entity_type):
+        """Get all available fields for an entity type."""
+        fields = get_entity_fields(entity_type)
+        if not fields:
+            return Response(
+                {'error': f'Unknown entity type: {entity_type}'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        return Response({
+            'entity_type': entity_type,
+            'fields': fields,
+            'count': len(fields),
+        })
+
+
+class AvailableEntitiesAPIView(APIView):
+    """
+    API endpoint for getting available entity types.
+    Used by the form builder admin interface.
+    """
+    permission_classes = [IsAdminUser]
+    
+    def get(self, request):
+        """Get all available entity types."""
+        entities = get_available_entities()
+        return Response({
+            'entities': entities,
+            'count': len(entities),
+        })
+
+
+class FormStepFieldsAPIView(APIView):
+    """
+    API endpoint for managing fields in a form step (TenantFormEntity).
+    Used by the form builder admin interface.
+    """
+    permission_classes = [IsAdminUser]
+    
+    def get(self, request, step_id):
+        """Get selected and available fields for a form step."""
+        try:
+            step = TenantFormEntity.objects.select_related('form').get(pk=step_id)
+        except TenantFormEntity.DoesNotExist:
+            return Response(
+                {'error': 'Form step not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        
+        # Get available fields for this entity type
+        available_fields = get_entity_fields(step.entity_type)
+        
+        # Get currently selected fields
+        selected = step.fields.all().order_by('order')
+        selected_keys = {f.field_key for f in selected}
+        
+        selected_fields = []
+        for field in selected:
+            # Find matching field metadata
+            field_meta = next(
+                (f for f in available_fields if f['key'] == field.field_key),
+                None
+            )
+            selected_fields.append({
+                'id': str(field.id),
+                'key': field.field_key,
+                'label': field.custom_label or (field_meta['label'] if field_meta else field.field_key),
+                'type': field_meta['type'] if field_meta else 'text',
+                'required': field.is_required,
+                'visible': field.is_visible,
+                'order': field.order,
+                'help_text': field.custom_help_text,
+            })
+        
+        # Mark which available fields are already selected
+        for field in available_fields:
+            field['selected'] = field['key'] in selected_keys
+        
+        return Response({
+            'step_id': str(step_id),
+            'step_name': step.step_name or step.entity_type.replace('_', ' ').title(),
+            'entity_type': step.entity_type,
+            'selected_fields': selected_fields,
+            'available_fields': available_fields,
+        })
+    
+    def post(self, request, step_id):
+        """Save field selection for a form step."""
+        try:
+            step = TenantFormEntity.objects.get(pk=step_id)
+        except TenantFormEntity.DoesNotExist:
+            return Response(
+                {'error': 'Form step not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        
+        fields_data = request.data.get('fields', [])
+        
+        with transaction.atomic():
+            # Delete existing fields
+            step.fields.all().delete()
+            
+            # Create new fields in order
+            for order, field_data in enumerate(fields_data):
+                TenantFormField.objects.create(
+                    form_entity=step,
+                    field_key=field_data['key'],
+                    is_visible=field_data.get('visible', True),
+                    is_required=field_data.get('required', False),
+                    order=order,
+                    custom_label=field_data.get('custom_label', ''),
+                    custom_help_text=field_data.get('help_text', ''),
+                )
+        
+        return Response({
+            'status': 'success',
+            'message': f'Saved {len(fields_data)} fields',
+            'step_id': str(step_id),
+        })
+
+
+class FormStepReorderAPIView(APIView):
+    """
+    API endpoint for reordering form steps.
+    Used by the form builder admin interface for drag-drop.
+    """
+    permission_classes = [IsAdminUser]
+    
+    def post(self, request, form_id):
+        """Reorder steps in a form."""
+        try:
+            form = TenantForm.objects.get(pk=form_id)
+        except TenantForm.DoesNotExist:
+            return Response(
+                {'error': 'Form not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        
+        step_order = request.data.get('step_order', [])
+        
+        with transaction.atomic():
+            for order, step_id in enumerate(step_order):
+                TenantFormEntity.objects.filter(
+                    id=step_id,
+                    form=form
+                ).update(order=order)
+        
+        return Response({
+            'status': 'success',
+            'message': f'Reordered {len(step_order)} steps',
+        })
+
+
+class SmartFieldMatchAPIView(APIView):
+    """
+    API endpoint for smart field matching suggestions.
+    Used by the auto-populate configuration in form builder.
+    """
+    permission_classes = [IsAdminUser]
+    
+    def post(self, request):
+        """
+        Find matching fields for auto-population.
+        
+        Request body:
+        {
+            "source_field": {"key": "email", "type": "email"},
+            "target_entity_type": "contact"
+        }
+        """
+        source_field = request.data.get('source_field')
+        target_entity_type = request.data.get('target_entity_type')
+        
+        if not source_field or not target_entity_type:
+            return Response(
+                {'error': 'source_field and target_entity_type are required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        matches = FieldRegistry.find_matching_fields(source_field, target_entity_type)
+        
+        return Response({
+            'source_field': source_field,
+            'target_entity_type': target_entity_type,
+            'matches': matches,
+        })
 
 
 class TenantFilteredModelViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
Phase 2 of Form Builder Enhancement - Field registry service and admin API endpoints.

## Changes

### Field Registry Service
- Maps entity types (supplier, customer, contact, etc.) to Django models
- Extracts comprehensive field metadata (type, label, required, choices, help text)
- Smart field matching algorithm for auto-population suggestions
- Sorted alphabetically by label for consistent UX

### Admin API Endpoints
| Endpoint | Method | Description |
|----------|--------|-------------|
| `/admin/entities/` | GET | List available entity types |
| `/admin/entities/<type>/fields/` | GET | Get fields for entity type |
| `/admin/steps/<id>/fields/` | GET/POST | Manage step field selection |
| `/admin/forms/<id>/reorder/` | POST | Reorder form steps |
| `/admin/smart-match/` | POST | Find matching fields |

### JavaScript Integration
- Updated form_builder.js to use real API endpoints
- Field selection loads actual model fields
- Selections persist to database via AJAX
- Step reordering saves automatically

## Files Added
- `services/__init__.py`
- `services/field_registry.py` 
- `tests_admin_api.py`

## Files Modified
- `views.py` - Admin API views
- `urls.py` - Admin API routes  
- `static/admin/workflows/js/form_builder.js` - API integration

## Testing
- ✅ All 12 existing workflow tests pass
- ✅ All 12 new admin API tests pass
- ✅ Total: 24 tests passing

## Next Steps (Phase 3)
- Add model fields for auto-populate config
- Build field configuration modal
- Implement smart matching UI