### PR TITLE
🔍 Debug: Add logging to diagnose container detection failure

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2468,6 +2468,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     
     console.log('[Container] =================================');
     console.log('[Container] Looking for containers at position:', position);
+    console.log('[Container] nodes.length in findContainer:', nodes.length);
+    console.log('[Container] All nodes:', nodes.map(n => ({ id: n.id, type: n.type })));
     console.log('[Container] Total containers on canvas:', containerNodes.length);
     console.log('[Container] Container types found:', containerNodes.map(n => ({ id: n.id, type: n.type, measured: !!n.measured })));
     
@@ -2668,6 +2670,24 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
       const type = event.dataTransfer.getData('application/reactflow-nodetype');
       if (!type) return;
+      
+      // ============================================================
+      // DEBUG: State at drop time
+      // ============================================================
+      console.log('[onDrop] =================================');
+      console.log('[onDrop] Drop initiated for node type:', type);
+      console.log('[onDrop] Current nodes array length:', nodes.length);
+      console.log('[onDrop] Nodes in array:', nodes.map(n => ({ id: n.id, type: n.type, parentId: n.parentId })));
+      const containersInArray = nodes.filter(n => n.type === 'formMultiStepContainer');
+      console.log('[onDrop] Containers in nodes array:', containersInArray.length);
+      console.log('[onDrop] Container details:', containersInArray.map(c => ({ 
+        id: c.id, 
+        position: c.position,
+        measured: c.measured,
+        width: c.width,
+        height: c.height 
+      })));
+      console.log('[onDrop] =================================');
       
       // Clear drag state
       setIsDragging(false);


### PR DESCRIPTION
## 🎯 Purpose

This PR adds comprehensive debug logging to diagnose why container detection fails at drop time.

## 📊 Background

**PR #2831 Status:**
- ✅ Props-based solution works (container shows 'Source: props')
- ✅ Child node discovery would work IF drop succeeded
- ❌ **NEW ISSUE**: Drop detection fails - containers not found at drop time

**Observable Behavior:**
- During drag (onDragOver): Container detected correctly (multiple '✅ Found container' logs)
- At drop time (onDrop): 'Total containers on canvas: 0' ❌
- Result: Node added to main canvas, not inside container

## 🔍 What This PR Does

### Added Logging in onDrop Handler (line 2669)
```typescript
console.log('[onDrop] Current nodes array length:', nodes.length);
console.log('[onDrop] Nodes in array:', nodes.map(n => ({ id, type, parentId })));
console.log('[onDrop] Containers in nodes array:', containers.length);
console.log('[onDrop] Container details:', containers.map(c => ({ id, position, measured })));
```

### Enhanced findContainerAtPosition Logging (line 2465)
```typescript
console.log('[Container] nodes.length in findContainer:', nodes.length);
console.log('[Container] All nodes:', nodes.map(n => ({ id: n.id, type: n.type })));
```

## 🧪 Testing Instructions

1. Start dev server: `npm run dev`
2. Open browser console (F12)
3. Drag a formStep node from palette
4. Drop it into a formMultiStepContainer
5. **Check console logs:**
   - `[onDrop]` section: How many nodes? How many containers?
   - `[Container]` section: Does it see the same nodes?
   - Compare: Is nodes.length consistent between the two?

## 🔬 What We're Looking For

### Scenario A: State Sync Issue
```
[onDrop] nodes.length: 1 (container exists)
[Container] nodes.length: 0 (container missing) ❌
→ Fix: Force state sync or use ref
```

### Scenario B: Boundary Detection Issue
```
[onDrop] nodes.length: 1
[Container] nodes.length: 1
[Container] ❌ Drop position outside container
→ Fix: Adjust boundary logic or test center drop
```

### Scenario C: Timing Issue
```
[onDrop] nodes.length: 0 (before container added)
[Container] nodes.length: 0
→ Fix: Ensure container exists before drop enabled
```

## 📈 Next Steps (After This PR)

1. **Analyze logs** from browser testing
2. **Create fix PR** based on root cause identified
3. **Verify** nodes appear inside container
4. **Remove** temporary debug logs

## 🔗 Related

- PR #2831: Props-based child discovery (merged)
- Issue: Container drop detection failure
- Previous: 45+ commits over 72 hours debugging related issues

## ⚠️ Note

This is a **diagnostic PR** - adds logging only, no behavior changes. Will be followed by actual fix PR once root cause is identified.

---

**Ready for browser testing** - Please test and paste console output! 🚀