### PR TITLE
fix: Entity select dropdown styling in Add Step modal

### DIFF
--- a/backend/tenant_apps/workflows/static/admin/workflows/css/form_builder.css
+++ b/backend/tenant_apps/workflows/static/admin/workflows/css/form_builder.css
@@ -804,6 +804,27 @@ kbd {
 
 .entity-select {
     width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--fb-border);
+    border-radius: var(--fb-radius-sm);
+    font-size: 14px;
+    background: var(--fb-bg);
+    color: var(--fb-fg);
+    min-height: 42px;
+    appearance: auto;
+    cursor: pointer;
+}
+
+.entity-select:focus {
+    outline: none;
+    border-color: var(--fb-primary);
+    box-shadow: 0 0 0 3px rgba(65, 118, 144, 0.1);
+}
+
+.entity-select option {
+    padding: 8px 12px;
+    background: var(--fb-bg);
+    color: var(--fb-fg);
 }
 
 .btn {


### PR DESCRIPTION
## Problem
The entity type dropdown in the Add Step modal was not readable - text was squished and hard to see.

## Root Cause
The `.entity-select` class only had `width: 100%`, missing all proper styling that should follow the universal theme system.

## Fix
Added explicit styling matching the theme:
- padding, border, border-radius
- font-size, background, color using `--fb-*` CSS variables
- `min-height: 42px` for proper visibility
- Focus state with border color and box-shadow
- Option element styling for dropdown items

## Testing
1. Go to Form Builder (Admin → Workflows → Forms → Edit any form)
2. Click "➕ Add Step" button
3. Verify the Entity Type dropdown is properly styled and readable