### PR TITLE
fix(ci): Only trigger Dependabot Auto-Merge for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,6 +21,8 @@ jobs:
   check-eligibility:
     name: "Check Eligibility"
     runs-on: ubuntu-latest
+    # Only run this workflow for Dependabot PRs
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       is_dependabot: ${{ steps.check.outputs.is_dependabot }}


### PR DESCRIPTION
## 🎯 Optimization: Reduce Unnecessary Workflow Runs

**Current Behavior**: 
- Dependabot Auto-Merge workflow runs on **every PR** (all types: labeled, synchronize, opened, reopened)
- Then checks inside the job if PR author is `dependabot[bot]`
- Wastes CI minutes on non-Dependabot PRs

**New Behavior**:
- Added job-level `if` condition: `github.event.pull_request.user.login == 'dependabot[bot]'`
- Workflow only executes for Dependabot PRs
- Skips immediately for all other PRs

**Impact**:
- ✅ Reduces unnecessary Actions runs
- ✅ Saves CI minutes
- ✅ Cleaner Actions UI (no skipped Dependabot runs on normal PRs)
- ✅ No functional changes - same automerge behavior

**Testing**: Workflow will still trigger correctly when Dependabot opens/updates PRs with `automerge` label