### PR TITLE
🚨 CRITICAL v2: Complete temporal dead zone fix (onDrag)

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1982,6 +1982,36 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     addToRecent(nodeTypeId);
   }, [addToRecent]);
   
+  // ============================================================================
+  // Container Detection Helper (Phase E)
+  // ============================================================================
+  
+  /**
+   * Detect if a position is inside a container node
+   * Used by onDrag, onDrop, and onNodeDragStop
+   */
+  const findContainerAtPosition = useCallback((position: { x: number; y: number }) => {
+    const containerNodes = nodes.filter(node => node.type === 'formMultiStepContainer');
+    
+    for (const container of containerNodes) {
+      // Approximate container bounds (typical node is ~300px wide, ~200px tall)
+      const containerWidth = 400; // Container nodes are wider
+      const containerHeight = 300;
+      
+      const isInside = 
+        position.x >= container.position.x &&
+        position.x <= container.position.x + containerWidth &&
+        position.y >= container.position.y &&
+        position.y <= container.position.y + containerHeight;
+      
+      if (isInside) {
+        return container;
+      }
+    }
+    
+    return null;
+  }, [nodes]);
+  
   const onDrag = useCallback((event: React.DragEvent) => {
     if (event.clientX === 0 && event.clientY === 0) return; // Ignore end event
     
@@ -2023,35 +2053,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     setNearbyNode(null);
     setHoveredContainerId(null); // Phase E: Clear container hover
   }, []);
-
-  // ============================================================================
-  // Container Detection Helper (Phase E)
-  // ============================================================================
-  
-  /**
-   * Detect if a position is inside a container node
-   */
-  const findContainerAtPosition = useCallback((position: { x: number; y: number }) => {
-    const containerNodes = nodes.filter(node => node.type === 'formMultiStepContainer');
-    
-    for (const container of containerNodes) {
-      // Approximate container bounds (typical node is ~300px wide, ~200px tall)
-      const containerWidth = 400; // Container nodes are wider
-      const containerHeight = 300;
-      
-      const isInside = 
-        position.x >= container.position.x &&
-        position.x <= container.position.x + containerWidth &&
-        position.y >= container.position.y &&
-        position.y <= container.position.y + containerHeight;
-      
-      if (isInside) {
-        return container;
-      }
-    }
-    
-    return null;
-  }, [nodes]);
 
   const onDrop = useCallback(
     (event: React.DragEvent) => {


### PR DESCRIPTION
## 🚨 EMERGENCY FIX v2: Complete Temporal Dead Zone Fix

### Why v2?
**PR #2651 was INCOMPLETE** - it fixed `onDrop` but MISSED `onDrag`

### Current State
Users **STILL** seeing crash after PR #2651 deployed:
```
Uncaught ReferenceError: Cannot access 'Gd' before initialization
    at UnifiedFlowEditor.tsx:2015
```

Hard refresh doesn't help because **onDrag still broken**.

### Root Cause

**THREE functions** use `findContainerAtPosition`:

```typescript
// Line 1985 - onDrag (BEFORE definition) ❌
const onDrag = useCallback(() => {
  const hoveredContainer = findContainerAtPosition(pos);  // Line 2013
  // ...
}, [findContainerAtPosition]);  // Line 2015 - ERROR HERE

// Line 2034 - findContainerAtPosition definition
const findContainerAtPosition = useCallback(() => { /* ... */ }, [nodes]);

// Line 2056 - onDrop (AFTER definition) ✅
const onDrop = useCallback(() => {
  const targetContainer = findContainerAtPosition(pos);
  // ...
}, [findContainerAtPosition]);

// Line 2146 - onNodeDragStop (AFTER definition) ✅
const onNodeDragStop = useCallback(() => {
  const container = findContainerAtPosition(pos);
  // ...
}, [findContainerAtPosition]);
```

**PR #2651 moved it from 2121 → 2034, but onDrag is at 1985echo ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*

### The Complete Fix

Move `findContainerAtPosition` to line 1993 - **BEFORE ALL THREE**:

```typescript
// Line 1993 - findContainerAtPosition DEFINED ✅
const findContainerAtPosition = useCallback(() => { /* ... */ }, [nodes]);

// Line 2015 - onDrag (now AFTER) ✅
const onDrag = useCallback(() => {
  const hoveredContainer = findContainerAtPosition(pos);  // Safe!
}, [findContainerAtPosition]);

// Line 2057 - onDrop (still AFTER) ✅
const onDrop = useCallback(() => { /* ... */ }, [findContainerAtPosition]);

// Line 2151 - onNodeDragStop (still AFTER) ✅
const onNodeDragStop = useCallback(() => { /* ... */ }, [findContainerAtPosition]);
```

### Function Declaration Timeline

**WRONG (what's deployed now):**
1. Line 1985: `onDrag` → uses `findContainerAtPosition` ❌
2. Line 2034: `findContainerAtPosition` → defined here ❌
3. Line 2056: `onDrop` → uses `findContainerAtPosition` ✅
4. Line 2146: `onNodeDragStop` → uses `findContainerAtPosition` ✅

**CORRECT (this PR):**
1. Line 1993: `findContainerAtPosition` → defined here ✅
2. Line 2015: `onDrag` → uses it ✅
3. Line 2057: `onDrop` → uses it ✅
4. Line 2151: `onNodeDragStop` → uses it ✅

### Why This Happened

PR #2645 added container hover feedback to `onDrag`:
```typescript
// Phase E: Detect if hovering over a container for visual feedback
const hoveredContainer = findContainerAtPosition(snappedPosition);
```

But `findContainerAtPosition` was defined 49 lines later → temporal dead zone.

PR #2651 moved it forward but not far enough!

### Changes
- `frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx`
  - Moved `findContainerAtPosition` from line 2034 → 1993
  - Now before ALL consumers
  - Pure refactor, zero logic changes

### Testing
✅ Editor loads without crash
✅ Container hover feedback works  
✅ Container drop detection works
✅ Drag-in/drag-out updates work

**MERGE IMMEDIATELY** - Production still broken!