### PR TITLE
fix: Change FormStep import from named to default export

### DIFF
--- a/frontend/src/components/FormSubmission/TaskRenderer.tsx
+++ b/frontend/src/components/FormSubmission/TaskRenderer.tsx
@@ -28,7 +28,7 @@ import styled from 'styled-components';
 import { AlertCircle } from 'lucide-react';
 import { WorkflowContext } from './hooks/useWorkflowContext';
 import { getCardDefinition, detectCardType, InteractionCardDefinition } from './InteractionCardRegistry';
-import { FormStep } from './FormStep';
+import FormStep from './FormStep';
 
 // ============================================================================
 // TypeScript Interfaces


### PR DESCRIPTION
## 🚨 Critical Build Fix

### Problem
All 4 recent deployments failed with:
- ❌ Run #21967905933  
- ❌ Run #21968103530  
- ❌ Run #21968858500  
- ❌ Run #21969352377  

**Root Cause:** TaskRenderer.tsx was importing `FormStep` as a named export, but FormStep.tsx uses a **default export**.

**Error:**
```
"FormStep" is not exported by "src/components/FormSubmission/FormStep.tsx", imported by "src/components/FormSubmission/TaskRenderer.tsx"
```

### Solution
Changed from named import to default import:
```diff
-import { FormStep } from './FormStep';
+import FormStep from './FormStep';
```

### Verification
✅ Local build succeeds: `npm run build` completes without errors  
✅ 6270 modules transformed successfully

### Related PRs
- PR #2871 - Phase 4: Hybrid Task Renderer (introduced bug)  
- PR #2873 - TaskRenderer Integration (missed this export issue)  
- PR #2874 - Phase 6: Ghost Node Cleanup  
- PR #2876 - Empty commit deployment trigger  
- PR #2877 - Build timestamp trigger  

This PR completes the deployment fix pipeline.