### PR TITLE
fix(admin): Add missing i18n template tag + clarify URL naming

### DIFF
--- a/backend/projectmeats/urls.py
+++ b/backend/projectmeats/urls.py
@@ -29,9 +29,9 @@ urlpatterns = [
     path("api/v1/ready/", ready_check, name="ready-check"),
     # NOTE: System Configuration Studio ARCHIVED 2026-02-14 (superseded by apps.system)
     # Admin interface (using custom three-tier admin site)
-    path("admin/", admin_site.urls),
+    path("admin/", admin_site.urls, name='admin'),  # Custom three-tier admin (primary)
     # Legacy admin (redirect to custom admin)
-    path("admin-legacy/", admin.site.urls),
+    path("admin-legacy/", admin.site.urls, name='admin-legacy'),  # Django default admin (legacy)
     # API v1 endpoints
     path("api/v1/system/", include("apps.system.urls")),  # NEW: Centralized config system (v2.0 Wave 1)
     path("api/v1/", include("apps.tenants.urls")),  # Multi-tenancy endpoints (shared)

--- a/backend/templates/admin/index.html
+++ b/backend/templates/admin/index.html
@@ -1,4 +1,5 @@
 {% extends "admin/index.html" %}
+{% load i18n %}
 {% load static %}
 
 {% block extrahead %}


### PR DESCRIPTION
Fixes Django admin template errors related to internationalization.

## Changes

1. **Admin Template**: Added {% load i18n %} to backend/templates/admin/index.html
2. **URL Configuration**: Added name parameters to admin paths for clarity

## Verification

✓ python manage.py check (0 issues)
✓ collectstatic --dry-run (passed)

## Testing

Access /admin/ on dev.meatscentral.com and verify blocktrans renders correctly.