### PR TITLE
fix: Replace EntityFormStepModal with SidePanel + FormStepConfigPanel

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -107,7 +107,6 @@ import { HelpModal } from './HelpModal'; // Workform Editor Enhancements
 import { TemplateSelector } from './templates/TemplateSelector';
 import { FlowTemplate, FLOW_TEMPLATES } from './templates/flowTemplates';
 import { SidePanel } from './SidePanel';
-import { EntityFormStepModal, type FormStepData } from './Modals/EntityFormStepModal';
 import { FormMultiStepContainerModal, type ContainerData } from './Modals/FormMultiStepContainerModal';
 import { WorkflowManagementModal, type WorkflowMetadata } from './Modals/WorkflowManagementModal'; // Phase 8.2
 import { PreviewPanel } from './panels/PreviewPanel';
@@ -5147,17 +5146,30 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         onStartBlank={handleStartBlank}
       />
       
-      {/* EntityFormStep Configuration Modal (Phase 3 - WF-ENH-2026-Q1) */}
-      <EntityFormStepModal
+      {/* FormStep Configuration Panel (using SidePanel instead of EntityFormStepModal) */}
+      <SidePanel
         isOpen={formStepModalOpen && !!selectedFormStep}
         onClose={() => {
           setFormStepModalOpen(false);
           setSelectedFormStep(null);
         }}
-        onSave={handleEntityFormStepSave}
-        initialData={selectedFormStep ? convertNodeDataToFormStepData(selectedFormStep) : undefined}
-        nodeId={selectedFormStep?.id}
-      />
+      >
+        {selectedFormStep && (
+          <FormStepConfigPanel
+            step={selectedFormStep.data}
+            onChange={(updatedStepData) => {
+              handleNodeUpdate(selectedFormStep.id, updatedStepData);
+              setFormStepModalOpen(false);
+              setSelectedFormStep(null);
+            }}
+            onClose={() => {
+              setFormStepModalOpen(false);
+              setSelectedFormStep(null);
+            }}
+            availableFields={getPreviousStepFields(selectedFormStep.id)}
+          />
+        )}
+      </SidePanel>
       
       {/* FormMultiStepContainer Configuration Modal (Phase 4.3) */}
       <FormMultiStepContainerModal


### PR DESCRIPTION
## Summary
Replaces full-screen 3-step wizard (EntityFormStepModal) with right-sliding SidePanel using FormStepConfigPanel.

## Problem
- User reported: EntityFormStepModal "DOES NOT WORK WELL"
- Full-screen wizard interrupts workflow
- Inconsistent with other node types (FormField, Section, Document use SidePanel)

## Solution
- FormStep edit now opens SidePanel (slides from right)
- Uses existing FormStepConfigPanel (891 lines)
- User confirmed: "everything is already similar if not better than the admin formbuilder"

## Changes
- `UnifiedFlowEditor.tsx`:
  - Line 5150-5173: Replaced EntityFormStepModal with SidePanel wrapper
  - Removed EntityFormStepModal import
  - FormStepConfigPanel provides entity dropdown, field picker, validation config

## Testing
1. Edit formStep node → SidePanel opens from right (not full-screen modal)
2. FormStepConfigPanel shows step config UI
3. Consistent pattern with other node types

## Related PRs
- Part of ongoing FormStep modal improvements
- Follows pattern from FormField/Section/Document nodes

## User Feedback
> "replace with sidepanel + enhanced formstepconfigpanel (primarily the enhanced formstepconfigpanel)"
> "everything is already similar if not better than the admin formbuilder"