### PR TITLE
fix: Remove horizontal scrollbars from Form Builder and Schema Editor

### DIFF
--- a/backend/apps/schema_builder/static/admin/schema_builder/css/schema_editor.css
+++ b/backend/apps/schema_builder/static/admin/schema_builder/css/schema_editor.css
@@ -37,6 +37,23 @@
 }
 
 /* ==========================================================================
+   Global Rules - No Horizontal Scrollbars
+   ========================================================================== */
+.schema-editor-container,
+.schema-editor-container *,
+.se-modal,
+.se-modal * {
+    box-sizing: border-box;
+}
+
+/* Prevent horizontal overflow globally in schema editor containers */
+.schema-editor-container,
+.se-modal-body,
+.se-modal-content {
+    overflow-x: hidden;
+}
+
+/* ==========================================================================
    Main Container
    ========================================================================== */
 .schema-editor-container {

--- a/backend/tenant_apps/workflows/static/admin/workflows/css/form_builder.css
+++ b/backend/tenant_apps/workflows/static/admin/workflows/css/form_builder.css
@@ -37,6 +37,26 @@
 }
 
 /* ==========================================================================
+   Global Rules - No Horizontal Scrollbars
+   ========================================================================== */
+.form-builder-section,
+.form-builder-section *,
+.form-rules-section,
+.form-rules-section *,
+.modal-content,
+.modal-content * {
+    box-sizing: border-box;
+}
+
+/* Prevent horizontal overflow globally in form builder containers */
+.form-builder-section,
+.form-rules-section,
+.modal-body,
+.modal-content {
+    overflow-x: hidden;
+}
+
+/* ==========================================================================
    Form Builder Section
    ========================================================================== */
 .form-builder-section,
@@ -130,9 +150,9 @@ kbd {
    ========================================================================== */
 .step-cards-container {
     display: flex;
+    flex-wrap: wrap;
     gap: 16px;
     padding: 20px 0;
-    overflow-x: auto;
     min-height: 200px;
 }
 
@@ -512,6 +532,7 @@ kbd {
 .modal-body {
     padding: 20px;
     overflow-y: auto;
+    overflow-x: hidden;
     flex: 1;
     background: var(--fb-bg);
 }
@@ -532,6 +553,14 @@ kbd {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 20px;
+    overflow: hidden;
+}
+
+/* Responsive: stack on smaller screens */
+@media (max-width: 700px) {
+    .field-editor-container {
+        grid-template-columns: 1fr;
+    }
 }
 
 .field-list-section h4 {
@@ -563,6 +592,7 @@ kbd {
 .field-list {
     max-height: 300px;
     overflow-y: auto;
+    overflow-x: hidden;
     border: 1px solid var(--fb-border);
     border-radius: var(--fb-radius-sm);
     background: var(--fb-bg);
@@ -571,11 +601,13 @@ kbd {
 .field-item {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
     padding: 10px 12px;
     border-bottom: 1px solid var(--fb-hairline);
     transition: background 0.15s;
     color: var(--fb-fg);
+    word-break: break-word;
 }
 
 .field-item:last-child {
@@ -598,8 +630,10 @@ kbd {
 
 .field-name {
     flex: 1;
+    min-width: 0;
     font-size: 13px;
     color: var(--fb-fg);
+    word-break: break-word;
 }
 
 .field-type-badge {


### PR DESCRIPTION
## Problem
Horizontal scrollbars appearing in popups and containers. Content should wrap to fit instead of scrolling horizontally.

## Solution
Added comprehensive CSS rules to prevent horizontal overflow:

### Global Rules (both editors)
- `box-sizing: border-box` on all elements
- `overflow-x: hidden` on containers and modals

### Form Builder Changes
1. **step-cards-container**: Changed from `overflow-x: auto` to `flex-wrap: wrap`
   - Cards now wrap to next row instead of horizontal scroll
2. **modal-body**: Added `overflow-x: hidden`
3. **field-list**: Added `overflow-x: hidden`
4. **field-editor-container**: Added `overflow: hidden` and responsive breakpoint
5. **field-item**: Added `flex-wrap: wrap` and `word-break: break-word`
6. **field-name**: Added `min-width: 0` and `word-break: break-word`

### Schema Editor Changes
- Added same global `box-sizing` and `overflow-x: hidden` rules

### Responsive Design
- Field editor grid stacks to single column on screens < 700px

## Testing
1. Go to Form Builder and open any modal
2. Resize browser window to various sizes
3. Verify no horizontal scrollbars appear
4. Verify content wraps properly