### PR TITLE
🎯 Debug: Add confirmation logging to verify onDrop fires

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2666,10 +2666,20 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
   const onDrop = useCallback(
     (event: React.DragEvent) => {
+      console.log('🎯🎯🎯 [onDrop] ===== DROP EVENT FIRED =====');
+      console.log('🎯 [onDrop] Event target:', event.target);
+      console.log('🎯 [onDrop] Event currentTarget:', event.currentTarget);
+      
       event.preventDefault();
 
       const type = event.dataTransfer.getData('application/reactflow-nodetype');
-      if (!type) return;
+      console.log('🎯 [onDrop] Node type from dataTransfer:', type);
+      
+      if (!type) {
+        console.error('❌ [onDrop] No node type found in dataTransfer!');
+        console.log('📦 [onDrop] Available dataTransfer types:', event.dataTransfer.types);
+        return;
+      }
       
       // ============================================================
       // DEBUG: State at drop time


### PR DESCRIPTION
## 🚨 Critical Issue Discovered

Previous test logs show formStep was **dragged** over container (✅ detected) but **NO onDrop event** appeared.

## 📊 Evidence from Test Logs

**What worked:**
- ✅ Container dropped onto canvas (first onDrop event - line 692)
- ✅ formStep dragged OVER container (onDrag events show `✅ Found container` repeatedly)
- ✅ Container detection working (`Drop point: x=720, y=450` inside bounds)

**What's missing:**
- ❌ Second `[onDrop]` event for formStep (never appeared in logs)
- ❌ User confirms they dropped it, but event didn't fire

## 🔍 What This PR Does

Adds **impossible-to-miss** logging at the very START of onDrop handler (before ANY conditions):

```typescript
console.log('🎯🎯🎯 [onDrop] ===== DROP EVENT FIRED =====');
console.log('🎯 [onDrop] Event target:', event.target);
console.log('🎯 [onDrop] Node type from dataTransfer:', type);
console.log('📦 [onDrop] Available dataTransfer types:', event.dataTransfer.types);
```

## 🎯 What This Will Prove

### If you see 🎯 banner:
- ✅ onDrop IS firing
- ✅ Event handler attached correctly
- Issue is AFTER drop fires (child creation logic)

### If you DON'T see 🎯 banner:
- ❌ onDrop NOT firing for formStep nodes
- ❌ Different root cause (React Flow event system, drag/drop API, browser)
- Need to investigate why drop event blocked

## 🧪 Testing Instructions

### Critical: Test Method
**DO NOT open DevTools until AFTER droppingecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*

Reason: Browser DevTools can interfere with drag/drop events.

1. Start dev server: `npm run dev`
2. Open browser (DevTools CLOSED)
3. Drag formStep from palette
4. Drop INTO container (center of blue area)
5. **THEN** open DevTools console (F12)
6. Check for 🎯 banner

### Expected Results

**Scenario A: Banner appears**
```
🎯🎯🎯 [onDrop] ===== DROP EVENT FIRED =====
🎯 [onDrop] Node type from dataTransfer: formStep
[onDrop] Current nodes array length: 1
[Container] ✅ Found container: node-1
<continue debugging child creation>
```

**Scenario B: Banner missing**
```
[DEBUG] Drag coordinates...
[Container] ✅ Found container...
<no 🎯 banner>
→ onDrop not firing - investigate React Flow event attachment
```

## 📋 Alternative Test Method

If drop still doesn't work with DevTools closed:

1. Keep DevTools open
2. Drag formStep over container
3. **Hold mouse STILL for 1 second** while hovering
4. Release mouse button gently
5. Check for 🎯 banner

## 🔗 Related

- PR #2831: Props-based child discovery (✅ merged, working)
- PR #2833: Container detection logging (✅ merged, shows drag working)
- **This PR**: Confirm if drop event fires at all

---

**This is THE critical diagnostic step.** The 🎯 banner will tell us definitively if onDrop is firing. 🚀