### PR TITLE
fix(flow): Complete form node rename + schema registry fix + debug logs

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -100,8 +100,18 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
 
   // Get schema for this node type
   const schema = useMemo(() => {
-    return schemaRegistry.getSchema(node.type!);
-  }, [node.type]);
+    const resolvedSchema = schemaRegistry.getSchema(node.type!);
+    
+    // Debug logging for schema resolution
+    console.log('[DynamicConfigPanel] Schema resolution:', {
+      nodeType: node.type,
+      nodeId: node.id,
+      schemaFound: !!resolvedSchema,
+      schemaDisplayName: resolvedSchema?.displayName,
+    });
+    
+    return resolvedSchema;
+  }, [node.type, node.id]);
 
   // Reset form data when node changes
   useEffect(() => {

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
@@ -151,6 +151,17 @@ export function renderEntityTypeSelect(
   // Fetch entity types from backend API (with fallback to hardcoded entities)
   const { data: entities = [], isLoading, error: fetchError } = useEntityList();
 
+  // Debug logging
+  React.useEffect(() => {
+    console.log('[EntityTypeSelect] Rendered with:', {
+      isLoading,
+      entityCount: entities.length,
+      entities: entities.map(e => e.label),
+      fetchError: fetchError ? String(fetchError) : null,
+      currentValue: value,
+    });
+  }, [isLoading, entities, fetchError, value]);
+
   return (
     <FormField key={field.id}>
       <Label>

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -839,4 +839,16 @@ import { schemaRegistry } from './schemaRegistry';
 
 // Initialize registry with all schemas on module load
 schemaRegistry.initialize(allSchemas);
-// Cache bust: 1771486119
+
+// Phase E Fix (2026-02-19): Register backward compatibility aliases
+// formStepSingle nodes should use the same schema as 'form' nodes
+schemaRegistry.register({
+  ...formSchema,
+  nodeType: 'formStepSingle',
+  displayName: 'Form (Legacy)',
+  description: '[DEPRECATED] Use the "Form" node instead. This exists for backward compatibility only.',
+}, true); // Allow overwrite
+
+console.log('[Schema Registry] Registered backward compatibility: formStepSingle → formSchema');
+
+// Cache bust: 1771488534

--- a/frontend/src/components/FlowEditor/nodes/FormStepSingleNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormStepSingleNode.tsx
@@ -202,12 +202,13 @@ export const FormStepSingleNode: React.FC<NodeProps<FormStepNodeData>> = (props)
   const nodeTypeDef = getNodeTypeDefinition('formStepSingle');
   
   // Safety check: provide fallback if nodeType is undefined
+  // Note: This fallback matches the registry definition (Form (Legacy))
   const nodeType = nodeTypeDef || {
     id: 'formStepSingle',
-    name: 'Form Step Single',
+    name: 'Form (Legacy)',  // Phase E Fix: Updated from 'Form Step Single'
     category: 'form' as const,
-    color: 'rgb(168, 85, 247)',
-    icon: 'ListChecks',
+    color: '#3b82f6',  // Match registry color
+    icon: '📋',  // Match registry icon
     maxInputs: 1,
     maxOutputs: 1,
     config: {},


### PR DESCRIPTION
## Critical Fixes

This PR addresses **root causes** preventing form node updates from appearing:

### 1. Schema Registry Missing Alias ❌→✅
**Problem:**  returned 
- Registry only had 'form' schema registered
- Backward compatibility nodes broke silently

**Fix:**
```typescript
schemaRegistry.register({
  ...formSchema,
  nodeType: 'formStepSingle',
  displayName: 'Form (Legacy)',
}, true);
```

### 2. Hardcoded Node Fallback Name ❌→✅
**Problem:** FormStepSingleNode.tsx had hardcoded fallback: 
- Even with registry updated, fallback still showed old name

**Fix:** Updated fallback to match registry: 

### 3. No Diagnostic Visibility ❌→✅
**Problem:** No way to verify if new code was running
- Changes appeared invisible due to cache

**Fix:** Added comprehensive debug logging:
```javascript
console.log('[Schema Registry] Registered backward compatibility...');
console.log('[DynamicConfigPanel] Schema resolution:', { nodeType, schemaFound });
console.log('[EntityTypeSelect] Rendered with:', { entities, isLoading });
```

## How to Verify

### Step 1: Open Browser DevTools Console
Look for these logs after PR merge + dev server restart:

```
[Schema Registry] Registered backward compatibility: formStepSingle → formSchema
[DynamicConfigPanel] Schema resolution: { nodeType: 'formStepSingle', schemaFound: true }
[EntityTypeSelect] Rendered with: { entities: ['Supplier', 'Customer', ...], entityCount: 8 }
```

### Step 2: Test in UI
1. Create new workflow
2. Add "Form" node (should show "Form" not "Form Step Single")
3. Click node → Config panel opens
4. Check "Entity Type" dropdown → should show 8 entities immediately

### Step 3: Test Backward Compat
1. Open existing workflow with old 'formStepSingle' nodes
2. Click node → should still work, show "Form (Legacy)" in header
3. Entity dropdown should populate

## Files Changed
-  - Fix hardcoded name
-  - Register alias
-  - Add logging
-  - Add logging

## Testing Checklist
- [x] Build succeeds (2,428.42 kB)
- [x] Cache cleared (rm -rf node_modules/.vite)
- [ ] Console shows debug logs
- [ ] Entity dropdown populates with 8 entities
- [ ] Node shows "Form" not "Form Step Single"
- [ ] Old formStepSingle nodes still work

## Related
- PR #3073 (previous fix attempt - incomplete)
- User report: "entity type dropdown list is always empty"
- Phase E form node overhaul