### PR TITLE
🔧 Fix: Forward drop handlers to nested MiniReactFlow

### DIFF
--- a/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
+++ b/frontend/src/components/FlowEditor/NestedContainer/MiniReactFlow.tsx
@@ -50,6 +50,8 @@ interface MiniReactFlowProps {
   interactive?: boolean; // Phase 4.5: Allow interactive mode when expanded
   onNodeClick?: (event: React.MouseEvent, node: Node) => void; // Optional click handler for nodes
   onNodesChange?: (changes: any) => void; // Optional handler for node position changes
+  onDrop?: (event: React.DragEvent) => void; // Drop handler for palette nodes
+  onDragOver?: (event: React.DragEvent) => void; // Drag over handler for drop feedback
   // Phase 2.2: Removed readOnly prop (always read-only now)
 }
 
@@ -126,6 +128,8 @@ export const MiniReactFlow: React.FC<MiniReactFlowProps> = ({
   interactive = false,
   onNodeClick,
   onNodesChange,
+  onDrop,
+  onDragOver,
 }) => {
   // Phase 2.2: Simplified - no callbacks, read-only preview
   // Phase 4.5: Added interactive mode for expanded containers
@@ -189,6 +193,8 @@ export const MiniReactFlow: React.FC<MiniReactFlowProps> = ({
           edgeTypes={edgeTypes}
           onNodeClick={interactive ? onNodeClick : undefined} // Only handle clicks in interactive mode
           onNodesChange={interactive ? onNodesChange : undefined} // Only handle changes in interactive mode
+          onDrop={onDrop} // Forward drop events to main handler
+          onDragOver={onDragOver} // Forward dragover events for drop feedback
           fitView
           fitViewOptions={{
             padding: 0.2,

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1483,28 +1483,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   const reactFlowInstance = useReactFlow();
   
   // ============================================================================
-  // Dynamic Node Types (Phase: Container Child Node Discovery Fix)
-  // ============================================================================
-  
-  /**
-   * Create nodeTypes with container node that receives full nodes array.
-   * This fixes the bug where FormMultiStepContainerNode couldn't find child nodes
-   * because useNodes() hook may filter hidden nodes or not work in nested contexts.
-   * 
-   * Solution: Pass allNodes explicitly as a prop to container nodes.
-   */
-  const nodeTypes = useMemo<NodeTypes>(() => ({
-    ...staticNodeTypes,
-    formMultiStepContainer: (props: NodeProps) => (
-      <FormMultiStepContainerNode
-        {...props}
-        allNodes={nodes}  // Pass full node array to container
-        allEdges={edges}  // Pass edges too for consistency
-      />
-    ),
-  }), [nodes, edges]);
-  
-  // ============================================================================
   // Container State Restoration (Phase 4 Batch 5)
   // ============================================================================
   
@@ -2974,6 +2952,31 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
   }, []);
+
+  // ============================================================================
+  // Dynamic Node Types (Phase: Container Drop Handler Fix)
+  // ============================================================================
+  
+  /**
+   * Create nodeTypes with container node that receives:
+   * 1. Full nodes/edges arrays (fixes child discovery)
+   * 2. Drop handlers (fixes drops into nested MiniReactFlow)
+   * 
+   * This solves the bug where drops onto expanded containers were being
+   * captured by the nested ReactFlow instance which had no onDrop handler.
+   */
+  const nodeTypes = useMemo<NodeTypes>(() => ({
+    ...staticNodeTypes,
+    formMultiStepContainer: (props: NodeProps) => (
+      <FormMultiStepContainerNode
+        {...props}
+        allNodes={nodes}              // Pass full node array to container
+        allEdges={edges}              // Pass edges too for consistency
+        onDropFromPalette={onDrop}    // Forward drop handler to MiniReactFlow
+        onDragOverFromPalette={onDragOver} // Forward dragover handler
+      />
+    ),
+  }), [nodes, edges, onDrop, onDragOver]);
 
   // ============================================================================
   // Container Drag-Drop Logic (Phase 4.4)

--- a/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormMultiStepContainerNode.tsx
@@ -46,6 +46,10 @@ export interface FormMultiStepContainerNodeProps extends NodeProps<ContainerNode
   // Explicit props to receive full node/edge arrays from parent
   allNodes?: Node[];
   allEdges?: Edge[];
+  // Phase: Drop Handler Fix
+  // Forward drop handlers to nested MiniReactFlow
+  onDropFromPalette?: (event: React.DragEvent) => void;
+  onDragOverFromPalette?: (event: React.DragEvent) => void;
 }
 
 // ============================================================================
@@ -331,6 +335,8 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
   selected,
   allNodes: propsAllNodes,  // New: Explicitly passed from parent
   allEdges: propsAllEdges,  // New: Explicitly passed from parent
+  onDropFromPalette,        // New: Drop handler for nested MiniReactFlow
+  onDragOverFromPalette,    // New: DragOver handler for nested MiniReactFlow
 }) => {
   const [isExpanded, setIsExpanded] = useState(data.isExpanded ?? true);
   
@@ -486,6 +492,8 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
                       nodes={stats.childNodes}
                       edges={stats.childEdges}
                       containerHeight={150} // Smaller height for preview
+                      onDrop={onDropFromPalette}
+                      onDragOver={onDragOverFromPalette}
                     />
                 </MiniFlowWrapper>
               )}
@@ -511,6 +519,8 @@ export const FormMultiStepContainerNode: React.FC<FormMultiStepContainerNodeProp
                       interactive={true}
                       onNodeClick={handleNodeClick}
                       onNodesChange={handleNodesChange}
+                      onDrop={onDropFromPalette}
+                      onDragOver={onDragOverFromPalette}
                     />
                   </div>
                   


### PR DESCRIPTION
## 🎯 Root Cause Identified

**The problem**: Drops onto expanded containers were being **captured by the nested MiniReactFlow's ReactFlow instance**, which had **NO onDrop handler**!

### Architecture Issue

```
UnifiedFlowEditor (Main Canvas)
└─ ReactFlow
   ├─ onDrop={onDrop} ✅ HAS handler
   └─ FormMultiStepContainerNode (expanded)
      └─ MiniReactFlow
         └─ ReactFlow
            ├─ onDrop={???} ❌ NO HANDLER!
            └─ pointer-events: auto (captures events)
```

When container is expanded, MiniReactFlow has `interactive={true}` which enables `pointer-events: auto`. Drops land on the nested ReactFlow, which eats the event because it has no handler.

## 📊 Evidence from Testing

**What worked:**
- ✅ Drag events reached main canvas (`onDrag` logs showed `✅ Found container`)
- ✅ Container detection logic worked (boundary checks passed)
- ✅ Props fix worked (container showed `Source: props`)

**What failed:**
- ❌ Drop onto expanded container never fired 🎯 banner
- ❌ Only 1 onDrop event (for container itself, not formStep)
- ❌ MiniReactFlow had no handlers to forward the drop

## 🔧 The Fix

### 1. Added Drop Handlers to MiniReactFlow

**File**: `MiniReactFlow.tsx`

```typescript
interface MiniReactFlowProps {
  // ... existing props
  onDrop?: (event: React.DragEvent) => void;
  onDragOver?: (event: React.DragEvent) => void;
}

<ReactFlow
  // ... existing props
  onDrop={onDrop}          // Forward to main handler
  onDragOver={onDragOver}  // Forward for drop feedback
/>
```

### 2. Updated FormMultiStepContainerNode

**File**: `FormMultiStepContainerNode.tsx`

```typescript
interface FormMultiStepContainerNodeProps {
  // ... existing props
  onDropFromPalette?: (event: React.DragEvent) => void;
  onDragOverFromPalette?: (event: React.DragEvent) => void;
}

// Pass to BOTH MiniReactFlow instances (collapsed + expanded)
<MiniReactFlow
  // ... existing props
  onDrop={onDropFromPalette}
  onDragOver={onDragOverFromPalette}
/>
```

### 3. Wired Up in UnifiedFlowEditor

**File**: `UnifiedFlowEditor.tsx`

```typescript
// Moved nodeTypes definition to AFTER onDrop/onDragOver are defined
const nodeTypes = useMemo<NodeTypes>(() => ({
  ...staticNodeTypes,
  formMultiStepContainer: (props: NodeProps) => (
    <FormMultiStepContainerNode
      {...props}
      allNodes={nodes}
      allEdges={edges}
      onDropFromPalette={onDrop}       // Pass main handler
      onDragOverFromPalette={onDragOver}
    />
  ),
}), [nodes, edges, onDrop, onDragOver]);
```

## 🧪 Testing Instructions

### Step 1: Ensure Container is Expanded
1. Start dev server: `npm run dev`
3. Container should be in expanded state (blue interactive area visible)

### Step 2: Drop FormStep Into Container
1. Drag **formStep** node from palette
2. Drop INTO the **blue MiniReactFlow area** inside container
3. **Critical**: Drop INSIDE the container, not on empty canvas

### Step 3: Verify Success

**Expected console logs:**
```
🎯🎯🎯 [onDrop] ===== DROP EVENT FIRED =====
🎯 [onDrop] Node type from dataTransfer: formStep
[onDrop] Current nodes array length: 1
[onDrop] Containers in nodes array: 1
[Container] ✅ Found container: node-1
[Container node-1] My children: 1  ← SUCCESS! 🎉
```

**Expected visual result:**
- Node appears INSIDE container (nested child)
- Container header shows correct count
- Node is editable when container expanded
- Node has `parentId` set correctly

### Step 4: Test Interactive Features Still Work
1. Try clicking nodes inside container (should work)
2. Try dragging nodes inside container (should work if interactive)
3. Try zooming/panning MiniReactFlow (should work if interactive)

## 🔗 Related PRs

- **PR #2831**: Props-based child discovery (✅ merged, fixed useNodes issue)
- **PR #2833**: Container detection logging (✅ merged, showed drag working)
- **PR #2835**: Confirmation logging (✅ merged, revealed onDrop not firing)

## 📈 Timeline

- **Feb 9-11**: 45+ commits attempting various fixes
- **Feb 12**: PR #2831 - Fixed child discovery with props ✅
- **Feb 12**: PR #2833 - Added container detection logs ✅  
- **Feb 12**: PR #2835 - Added 🎯 confirmation logs ✅
- **Feb 12**: Root cause found - MiniReactFlow has no onDrop handler
- **Feb 12**: This PR - Proper fix implemented 🎉

## ⚠️ Breaking Changes

None. This is additive - adds optional props with sensible defaults.

## ✅ Pre-Merge Checklist

- [x] TypeScript compilation successful
- [x] Frontend build successful (31.80s)
- [x] No breaking changes to existing APIs
- [x] Backwards compatible (props are optional)
- [x] Follows existing patterns (prop forwarding)
- [ ] **Browser testing** (waiting for user confirmation)

---

**Status**: 🚀 Ready for testing
**Impact**: Should fix the 72-hour container drop bug
**Risk**: Low (additive change, optional props, no behavior changes if props not provided)

Please test and confirm the fix works! 🙏