### PR TITLE
fix(workform): Add explicit logging to debug node click modal behavior

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -3861,11 +3861,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     const selectedNodes = params.nodes || [];
     if (selectedNodes.length === 1) {
       const node = selectedNodes[0];
-      console.log('[UnifiedFlowEditor] Node selected:', node.type, node);
+      console.log('[Selection] Node selected (no modal):', node.type, node.id);
       
-      // Only store selected node reference, don't open modal
+      // IMPORTANT: Only store selected node reference, NEVER open modal on selection
+      // Modals only open via explicit Edit button click in handleNodeEdit()
       setSelectedNode(node);
     } else {
+      console.log('[Selection] Cleared selection');
       // Clear all selections when nothing selected
       setSelectedNode(null);
       setSelectedFormStep(null);
@@ -3886,11 +3888,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   }, []);
   
   // Batch 3: Handler to open modal from Edit button
+  // IMPORTANT: This is the ONLY place modals should be opened (except programmatic saves)
   const handleNodeEdit = useCallback((nodeId: string) => {
     const node = nodes.find(n => n.id === nodeId);
     if (!node) return;
     
-    console.log('[UnifiedFlowEditor] Edit button clicked for node:', node.type, node);
+    console.log('✏️ [EDIT BUTTON] Opening modal for:', node.type, nodeId);
     
     // Close all modals first
     setFormStepModalOpen(false);
@@ -3904,27 +3907,32 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     // Route to appropriate config panel based on node type
     switch (node.type) {
       case 'formStep':
+        console.log('✏️ [EDIT BUTTON] Opening FormStep modal');
         setSelectedFormStep(node);
         setFormStepModalOpen(true);
         break;
       
       case 'formMultiStepContainer':
+        console.log('✏️ [EDIT BUTTON] Opening Container modal');
         setSelectedContainer(node);
         setContainerModalOpen(true);
         break;
         
       case 'formReference':
+        console.log('✏️ [EDIT BUTTON] Opening FormReference modal');
         setSelectedFormReference(node);
         setFormReferenceModalOpen(true);
         break;
         
       case 'formField':
+        console.log('✏️ [EDIT BUTTON] Opening FormField modal');
         setSelectedFormField(node);
         setFormFieldModalOpen(true);
         break;
         
       case 'formSection':
       case 'section':
+        console.log('✏️ [EDIT BUTTON] Opening Section modal');
         setSelectedSection(node);
         setSectionModalOpen(true);
         break;
@@ -3932,6 +3940,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       case 'formFileUpload':
       case 'document':
       case 'upload':
+        console.log('✏️ [EDIT BUTTON] Opening Document modal');
         setSelectedDocument(node);
         setDocumentModalOpen(true);
         break;
@@ -3939,6 +3948,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       case 'action':
         const actionType = node.data.actionType;
         if (actionType === 'createRecord') {
+          console.log('✏️ [EDIT BUTTON] Opening CreateRecord modal');
           setSelectedCreateRecord(node);
           setCreateRecordModalOpen(true);
         } else {

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -277,6 +277,8 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
   
   const handleEdit = (e: React.MouseEvent) => {
     e.stopPropagation();
+    e.preventDefault(); // Also prevent default to be extra safe
+    console.log('🔘 [BaseNode] Edit button clicked - calling onEdit');
     if (onEdit) onEdit();
   };
   


### PR DESCRIPTION
## �� Problem

User reported that nodes are opening configuration modals when clicked anywhere on the node, rather than only when the Edit button is clicked.

## 🔍 Investigation

After thorough code review, the implementation is **already correct**:
- ✅ Batch 3 (PR #2747) removed auto-opening modals on selection
- ✅ `handleSelectionChange` only tracks selection, doesn't open modals
- ✅ `handleNodeEdit` is the ONLY place modals are opened
- ✅ Edit button uses `stopPropagation()` to prevent event bubbling
- ✅ No `useEffect` that opens modals based on selection

## 🛠️ Changes

This PR adds extensive logging to verify behavior and help debug the issue:

1. **Enhanced Selection Logging**
   - Added clearer console messages: `[Selection] Node selected (no modal)`
   - Explicit comment: "NEVER open modal on selection"

2. **Enhanced Edit Button Logging**
   - Added emoji markers: 🔘 for BaseNode, ✏️ for Edit button
   - Clear logging for each modal type being opened
   - Added `preventDefault()` for extra safety

3. **Verification**
   - Code review confirms no other modal opening paths
   - No double-click handlers
   - No onClick on NodeContainer

## 🧪 Testing

- ✅ TypeScript compilation passes
- ✅ Linter passes (console.log warnings are intentional for debugging)
- ✅ Code inspection confirms correct behavior

## 📝 Expected Behavior

When deployed, users should see in console:
- `[Selection] Node selected (no modal): formStep node-123` - when clicking node body
- `🔘 [BaseNode] Edit button clicked - calling onEdit` - when clicking edit icon
- `✏️ [EDIT BUTTON] Opening FormStep modal` - when modal actually opens

**Modal should ONLY appear after the ✏️ logs, not after [Selection] logs.**

## 🚀 Next Steps

1. Deploy to dev
2. Ask user to check browser console for log patterns
3. If modals still appear without ✏️ logs, investigate browser caching or other code paths

---

**Related**: Batch 3 work in PR #2747