### PR TITLE
fix: Show dropped nodes in container MiniReactFlow

### DIFF
--- a/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
+++ b/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
@@ -141,6 +141,7 @@ export const MiniReactFlow: React.FC<MiniReactFlowProps> = ({
         draggable: interactive, // Allow dragging if interactive
         selectable: interactive, // Allow selection if interactive
         connectable: interactive, // Allow connections if interactive
+        hidden: false, // CRITICAL: Always show nodes in MiniReactFlow (even if hidden on main canvas)
         // CRITICAL: Explicitly NOT including:
         // - parentId (would cause lookup)
         // - parentNode (legacy, would cause lookup)


### PR DESCRIPTION
## Problem
When dragging and dropping nodes into a multi-step container, the nodes would **completely disappear** - not visible on the main canvas, and not visible inside the container either.

## Root Cause
Child nodes are correctly set to `hidden: true` to prevent double-rendering on the main canvas. However, when MiniReactFlow sanitized these nodes for display inside the container, it did not explicitly override the `hidden` property. As a result, the sanitized nodes inherited `hidden: true` and were not rendered in the mini canvas either.

## Solution
Added explicit `hidden: false` property when sanitizing nodes for MiniReactFlow display.

### Code Change
```typescript
const cleanNode: Node = {
  id: node.id,
  type: node.type,
  position: { x: node.position.x, y: node.position.y },
  data: { ...node.data },
  style: node.style,
  className: node.className,
  draggable: interactive,
  selectable: interactive,
  connectable: interactive,
  hidden: false, // ✅ CRITICAL: Always show nodes in MiniReactFlow
  // ...
};
```

## Behavior After Fix
- ✅ **Main Canvas**: Child nodes remain hidden (no double rendering)
- ✅ **Collapsed Container**: Nodes visible in preview MiniReactFlow (150px height)
- ✅ **Expanded Container**: Nodes visible in interactive MiniReactFlow (400px height)
- ✅ **Interactive Editing**: Users can drag, select, and reorder nodes inside expanded container

## Testing
- ✅ Build successful (`npm run build`)
- ✅ No TypeScript errors
- ✅ Single-line change with clear impact

## Impact
Fixes critical bug where dropped nodes would disappear, making the container feature unusable.

## Related PRs
- #2814 - Initial container drop fix
- #2816 - Added interactive MiniReactFlow
- #2818 - Set child nodes to always hidden
- #2820 - Fixed workflow persistence auth