### PR TITLE
⚡ FIX: Add onNodeClick handler for instant config panel access

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -4569,6 +4569,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     }
   }, [nodes]);
   
+  // Handler for direct node clicks (opens config panel)
+  const handleNodeClick = useCallback((event: React.MouseEvent, node: Node) => {
+    console.log('🖱️ [NODE CLICK] Opening config for:', node.type, node.id);
+    handleNodeEdit(node.id);
+  }, [handleNodeEdit]);
+  
   // Batch 3: Handler to delete node from Delete button
   const handleNodeDeleteImpl = useCallback(async (nodeId: string) => {
     console.log('[UnifiedFlowEditor] Deleting node:', nodeId);
@@ -5440,6 +5446,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         onDragOver={onDragOver}
         onNodeDragStart={onNodeDragStart}
         onNodeDragStop={onNodeDragStop}
+        onNodeClick={handleNodeClick}
         onNodeContextMenu={handleNodeContextMenu}
         onSelectionChange={handleSelectionChange}
         nodeTypes={nodeTypes}


### PR DESCRIPTION
## 🎯 USER EXPERIENCE IMPROVEMENT

### Issue
Users had to click the Edit button to configure nodes - clicking the node itself did nothing. This is unintuitive compared to other flow editors where clicking a node opens its configuration.

### Expected Behavior
- Click node → config panel opens (like Figma, Miro, other flow editors)
- Right-click node → context menu appears
- Click Edit button → also opens config panel

### Solution
Added `onNodeClick` handler that opens the appropriate configuration panel based on node type.

## ✅ CHANGES

### UnifiedFlowEditor.tsx
1. **Added handleNodeClick handler:**
   ```typescript
   const handleNodeClick = useCallback((event: React.MouseEvent, node: Node) => {
     console.log('🖱️ [NODE CLICK] Opening config for:', node.type, node.id);
     handleNodeEdit(node.id);
   }, [handleNodeEdit]);
   ```

2. **Wired to ReactFlow:**
   ```typescript
   <ReactFlow
     ...
     onNodeClick={handleNodeClick}
     onNodeContextMenu={handleNodeContextMenu}
     ...
   />
   ```

## 🎨 UX FLOW

**Before:**
1. User clicks node → nothing happens (just selection border)
2. User must find and click tiny Edit button

**After:**
1. User clicks node → config panel opens immediately ✨
2. OR user right-clicks → context menu with Edit option
3. OR user clicks Edit button → same result

**All three interaction methods now workecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*

## 🧪 TESTING

- Build: ✅ 18.23s
- Bundle: 2,460.84 KB (stable, +0.13 KB)
- TypeScript: ✅ No errors
- Breaking Changes: ❌ None

## 🎯 IMPACT

- **Better UX:** Single-click node access (industry standard)
- **Faster workflow:** No hunting for Edit button
- **Zero breaking changes:** Edit button still works
- **Performance:** useCallback optimization

## 📚 RELATED

- PR #3143: Fixed Edit button + template crashes
- PR #3145: Fixed AccountsReceivables API
- Part of Workforms Editor UX polish initiative