### PR TITLE
fix: pass allNodes prop to FormMultiStepContainerNode to fix child discovery

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1401,10 +1401,10 @@ const AlignmentGuide = styled.div<{ $orientation: 'horizontal' | 'vertical'; $po
 // Node & Edge Type Mapping
 // ============================================================================
 
-const nodeTypes: NodeTypes = {
+// Static node types (not containers that need node access)
+const staticNodeTypes: NodeTypes = {
   formStep: FormStepNode,
   formReference: FormReferenceNode,
-  formMultiStepContainer: FormMultiStepContainerNode,
   trigger: TriggerNode,
   condition: ConditionIfNode,
   action: ActionNode,
@@ -1481,6 +1481,28 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   
   // React Flow instance for viewport controls
   const reactFlowInstance = useReactFlow();
+  
+  // ============================================================================
+  // Dynamic Node Types (Phase: Container Child Node Discovery Fix)
+  // ============================================================================
+  
+  /**
+   * Create nodeTypes with container node that receives full nodes array.
+   * This fixes the bug where FormMultiStepContainerNode couldn't find child nodes
+   * because useNodes() hook may filter hidden nodes or not work in nested contexts.
+   * 
+   * Solution: Pass allNodes explicitly as a prop to container nodes.
+   */
+  const nodeTypes = useMemo<NodeTypes>(() => ({
+    ...staticNodeTypes,
+    formMultiStepContainer: (props: NodeProps) => (
+      <FormMultiStepContainerNode
+        {...props}
+        allNodes={nodes}  // Pass full node array to container
+        allEdges={edges}  // Pass edges too for consistency
+      />
+    ),
+  }), [nodes, edges]);
   
   // ============================================================================
   // Container State Restoration (Phase 4 Batch 5)

--- a/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
@@ -41,7 +41,12 @@ export interface ContainerNodeData extends BaseNodeData {
   isDropTarget?: boolean;
 }
 
-export interface FormMultiStepContainerNodeProps extends NodeProps<ContainerNodeData> {}
+export interface FormMultiStepContainerNodeProps extends NodeProps<ContainerNodeData> {
+  // Phase: Container Child Node Discovery Fix
+  // Explicit props to receive full node/edge arrays from parent
+  allNodes?: Node[];
+  allEdges?: Edge[];
+}
 
 // ============================================================================
 // Styled Components
@@ -311,22 +316,47 @@ const MiniFlowWrapper = styled.div`
 // Component
 // ============================================================================
 
+/**
+ * Form Multi-Step Container Node Component
+ * Renders a container that holds multiple form steps in a sequential workflow.
+ * 
+ * Phase: Container Child Node Discovery Fix
+ * - Now receives allNodes and allEdges as explicit props
+ * - Fallback to useNodes()/useEdges() hooks for backwards compatibility
+ * - This fixes bug where hidden child nodes weren't being found
+ */
 export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProps> = ({
   id,
   data,
   selected,
+  allNodes: propsAllNodes,  // New: Explicitly passed from parent
+  allEdges: propsAllEdges,  // New: Explicitly passed from parent
 }) => {
   const [isExpanded, setIsExpanded] = useState(data.isExpanded ?? true);
   
-  // Use reactive hooks that trigger re-renders on state changes
-  const allNodes = useNodes();
-  const allEdges = useEdges(); 
+  // Use reactive hooks as fallback (backwards compatibility)
+  const hookNodes = useNodes();
+  const hookEdges = useEdges();
   const { setNodes } = useReactFlow();
   
-  // Debug: Log when allNodes changes
+  // Prefer props over hooks (fixes child discovery bug)
+  const allNodes = propsAllNodes ?? hookNodes;
+  const allEdges = propsAllEdges ?? hookEdges;
+  
+  // Debug: Log node source and counts
   React.useEffect(() => {
-    console.log(`[Container ${id}] allNodes changed. Count:`, allNodes.length, 'My children:', allNodes.filter(n => n.parentId === id).length);
-  }, [allNodes, id]);
+    const source = propsAllNodes ? 'props' : 'hooks';
+    const total = allNodes.length;
+    const hidden = allNodes.filter(n => n.hidden).length;
+    const children = allNodes.filter(n => n.parentId === id).length;
+    
+    console.group(`[Container ${id}] Node Discovery (${source})`);
+    console.log('Total nodes:', total);
+    console.log('Hidden nodes:', hidden);
+    console.log('My children:', children);
+    console.log('Source:', source);
+    console.groupEnd();
+  }, [allNodes, propsAllNodes, id]);
   
   const nodeDef = getNodeTypeDefinition('formMultiStepContainer');
   


### PR DESCRIPTION
## Problem

Container nodes couldn't find child nodes after drop:
- Logs showed `My children: 0` despite `parentId` being set correctly
- Container header displayed "0 nodes" instead of actual count
- MiniReactFlow preview was empty
- Child nodes existed in state but weren't being discovered

## Root Cause Analysis

After analyzing 72 hours of PRs (45+ commits):
1. ✅ Race conditions fixed (PR #2770)
2. ✅ Node ordering fixed (PR #2775)
3. ✅ Child nodes set to `hidden: true` (PR #2818)
4. ❌ **Container couldn't query hidden children**

**Issue**: `FormMultiStepContainerNode` used `useNodes()` hook which may:
- Filter out `hidden: true` nodes
- Not work properly in nested ReactFlowProvider contexts

## Solution Implemented

### 1. Pass Nodes as Props
Modified `UnifiedFlowEditor` to explicitly pass full node/edge arrays:
```typescript
const nodeTypes = useMemo<NodeTypes>(() => ({
  ...staticNodeTypes,
  formMultiStepContainer: (props: NodeProps) => (
    <FormMultiStepContainerNode
      {...props}
      allNodes={nodes}  // ✅ Explicit prop passing
      allEdges={edges}
    />
  ),
}), [nodes, edges]);
```

### 2. Update Container Component
Container now prefers props over hooks:
```typescript
const allNodes = propsAllNodes ?? hookNodes;  // Prefer props, fallback to hooks
const childNodes = allNodes.filter(n => n.parentId === id);
```

### 3. Debug Logging
Added comprehensive logging to trace node discovery:
```
[Container node-1] Node Discovery (props)
  Total nodes: 2
  Hidden nodes: 1
  My children: 1  ← Should be 1+, not 0!
```

## Changes Made

**Files Modified:**
1. `frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx`
   - Created dynamic `nodeTypes` with `useMemo`
   - Pass `allNodes` and `allEdges` to container nodes

2. `frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx`
   - Added `allNodes?` and `allEdges?` to props interface
   - Use props with hooks as fallback (backwards compatible)
   - Enhanced debug logging

## Validation

- ✅ TypeScript compilation successful
- ✅ Frontend build successful (22.05s)
- ✅ No errors or warnings
- ⏳ Browser testing required (see below)

## Testing Instructions

1. Start dev server: `npm run dev`
2. Open browser DevTools Console (F12)
3. Drag a node into Multi-Step Container
4. **Expected console output:**
   ```
   [Container node-1] Node Discovery (props)  ← Should say "props"!
     Total nodes: 2
     Hidden nodes: 1
     My children: 1  ← Should be 1+, not 0! ✅
   ```

## Success Criteria

- [ ] Console shows "Source: props" (not "hooks")
- [ ] "My children: 1" or more (not 0)
- [ ] Container header shows correct node count
- [ ] MiniReactFlow renders children visually
- [ ] Nodes editable in expanded container
- [ ] Save/reload persists children

## Related Work

- PR #2770: Fixed race conditions with dropSucceededRef
- PR #2775: Fixed ordering with sortNodesTopologically
- PR #2818: Set child nodes to hidden: true
- This PR: Fixes child node discovery

## Rollback Plan

If issues occur:
```bash
git revert 0849ad91
npm run build
```

Component falls back to `useNodes()` hook if props not provided (backwards compatible).

## Documentation

See also:
- `docs/REACT_FLOW_LESSONS_LEARNED.md`
- `docs/MULTI_STEP_CONTAINER_ROOT_CAUSE_ANALYSIS.md`
- React Flow official: https://reactflow.dev/examples/grouping/sub-flows
