### PR TITLE
hotfix: Add missing EmptyState component

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
@@ -299,6 +299,17 @@ const ValidationModeButton = styled.button<{ $active: boolean }>`
   }
 `;
 
+const EmptyState = styled.div`
+  padding: 40px 20px;
+  text-align: center;
+  color: rgb(var(--color-text-secondary));
+  font-size: 14px;
+  line-height: 1.6;
+  background: rgba(var(--color-border), 0.1);
+  border-radius: var(--radius-md);
+  margin: 12px 0;
+`;
+
 // ============================================================================
 // Helper Functions
 // ============================================================================


### PR DESCRIPTION
**Bug**: FormStepConfigPanel crashes with `ReferenceError: EmptyState is not defined`

**Fix**: Add EmptyState styled component

**Impact**: Critical - blocks Form Step node configuration