### PR TITLE
fix: Eliminate duplicate node rendering in expanded containers

### DIFF
--- a/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
+++ b/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
@@ -62,6 +62,7 @@ const MiniFlowContainer = styled.div<{ $height: number }>`
   border: 1px solid rgba(var(--color-border), 0.5);
   border-radius: 8px;
   overflow: hidden;
+  pointer-events: none; /* Prevent click interception - MiniReactFlow is purely visual */
   
   .react-flow__node {
     cursor: pointer !important;

--- a/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
@@ -421,18 +421,32 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
           </ContainerHeader>
           
           {!isExpanded && (
-            <ContainerSummary>
-              <SummaryRow>
-                <span className="label">Nodes:</span>
-                <span className="value">{stats.nodeCount}</span>
-              </SummaryRow>
-              {stats.formRefs > 0 && (
+            <>
+              <ContainerSummary>
                 <SummaryRow>
-                  <span className="label">Forms:</span>
-                  <span className="value">{stats.formRefs}</span>
+                  <span className="label">Nodes:</span>
+                  <span className="value">{stats.nodeCount}</span>
                 </SummaryRow>
+                {stats.formRefs > 0 && (
+                  <SummaryRow>
+                    <span className="label">Forms:</span>
+                    <span className="value">{stats.formRefs}</span>
+                  </SummaryRow>
+                )}
+              </ContainerSummary>
+              
+              {/* Phase 2.2: Mini React Flow Preview (only when collapsed) */}
+              {stats.hasNodes && (
+                <MiniFlowWrapper>
+                  <MiniReactFlow
+                    key={stats.nodeCount} // Force remount when child count changes
+                    nodes={stats.childNodes}
+                    edges={stats.childEdges}
+                    containerHeight={200}
+                  />
+                </MiniFlowWrapper>
               )}
-            </ContainerSummary>
+            </>
           )}
           
           {isExpanded && (
@@ -451,15 +465,12 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
                     </SummaryRow>
                   )}
                   
-                  {/* Phase 2.2: Mini React Flow Canvas (read-only preview) */}
-                  <MiniFlowWrapper>
-                    <MiniReactFlow
-                      key={stats.nodeCount} // Force remount when child count changes
-                      nodes={stats.childNodes}
-                      edges={stats.childEdges}
-                      containerHeight={250}
-                    />
-                  </MiniFlowWrapper>
+                  {/* Phase 2.2: No MiniReactFlow when expanded - React Flow renders children naturally via extent: 'parent' */}
+                  <div style={{ marginTop: '12px', padding: '12px', background: 'rgba(var(--color-surface), 0.5)', borderRadius: '6px' }}>
+                    <div style={{ fontSize: '12px', color: 'rgba(var(--color-text-secondary), 1)', marginBottom: '8px' }}>
+                      💡 Child nodes are rendered directly on the canvas when expanded
+                    </div>
+                  </div>
                   
                   {nodeTypeEntries.length > 0 && (
                     <>


### PR DESCRIPTION
## Problem
When a Multi-Step Container is expanded, child nodes were being rendered twice:
1. Once by React Flow naturally (via `parentId` and `extent: 'parent'`)
2. Again by the MiniReactFlow preview component inside the container

This caused visual duplication and made the UI confusing.

## Solution
**MiniReactFlow is now only shown when the container is COLLAPSED** (as a preview). When expanded, React Flow's native parent-child rendering handles everything.

### Changes
1. **MiniReactFlow.tsx**: Added `pointer-events: none` to prevent click interception (purely visual component)
2. **FormMultiStepContainerNode.tsx**:
   - Collapsed state: Show MiniReactFlow preview (200px height)
   - Expanded state: Remove MiniReactFlow, let React Flow render children naturally
   - Added helpful hint text explaining the rendering behavior

## Impact
- ✅ No more duplicate node visuals
- ✅ Buttons (Enter Container, Configure) remain clickable
- ✅ MiniReactFlow is purely visual (no click interference)
- ✅ Clean separation of collapsed preview vs expanded native rendering

## Testing
- [x] Build successful
- [x] No TypeScript errors
- [ ] Manual testing: Expand/collapse container to verify single rendering
- [ ] Manual testing: Verify buttons are clickable

## Related
- Refs: Phase 2.2 Container Implementation Plan
- Related PRs: #2793, #2795