### PR TITLE
🔥 CRITICAL: Fix container drop double-subtract coordinate bug

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2496,9 +2496,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       relativeY: event.clientY - reactFlowBounds.top,
     });
     
+    // FIX: screenToFlowPosition expects ABSOLUTE screen coordinates
+    // It handles viewport transformation internally - do NOT subtract bounds
     const flowPosition = reactFlowInstance.screenToFlowPosition({
-      x: event.clientX - reactFlowBounds.left,
-      y: event.clientY - reactFlowBounds.top,
+      x: event.clientX,
+      y: event.clientY,
     });
     
     console.log('[DEBUG] Flow position after transform:', flowPosition);
@@ -2626,9 +2628,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         boundsHeight: reactFlowBounds.height,
       });
       
+      // FIX: screenToFlowPosition expects ABSOLUTE screen coordinates
+      // It handles viewport transformation internally - do NOT subtract bounds
       const position = reactFlowInstance.screenToFlowPosition({
-        x: event.clientX - reactFlowBounds.left,
-        y: event.clientY - reactFlowBounds.top,
+        x: event.clientX,
+        y: event.clientY,
       });
       
       console.log('[DEBUG] Calculated flow position:', position);
@@ -2717,7 +2721,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           };
           
           // Phase 1.4: Set parentNode property (React Flow native)
-          newNode.parentNode = targetContainer.id;
+          newNode.parentId = targetContainer.id;
           
           // Phase 1.4: Constrain node movement to parent bounds
           newNode.extent = 'parent';
@@ -2918,7 +2922,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
                   x: absolutePosition.x - containerNode.position.x,
                   y: absolutePosition.y - containerNode.position.y,
                 };
-                updatedNode.parentNode = newParentId;
+                updatedNode.parentId = newParentId;
                 updatedNode.extent = 'parent';
                 console.log(`[Container] Node ${node.id} added to container ${newParentId}`);
               }
@@ -2954,7 +2958,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   const updateContainerStats = useCallback((containerId: string) => {
     setNodes((nds) => {
       // Count nodes in this container using React Flow's parentNode property
-      const childNodes = nds.filter(n => n.parentNode === containerId);
+      const childNodes = nds.filter(n => n.parentId === containerId);
       const nodeTypeBreakdown: Record<string, number> = {};
       const formReferences: string[] = [];
       
@@ -3236,7 +3240,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       
       if (containerNodes.length > 0) {
         containerNodes.forEach(container => {
-          const childNodes = nodes.filter(n => n.parentNode === container.id); // Phase E: Using parentNode
+          const childNodes = nodes.filter(n => n.parentId === container.id); // Phase E: Using parentNode
           console.log(`  - Container ${container.id}: ${childNodes.length} nodes`);
         });
       }
@@ -3265,7 +3269,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     
     for (const container of containerNodes) {
       // Get child nodes
-      const childNodes = nodes.filter(n => n.parentNode === container.id);
+      const childNodes = nodes.filter(n => n.parentId === container.id);
       
       // Check for at least one form step
       const formSteps = childNodes.filter(


### PR DESCRIPTION
## 🐛 Critical Bug Fix

### Problem
Container drop detection was completely broken - nodes could not be dropped into containers despite container detection logic being correct.

### Root Cause
**Double-subtraction bug in coordinate transformation**

The bug was in these two locations:
1. `onDrop()` handler (line 2629)
2. `onDrag()` handler (line 2499)

**What was happening:**
```typescript
// ❌ WRONG CODE (before fix)
const position = reactFlowInstance.screenToFlowPosition({
  x: event.clientX - reactFlowBounds.left,  // ← Subtracting bounds
  y: event.clientY - reactFlowBounds.top,   // ← Subtracting bounds
});
```

**Why it was wrong:**
- `screenToFlowPosition()` expects **absolute screen coordinates** (raw clientX/clientY)
- It **internally** handles bounds subtraction + viewport transformation
- By subtracting bounds BEFORE calling it, we were **double-subtracting**

**Result:**
- Mouse at screen position: (600, 600)
- Container at flow position: (105, -165) with bounds [105→505] × [-165→135]
- Calculated drop point: **(-405, -450)** ← 500px+ offset!
- Detection failed: -405 is NOT in range [105, 505]

### The Fix

```typescript
// ✅ CORRECT CODE (after fix)
const position = reactFlowInstance.screenToFlowPosition({
  x: event.clientX,  // Absolute screen coordinates
  y: event.clientY,  // Let React Flow handle transformation
});
```

### Additional Improvements

**Updated deprecated property** (React Flow v11.11+):
- Replaced `node.parentNode = id` with `node.parentId = id` 
- Updated all 5 occurrences in the file
- Prevents future deprecation warnings

### Evidence from Logs

From user-provided logs showing the bug:
```
[Container] Container at: (105, -165)
[Container] Bounds: [105→505] × [-165→135]
[Container] Drop point: (-405, -450)
[Container] ❌ Drop position outside container
[Container]   X ✗ (-405 vs [105, 505])
[Container]   Y ✗ (-465 vs [-165, 135])
```

The math was clearly wrong - the drop point was hundreds of pixels off.

### Files Changed
- `UnifiedFlowEditor.tsx`:
  - Line ~2500: Fixed onDrag coordinate transform
  - Line ~2630: Fixed onDrop coordinate transform  
  - Lines 2724, 2925, 2961, 3243, 3272: Replaced parentNode → parentId

### Testing
- ✅ Build passes
- ✅ No TypeScript errors
- ✅ Coordinate math now correct
- ⏳ User testing required to confirm container drops work

### Impact
**CRITICAL**: This bug prevented the entire container feature from working. Users could not:
- Drop form steps into containers
- Build multi-step workflows
- Use container organization features

**Priority**: Merge ASAP and deploy to unblock container functionality.

### Related PRs
- #2744 - Initial container coordinate investigation (identified viewport issue)
- #2741 - Container modal CSS fix
- This PR completes the container drop fix chain

---

**Ready for immediate merge and deployment**