### PR TITLE
fix(ci): Quote $GITHUB_OUTPUT to prevent ShellCheck SC2086

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -66,14 +66,14 @@ jobs:
           
           if [ "$TRIGGER_SHA" = "$LATEST_SHA" ]; then
             echo "✅ This is the latest commit - proceeding with deployment"
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
           else
             echo "⏭️  Newer commit exists ($LATEST_SHA) - skipping this deployment"
             echo "This commit will be included in the next deployment"
-            echo "should_deploy=false" >> $GITHUB_OUTPUT
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
           fi
           
-          echo "latest_sha=$LATEST_SHA" >> $GITHUB_OUTPUT
+          echo "latest_sha=$LATEST_SHA" >> "$GITHUB_OUTPUT"
 
   # ==========================================
   # Route to Development


### PR DESCRIPTION
## 🔧 Fix: ShellCheck SC2086 Error

**Issue**: ShellCheck fails on unquoted `$GITHUB_OUTPUT` variable expansions

**Error**: SC2086 - Double quote to prevent globbing and word splitting

**Fix**: Add quotes around `$GITHUB_OUTPUT` in 3 locations:

```bash
# Before
echo "should_deploy=true" >> $GITHUB_OUTPUT

# After  
echo "should_deploy=true" >> "$GITHUB_OUTPUT"
```

**Lines Changed**:
- Line 69: `should_deploy=true` output
- Line 73: `should_deploy=false` output
- Line 76: `latest_sha` output

**Impact**: Satisfies ShellCheck validation, prevents potential word-splitting issues

**Related**: 
- [Failed workflow run](https://github.com/Meats-Central/ProjectMeats/actions/runs/22152927130/job/64048966959)
- Previous fix: PR #2990 (quoted $BRANCH)