### PR TITLE
Fix: Form node config modals not opening

### DIFF
--- a/frontend/src/components/FlowEditor/SidePanel.tsx
+++ b/frontend/src/components/FlowEditor/SidePanel.tsx
@@ -1,0 +1,104 @@
+/**
+ * Side Panel Wrapper
+ * 
+ * Portal-based wrapper for slide-in configuration panels.
+ * Renders panel content outside the editor DOM hierarchy to avoid z-index and overflow issues.
+ * 
+ * Features:
+ * - Uses React Portal for proper rendering
+ * - Fixed positioning relative to viewport
+ * - Backdrop with click-to-close
+ * - Escape key support
+ * - Slide-in animation
+ * 
+ * Created: 2026-02-05 - Fix for form node modals not rendering
+ */
+import React, { useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import styled from 'styled-components';
+
+interface SidePanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export const SidePanel: React.FC<SidePanelProps> = ({ isOpen, onClose, children }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return ReactDOM.createPortal(
+    <Backdrop onClick={handleBackdropClick}>
+      <PanelContent onClick={(e) => e.stopPropagation()}>
+        {children}
+      </PanelContent>
+    </Backdrop>,
+    document.body
+  );
+};
+
+const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 9999;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+`;
+
+const PanelContent = styled.div`
+  position: relative;
+  width: 450px;
+  max-width: 90vw;
+  background: rgb(var(--color-surface));
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
+  animation: slideIn 0.25s ease-out;
+  overflow-y: auto;
+
+  @keyframes slideIn {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+
+  /* Custom scrollbar */
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: rgb(var(--color-background));
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: rgb(var(--color-border));
+    border-radius: 4px;
+  }
+`;
+
+export default SidePanel;

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -63,6 +63,7 @@ import { DocumentConfigPanel } from './ConfigPanel/DocumentConfigPanel';
 import { CreateRecordConfigPanel } from './ConfigPanel/CreateRecordConfigPanel';
 import { TemplateSelector } from './templates/TemplateSelector';
 import { FlowTemplate } from './templates/flowTemplates';
+import { SidePanel } from './SidePanel';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -2703,98 +2704,143 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       />
       
       {/* FormStep Configuration Modal (Phase 4.2.B Integration) */}
-      {formStepModalOpen && selectedFormStep && (
-        <FormStepConfigPanel
-          step={selectedFormStep.data}
-          onChange={handleFormStepUpdate}
-          onClose={() => {
-            setFormStepModalOpen(false);
-            setSelectedFormStep(null);
-          }}
-          onEditField={handleEditField}
-          onAddField={handleAddField}
-          availableFields={getPreviousStepFields(selectedFormStep.id)}
-        />
-      )}
+      <SidePanel
+        isOpen={formStepModalOpen && !!selectedFormStep}
+        onClose={() => {
+          setFormStepModalOpen(false);
+          setSelectedFormStep(null);
+        }}
+      >
+        {selectedFormStep && (
+          <FormStepConfigPanel
+            step={selectedFormStep.data}
+            onChange={handleFormStepUpdate}
+            onClose={() => {
+              setFormStepModalOpen(false);
+              setSelectedFormStep(null);
+            }}
+            onEditField={handleEditField}
+            onAddField={handleAddField}
+            availableFields={getPreviousStepFields(selectedFormStep.id)}
+          />
+        )}
+      </SidePanel>
       
       {/* FormField Configuration Modal - Direct Selection (Phase 1 of Navigation Fix Plan) */}
-      {formFieldModalOpen && selectedFormField && (
-        <FormFieldConfigPanel
-          field={selectedFormField.data}
-          onChange={(updatedFieldData) => {
-            handleNodeUpdate(selectedFormField.id, updatedFieldData);
-            setFormFieldModalOpen(false);
-            setSelectedFormField(null);
-          }}
-          onClose={() => {
-            setFormFieldModalOpen(false);
-            setSelectedFormField(null);
-          }}
-          availableFields={getPreviousStepFields(selectedFormField.id)}
-          tenantLists={tenantLists}
-        />
-      )}
+      <SidePanel
+        isOpen={formFieldModalOpen && !!selectedFormField}
+        onClose={() => {
+          setFormFieldModalOpen(false);
+          setSelectedFormField(null);
+        }}
+      >
+        {selectedFormField && (
+          <FormFieldConfigPanel
+            field={selectedFormField.data}
+            onChange={(updatedFieldData) => {
+              handleNodeUpdate(selectedFormField.id, updatedFieldData);
+              setFormFieldModalOpen(false);
+              setSelectedFormField(null);
+            }}
+            onClose={() => {
+              setFormFieldModalOpen(false);
+              setSelectedFormField(null);
+            }}
+            availableFields={getPreviousStepFields(selectedFormField.id)}
+            tenantLists={tenantLists}
+          />
+        )}
+      </SidePanel>
       
       {/* Section Configuration Modal - Direct Selection (Phase 1 Task 1.2) */}
-      {sectionModalOpen && selectedSection && (
-        <SectionConfigPanel
-          section={selectedSection.data}
-          onChange={(updatedSectionData) => {
-            handleNodeUpdate(selectedSection.id, updatedSectionData);
-            setSectionModalOpen(false);
-            setSelectedSection(null);
-          }}
-          onClose={() => {
-            setSectionModalOpen(false);
-            setSelectedSection(null);
-          }}
-          availableFields={getPreviousStepFields(selectedSection.id)}
-        />
-      )}
+      <SidePanel
+        isOpen={sectionModalOpen && !!selectedSection}
+        onClose={() => {
+          setSectionModalOpen(false);
+          setSelectedSection(null);
+        }}
+      >
+        {selectedSection && (
+          <SectionConfigPanel
+            section={selectedSection.data}
+            onChange={(updatedSectionData) => {
+              handleNodeUpdate(selectedSection.id, updatedSectionData);
+              setSectionModalOpen(false);
+              setSelectedSection(null);
+            }}
+            onClose={() => {
+              setSectionModalOpen(false);
+              setSelectedSection(null);
+            }}
+            availableFields={getPreviousStepFields(selectedSection.id)}
+          />
+        )}
+      </SidePanel>
       
       {/* Document Configuration Modal - Direct Selection (Phase 1 Task 1.3) */}
-      {documentModalOpen && selectedDocument && (
-        <DocumentConfigPanel
-          document={selectedDocument.data}
-          onChange={(updatedDocumentData) => {
-            handleNodeUpdate(selectedDocument.id, updatedDocumentData);
-            setDocumentModalOpen(false);
-            setSelectedDocument(null);
-          }}
-          onClose={() => {
-            setDocumentModalOpen(false);
-            setSelectedDocument(null);
-          }}
-          availableFields={getPreviousStepFields(selectedDocument.id)}
-        />
-      )}
+      <SidePanel
+        isOpen={documentModalOpen && !!selectedDocument}
+        onClose={() => {
+          setDocumentModalOpen(false);
+          setSelectedDocument(null);
+        }}
+      >
+        {selectedDocument && (
+          <DocumentConfigPanel
+            document={selectedDocument.data}
+            onChange={(updatedDocumentData) => {
+              handleNodeUpdate(selectedDocument.id, updatedDocumentData);
+              setDocumentModalOpen(false);
+              setSelectedDocument(null);
+            }}
+            onClose={() => {
+              setDocumentModalOpen(false);
+              setSelectedDocument(null);
+            }}
+            availableFields={getPreviousStepFields(selectedDocument.id)}
+          />
+        )}
+      </SidePanel>
       
       {/* Create Record Action Configuration Modal (Phase 2 Task 2.2) */}
-      {createRecordModalOpen && selectedCreateRecord && (
-        <CreateRecordConfigPanel
-          node={selectedCreateRecord}
-          onUpdate={(nodeId, data) => {
-            handleNodeUpdate(nodeId, data);
-            setCreateRecordModalOpen(false);
-            setSelectedCreateRecord(null);
-          }}
-          onClose={() => {
-            setCreateRecordModalOpen(false);
-            setSelectedCreateRecord(null);
-          }}
-        />
-      )}
+      <SidePanel
+        isOpen={createRecordModalOpen && !!selectedCreateRecord}
+        onClose={() => {
+          setCreateRecordModalOpen(false);
+          setSelectedCreateRecord(null);
+        }}
+      >
+        {selectedCreateRecord && (
+          <CreateRecordConfigPanel
+            node={selectedCreateRecord}
+            onUpdate={(nodeId, data) => {
+              handleNodeUpdate(nodeId, data);
+              setCreateRecordModalOpen(false);
+              setSelectedCreateRecord(null);
+            }}
+            onClose={() => {
+              setCreateRecordModalOpen(false);
+              setSelectedCreateRecord(null);
+            }}
+          />
+        )}
+      </SidePanel>
       
       {/* FormField Configuration Modal (nested) - From within FormStep */}
-      {editingField && (
-        <FormFieldConfigPanel
-          field={editingField}
-          onChange={handleFieldUpdate}
-          onClose={() => setEditingField(null)}
-          availableFields={selectedFormStep?.data?.fields || []}
-          tenantLists={tenantLists}
-        />
-      )}
+      <SidePanel
+        isOpen={!!editingField}
+        onClose={() => setEditingField(null)}
+      >
+        {editingField && (
+          <FormFieldConfigPanel
+            field={editingField}
+            onChange={handleFieldUpdate}
+            onClose={() => setEditingField(null)}
+            availableFields={selectedFormStep?.data?.fields || []}
+            tenantLists={tenantLists}
+          />
+        )}
+      </SidePanel>
     </EditorContainer>
   );
 };


### PR DESCRIPTION
## Problem
FormStep, FormField, and FormSection nodes were not opening their configuration modals when clicked. Console logs showed the modals were being triggered, but nothing appeared on screen.

## Root Cause
Config panels were rendering inside EditorContainer which has:
- Limited height (600px)
- Relative positioning
- Potential overflow: hidden

The panels expected to be fixed-positioned relative to viewport, but were constrained by parent container.

## Solution
Created `SidePanel.tsx` wrapper component that:
- Uses React Portal to render outside DOM hierarchy
- Fixed positioning relative to viewport
- Backdrop with click-to-close
- Escape key support
- Preserves slide-in animations

## Changes
- Created `frontend/src/components/FlowEditor/SidePanel.tsx`
- Wrapped all 6 config panels in SidePanel:
  - FormStepConfigPanel
  - FormFieldConfigPanel (2 instances)
  - SectionConfigPanel
  - DocumentConfigPanel
  - CreateRecordConfigPanel

## Testing
✅ Build passes (17.29s)
✅ No TypeScript errors
✅ All config panels now render properly

Resolves form node modal rendering issues.