### PR TITLE
hotfix: Force deployment with build timestamp

### DIFF
--- a/frontend/.buildinfo
+++ b/frontend/.buildinfo
@@ -1,0 +1,1 @@
+# Build timestamp: Fri Feb 13 00:10:29 UTC 2026


### PR DESCRIPTION
## Force Deployment

This PR adds a build timestamp file to force the Master Pipeline to run.

**Problem:** The previous empty commit didn't trigger the Master Pipeline deployment.

**Solution:** Touch a frontend file () to ensure paths-ignore doesn't block the pipeline.

**Includes all fixes from:**
- ✅ PR #2873 (TaskRenderer Integration) - Fixed import paths  
- ✅ PR #2874 (Phase 6) - Ghost Node Cleanup
- ✅ PR #2876 (Hotfix) - Trigger attempt

**This will deploy commit e80f68ae with the corrected import paths.**