### PR TITLE
fix: Register formMultiStepContainer node type (CRITICAL)

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1404,6 +1404,7 @@ const AlignmentGuide = styled.div<{ $orientation: 'horizontal' | 'vertical'; $po
 const staticNodeTypes: NodeTypes = {
   formStep: FormStepNode,
   formReference: FormReferenceNode,
+  formMultiStepContainer: FormMultiStepContainerNode,
   trigger: TriggerNode,
   condition: ConditionIfNode,
   action: ActionNode,


### PR DESCRIPTION
## 🚨 CRITICAL BUG FIX

Container node was rendering as **React Flow default** instead of our custom component.

## Root Cause
`formMultiStepContainer` was **imported but NOT registered** in `staticNodeTypes` mapping (line 1404-1414).

## Evidence
User-provided HTML showed:
```html
<div class="react-flow__node react-flow__node-default">
  Multi-Step Container
</div>
```

**Key indicators:**
- ❌ `react-flow__node-default` (should be custom type)
- ❌ Plain text rendering (not our ContainerWrapper/ContainerHeader)
- ❌ No purple background, no edit/delete buttons
- ❌ No custom styling at all

## Fix
**Added ONE line** to `staticNodeTypes` (line 1406):
```typescript
formMultiStepContainer: FormMultiStepContainerNode,
```

This registers the node type so React Flow uses our custom component instead of default renderer.

## What Happened
During refactoring from dual-ReactFlow to single-ReactFlow (PRs #2839-2842), the container node registration was **accidentally removed** from `staticNodeTypes`. The component file exists and is correct - it just wasn't mapped.

## Testing
✅ Build successful (17.53s)
⏳ Deploy to see styled container with purple background + edit/delete buttons

## Impact
**HIGH** - Container nodes completely broken without this registration.

## Related
- PR #2857: Added edit/delete buttons (but node wasn't rendering our component)
- PR #2839-2842: Single ReactFlow refactor (when registration was lost)

## User Feedback
> "the multi-step container node is still blank white no styling applied, and still doesn't have edit and delete buttons"
> "i ALWWAYS DO A HARD REFRESH after deployment/merge"

User was right - hard refresh confirmed it wasn't a cache issue. The node type literally wasn't registered.