### PR TITLE
docs: Add Unified WorkForm Overhaul Plan

### DIFF
--- a/docs/plans/UNIFIED_WORKFORM_OVERHAUL_PLAN.md
+++ b/docs/plans/UNIFIED_WORKFORM_OVERHAUL_PLAN.md
@@ -1,0 +1,578 @@
+# Unified WorkForm Overhaul - Comprehensive Implementation Plan
+
+## Executive Summary
+
+This plan unifies the **WorkForm Editor** and **Form Builder** into a single visual development environment with:
+- Automatic container versioning and reusable templates
+- Shadow state for non-destructive sidebar editing
+- Cascading entity/field selection from Django system schema
+- Hybrid task renderer for forms AND action cards
+- Data inheritance between workflow steps
+- Intelligent ghost node cleanup
+
+**Estimated Effort**: 6 phases, ~40-60 hours total
+**Prerequisites**: PR #2860 merged (container node registration fix)
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        UNIFIED WORKFORM EDITOR                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐   ┌─────────────┐ │
+│  │   Phase 1   │   │   Phase 2   │   │   Phase 3   │   │   Phase 4   │ │
+│  │  Recursive  │──▶│   Shadow    │──▶│   Schema    │──▶│   Hybrid    │ │
+│  │ Persistence │   │    State    │   │   Bridge    │   │  Renderer   │ │
+│  └─────────────┘   └─────────────┘   └─────────────┘   └─────────────┘ │
+│         │                                                      │        │
+│         ▼                                                      ▼        │
+│  ┌─────────────┐                                       ┌─────────────┐ │
+│  │   Phase 6   │◀──────────────────────────────────────│   Phase 5   │ │
+│  │ Ghost Node  │                                       │   Context   │ │
+│  │   Cleanup   │                                       │ Inheritance │ │
+│  └─────────────┘                                       └─────────────┘ │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Phase 1: Recursive Persistence & Container Versioning
+
+**Goal**: Automatically snapshot `formMultiStepContainer` nodes into reusable, versioned `TenantForm` records.
+
+### Current State Analysis
+- **TenantWorkFormSerializer**: Handles workflow CRUD, extracts form references
+- **TenantForm Model**: Has `version` field (manual increment), `usage_count` tracking
+- **Container Methods**: `get_container_nodes()`, `get_nodes_in_container()` exist
+- **Gap**: No automatic versioning when container contents change
+
+### Tasks
+
+- [ ] **1.1** Enhance `TenantWorkFormSerializer.update()` to detect `formMultiStepContainer` nodes
+  - File: `backend/apps/system/workform_serializers.py`
+  - Add method: `_extract_container_definitions(nodes)`
+  - Return: List of container node IDs + their child formStep nodes
+
+- [ ] **1.2** Create container snapshot logic
+  - File: `backend/apps/system/services/container_versioning.py` (NEW)
+  - Method: `snapshot_container(container_node, child_steps, tenant)`
+  - Logic:
+    ```python
+    def snapshot_container(container_node, child_steps, tenant):
+        # 1. Build form_definition from container + steps
+        definition = {
+            'container_id': container_node['id'],
+            'container_label': container_node['data']['label'],
+            'steps': [serialize_step(s) for s in child_steps],
+            'layout': container_node['data'].get('layout', {})
+        }
+        
+        # 2. Check if identical snapshot exists
+        existing = TenantForm.objects.filter(
+            tenant=tenant,
+            form_definition__hash=hash_definition(definition)
+        ).first()
+        
+        if existing:
+            existing.usage_count += 1
+            existing.save()
+            return existing
+        
+        # 3. Create new version
+        return TenantForm.objects.create(
+            tenant=tenant,
+            name=f"Container: {container_node['data']['label']}",
+            form_type='multi_step',
+            form_definition=definition,
+            version=get_next_version(tenant, container_node['id']),
+            is_template=True
+        )
+    ```
+
+- [ ] **1.3** Implement version comparison
+  - Method: `has_container_changed(container_node, existing_form)`
+  - Compare: step count, field definitions, validation rules, labels
+  - Return: Boolean + diff summary
+
+- [ ] **1.4** Add atomic transaction wrapper
+  - Wrap entire save in `transaction.atomic()`
+  - Rollback if any container snapshot fails
+  - Update `tenantFormId` reference on each container node
+
+- [ ] **1.5** Create migration for new fields
+  - Add `TenantForm.source_node_id` (tracks original container node)
+  - Add `TenantForm.definition_hash` (for deduplication)
+  - Add index on `(tenant, source_node_id, version)`
+
+### Acceptance Criteria
+- [ ] Saving a workflow auto-creates TenantForm records for containers
+- [ ] Identical container definitions reuse existing TenantForm (usage_count++)
+- [ ] Changed containers create new version (version++)
+- [ ] Container nodes reference their TenantForm via `tenantFormId`
+- [ ] All operations are atomic (full save or full rollback)
+
+---
+
+## Phase 2: Shadow State Sidebar
+
+**Goal**: Capture unsaved sidebar edits in `shadowConfig` without polluting primary node `config`.
+
+### Current State Analysis
+- **NodeConfigPanel**: Directly updates `node.data` via `onUpdate` callback
+- **Pattern**: `handleNodeUpdate(nodeId, newData) → setNodes(map...spread)`
+- **Problem**: Every keystroke triggers history entry + re-renders
+- **Gap**: No staging area for "work in progress" edits
+
+### Tasks
+
+- [ ] **2.1** Add `shadowConfig` to node data structure
+  - File: `frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx`
+  - Extend node type:
+    ```typescript
+    interface ExtendedNodeData {
+      config: NodeConfig;         // Committed configuration
+      shadowConfig?: NodeConfig;  // Uncommitted changes (sidebar WIP)
+      configStatus: 'pristine' | 'editing' | 'dirty';
+    }
+    ```
+
+- [ ] **2.2** Create `useNodeShadowState` hook
+  - File: `frontend/src/components/FlowEditor/hooks/useNodeShadowState.ts` (NEW)
+  - API:
+    ```typescript
+    const { 
+      shadowConfig, 
+      updateShadow, 
+      commitShadow, 
+      discardShadow, 
+      isDirty 
+    } = useNodeShadowState(nodeId);
+    ```
+
+- [ ] **2.3** Refactor NodeConfigPanel to use shadow state
+  - File: `frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanel.tsx`
+  - Replace: `onUpdate(nodeId, changes)` → `updateShadow(changes)`
+  - Add: "Apply Changes" button → `commitShadow()`
+  - Add: "Discard" button → `discardShadow()`
+
+- [ ] **2.4** Add visual dirty indicator
+  - Show asterisk (*) on node when `shadowConfig` differs from `config`
+  - Show "Unsaved changes" warning when closing sidebar with dirty state
+  - Style: Yellow border on editing nodes
+
+- [ ] **2.5** Integrate with history system
+  - Only create history entry on `commitShadow()`, not on every keystroke
+  - Reduces history bloat significantly
+
+### Acceptance Criteria
+- [ ] Sidebar edits don't affect node until "Apply Changes" clicked
+- [ ] Dirty indicator shows when uncommitted changes exist
+- [ ] "Discard" reverts to last committed state
+- [ ] History only records committed changes (not keystrokes)
+- [ ] Closing sidebar with dirty state shows confirmation dialog
+
+---
+
+## Phase 3: Intelligent Schema Bridge
+
+**Goal**: Link form steps to Django system schema API for cascading field selection.
+
+### Current State Analysis
+- **Endpoint**: `GET /api/v1/system/field-schemas/{field_path}/`
+- **ConfigResolver**: 3-tier lookup (Tenant → System → Code defaults)
+- **SystemFieldSchema Model**: field_type, validation_rules, choice_list_slug
+- **Gap**: Frontend doesn't fetch/display entity fields dynamically
+
+### Tasks
+
+- [ ] **3.1** Create entity type registry
+  - File: `frontend/src/services/schemaService.ts` (NEW)
+  - Method: `getEntityTypes()` → List of available entity types
+  - Hardcode initially, then API endpoint:
+    ```typescript
+    const ENTITY_TYPES = [
+      { id: 'sales_order', label: 'Sales Order', app: 'sales_orders', model: 'salesorder' },
+      { id: 'purchase_order', label: 'Purchase Order', app: 'purchase_orders', model: 'purchaseorder' },
+      { id: 'customer', label: 'Customer', app: 'customers', model: 'customer' },
+      { id: 'supplier', label: 'Supplier', app: 'suppliers', model: 'supplier' },
+      { id: 'product', label: 'Product', app: 'products', model: 'product' },
+      { id: 'invoice', label: 'Invoice', app: 'invoices', model: 'invoice' },
+      // ... all tenant_apps models
+    ];
+    ```
+
+- [ ] **3.2** Create field fetching service
+  - File: `frontend/src/services/schemaService.ts`
+  - Method: `getEntityFields(entityType: string)` 
+  - Returns: Array of field definitions with metadata
+  - Cache: React Query with 5-minute stale time
+
+- [ ] **3.3** Create `EntityFieldPicker` component enhancement
+  - File: `frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPicker.tsx`
+  - Props: `entityType`, `selectedFields`, `onFieldsChange`
+  - Features:
+    - Entity type dropdown (triggers field fetch)
+    - Available fields list (from schema API)
+    - Selected fields list (drag to reorder)
+    - Field type icons (text, number, date, choice, etc.)
+    - Lookup field auto-configuration
+
+- [ ] **3.4** Integrate with FormStepConfigPanel
+  - File: `frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx`
+  - Add: Entity type selector at top of Fields tab
+  - Show: Fields from selected entity (via EntityFieldPicker)
+  - Auto-configure: Validation rules from schema
+  - Auto-configure: Choice lists for CHOICE fields
+
+- [ ] **3.5** Backend: Create entity list endpoint
+  - File: `backend/apps/system/views.py`
+  - Endpoint: `GET /api/v1/system/entities/`
+  - Returns: List of all tenant_app models with metadata
+  - Include: Field count, common fields, description
+
+- [ ] **3.6** Backend: Create entity fields endpoint
+  - File: `backend/apps/system/views.py`
+  - Endpoint: `GET /api/v1/system/entities/{entity_type}/fields/`
+  - Returns: All fields for entity with:
+    - `field_name`, `field_type`, `label`
+    - `is_required`, `validation_rules`
+    - `choices` (for choice fields)
+    - `related_entity` (for FK fields)
+
+### Acceptance Criteria
+- [ ] Entity type dropdown shows all business entities
+- [ ] Selecting entity loads its fields from API
+- [ ] Fields display with correct types, icons, and metadata
+- [ ] Choice fields include their options
+- [ ] Lookup fields show display name field (not raw ID)
+- [ ] Validation rules auto-populate from schema
+
+---
+
+## Phase 4: Hybrid Task Renderer
+
+**Goal**: Refactor FormSubmissionModal into orchestrator for forms AND action cards.
+
+### Current State Analysis
+- **FormSubmissionModal**: 66.7KB, handles multi-step forms only
+- **FormStep.tsx**: Renders form fields only
+- **Gap**: No support for non-form nodes (approvals, uploads, AI verification)
+
+### Sub-Phase 4.1: Interaction Card Registry
+
+```typescript
+interface InteractionCardDefinition {
+  nodeType: string;
+  title: string;
+  icon: LucideIcon;
+  renderer: React.ComponentType<InteractionCardProps>;
+  requiredFields: string[];
+  completionCondition: (data: any) => boolean;
+}
+
+const INTERACTION_CARDS: Record<string, InteractionCardDefinition> = {
+  wait_for_document: {
+    nodeType: 'pendingDocument',
+    title: 'Upload Document',
+    icon: FileUp,
+    renderer: DocumentUploadCard,
+    requiredFields: ['file_uuid'],
+    completionCondition: (data) => !!data.file_uuid
+  },
+  manual_approval: {
+    nodeType: 'pendingApproval',
+    title: 'Approval Required',
+    icon: CheckSquare,
+    renderer: ApprovalDecisionCard,
+    requiredFields: ['decision', 'comment'],
+    completionCondition: (data) => data.decision !== undefined
+  },
+  ai_verification: {
+    nodeType: 'actionScript',
+    title: 'AI Verification',
+    icon: Cpu,
+    renderer: AIVerificationCard,
+    requiredFields: ['confidence_score'],
+    completionCondition: (data) => data.confidence_score !== undefined
+  }
+};
+```
+
+### Tasks
+
+- [ ] **4.1** Create Interaction Card Registry
+  - File: `frontend/src/components/FormSubmission/InteractionCardRegistry.ts` (NEW)
+
+- [ ] **4.2** Create DocumentUploadCard component
+  - File: `frontend/src/components/FormSubmission/cards/DocumentUploadCard.tsx` (NEW)
+  - Features:
+    - File drag-and-drop zone
+    - Upload progress indicator
+    - File type validation
+    - Workflow pauses until file UUID registered
+
+- [ ] **4.3** Create ApprovalDecisionCard component
+  - File: `frontend/src/components/FormSubmission/cards/ApprovalDecisionCard.tsx` (NEW)
+  - Features:
+    - Approve/Reject toggle (boolean decision)
+    - Required comment textarea
+    - Summary of what's being approved (from workflow context)
+    - Timestamp and approver name on completion
+
+- [ ] **4.4** Create AIVerificationCard component
+  - File: `frontend/src/components/FormSubmission/cards/AIVerificationCard.tsx` (NEW)
+  - Features:
+    - "Processing" animation state
+    - Polls backend for AI confidence score
+    - Shows result when complete
+    - Manual override option if confidence < threshold
+
+- [ ] **4.5** Create TaskRenderer orchestrator
+  - File: `frontend/src/components/FormSubmission/TaskRenderer.tsx` (NEW)
+  - Logic:
+    ```typescript
+    const TaskRenderer: React.FC<{ node: WorkflowNode; context: WorkflowContext }> = ({ node, context }) => {
+      if (node.type === 'formStep') {
+        return <FormStep step={node.data} context={context} />;
+      }
+      
+      const cardDef = INTERACTION_CARDS[node.data.interactionType];
+      if (cardDef) {
+        const CardComponent = cardDef.renderer;
+        return <CardComponent node={node} context={context} />;
+      }
+      
+      return <AutoExecuteNode node={node} />;
+    };
+    ```
+
+- [ ] **4.6** Refactor FormSubmissionModal to use TaskRenderer
+  - File: `frontend/src/components/FormSubmission/FormSubmissionModal.tsx`
+  - Replace: Step-specific rendering → `<TaskRenderer node={currentNode} />`
+  - Add: Automatic transition after interaction card completion
+
+### Acceptance Criteria
+- [ ] FormSubmissionModal renders forms AND action cards
+- [ ] Document upload pauses workflow until file uploaded
+- [ ] Approval card shows decision toggle + comment
+- [ ] AI verification shows progress, auto-advances on completion
+- [ ] Automatic transition between steps after completion
+
+---
+
+## Phase 5: Context Inheritance & Data Mapping
+
+**Goal**: Implement `useWorkflowContext` hook to resolve `{{nodeId.fieldKey}}` mappings.
+
+### Sub-Phase 5.1: Data Inheritance Mapping
+
+Mustache-style syntax for inheritance:
+- `{{node_uuid_step_1.customer_name}}` - Reference previous step data
+- `{{previousStep.address.city}}` - Nested field access  
+- `{{step1.name|"Unknown"}}` - Default fallback
+
+### Tasks
+
+- [ ] **5.1** Create `useWorkflowContext` hook
+  - File: `frontend/src/components/FormSubmission/hooks/useWorkflowContext.ts` (NEW)
+  - API:
+    ```typescript
+    interface WorkflowContext {
+      data: Record<string, Record<string, any>>;
+      resolve: (template: string) => any;
+      getValue: (nodeId: string, fieldKey: string) => any;
+      setValue: (fieldKey: string, value: any) => void;
+      currentNode: WorkflowNode;
+      previousNodes: WorkflowNode[];
+      availableData: Array<{ nodeId: string; label: string; fields: string[] }>;
+    }
+    ```
+
+- [ ] **5.2** Implement mustache-style resolver
+  - Pattern: `{{nodeId.fieldKey}}` or `{{previousStep.customer_name}}`
+  - Support nested: `{{step1.address.city}}`
+  - Support defaults: `{{step1.name|"Unknown"}}`
+
+- [ ] **5.3** Add "Context Bubble" UI in NodeConfigPanel
+  - File: `frontend/src/components/FlowEditor/ConfigPanel/ContextBubble.tsx` (NEW)
+  - Shows: Available data from previous nodes
+  - Grouped by: Node label
+  - Clickable: Inserts `{{nodeId.fieldKey}}` into current field
+
+- [ ] **5.4** Implement field pre-filling
+  - On step mount: Resolve all `defaultValue` templates
+  - Pre-populate: Field values from resolved context
+  - Mark: Pre-filled fields with visual indicator
+
+- [ ] **5.5** Add data inheritance mapping UI
+  - Feature: "Auto-populate from" dropdown per field
+  - Options: List of compatible fields from previous steps
+  - Generates: `{{nodeId.fieldKey}}` syntax automatically
+
+### Acceptance Criteria
+- [ ] `{{nodeId.fieldKey}}` syntax resolves at runtime
+- [ ] Context Bubble shows available data from previous nodes
+- [ ] Clicking Context Bubble item inserts reference
+- [ ] Pre-filling works with resolved values
+- [ ] Nested references and default fallbacks work
+
+---
+
+## Phase 6: Ghost Node Cleanup & Deletion Lifecycle
+
+**Goal**: Manage deletion of nodes vs. their reusable templates intelligently.
+
+### Sub-Phase 6.1: Ghost Node Cleanup Flow
+
+When a `formMultiStepContainer` is deleted:
+1. **Check usage**: If `usage_count > 1`, only remove the reference
+2. **Prompt User**: "This container is a shared template. Delete from library or just remove from this flow?"
+3. **Pruning**: Background task deletes `TenantForm` records where `is_template=False` and `usage_count=0`
+
+### Tasks
+
+- [ ] **6.1** Implement deletion lifecycle in frontend
+  - Enhance: `handleNodeDelete()` to check usage_count
+  - Show modal for shared templates
+
+- [ ] **6.2** Create SharedTemplateDeleteModal component
+  - File: `frontend/src/components/FlowEditor/Modals/SharedTemplateDeleteModal.tsx` (NEW)
+
+- [ ] **6.3** Backend: Create usage tracking endpoints
+  - Endpoint: `POST /api/v1/system/tenant-forms/{id}/decrement-usage/`
+  - Endpoint: `GET /api/v1/system/tenant-forms/{id}/usage/`
+
+- [ ] **6.4** Backend: Create orphan cleanup task
+  - File: `backend/apps/system/tasks.py` (NEW)
+  - Schedule: Daily via Celery beat
+  - Logic: Delete TenantForms with usage_count=0 older than 30 days
+
+- [ ] **6.5** RLS verification on save
+  - Verify tenant_id matches session before TenantForm creation
+  - Prevent cross-tenant template creation
+
+- [ ] **6.6** Implement version pinning for ACTIVE workflows
+  - When workflow status changes to 'ACTIVE':
+    - Lock all `tenantFormId` references to current versions
+    - Store version snapshot in workflow metadata
+    - Prevent container edits in ACTIVE workflows
+
+### Acceptance Criteria
+- [ ] Deleting shared template shows usage count warning
+- [ ] "Remove from flow" vs "Delete from library" options work
+- [ ] usage_count decrements correctly
+- [ ] Orphan cleanup runs daily with 30-day grace period
+- [ ] ACTIVE workflows lock container versions
+
+---
+
+## Strategic Recommendations
+
+### UI/UX Enhancements
+
+1. **Context Bubble UI** (Phase 5.3)
+   - Floating panel showing "Available Data" from previous nodes
+   - Click to insert `{{nodeId.field}}` - prevents memorizing node IDs
+
+2. **Template Library Panel** (Post Phase 6)
+   - New sidebar tab: "Templates"
+   - Drag templates to add to workflow
+   - Preview contents on hover
+
+3. **Version History Timeline** (Post Phase 1)
+   - Visual timeline of container versions
+   - Compare and restore previous versions
+
+### Security & Data Integrity
+
+1. **RLS-First Snapshotting** (Phase 6.5)
+   - Verify tenant_id on every TenantForm creation
+   - Audit log for all template operations
+
+2. **Version Pinning** (Phase 6.6)
+   - ACTIVE workflows use pinned versions
+   - Ensures deterministic workflow behavior
+
+3. **Atomic Transactions** (Phase 1.4)
+   - Full success or full rollback
+   - No partial saves
+
+---
+
+## Implementation Order
+
+```
+Phase 1 ──▶ Foundation (Backend persistence)
+   │
+   ▼
+Phase 3 ──▶ Data Model (Schema API - needed for Phase 2)
+   │
+   ▼
+Phase 2 ──▶ Editor UX (Shadow state with schema integration)
+   │
+   ▼
+Phase 5 ──▶ Data Flow (Context inheritance)
+   │
+   ▼
+Phase 4 ──▶ Execution (Hybrid renderer with context)
+   │
+   ▼
+Phase 6 ──▶ Maintenance (Cleanup & polish)
+```
+
+---
+
+## File Change Summary
+
+### New Files
+```
+backend/apps/system/services/container_versioning.py     # Phase 1
+backend/apps/system/tasks.py                             # Phase 6
+
+frontend/src/services/schemaService.ts                   # Phase 3
+frontend/src/components/FlowEditor/hooks/useNodeShadowState.ts  # Phase 2
+frontend/src/components/FlowEditor/ConfigPanel/ContextBubble.tsx  # Phase 5
+frontend/src/components/FlowEditor/Modals/SharedTemplateDeleteModal.tsx  # Phase 6
+frontend/src/components/FormSubmission/InteractionCardRegistry.ts  # Phase 4
+frontend/src/components/FormSubmission/TaskRenderer.tsx  # Phase 4
+frontend/src/components/FormSubmission/cards/DocumentUploadCard.tsx  # Phase 4.1
+frontend/src/components/FormSubmission/cards/ApprovalDecisionCard.tsx  # Phase 4.1
+frontend/src/components/FormSubmission/cards/AIVerificationCard.tsx  # Phase 4.1
+frontend/src/components/FormSubmission/hooks/useWorkflowContext.ts  # Phase 5
+```
+
+### Files to Modify
+```
+backend/apps/system/workform_serializers.py              # Phase 1, 6
+backend/apps/system/workform_views.py                    # Phase 3, 5, 6
+backend/apps/system/views.py                             # Phase 3
+backend/apps/system/models/tenant_form.py                # Phase 1 (migration)
+
+frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx # Phase 2, 6
+frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanel.tsx  # Phase 2, 5
+frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx  # Phase 3
+frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPicker.tsx  # Phase 3
+frontend/src/components/FlowEditor/ConfigPanel/FieldMappingPanel.tsx  # Phase 5
+frontend/src/components/FormSubmission/FormSubmissionModal.tsx  # Phase 4, 5
+frontend/src/components/FormSubmission/FormStep.tsx      # Phase 5
+```
+
+---
+
+## Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| Container save success rate | 99.9% |
+| Schema API response time | < 200ms |
+| Shadow state memory overhead | < 5% |
+| Form submission completion rate | +15% |
+| Template reuse rate | > 30% |
+| Orphan cleanup efficiency | 100% |
+
+---
+
+**Status**: 📋 PLAN COMPLETE - Ready for implementation
+**Next Step**: Confirm plan, then begin Phase 1


### PR DESCRIPTION
## Summary
Comprehensive 6-phase plan to unify WorkForm Editor and Form Builder into a single visual development environment.

## Plan Overview

### Phase 1: Recursive Persistence
- Auto-snapshot containers to versioned TenantForm records
- Hash-based deduplication
- Atomic transactions

### Phase 2: Shadow State Sidebar
- Non-destructive editing with `shadowConfig`
- Apply/Discard buttons
- Reduce history bloat

### Phase 3: Schema Bridge
- Cascading entity/field selection from Django API
- Integration with SystemFieldSchema
- Auto-configure validation rules

### Phase 4: Hybrid Task Renderer
- Support forms AND action cards
- Interaction cards: document upload, approval, AI verification
- Automatic step transitions

### Phase 5: Context Inheritance
- `{{nodeId.fieldKey}}` mustache-style resolution
- Context Bubble UI for data mapping
- Field pre-filling from previous steps

### Phase 6: Ghost Node Cleanup
- Usage tracking for shared templates
- Intelligent deletion (remove vs delete)
- Background orphan pruning (30-day grace period)

## Deliverables
- **13 new files** to create
- **11 existing files** to modify
- **1 migration** for TenantForm fields

## Estimated Effort
40-60 hours across 6 phases

## Prerequisites
- ✅ PR #2860 merged (container node registration fix)

## Documentation
- Plan: `docs/plans/UNIFIED_WORKFORM_OVERHAUL_PLAN.md`
- Implementation order: Phase 1 → 3 → 2 → 5 → 4 → 6

---

**This PR only adds documentation. Implementation will follow in subsequent PRs.**