### PR TITLE
Fix: Convert Jest to Vitest in SidePanel tests

### DIFF
--- a/frontend/src/components/FlowEditor/__tests__/SidePanel.test.tsx
+++ b/frontend/src/components/FlowEditor/__tests__/SidePanel.test.tsx
@@ -6,10 +6,11 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { SidePanel } from '../SidePanel';
 
 describe('SidePanel', () => {
-  const mockOnClose = jest.fn();
+  const mockOnClose = vi.fn();
   const testContent = <div>Test Content</div>;
 
   beforeEach(() => {


### PR DESCRIPTION
## Problem

Deployment pipeline failed with:
```
ReferenceError: jest is not defined
```

The test file was written with Jest syntax but the project uses Vitest.

## Solution

- Replaced `jest.fn()` with `vi.fn()`
- Added proper Vitest imports: `vi, describe, it, expect, beforeEach`
- Tests now compatible with Vitest test runner

## Test Results

✅ All 5 tests passing locally:
```
✓ src/components/FlowEditor/__tests__/SidePanel.test.tsx (5 tests) 42ms
  Test Files  1 passed (1)
       Tests  5 passed (5)
```

## Impact

- Fixes Master Pipeline deployment failure
- Allows development deployment to proceed
- No functional changes, only test framework syntax

Fixes run: #21732538834