### PR TITLE
feat(phase-c3): Add upstream variable propagation system

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx
@@ -1,0 +1,537 @@
+/**
+ * Variable Picker with Upstream Support
+ * 
+ * Phase C.3: Enhanced Variable Picker that uses graph-based upstream variable detection
+ * instead of relying on WorkflowContext (which may not be initialized).
+ * 
+ * Features:
+ * - Automatic detection of upstream Form Step Single nodes
+ * - Graph traversal to find all available variables
+ * - Type-aware field suggestions
+ * - Distance-based grouping (direct parents first)
+ * - Search/filter capability
+ * - Keyboard navigation
+ * - Click to insert {{nodeId.fieldName}} template
+ * 
+ * Usage:
+ * ```typescript
+ * <VariablePickerWithUpstream
+ *   currentNodeId="node-123"
+ *   nodes={nodes}
+ *   edges={edges}
+ *   isOpen={showPicker}
+ *   onSelect={(template) => insertVariable(template)}
+ *   onClose={() => setShowPicker(false)}
+ *   position={{ top: 100, left: 200 }}
+ * />
+ * ```
+ * 
+ * Created: 2026-02-17 - Phase C.3 Upstream Variable Propagation
+ */
+
+import React, { useState, useMemo, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { Node, Edge } from 'reactflow';
+import { 
+  Search, 
+  ChevronRight, 
+  Type, 
+  Hash, 
+  Calendar, 
+  ToggleLeft, 
+  List, 
+  FileText,
+  Mail,
+  Phone,
+  Link as LinkIcon,
+  File,
+  Code,
+  AlertCircle,
+} from 'lucide-react';
+import { useUpstreamVariables, UpstreamVariable } from '../hooks/useUpstreamVariables';
+
+// ============================================================================
+// TypeScript Interfaces
+// ============================================================================
+
+export interface VariablePickerWithUpstreamProps {
+  /** Current node ID (to find upstream variables for) */
+  currentNodeId: string;
+  
+  /** All nodes in workflow */
+  nodes: Node[];
+  
+  /** All edges in workflow */
+  edges: Edge[];
+  
+  /** Whether picker is visible */
+  isOpen: boolean;
+  
+  /** Called when user selects a variable */
+  onSelect: (template: string, variable: UpstreamVariable) => void;
+  
+  /** Called when picker should close */
+  onClose: () => void;
+  
+  /** Position for popover */
+  position?: { top: number; left: number };
+  
+  /** Optional initial search query */
+  searchQuery?: string;
+  
+  /** Optional field type filter */
+  fieldTypeFilter?: UpstreamVariable['fieldType'][];
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function getTypeIcon(type: UpstreamVariable['fieldType']): React.ReactNode {
+  const iconMap: Record<UpstreamVariable['fieldType'], React.ReactNode> = {
+    string: <Type size={14} />,
+    number: <Hash size={14} />,
+    date: <Calendar size={14} />,
+    boolean: <ToggleLeft size={14} />,
+    select: <List size={14} />,
+    file: <File size={14} />,
+    textarea: <FileText size={14} />,
+    email: <Mail size={14} />,
+    phone: <Phone size={14} />,
+    url: <LinkIcon size={14} />,
+    json: <Code size={14} />,
+  };
+  
+  return iconMap[type] || <Type size={14} />;
+}
+
+function getTypeColor(type: UpstreamVariable['fieldType']): string {
+  const colorMap: Record<UpstreamVariable['fieldType'], string> = {
+    string: '#6366f1',
+    number: '#10b981',
+    date: '#f59e0b',
+    boolean: '#8b5cf6',
+    select: '#3b82f6',
+    file: '#ef4444',
+    textarea: '#6366f1',
+    email: '#06b6d4',
+    phone: '#14b8a6',
+    url: '#3b82f6',
+    json: '#84cc16',
+  };
+  
+  return colorMap[type] || '#6366f1';
+}
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const PickerContainer = styled.div<{ $position?: { top: number; left: number } }>`
+  position: fixed;
+  top: ${props => props.$position?.top ?? 100}px;
+  left: ${props => props.$position?.left ?? 200}px;
+  width: 420px;
+  max-height: 500px;
+  background: white;
+  border: 1px solid rgb(var(--color-border));
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+  z-index: 10000;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: var(--font-family-body);
+`;
+
+const Header = styled.div`
+  padding: 12px 16px;
+  border-bottom: 1px solid rgb(var(--color-border));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgb(var(--color-surface));
+`;
+
+const Title = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  color: rgb(var(--color-text-primary));
+`;
+
+const Count = styled.div`
+  font-size: 12px;
+  color: rgb(var(--color-text-secondary));
+`;
+
+const SearchContainer = styled.div`
+  padding: 12px 16px;
+  border-bottom: 1px solid rgb(var(--color-border));
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: white;
+  
+  svg {
+    color: rgb(var(--color-text-secondary));
+  }
+`;
+
+const SearchInput = styled.input`
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  color: rgb(var(--color-text-primary));
+  
+  &::placeholder {
+    color: rgb(var(--color-text-tertiary));
+  }
+`;
+
+const VariableList = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+`;
+
+const NodeGroup = styled.div`
+  margin-bottom: 8px;
+`;
+
+const NodeHeader = styled.div`
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgb(var(--color-text-secondary));
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  background: rgb(var(--color-surface));
+  border-top: 1px solid rgb(var(--color-border-light));
+  border-bottom: 1px solid rgb(var(--color-border-light));
+`;
+
+const DistanceBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgb(var(--color-surface-hover));
+  font-size: 10px;
+  font-weight: 500;
+  color: rgb(var(--color-text-tertiary));
+`;
+
+const VariableItem = styled.div<{ $selected?: boolean }>`
+  padding: 10px 16px 10px 28px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  background: ${props => props.$selected ? 'rgb(var(--color-primary-light))' : 'transparent'};
+  transition: background-color 0.15s ease;
+  
+  &:hover {
+    background: ${props => props.$selected ? 'rgb(var(--color-primary-light))' : 'rgb(var(--color-surface-hover))'};
+  }
+`;
+
+const TypeIcon = styled.div<{ $color: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: ${props => props.$color}15;
+  color: ${props => props.$color};
+  flex-shrink: 0;
+`;
+
+const FieldInfo = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const FieldLabel = styled.div`
+  font-size: 14px;
+  font-weight: 500;
+  color: rgb(var(--color-text-primary));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const FieldName = styled.div`
+  font-size: 12px;
+  color: rgb(var(--color-text-tertiary));
+  font-family: var(--font-family-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const Template = styled.div`
+  font-size: 11px;
+  font-family: var(--font-family-mono);
+  color: rgb(var(--color-text-secondary));
+  background: rgb(var(--color-surface));
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+`;
+
+const EmptyState = styled.div`
+  padding: 40px 20px;
+  text-align: center;
+  color: rgb(var(--color-text-secondary));
+`;
+
+const EmptyIcon = styled.div`
+  margin-bottom: 12px;
+  color: rgb(var(--color-text-tertiary));
+  
+  svg {
+    width: 48px;
+    height: 48px;
+  }
+`;
+
+const EmptyTitle = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
+`;
+
+const EmptyMessage = styled.div`
+  font-size: 13px;
+`;
+
+const Footer = styled.div`
+  padding: 8px 16px;
+  border-top: 1px solid rgb(var(--color-border));
+  font-size: 11px;
+  color: rgb(var(--color-text-tertiary));
+  background: rgb(var(--color-surface));
+  text-align: center;
+`;
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export const VariablePickerWithUpstream: React.FC<VariablePickerWithUpstreamProps> = ({
+  currentNodeId,
+  nodes,
+  edges,
+  isOpen,
+  onSelect,
+  onClose,
+  position,
+  searchQuery = '',
+  fieldTypeFilter,
+}) => {
+  const [internalSearch, setInternalSearch] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const pickerRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  
+  const search = searchQuery || internalSearch;
+  
+  // Get upstream variables using the hook
+  const { variables, variablesByNode, loading, error } = useUpstreamVariables({
+    currentNodeId,
+    nodes,
+    edges,
+  });
+  
+  // Focus search input when opened
+  useEffect(() => {
+    if (isOpen && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [isOpen]);
+  
+  // Handle click outside to close
+  useEffect(() => {
+    if (!isOpen) return;
+    
+    const handleClickOutside = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen, onClose]);
+  
+  // Filter variables by search and type
+  const filteredVariables = useMemo(() => {
+    let filtered = variables;
+    
+    // Filter by search query
+    if (search) {
+      const searchLower = search.toLowerCase();
+      filtered = filtered.filter(v => 
+        v.nodeName.toLowerCase().includes(searchLower) ||
+        v.fieldName.toLowerCase().includes(searchLower) ||
+        v.fieldLabel.toLowerCase().includes(searchLower) ||
+        v.template.toLowerCase().includes(searchLower)
+      );
+    }
+    
+    // Filter by field type
+    if (fieldTypeFilter && fieldTypeFilter.length > 0) {
+      filtered = filtered.filter(v => fieldTypeFilter.includes(v.fieldType));
+    }
+    
+    return filtered;
+  }, [variables, search, fieldTypeFilter]);
+  
+  // Group filtered variables by node
+  const filteredGroupedVariables = useMemo(() => {
+    const groups: Record<string, UpstreamVariable[]> = {};
+    
+    filteredVariables.forEach(variable => {
+      if (!groups[variable.nodeId]) {
+        groups[variable.nodeId] = [];
+      }
+      groups[variable.nodeId].push(variable);
+    });
+    
+    return groups;
+  }, [filteredVariables]);
+  
+  // Handle keyboard navigation
+  useEffect(() => {
+    if (!isOpen) return;
+    
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex(prev => Math.min(prev + 1, filteredVariables.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex(prev => Math.max(prev - 1, 0));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (filteredVariables[selectedIndex]) {
+          handleSelect(filteredVariables[selectedIndex]);
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, filteredVariables, selectedIndex]);
+  
+  if (!isOpen) return null;
+  
+  const handleSelect = (variable: UpstreamVariable) => {
+    onSelect(variable.template, variable);
+    onClose();
+  };
+  
+  let currentIndex = 0;
+  
+  return (
+    <PickerContainer ref={pickerRef} $position={position}>
+      {/* Header */}
+      <Header>
+        <Title>Available Variables</Title>
+        <Count>{filteredVariables.length} {filteredVariables.length === 1 ? 'variable' : 'variables'}</Count>
+      </Header>
+      
+      {/* Search Input */}
+      <SearchContainer>
+        <Search size={16} />
+        <SearchInput
+          ref={searchInputRef}
+          type="text"
+          placeholder="Search variables..."
+          value={internalSearch}
+          onChange={(e) => setInternalSearch(e.target.value)}
+          onKeyDown={(e) => e.stopPropagation()}
+        />
+      </SearchContainer>
+      
+      {/* Variable List */}
+      <VariableList>
+        {error && (
+          <EmptyState>
+            <EmptyIcon><AlertCircle /></EmptyIcon>
+            <EmptyTitle>Error Loading Variables</EmptyTitle>
+            <EmptyMessage>{error}</EmptyMessage>
+          </EmptyState>
+        )}
+        
+        {!error && filteredVariables.length === 0 && (
+          <EmptyState>
+            <EmptyIcon><Search /></EmptyIcon>
+            <EmptyTitle>No Variables Found</EmptyTitle>
+            <EmptyMessage>
+              {search ? `No variables match "${search}"` : 'No upstream Form Step nodes found'}
+            </EmptyMessage>
+          </EmptyState>
+        )}
+        
+        {!error && filteredVariables.length > 0 && Object.entries(filteredGroupedVariables).map(([nodeId, nodeVariables]) => {
+          const firstVar = nodeVariables[0];
+          
+          return (
+            <NodeGroup key={nodeId}>
+              <NodeHeader>
+                <ChevronRight size={14} />
+                <span>{firstVar.nodeName}</span>
+                <DistanceBadge>{firstVar.distance} step{firstVar.distance > 1 ? 's' : ''} back</DistanceBadge>
+              </NodeHeader>
+              
+              {nodeVariables.map(variable => {
+                const isSelected = currentIndex === selectedIndex;
+                const itemIndex = currentIndex++;
+                
+                return (
+                  <VariableItem
+                    key={`${variable.nodeId}-${variable.fieldName}`}
+                    $selected={isSelected}
+                    onClick={() => handleSelect(variable)}
+                    onMouseEnter={() => setSelectedIndex(itemIndex)}
+                  >
+                    <TypeIcon $color={getTypeColor(variable.fieldType)}>
+                      {getTypeIcon(variable.fieldType)}
+                    </TypeIcon>
+                    
+                    <FieldInfo>
+                      <FieldLabel>
+                        {variable.fieldLabel}
+                        {variable.required && <span style={{ color: 'rgb(var(--color-error))' }}> *</span>}
+                      </FieldLabel>
+                      <FieldName>{variable.fieldName}</FieldName>
+                    </FieldInfo>
+                    
+                    <Template>{variable.template}</Template>
+                  </VariableItem>
+                );
+              })}
+            </NodeGroup>
+          );
+        })}
+      </VariableList>
+      
+      {/* Footer */}
+      <Footer>
+        Use <kbd>↑</kbd> <kbd>↓</kbd> to navigate • <kbd>Enter</kbd> to select • <kbd>Esc</kbd> to close
+      </Footer>
+    </PickerContainer>
+  );
+};
+
+export default VariablePickerWithUpstream;

--- a/frontend/src/components/FlowEditor/hooks/useUpstreamVariables.ts
+++ b/frontend/src/components/FlowEditor/hooks/useUpstreamVariables.ts
@@ -1,0 +1,374 @@
+/**
+ * useUpstreamVariables Hook
+ * 
+ * Phase C.3: Upstream Variable Propagation
+ * Analyzes workflow graph to find all upstream nodes and extract their output fields.
+ * Makes variables available for downstream nodes to reference.
+ * 
+ * Features:
+ * - Graph traversal from current node backwards
+ * - Extracts fields from Form Step Single nodes
+ * - Formats variables as {{nodeId.fieldName}} templates
+ * - Type-aware suggestions (string, number, date)
+ * - Handles circular dependencies
+ * - Caches results for performance
+ * 
+ * Usage:
+ * ```typescript
+ * const { variables, loading } = useUpstreamVariables({
+ *   currentNodeId: 'node-123',
+ *   nodes,
+ *   edges
+ * });
+ * 
+ * // variables = [
+ * //   { nodeId: 'step1', nodeName: 'Customer Info', fieldName: 'email', fieldType: 'string', template: '{{step1.email}}' },
+ * //   { nodeId: 'step2', nodeName: 'Product Selection', fieldName: 'quantity', fieldType: 'number', template: '{{step2.quantity}}' }
+ * // ]
+ * ```
+ * 
+ * Created: 2026-02-17 - Phase C.3 Upstream Variable Propagation
+ */
+
+import { useMemo } from 'react';
+import { Node, Edge } from 'reactflow';
+
+// ============================================================================
+// TypeScript Interfaces
+// ============================================================================
+
+export interface UpstreamVariable {
+  /** Source node ID */
+  nodeId: string;
+  
+  /** Human-readable node name */
+  nodeName: string;
+  
+  /** Field name/key */
+  fieldName: string;
+  
+  /** Human-readable field label */
+  fieldLabel: string;
+  
+  /** Field data type */
+  fieldType: 'string' | 'number' | 'date' | 'boolean' | 'select' | 'file' | 'textarea' | 'email' | 'phone' | 'url' | 'json';
+  
+  /** Template string for insertion: {{nodeId.fieldName}} */
+  template: string;
+  
+  /** Distance from current node (1 = direct parent, 2 = grandparent, etc.) */
+  distance: number;
+  
+  /** Node type (formStepSingle, formProcess, etc.) */
+  nodeType: string;
+  
+  /** Whether field is required in the source node */
+  required?: boolean;
+}
+
+export interface UseUpstreamVariablesParams {
+  /** Current node ID to find upstream variables for */
+  currentNodeId: string;
+  
+  /** All nodes in the workflow */
+  nodes: Node[];
+  
+  /** All edges in the workflow */
+  edges: Edge[];
+  
+  /** Maximum distance to traverse (default: 10) */
+  maxDistance?: number;
+}
+
+export interface UseUpstreamVariablesResult {
+  /** Array of available upstream variables */
+  variables: UpstreamVariable[];
+  
+  /** Variables grouped by source node */
+  variablesByNode: Record<string, UpstreamVariable[]>;
+  
+  /** Whether calculation is in progress */
+  loading: boolean;
+  
+  /** Error if any */
+  error: string | null;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Find all upstream nodes using breadth-first search
+ */
+function findUpstreamNodes(
+  currentNodeId: string,
+  edges: Edge[],
+  maxDistance: number = 10
+): Map<string, number> {
+  const upstreamNodes = new Map<string, number>(); // nodeId -> distance
+  const visited = new Set<string>();
+  const queue: Array<{ nodeId: string; distance: number }> = [{ nodeId: currentNodeId, distance: 0 }];
+  
+  while (queue.length > 0) {
+    const { nodeId, distance } = queue.shift()!;
+    
+    if (visited.has(nodeId) || distance > maxDistance) {
+      continue;
+    }
+    
+    visited.add(nodeId);
+    
+    // Find all edges that point TO this node (target = current)
+    const incomingEdges = edges.filter(edge => edge.target === nodeId);
+    
+    for (const edge of incomingEdges) {
+      const sourceNodeId = edge.source;
+      const sourceDistance = distance + 1;
+      
+      // Only add if we haven't seen this node or found a shorter path
+      if (!upstreamNodes.has(sourceNodeId) || upstreamNodes.get(sourceNodeId)! > sourceDistance) {
+        upstreamNodes.set(sourceNodeId, sourceDistance);
+        queue.push({ nodeId: sourceNodeId, distance: sourceDistance });
+      }
+    }
+  }
+  
+  // Remove the current node itself
+  upstreamNodes.delete(currentNodeId);
+  
+  return upstreamNodes;
+}
+
+/**
+ * Extract field definitions from a Form Step Single node
+ */
+function extractFieldsFromFormStep(node: Node): Array<{
+  fieldName: string;
+  fieldLabel: string;
+  fieldType: string;
+  required?: boolean;
+}> {
+  const fields: Array<{
+    fieldName: string;
+    fieldLabel: string;
+    fieldType: string;
+    required?: boolean;
+  }> = [];
+  
+  // Check if this is a Form Step Single node
+  if (node.type !== 'formStepSingle' && node.type !== 'formStep') {
+    return fields;
+  }
+  
+  // Extract fields from node data
+  const nodeData = node.data || {};
+  const selectedFields = nodeData.selectedFields || nodeData.fields || [];
+  
+  // Handle both array of objects and array of strings
+  if (Array.isArray(selectedFields)) {
+    for (const field of selectedFields) {
+      if (typeof field === 'string') {
+        // Simple string field name
+        fields.push({
+          fieldName: field,
+          fieldLabel: field,
+          fieldType: 'string',
+        });
+      } else if (typeof field === 'object' && field !== null) {
+        // Object with field metadata
+        fields.push({
+          fieldName: field.name || field.key || field.id || 'unknown',
+          fieldLabel: field.label || field.display_name || field.name || 'Unknown Field',
+          fieldType: field.type || field.field_type || 'string',
+          required: field.required || false,
+        });
+      }
+    }
+  }
+  
+  // Also check for entity fields if entity is selected
+  const entityType = nodeData.entityType || nodeData.entity;
+  if (entityType && fields.length === 0) {
+    // If no fields explicitly selected, check if there's an entity configuration
+    const entityFields = nodeData.entityFields || [];
+    if (Array.isArray(entityFields)) {
+      for (const field of entityFields) {
+        fields.push({
+          fieldName: field.name || field.key || 'unknown',
+          fieldLabel: field.label || field.display_name || 'Unknown',
+          fieldType: field.type || 'string',
+          required: field.required || false,
+        });
+      }
+    }
+  }
+  
+  return fields;
+}
+
+/**
+ * Map backend field types to standardized types
+ */
+function normalizeFieldType(type: string): UpstreamVariable['fieldType'] {
+  const typeMap: Record<string, UpstreamVariable['fieldType']> = {
+    'CharField': 'string',
+    'TextField': 'textarea',
+    'IntegerField': 'number',
+    'DecimalField': 'number',
+    'FloatField': 'number',
+    'DateField': 'date',
+    'DateTimeField': 'date',
+    'BooleanField': 'boolean',
+    'EmailField': 'email',
+    'URLField': 'url',
+    'FileField': 'file',
+    'ImageField': 'file',
+    'JSONField': 'json',
+    'ForeignKey': 'select',
+    'ManyToManyField': 'select',
+  };
+  
+  // Check direct match
+  if (type in typeMap) {
+    return typeMap[type];
+  }
+  
+  // Check lowercase match
+  const lowerType = type.toLowerCase();
+  if (lowerType.includes('email')) return 'email';
+  if (lowerType.includes('phone')) return 'phone';
+  if (lowerType.includes('url')) return 'url';
+  if (lowerType.includes('date')) return 'date';
+  if (lowerType.includes('number') || lowerType.includes('int') || lowerType.includes('float') || lowerType.includes('decimal')) return 'number';
+  if (lowerType.includes('bool')) return 'boolean';
+  if (lowerType.includes('text') && lowerType.includes('area')) return 'textarea';
+  if (lowerType.includes('file') || lowerType.includes('image')) return 'file';
+  if (lowerType.includes('json')) return 'json';
+  if (lowerType.includes('select') || lowerType.includes('choice')) return 'select';
+  
+  // Default to string
+  return 'string';
+}
+
+// ============================================================================
+// Main Hook
+// ============================================================================
+
+export function useUpstreamVariables({
+  currentNodeId,
+  nodes,
+  edges,
+  maxDistance = 10,
+}: UseUpstreamVariablesParams): UseUpstreamVariablesResult {
+  
+  const result = useMemo<UseUpstreamVariablesResult>(() => {
+    try {
+      // Find all upstream nodes
+      const upstreamNodeMap = findUpstreamNodes(currentNodeId, edges, maxDistance);
+      
+      // Extract variables from each upstream node
+      const variables: UpstreamVariable[] = [];
+      
+      for (const [nodeId, distance] of upstreamNodeMap.entries()) {
+        // Find the node object
+        const node = nodes.find(n => n.id === nodeId);
+        if (!node) continue;
+        
+        // Get node name (fallback to ID if no label)
+        const nodeName = node.data?.label || node.data?.name || nodeId;
+        
+        // Extract fields from this node
+        const fields = extractFieldsFromFormStep(node);
+        
+        // Create variable entry for each field
+        for (const field of fields) {
+          variables.push({
+            nodeId,
+            nodeName,
+            fieldName: field.fieldName,
+            fieldLabel: field.fieldLabel,
+            fieldType: normalizeFieldType(field.fieldType),
+            template: `{{${nodeId}.${field.fieldName}}}`,
+            distance,
+            nodeType: node.type || 'unknown',
+            required: field.required,
+          });
+        }
+      }
+      
+      // Sort by distance (closer nodes first), then by node name
+      variables.sort((a, b) => {
+        if (a.distance !== b.distance) {
+          return a.distance - b.distance;
+        }
+        return a.nodeName.localeCompare(b.nodeName);
+      });
+      
+      // Group by node
+      const variablesByNode: Record<string, UpstreamVariable[]> = {};
+      for (const variable of variables) {
+        if (!variablesByNode[variable.nodeId]) {
+          variablesByNode[variable.nodeId] = [];
+        }
+        variablesByNode[variable.nodeId].push(variable);
+      }
+      
+      return {
+        variables,
+        variablesByNode,
+        loading: false,
+        error: null,
+      };
+      
+    } catch (err) {
+      return {
+        variables: [],
+        variablesByNode: {},
+        loading: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      };
+    }
+  }, [currentNodeId, nodes, edges, maxDistance]);
+  
+  return result;
+}
+
+/**
+ * Helper hook to get variables for a specific field type
+ */
+export function useUpstreamVariablesFiltered(
+  params: UseUpstreamVariablesParams,
+  fieldTypes?: UpstreamVariable['fieldType'][]
+): UseUpstreamVariablesResult {
+  const allVariables = useUpstreamVariables(params);
+  
+  const filtered = useMemo(() => {
+    if (!fieldTypes || fieldTypes.length === 0) {
+      return allVariables;
+    }
+    
+    const filteredVariables = allVariables.variables.filter(
+      v => fieldTypes.includes(v.fieldType)
+    );
+    
+    const filteredByNode: Record<string, UpstreamVariable[]> = {};
+    for (const variable of filteredVariables) {
+      if (!filteredByNode[variable.nodeId]) {
+        filteredByNode[variable.nodeId] = [];
+      }
+      filteredByNode[variable.nodeId].push(variable);
+    }
+    
+    return {
+      variables: filteredVariables,
+      variablesByNode: filteredByNode,
+      loading: allVariables.loading,
+      error: allVariables.error,
+    };
+  }, [allVariables, fieldTypes]);
+  
+  return filtered;
+}
+
+export default useUpstreamVariables;


### PR DESCRIPTION
## Phase C.3: Upstream Variable Propagation (CORE COMPLETE)

Graph-based variable detection for workflow editor - allows downstream nodes to reference fields from upstream Form Step nodes using `{{nodeId.fieldName}}` template syntax.

## Files Added (2):
1. `frontend/src/components/FlowEditor/hooks/useUpstreamVariables.ts` (374 lines)
2. `frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx` (487 lines)

## Key Features:
- 🔍 BFS graph traversal (O(N+E) complexity)
- 📏 Distance-based grouping
- 🏷️ 11 field type support
- ⌨️ Keyboard navigation (↑↓ Enter Esc)
- 🎨 Type-aware icons & colors

## Next Steps:
- C.3.1: Integrate with config panels
- C.3.2: Enhance ExpressionInput
- C.3.3: Testing & validation

**Total**: 861 lines added  
**Breaking Changes**: None