### PR TITLE
fix: Set child node visibility based on parent container expansion state

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2765,11 +2765,18 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           // Phase 1.4: Auto-expand parent if node dropped near edge
           newNode.expandParent = true;
           
+          // Phase 4.4: Child nodes should only be visible inside parent container
+          // Check if parent container is currently expanded
+          const isParentExpanded = targetContainer.data?.isExpanded !== false;
+          newNode.hidden = !isParentExpanded;
+          
           console.log(`[Container] ✅ Node configured:`, {
             id: newNode.id,
             parentId: newNode.parentId,
             position: newNode.position,
             extent: newNode.extent,
+            hidden: newNode.hidden,
+            parentExpanded: isParentExpanded,
           });
           
           // Add node to main state


### PR DESCRIPTION
## Problem
Child nodes dropped into multi-step containers were always visible on the main canvas, appearing to 'hover' above the container regardless of expansion state.

## Solution
Added logic to check parent container's `isExpanded` state when dropping nodes and set child node's `hidden` property accordingly.

## Changes
- Check `targetContainer.data?.isExpanded` when setting up parent-child relationship
- Added debug logging for visibility state

## Behavior
- **Container Expanded** (default): Child nodes visible inside container bounds ✅
- **Container Collapsed**: Child nodes hidden from main canvas (only in MiniReactFlow preview) ✅

Fixes visibility issue reported in Phase 4.4