### PR TITLE
fix(ci): Group all GITHUB_STEP_SUMMARY redirects to fix SC2129

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -128,27 +128,31 @@ jobs:
             --body "🤖 Auto-merged: All checks passed. Category: $CATEGORY" \
             --repo ${{ github.repository }}
           
-          echo "## ✅ Auto-Merge Successful" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Category:** $CATEGORY" >> $GITHUB_STEP_SUMMARY
-          echo "**PR:** #$PR_NUMBER" >> $GITHUB_STEP_SUMMARY
-          echo "**Title:** ${{ github.event.pull_request.title }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ✅ Auto-Merge Successful"
+            echo ""
+            echo "**Category:** $CATEGORY"
+            echo "**PR:** #$PR_NUMBER"
+            echo "**Title:** ${{ github.event.pull_request.title }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Skip Docker updates
         if: |
           steps.check.outputs.status == 'success' &&
           steps.classify.outputs.category == 'docker'
         run: |
-          echo "## ⚠️ Manual Review Required" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Category:** Docker base image update" >> $GITHUB_STEP_SUMMARY
-          echo "**Reason:** Can break golden pipeline (build failures)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Action Required:**" >> $GITHUB_STEP_SUMMARY
-          echo "1. Review Dockerfile changes" >> $GITHUB_STEP_SUMMARY
-          echo "2. Test build locally: \`docker build -t test .\`" >> $GITHUB_STEP_SUMMARY
-          echo "3. Verify no breaking changes in base image changelog" >> $GITHUB_STEP_SUMMARY
-          echo "4. Merge manually if safe" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ⚠️ Manual Review Required"
+            echo ""
+            echo "**Category:** Docker base image update"
+            echo "**Reason:** Can break golden pipeline (build failures)"
+            echo ""
+            echo "**Action Required:**"
+            echo "1. Review Dockerfile changes"
+            echo "2. Test build locally: \`docker build -t test .\`"
+            echo "3. Verify no breaking changes in base image changelog"
+            echo "4. Merge manually if safe"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Log skipped
         if: |
@@ -156,24 +160,30 @@ jobs:
           steps.classify.outputs.safe == 'false' &&
           steps.classify.outputs.category != 'docker'
         run: |
-          echo "## ⏭️ Skipped Auto-Merge" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Category:** ${{ steps.classify.outputs.category }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Reason:** Not in auto-merge whitelist" >> $GITHUB_STEP_SUMMARY
-          echo "**Action:** Manual review required" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ⏭️ Skipped Auto-Merge"
+            echo ""
+            echo "**Category:** ${{ steps.classify.outputs.category }}"
+            echo "**Reason:** Not in auto-merge whitelist"
+            echo "**Action:** Manual review required"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Log pending
         if: steps.check.outputs.status == 'pending'
         run: |
-          echo "## ⏳ Waiting for Checks" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Pending checks:** ${{ steps.check.outputs.pending }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Note:** Auto-merge will run when all checks complete" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ⏳ Waiting for Checks"
+            echo ""
+            echo "**Pending checks:** ${{ steps.check.outputs.pending }}"
+            echo "**Note:** Auto-merge will run when all checks complete"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Log failed
         if: steps.check.outputs.status == 'failed'
         run: |
-          echo "## ❌ Checks Failed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Failed checks:** ${{ steps.check.outputs.failed }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Action:** Fix failures before merging" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ❌ Checks Failed"
+            echo ""
+            echo "**Failed checks:** ${{ steps.check.outputs.failed }}"
+            echo "**Action:** Fix failures before merging"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🔧 Fix: ShellCheck SC2129 - Use Single Redirect

**Issue**: ShellCheck SC2129 warns about multiple independent redirects to the same file

**Root Cause**: Each `echo` statement had its own `>> $GITHUB_STEP_SUMMARY` redirect

**Fix**: Group all echo statements with single redirect using `{ ... } >> "$GITHUB_STEP_SUMMARY"`

### Changes in dependabot-auto-merge.yml

**5 blocks fixed:**

1. **Auto-merge successful** (lines 131-135)
   - 5 echo statements → 1 grouped redirect

2. **Skip Docker updates** (lines 142-151)
   - 10 echo statements → 1 grouped redirect

3. **Log skipped** (lines 159-163)
   - 5 echo statements → 1 grouped redirect

4. **Log pending** (lines 168-171)
   - 4 echo statements → 1 grouped redirect

5. **Log failed** (lines 176-179)
   - 4 echo statements → 1 grouped redirect

### Benefits
- ✅ Satisfies ShellCheck SC2129
- ✅ More efficient (single file handle)
- ✅ Cleaner, more maintainable code
- ✅ Prevents future SC2129 errors

**Related**: 
- [Failed run](https://github.com/Meats-Central/ProjectMeats/actions/runs/22153008047/job/64049245650)
- ShellCheck docs: [SC2129](https://www.shellcheck.net/wiki/SC2129)