### PR TITLE
fix(workform): Container node count not updating

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
@@ -12,7 +12,7 @@
  */
 import React, { useState, useMemo, useCallback } from 'react';
 import styled from 'styled-components';
-import { NodeProps, Node, Edge, useReactFlow } from '@xyflow/react';
+import { NodeProps, Node, Edge, useReactFlow, useNodes, useEdges } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { getNodeTypeDefinition } from '../nodeTypes';
 import { ChevronDown, ChevronRight, Maximize2, Minimize2, LogIn, ZoomIn } from 'lucide-react';
@@ -308,15 +308,16 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
   selected,
 }) => {
   const [isExpanded, setIsExpanded] = useState(data.isExpanded ?? true);
-  const { getNodes, getEdges } = useReactFlow(); // Phase 2.2: Access React Flow state
+  
+  // Phase 2.2: Use reactive hooks that trigger re-renders on state changes
+  const allNodes = useNodes(); // ✅ Triggers re-render when nodes change
+  const allEdges = useEdges(); // ✅ Triggers re-render when edges change
   
   const nodeDef = getNodeTypeDefinition('formMultiStepContainer');
   
   // Phase 2.2: Calculate statistics from React Flow state (not shadow array)
+  // FIXED: Now depends on actual nodes/edges arrays, not getter functions
   const stats = useMemo(() => {
-    const allNodes = getNodes();
-    const allEdges = getEdges();
-    
     // Phase 2.2: Query child nodes via parentId property (updated from deprecated parentNode)
     const childNodes = allNodes.filter(node => node.parentId === id);
     
@@ -348,7 +349,7 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
       childNodes, // Phase 2.2: From React Flow state, not shadow array
       childEdges, // Phase 2.2: From React Flow state, not shadow array
     };
-  }, [id, getNodes, getEdges]); // Phase 2.2: Dependency on React Flow state
+  }, [id, allNodes, allEdges]); // Phase 2.2: Reactive dependencies on actual state
   
   const isConfigured = data.configured || stats.hasNodes;
   


### PR DESCRIPTION
## 🐛 Bug Fix: Container Node Count

Fixes container multi-step node showing **"0 nodes"** even when children were successfully added via drag-and-drop.

## 🔍 Root Cause

The issue was in the `useMemo` dependencies in `FormMultiStepContainerNode.tsx`:

```typescript
// ❌ BEFORE (broken)
const { getNodes, getEdges } = useReactFlow();
const stats = useMemo(() => {
  const allNodes = getNodes();
  const allEdges = getEdges();
  // ... calculate stats
}, [id, getNodes, getEdges]); // ⚠️ Functions don't change!
```

**Problem**: `getNodes` and `getEdges` are **function references** that don't change when the underlying state changes. Since `useMemo` depends on these stable function references, it **never re-computes** when nodes are added/removed.

**Result**: Container stats remain at `{nodeCount: 0}` even though `parentId` is correctly set on child nodes.

## ✅ Solution

Use the **reactive hooks** `useNodes()` and `useEdges()` instead:

```typescript
// ✅ AFTER (fixed)
const allNodes = useNodes(); // Triggers re-render on state change
const allEdges = useEdges(); // Triggers re-render on state change

const stats = useMemo(() => {
  const childNodes = allNodes.filter(node => node.parentId === id);
  // ... calculate stats
}, [id, allNodes, allEdges]); // ✅ Arrays change when state changes!
```

**How it works**:
- `useNodes()` returns the actual nodes array from React Flow state
- When nodes change (e.g., child added), React Flow updates the array
- `useMemo` detects the array reference changed and re-computes
- Container displays updated count immediately

## 📊 Changes

### Modified Files
- `components/FlowEditor/nodes/FormMultiStepContainerNode.tsx`:
  - Added `useNodes, useEdges` to imports
  - Replaced `getNodes()/getEdges()` with `allNodes/allEdges` hooks
  - Updated `useMemo` dependencies to `[id, allNodes, allEdges]`
  - Added explanatory comments

## 🧪 Testing

**Before**: Container showed "0 nodes" after successful drop  
**After**: Container shows correct count ("1 node", "2 nodes", etc.)

**Test Steps**:
1. Drag container node to canvas
2. Drag form step into container (should show "1 node")
3. Drag another form step into container (should show "2 nodes")
4. Mini canvas preview should show both child nodes
5. Expand container to see stats breakdown

## 🔗 Related PRs

- PR #2750: Container drop coordinates (final fix)
- PR #2753: Container child display (parentNode → parentId)
- This PR: Container node count display (useMemo reactivity)

Together these 3 PRs complete the container feature! 🎉

## 📝 Technical Notes

**React Flow Hooks**:
- `useReactFlow()`: Low-level API, returns getter functions
- `useNodes()`: Reactive hook, subscribes to state changes
- `useEdges()`: Reactive hook, subscribes to state changes

**When to use what**:
- Use `useNodes/useEdges` for **rendering** (needs reactivity)
- Use `getNodes/getEdges` for **actions** (one-time reads)

**Similar patterns in codebase**:
- Check other container-related components for similar issues
- Audit useMemo/useCallback dependencies on React Flow state

---

**Review Priority**: High (fixes user-visible bug)  
**Testing**: Manual (drop nodes into container and verify count)  
**Merge After**: All checks pass