### PR TITLE
🚨 BACKEND: Fix entity endpoint URL duplication (404 → 200)

### DIFF
--- a/backend/apps/core/urls.py
+++ b/backend/apps/core/urls.py
@@ -12,8 +12,8 @@ router.register(r'preferences', views.UserPreferencesViewSet, basename='user-pre
 
 # WorkForms router (Phase 1.4-1.6)
 workforms_router = DefaultRouter()
-workforms_router.register(r'v1/tenant-forms', workform_views.TenantFormViewSet, basename='tenant-form')
-workforms_router.register(r'v1/tenant-workforms', workform_views.TenantWorkFormViewSet, basename='tenant-workform')
+workforms_router.register(r'tenant-forms', workform_views.TenantFormViewSet, basename='tenant-form')
+workforms_router.register(r'tenant-workforms', workform_views.TenantWorkFormViewSet, basename='tenant-workform')
 
 urlpatterns = [
     # Legacy auth endpoints (for backward compatibility)
@@ -50,13 +50,13 @@ urlpatterns = [
     
     # WorkForms Enhancement API (Phase 1: WF-ENH-2026-Q1)
     # Entity Registry & Schema Endpoints (Phase 1.1-1.3)
-    path("v1/entities/", entity_views.entity_registry, name="entity-registry"),
-    path("v1/entities/<str:entity_type>/schema/", entity_views.entity_schema, name="entity-schema"),
-    path("v1/entities/<str:entity_type>/lookup/", entity_views.entity_lookup, name="entity-lookup"),
+    path("entities/", entity_views.entity_registry, name="entity-registry"),
+    path("entities/<str:entity_type>/schema/", entity_views.entity_schema, name="entity-schema"),
+    path("entities/<str:entity_type>/lookup/", entity_views.entity_lookup, name="entity-lookup"),
     
     # Form Management Endpoints (Phase 1.5)
-    path("v1/tenant-forms/merge/", workform_views.merge_forms, name="tenant-forms-merge"),
-    path("v1/tenant-forms/split/", workform_views.split_form, name="tenant-forms-split"),
+    path("tenant-forms/merge/", workform_views.merge_forms, name="tenant-forms-merge"),
+    path("tenant-forms/split/", workform_views.split_form, name="tenant-forms-split"),
     
     # Include router URLs
     path("", include(router.urls)),


### PR DESCRIPTION
## 🚨 CRITICAL: Backend URL Duplication Bug

### Symptom
```
GET /api/v1/entities/ → 404 Not Found
```

WorkForms editor cannot load entities - completely broken.

### Root Cause

**Exact same URL duplication bug as frontend (PR #2643)echo ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*

Backend has DOUBLE `v1/` in paths:

```python
# projectmeats/urls.py line 52
path("api/v1/", include("apps.core.urls"))  # Includes under api/v1/

# apps/core/urls.py lines 53-59
path("v1/entities/", ...)              # ❌ Has v1/ AGAIN
path("v1/tenant-forms/merge/", ...)   # ❌ Has v1/ AGAIN

# Result: /api/v1/v1/entities/ → 404!
```

### The Fix

**Remove `v1/` prefix from core URLs** - already under `api/v1/` include:

```python
# apps/core/urls.py (FIXED)
path("entities/", ...)              # ✅ No duplication
path("tenant-forms/merge/", ...)   # ✅ No duplication

# Result: /api/v1/entities/ → 200 OK!
```

### Why This Happened

Phase 1.1-1.3 entity endpoints were added with `v1/` prefix:
- Assumed they'd be at root level
- But they're included under `api/v1/` in main urls.py
- Created: `/api/v1/v1/entities/` (invalid path)

**This is identical to frontend issue (PR #2643):**
- Frontend had `apiClient.baseURL = '/api/v1'`
- Then called `/api/v1/entities/`
- Created: `/api/v1/api/v1/entities/`

Both frontend and backend made the same mistake!

### Endpoints Fixed

**Entity Endpoints:**
- `GET /api/v1/entities/` - Entity registry
- `GET /api/v1/entities/<type>/schema/` - Field schemas
- `GET /api/v1/entities/<type>/lookup/` - Dropdown data

**Form Management:**
- `/api/v1/tenant-forms/` (CRUD operations)
- `POST /api/v1/tenant-forms/merge/` 
- `POST /api/v1/tenant-forms/split/`
- `/api/v1/tenant-workforms/` (CRUD operations)

### Files Changed
- `backend/apps/core/urls.py`
  - Lines 53-55: Entity endpoints (removed `v1/`)
  - Lines 58-59: Form management (removed `v1/`)
  - Lines 15-16: Router registrations (removed `v1/`)

### Testing After Deployment

```bash
# Should return entity list (Supplier, Customer, etc)
curl https://dev.meatscentral.com/api/v1/entities/
```

**Expected:** 200 OK with JSON entity list  
**Before:** 404 Not Found

**WorkForms editor will work after this deploysecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*

### Related PRs
- PR #2643: Frontend URL duplication fix
- PR #2648: Backend restart trigger (unnecessary now)
- PR #2653: Frontend temporal dead zone fix

**MERGE IMMEDIATELY** - This is the final piece!