### PR TITLE
feat(api): add accounting URL alias - Wave 1 Week 4

### DIFF
--- a/backend/projectmeats/urls.py
+++ b/backend/projectmeats/urls.py
@@ -36,7 +36,9 @@ urlpatterns = [
     path("api/v1/", include("tenant_apps.plants.urls")),
     path("api/v1/", include("tenant_apps.carriers.urls")),
     path("api/v1/", include("tenant_apps.products.urls")),
-    path("api/v1/", include("tenant_apps.invoices.urls")),
+    # Invoices → Accounting rename (v2.0 Wave 1 Week 4)
+    path("api/v1/", include("tenant_apps.invoices.urls")),                      # Legacy (deprecated)
+    path("api/v1/accounting/", include("tenant_apps.invoices.urls")),           # NEW canonical path
     path("api/v1/", include("tenant_apps.locations.urls")),
     path("api/v1/ai-assistant/", include("tenant_apps.ai_assistant.urls")),
     path("api/v1/", include("apps.core.urls")),  # Core shared utilities

--- a/frontend/src/components/Shared/CreateInvoiceModal.tsx
+++ b/frontend/src/components/Shared/CreateInvoiceModal.tsx
@@ -310,7 +310,7 @@ export const CreateInvoiceModal: React.FC<CreateInvoiceModalProps> = ({
         payload.our_sales_order_num = formData.sales_order_ref;
       }
 
-      await apiClient.post('invoices/', payload);
+      await apiClient.post('accounting/invoices/', payload);
 
       // Success!
       onSuccess();

--- a/frontend/src/pages/Accounting/Invoices.tsx
+++ b/frontend/src/pages/Accounting/Invoices.tsx
@@ -413,7 +413,7 @@ const Invoices: React.FC = () => {
         params.status = statusFilter;
       }
       
-      const response = await apiClient.get('invoices/', { params });
+      const response = await apiClient.get('accounting/invoices/', { params });
       const invoicesData = response.data.results || response.data;
       
       // Calculate outstanding amounts (mocked for now - backend enhancement needed)


### PR DESCRIPTION
## Summary
Add URL alias for invoices → accounting rename as part of v2.0 Wave 1 Foundation.

## Changes
- **Backend**: Add `/api/v1/accounting/` as canonical path for invoices app
- **Frontend**: Update API calls to use `accounting/invoices/` instead of `invoices/`

## Backward Compatibility
Old path (`/api/v1/invoices/`) remains functional (deprecated).

## Testing
- `python manage.py check` passes
- `npm run lint` passes (same pre-existing warnings)

## Wave 1 Progress
- Week 1: ✅ App deletions (PR #2201)
- Week 2: ✅ Config system (PR #2204)  
- Week 3: ✅ bug_reports→feedback, cockpit→workspace (PR #2206)
- Week 4: ✅ invoices→accounting (this PR)