### PR TITLE
refactor: Optimize MiniReactFlow preview and clarify rendering logic

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
@@ -435,14 +435,14 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
                 )}
               </ContainerSummary>
               
-              {/* Phase 2.2: Mini React Flow Preview (ONLY when collapsed - prevents duplicate rendering) */}
-              {stats.hasNodes && !isExpanded && (
+              {/* Phase 2.2: Mini React Flow Preview - ONLY shown when collapsed (read-only preview) */}
+              {stats.hasNodes && (
                 <MiniFlowWrapper>
                   <MiniReactFlow
                     key={stats.nodeCount} // Force remount when child count changes
                     nodes={stats.childNodes}
                     edges={stats.childEdges}
-                    containerHeight={200}
+                    containerHeight={150}
                   />
                 </MiniFlowWrapper>
               )}


### PR DESCRIPTION
## Summary
Optimizes the MiniReactFlow preview component in the container node for better UX and code clarity.

## Changes Made

### 1. Reduced Preview Height
- **Before**: `containerHeight={200}`
- **After**: `containerHeight={150}`
- **Why**: Smaller preview fits better in collapsed state, reduces visual clutter

### 2. Removed Redundant Check
- **Before**: `{stats.hasNodes && !isExpanded && (...)}`
- **After**: `{stats.hasNodes && (...)}`
- **Why**: Already inside `{!isExpanded && (...)}` block, redundant check removed

### 3. Improved Comment
- Updated to clarify this is a **read-only preview** shown **ONLY when collapsed**

## Architecture Verification ✅

**Collapsed State (`!isExpanded`):**
- ✅ Shows MiniReactFlow preview (150px height)
- ✅ Displays node count summary
- ✅ Read-only visualization

**Expanded State (`isExpanded`):**
- ✅ NO MiniReactFlow (prevents duplicate rendering)
- ✅ Shows simple background container
- ✅ React Flow renders children via `parentId` on main canvas
- ✅ EnterButton and ConfigButton fully clickable

## Testing
- [x] MiniReactFlow only renders when collapsed
- [x] No duplicate nodes when expanded
- [x] Buttons clickable in expanded state
- [x] Preview height appropriate for collapsed state

## Impact
- Zero breaking changes
- Improved code readability
- Better UX with smaller preview