### PR TITLE
fix(workform): Update parentNode to parentId in container node queries

### DIFF
--- a/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
+++ b/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
@@ -44,7 +44,7 @@ import { CustomEdge } from '../edges/CustomEdge';
 // ============================================================================
 
 interface MiniReactFlowProps {
-  nodes: Node[]; // Phase 2.2: Filtered by parentNode in UnifiedFlowEditor
+  nodes: Node[]; // Phase 2.2: Filtered by parentId in UnifiedFlowEditor (React Flow v11+)
   edges: Edge[]; // Phase 2.2: Filtered to edges between child nodes
   containerHeight?: number; // Height of mini canvas
   // Phase 2.2: Removed onNodesChange, onEdgesChange, onConnect (read-only)

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2731,7 +2731,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           
           console.log(`[Container] ✅ Node configured:`, {
             id: newNode.id,
-            parentNode: newNode.parentNode,
+            parentId: newNode.parentId,
             position: newNode.position,
             extent: newNode.extent,
           });

--- a/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
@@ -2,13 +2,13 @@
  * Form Multi-Step Container Node Component
  * 
  * Phase 2: Migrated to React Flow Native System
- * - Uses parentNode property instead of childNodes array
+ * - Uses parentId property instead of childNodes array
  * - Queries children from main React Flow state via useReactFlow
  * - No shadow graph - single source of truth
  * 
  * Phase 4.2 of WF-ENH-2026-Q1
  * Created: 2026-02-06
- * Updated: 2026-02-08 - Phase 2: Migrated to React Flow native parent-child
+ * Updated: 2026-02-09 - Fixed: parentNode → parentId (React Flow v11+)
  */
 import React, { useState, useMemo, useCallback } from 'react';
 import styled from 'styled-components';
@@ -317,8 +317,8 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
     const allNodes = getNodes();
     const allEdges = getEdges();
     
-    // Phase 2.2: Query child nodes via parentNode property
-    const childNodes = allNodes.filter(node => node.parentNode === id);
+    // Phase 2.2: Query child nodes via parentId property (updated from deprecated parentNode)
+    const childNodes = allNodes.filter(node => node.parentId === id);
     
     // Phase 2.2: Query edges between child nodes
     const childNodeIds = new Set(childNodes.map(n => n.id));

--- a/frontend/src/components/FlowEditor/utils/containerLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/containerLayout.ts
@@ -68,8 +68,8 @@ export function calculateContainerLayout(
 ): LayoutResult {
   console.log(`[Layout] Calculating layout for container ${containerId}`);
   
-  // Filter child nodes
-  const childNodes = allNodes.filter(node => node.parentNode === containerId);
+  // Filter child nodes (using parentId - React Flow v11+)
+  const childNodes = allNodes.filter(node => node.parentId === containerId);
   
   if (childNodes.length === 0) {
     console.log(`[Layout] No child nodes found for container ${containerId}`);
@@ -256,8 +256,8 @@ export function autoConnectSequentialSteps(
 ): ConnectionResult {
   console.log(`[AutoConnect] Creating sequential connections for container ${containerId}`);
   
-  // Filter child nodes
-  const childNodes = allNodes.filter(node => node.parentNode === containerId);
+  // Filter child nodes (using parentId - React Flow v11+)
+  const childNodes = allNodes.filter(node => node.parentId === containerId);
   
   // Get only form steps and sort by x-position (left-to-right)
   const formSteps = childNodes
@@ -279,8 +279,8 @@ export function autoConnectSequentialSteps(
     const sourceNode = allNodes.find(n => n.id === edge.source);
     const targetNode = allNodes.find(n => n.id === edge.target);
     
-    // Keep if either node is not in this container
-    return sourceNode?.parentNode !== containerId || targetNode?.parentNode !== containerId;
+    // Keep if either node is not in this container (using parentId - React Flow v11+)
+    return sourceNode?.parentId !== containerId || targetNode?.parentId !== containerId;
   });
   
   console.log(`[AutoConnect] Removed ${allEdges.length - nonAutoEdges.length} old auto-edges`);

--- a/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
+++ b/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
@@ -150,10 +150,10 @@ export const prepareWorkflowForSave = (
   const nodesCopy = JSON.parse(JSON.stringify(nodes));
   const edgesCopy = JSON.parse(JSON.stringify(edges));
   
-  // Ensure all nodes have proper parentNode metadata
+  // Ensure all nodes have proper parentId metadata (React Flow v11+)
   // (This is already set by React Flow, but we verify it's serialized)
   for (const node of nodesCopy) {
-    if (node.parentNode) {
+    if (node.parentId) {
       // Ensure extent is serialized
       if (!node.extent) {
         node.extent = 'parent';
@@ -269,14 +269,14 @@ export const saveWorkflow = async (
 /**
  * Reconstruct parent-child relationships after loading
  * 
- * React Flow requires nodes to have parentNode property set correctly.
+ * React Flow v11+ requires nodes to have parentId property set correctly.
  * This ensures all container children are properly linked.
  */
 export const reconstructParentChildRelationships = (nodes: Node[]): Node[] => {
   const reconstructed = JSON.parse(JSON.stringify(nodes));
   
   for (const node of reconstructed) {
-    if (node.parentNode) {
+    if (node.parentId) {
       // Ensure extent is set for constrained movement
       if (!node.extent) {
         node.extent = 'parent';


### PR DESCRIPTION
Critical Bug Fix: Container Node Display

Problem: Container nodes showing 0 nodes despite successful drops
Cause: React Flow v11+ parentNode deprecated to parentId
Fix: Updated all container queries to use parentId

Impact: Container now displays child nodes correctly with proper count and mini preview