### PR TITLE
fix: Add explicit guard to prevent MiniReactFlow in expanded state

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
@@ -435,8 +435,8 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
                 )}
               </ContainerSummary>
               
-              {/* Phase 2.2: Mini React Flow Preview (only when collapsed) */}
-              {stats.hasNodes && (
+              {/* Phase 2.2: Mini React Flow Preview (ONLY when collapsed - prevents duplicate rendering) */}
+              {stats.hasNodes && !isExpanded && (
                 <MiniFlowWrapper>
                   <MiniReactFlow
                     key={stats.nodeCount} // Force remount when child count changes


### PR DESCRIPTION
## Issue
User reported continued visual duplication. While code was already correct (MiniReactFlow in `!isExpanded` block), this adds defense-in-depth.

## Changes
- Added explicit `&& !isExpanded` check to MiniReactFlow condition
- Updated comment to emphasize prevention of duplicate rendering
- Provides redundant safeguard against edge cases

## Why This Helps
1. Defense in depth: Double guarantee
2. Code clarity: Makes intent explicit
3. Runtime safety: Catches state inconsistencies