### PR TITLE
fix: Make child nodes interactive inside expanded containers

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
@@ -49,7 +49,9 @@ export interface FormMultiStepContainerNodeProps extends NodeProps<ContainerNode
 
 const ContainerWrapper = styled.div<{ isExpanded: boolean }>`
   min-width: ${props => props.isExpanded ? '400px' : '280px'};
-  background: rgba(var(--color-background-secondary), 0.95);
+  background: ${props => props.isExpanded 
+    ? 'transparent' 
+    : 'rgba(var(--color-background-secondary), 0.95)'};
   border: 2px solid rgb(139, 92, 246); /* Purple - container color */
   border-radius: 12px;
   box-shadow: 
@@ -148,9 +150,14 @@ const ContainerBody = styled.div<{ isExpanded: boolean }>`
   display: ${props => props.isExpanded ? 'block' : 'none'};
   min-height: ${props => props.isExpanded ? '200px' : 'auto'};
   min-width: 300px;
-  /* Ensure buttons are clickable */
-  position: relative; 
-  z-index: 10;
+  /* Allow clicks to pass through to child nodes */
+  pointer-events: none;
+  position: relative;
+  
+  /* Re-enable pointer events only for interactive elements */
+  button, a, input {
+    pointer-events: auto;
+  }
 `;
 
 const ContainerSummary = styled.div`
@@ -208,6 +215,7 @@ const EmptyState = styled.div`
   text-align: center;
   padding: 24px 16px;
   color: rgb(var(--color-text-secondary));
+  pointer-events: auto;
   
   .icon {
     font-size: 32px;
@@ -457,48 +465,38 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
             <ContainerBody isExpanded={isExpanded}>
               {stats.hasNodes ? (
                 <>
-                  <SummaryRow>
-                    <span className="label">Total Nodes:</span>
-                    <span className="value">{stats.nodeCount}</span>
-                  </SummaryRow>
-                  
-                  {stats.formRefs > 0 && (
+                  {/* Compact summary at the bottom */}
+                  <div style={{ 
+                    position: 'absolute', 
+                    bottom: '16px', 
+                    left: '16px', 
+                    right: '16px',
+                    background: 'rgba(var(--color-background-secondary), 0.95)',
+                    borderRadius: '8px',
+                    padding: '12px',
+                    pointerEvents: 'auto',
+                    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+                  }}>
                     <SummaryRow>
-                      <span className="label">Form References:</span>
-                      <span className="value">{stats.formRefs}</span>
+                      <span className="label">Total Nodes:</span>
+                      <span className="value">{stats.nodeCount}</span>
                     </SummaryRow>
-                  )}
-                  
-                  {/* CRITICAL FIX: REMOVED MiniReactFlow from here */}
-                  
-                  {nodeTypeEntries.length > 0 && (
-                    <>
-                      <div style={{ marginTop: '12px', marginBottom: '8px' }}>
-                        <span className="label" style={{ fontSize: '12px' }}>
-                          Node Breakdown:
-                        </span>
-                      </div>
-                      <NodeTypeGrid>
-                        {nodeTypeEntries.slice(0, 4).map(([type, count]) => (
-                          <NodeTypeCard key={type}>
-                            <div className="type-name">{type.replace(/([A-Z])/g, ' $1').trim()}</div>
-                            <div className="type-count">{count}</div>
-                          </NodeTypeCard>
-                        ))}
-                      </NodeTypeGrid>
-                    </>
-                  )}
-                  
-                  {/* Buttons moved below to ensure accessibility */}
-                  <div style={{ marginTop: '20px', position: 'relative', zIndex: 20 }}>
-                      <EnterButton onClick={handleEnterContainer}>
-                        <LogIn />
-                        Enter Container to Edit
-                      </EnterButton>
-                      
-                      <ConfigButton onClick={handleConfigClick}>
-                        Configure Container
-                      </ConfigButton>
+                    
+                    {stats.formRefs > 0 && (
+                      <SummaryRow>
+                        <span className="label">Form References:</span>
+                        <span className="value">{stats.formRefs}</span>
+                      </SummaryRow>
+                    )}
+                    
+                    <EnterButton onClick={handleEnterContainer} style={{ marginTop: '8px', marginBottom: '0' }}>
+                      <LogIn />
+                      Enter Container to Edit
+                    </EnterButton>
+                    
+                    <ConfigButton onClick={handleConfigClick} style={{ marginTop: '8px' }}>
+                      Configure Container
+                    </ConfigButton>
                   </div>
                 </>
               ) : (


### PR DESCRIPTION
## Problem
Users could not click on or interact with nodes inside expanded multi-step containers. The container's UI elements (statistics, buttons) were blocking pointer events to the child nodes.

## Solution
1. **Transparent background when expanded**: Container shows through to child nodes
2. **Pointer-events management**: 
   - ContainerBody has `pointer-events: none` to pass clicks through
   - Only buttons/inputs have `pointer-events: auto` re-enabled
3. **Simplified UI**: Moved statistics to bottom corner with solid background
4. **Removed blocking elements**: Node breakdown cards removed from expanded view

## Changes
- `ContainerWrapper`: Transparent background when expanded
- `ContainerBody`: pointer-events: none with selective re-enabling
- `EmptyState`: Added pointer-events: auto
- Statistics panel: Moved to absolute positioned bottom corner
- Removed node type breakdown cards from expanded view

## Behavior
### Before
- ❌ Nodes inside expanded container were not clickable
- ❌ Statistics blocked the entire interactive area

### After
- ✅ Child nodes are fully clickable, draggable, and editable
- ✅ Container controls (Enter/Configure buttons) remain accessible
- ✅ Statistics visible but non-blocking at bottom corner
- ✅ Collapsed view unchanged (MiniReactFlow preview still works)

## Testing
- [x] Drop nodes into expanded container → nodes interactive
- [x] Click nodes inside container → selection works
- [x] Drag nodes within container → movement works
- [x] Click Configure button → modal opens
- [x] Click Enter Container button → navigation works
- [x] Collapse container → nodes hidden, preview shown