### PR TITLE
fix(ci): Add quotes to prevent ShellCheck SC2086 warning

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -59,7 +59,7 @@ jobs:
           BRANCH="${{ github.ref_name }}"
           
           # Get latest commit on branch
-          LATEST_SHA=$(git rev-parse origin/$BRANCH)
+          LATEST_SHA=$(git rev-parse "origin/$BRANCH")
           
           echo "Trigger SHA: $TRIGGER_SHA"
           echo "Latest SHA:  $LATEST_SHA"


### PR DESCRIPTION
## 🔧 Fix: ShellCheck Warning in Workflow

**Issue**: ShellCheck SC2086 error in main-pipeline.yml line 62

**Error**: 
```
SC2086: Double quote to prevent globbing and word splitting
```

**Fix**: 
```bash
# Before
LATEST_SHA=$(git rev-parse origin/$BRANCH)

# After
LATEST_SHA=$(git rev-parse "origin/$BRANCH")
```

**Impact**: Prevents potential issues with branch names containing spaces or special characters

**Related**: [Failed workflow run](https://github.com/Meats-Central/ProjectMeats/actions/runs/22152776868/job/64048432765)