### PR TITLE
fix: prevent crashes when clicking form nodes without initialized arrays

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
@@ -515,11 +515,18 @@ export const FormFieldConfigPanel: React.FC<FormFieldConfigPanelProps> = ({
   availableFields = [],
   tenantLists = [],
 }) => {
-  const [localField, setLocalField] = useState<FormField>(field);
+  // Ensure required arrays are always initialized
+  const [localField, setLocalField] = useState<FormField>({
+    ...field,
+    validationRules: field.validationRules || [],
+  });
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    setLocalField(field);
+    setLocalField({
+      ...field,
+      validationRules: field.validationRules || [],
+    });
   }, [field]);
 
   const fieldTypeDef = FIELD_TYPE_DEFINITIONS[localField.type];

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
@@ -495,11 +495,18 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
   onAddField,
   availableFields = [],
 }) => {
-  const [localStep, setLocalStep] = useState<FormStepData>(step);
+  // Ensure fields array is always initialized
+  const [localStep, setLocalStep] = useState<FormStepData>({
+    ...step,
+    fields: step.fields || [],
+  });
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    setLocalStep(step);
+    setLocalStep({
+      ...step,
+      fields: step.fields || [],
+    });
   }, [step]);
 
   const handleUpdate = (updates: Partial<FormStepData>) => {


### PR DESCRIPTION
## Problem
Form nodes (formStep, formField, formSection) were crashing when clicked due to attempting to read `.length` on undefined array properties.

## Root Cause
When nodes are created via drag-and-drop, the `getDefaultNodeData` function initializes form nodes with `fields: []`. However, if the node data is incomplete or the component receives props before full initialization, array properties like `fields` and `validationRules` could be undefined.

## Solution
Added defensive initialization in both configuration panels:
- **FormStepConfigPanel**: Ensures `fields` array always exists with fallback `fields: step.fields || []`
- **FormFieldConfigPanel**: Ensures `validationRules` array always exists with fallback `validationRules: field.validationRules || []`

## Changes
- `frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx`
  - Initialize `fields` array in useState and useEffect
- `frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx`
  - Initialize `validationRules` array in useState and useEffect

## Testing
- ✅ Frontend builds successfully
- ✅ No TypeScript errors
- Should be tested by clicking on formStep, formField, and formSection nodes in WorkForms editor

## Related
Fixes console error: `Cannot read properties of undefined (reading 'length')` at FormStepConfigPanel.tsx:589