### PR TITLE
feat(v2-wave1): Add URL aliases for app renames (cockpit→workspace, bug_reports→feedback)

### DIFF
--- a/backend/projectmeats/urls.py
+++ b/backend/projectmeats/urls.py
@@ -40,8 +40,12 @@ urlpatterns = [
     path("api/v1/", include("tenant_apps.locations.urls")),
     path("api/v1/ai-assistant/", include("tenant_apps.ai_assistant.urls")),
     path("api/v1/", include("apps.core.urls")),  # Core shared utilities
-    path("api/v1/bug-reports/", include("tenant_apps.bug_reports.urls")),
-    path("api/v1/cockpit/", include("tenant_apps.cockpit.urls")),
+    # Bug Reports → Feedback rename (v2.0 Wave 1 Week 3)
+    path("api/v1/bug-reports/", include("tenant_apps.bug_reports.urls")),  # Legacy (deprecated)
+    path("api/v1/feedback/", include("tenant_apps.bug_reports.urls")),      # NEW canonical path
+    # Cockpit → Workspace rename (v2.0 Wave 1 Week 3)
+    path("api/v1/cockpit/", include("tenant_apps.cockpit.urls")),           # Legacy (deprecated)
+    path("api/v1/workspace/", include("tenant_apps.cockpit.urls")),         # NEW canonical path
     path("api/v1/", include("tenant_apps.inquiries.urls")),  # Inquiry management
     path("api/v1/", include("tenant_apps.fulfillments.urls")),  # Fulfillment tracking
     path("api/v1/workflows/", include("tenant_apps.workflows.urls")),  # Bundle Two: Tenant Workflows

--- a/frontend/src/components/FormSubmission/StepNotes.tsx
+++ b/frontend/src/components/FormSubmission/StepNotes.tsx
@@ -247,7 +247,7 @@ export const StepNotes: React.FC<StepNotesProps> = ({
     const currentKey = `${submissionId}_${stepId}`;
     try {
       // Query activity logs for this step submission
-      const response = await apiClient.get('/api/cockpit/activity-logs/', {
+      const response = await apiClient.get('/api/workspace/activity-logs/', {
         params: {
           entity_type: 'form_step_submission',
           entity_id: currentKey,
@@ -274,7 +274,7 @@ export const StepNotes: React.FC<StepNotesProps> = ({
     setIsAdding(true);
     setError(null);
     try {
-      const response = await apiClient.post('/api/cockpit/activity-logs/', {
+      const response = await apiClient.post('/api/workspace/activity-logs/', {
         entity_type: 'form_step_submission',
         entity_id: `${submissionId}_${stepId}`,
         content: newNote.trim(),

--- a/frontend/src/components/Shared/ActivityFeed.tsx
+++ b/frontend/src/components/Shared/ActivityFeed.tsx
@@ -310,7 +310,7 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
       setLoading(true);
       setError(null);
       
-      const response = await apiClient.get('cockpit/activity-logs/', {
+      const response = await apiClient.get('workspace/activity-logs/', {
         params: {
           entity_type: entityType,
           entity_id: entityId,
@@ -336,7 +336,7 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
     try {
       setSubmitting(true);
       
-      const response = await apiClient.post('cockpit/activity-logs/', {
+      const response = await apiClient.post('workspace/activity-logs/', {
         entity_type: entityType,
         entity_id: entityId,
         title: formData.title.trim() || 'Note',

--- a/frontend/src/components/Shared/ScheduleCallModal.tsx
+++ b/frontend/src/components/Shared/ScheduleCallModal.tsx
@@ -417,10 +417,10 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
 
       if (isEditMode && initialData?.id) {
         // Update existing call
-        await apiClient.patch(`cockpit/scheduled-calls/${initialData.id}/`, payload);
+        await apiClient.patch(`workspace/scheduled-calls/${initialData.id}/`, payload);
       } else {
         // Create new call
-        await apiClient.post('cockpit/scheduled-calls/', payload);
+        await apiClient.post('workspace/scheduled-calls/', payload);
       }
 
       // Success

--- a/frontend/src/pages/Cockpit/CallLog.tsx
+++ b/frontend/src/pages/Cockpit/CallLog.tsx
@@ -632,7 +632,7 @@ export const CallLog: React.FC = () => {
       setLoading(true);
       setError(null);
 
-      const response = await apiClient.get('cockpit/scheduled-calls/');
+      const response = await apiClient.get('workspace/scheduled-calls/');
       const callsData = response.data.results || response.data;
 
       // Sort by scheduled_for (upcoming first)
@@ -661,7 +661,7 @@ export const CallLog: React.FC = () => {
 
   const handleCompleteCall = async (callId: number) => {
     try {
-      await apiClient.patch(`cockpit/scheduled-calls/${callId}/`, {
+      await apiClient.patch(`workspace/scheduled-calls/${callId}/`, {
         is_completed: true,
         outcome: 'Completed from call log',
       });
@@ -708,7 +708,7 @@ export const CallLog: React.FC = () => {
     }
     
     try {
-      await apiClient.delete(`cockpit/scheduled-calls/${callId}/`);
+      await apiClient.delete(`workspace/scheduled-calls/${callId}/`);
       await fetchScheduledCalls();
     } catch (err: any) {
       console.error('Failed to delete call:', err);
@@ -820,7 +820,7 @@ export const CallLog: React.FC = () => {
         .format('YYYY-MM-DDTHH:mm:ss');
       
       // Update backend
-      await apiClient.patch(`cockpit/scheduled-calls/${draggedCall.id}/`, {
+      await apiClient.patch(`workspace/scheduled-calls/${draggedCall.id}/`, {
         scheduled_for: newScheduledFor,
       });
       


### PR DESCRIPTION
## Summary

Implements **Wave 1 Week 3** of the ProjectMeats v2.0 Master Plan - Safe Renames (Backward Compatible).

## Approach

Following the Master Plan's "Zero Breaking Changes" principle:
1. Add URL aliases so **both old and new paths work**
2. Update frontend to use new canonical paths
3. Old paths remain functional (deprecated, not removed)

## Backend Changes

### URL Aliases Added

| Legacy Path | New Canonical Path | Status |
|-------------|-------------------|--------|
| `/api/v1/bug-reports/` | `/api/v1/feedback/` | Both work |
| `/api/v1/cockpit/` | `/api/v1/workspace/` | Both work |

```python
# Both paths work - no breaking changes
path('api/v1/bug-reports/', include('tenant_apps.bug_reports.urls')),  # Legacy
path('api/v1/feedback/', include('tenant_apps.bug_reports.urls')),      # NEW

path('api/v1/cockpit/', include('tenant_apps.cockpit.urls')),           # Legacy
path('api/v1/workspace/', include('tenant_apps.cockpit.urls')),         # NEW
```

## Frontend Changes

Updated all API calls to use new canonical paths:

| File | Change |
|------|--------|
| `ScheduleCallModal.tsx` | `cockpit/` → `workspace/` |
| `ActivityFeed.tsx` | `cockpit/` → `workspace/` |
| `StepNotes.tsx` | `cockpit/` → `workspace/` |
| `CallLog.tsx` | `cockpit/` → `workspace/` |

## Testing

```bash
# Both paths should return the same data:
curl /api/v1/cockpit/activity-logs/    # Legacy - works
curl /api/v1/workspace/activity-logs/  # New - works
```

## What's NOT Changed (Yet)

- App directory names (tenant_apps/cockpit, tenant_apps/bug_reports)
- Model names (ScheduledCall, ActivityLog, BugReport)
- Database table names
- Django admin references

These will be addressed in Week 4 with proper migrations.

## Related

- Master Plan v3.1: Wave 1 Week 3 Safe Renames
- Previous: PR #2204 (Config System)