### PR TITLE
fix: use delete operator for robust node sanitization in MiniReactFlow

### DIFF
--- a/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
+++ b/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
@@ -107,12 +107,35 @@ export const MiniReactFlow: React.FC<MiniReactFlowProps> = ({
   // This prevents "Parent node not found" errors when rendering child nodes
   // in isolation (container is not included in this mini canvas)
   const sanitizedNodes = useMemo(() => {
-    return nodes.map(node => ({
-      ...node,
-      parentId: undefined, // Remove parent reference (container not in this canvas)
-      extent: undefined,   // Remove extent restriction
-      // position is preserved (already relative to container)
-    }));
+    console.log('[MiniReactFlow] Input nodes:', nodes.map(n => ({ 
+      id: n.id, 
+      parentId: n.parentId,
+      type: n.type 
+    })));
+    
+    const sanitized = nodes.map(node => {
+      // Create a clean shallow copy
+      const cleanNode = { ...node };
+      
+      // Explicitly DELETE parent/extent constraints for the mini-preview
+      // Using delete ensures React Flow doesn't see these properties at all
+      delete (cleanNode as any).parentId;
+      delete (cleanNode as any).parentNode; // Legacy property (React Flow v10)
+      delete (cleanNode as any).extent;
+      delete (cleanNode as any).expandParent;
+      
+      // Preserve position (it's already relative to container origin)
+      return cleanNode;
+    });
+    
+    console.log('[MiniReactFlow] Sanitized nodes:', sanitized.map(n => ({ 
+      id: n.id, 
+      parentId: (n as any).parentId,
+      hasParentId: 'parentId' in n,
+      type: n.type 
+    })));
+    
+    return sanitized;
   }, [nodes]);
   
   return (


### PR DESCRIPTION
## Problem
- Previous fix (#2782) set `parentId: undefined` but property still existed in object
- React Flow v11+ detects property existence (not just value) causing 'Parent node not found' error
- Container node itself is not in MiniReactFlow's local scope, triggering crash

## Solution
- **Use `delete` operator** to completely remove parent properties from object
- Delete multiple properties: `parentId`, `parentNode` (legacy), `extent`, `expandParent`
- Added debug console logging to trace sanitization process
- Ensures React Flow cannot detect parent references at all

## Technical Details
```typescript
// ❌ OLD (still has property)
const cleanNode = { ...node, parentId: undefined };
'parentId' in cleanNode // true

// ✅ NEW (property completely removed)
const cleanNode = { ...node };
delete cleanNode.parentId;
'parentId' in cleanNode // false
```

## Impact
- ✅ Prevents 'Parent node node-X not found' crashes
- ✅ Multi-step containers can safely render child nodes
- ✅ Debug logs help diagnose any remaining issues
- ✅ More robust than setting to undefined

## Files Changed
- `frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx`

## Testing
1. Drop a form step node into a multi-step container
2. Check browser console for sanitization logs
3. Verify no 'Parent node not found' errors
4. Verify container preview renders correctly

## Related
- Improves upon #2782 (previous sanitization attempt)
- Part of WorkForms Editor Stabilization effort