### PR TITLE
🚨 Hotfix: Remove useMemo from static edge types (React Hook Rules violation)

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -17,7 +17,7 @@
  * React Flow Best Practices Applied (2026-02-21):
  * ✅ All node components wrapped in React.memo for performance
  * ✅ All edge components wrapped in React.memo
- * ✅ nodeTypes and edgeTypes objects memoized with useMemo
+ * ✅ nodeTypes and staticEdgeTypes objects are static (no useMemo needed for constants)
  * ✅ All callbacks use useCallback with correct dependencies
  * ✅ ARIA labels on all Handle components for accessibility
  * ✅ Snap-to-grid enabled (15x15 grid) for smooth dragging
@@ -1617,13 +1617,14 @@ const staticNodeTypes: NodeTypes = {
   terminal: TerminalNode,
 };
 
-const edgeTypes = useMemo<EdgeTypes>(() => ({
+// Static edge types (no useMemo needed - these are constant)
+const staticEdgeTypes: EdgeTypes = {
   custom: CustomEdge,
   conditional: ConditionalEdge,
   error: ErrorEdge,
   success: SuccessEdge,
   default: CustomEdge, // Fallback to custom for untyped edges
-}), []);
+};
 
 // ============================================================================
 // Component
@@ -5667,7 +5668,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         onPaneClick={handleCloseMenu}
         onSelectionChange={handleSelectionChange}
         nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
+        edgeTypes={staticEdgeTypes}
         defaultEdgeOptions={{ 
           type: 'custom',
           markerEnd: {


### PR DESCRIPTION
## 🚨 Critical Hotfix - Production Blocker

### Issue
**dev.meatscentral.com is broken** with `TypeError: Cannot read properties of null (reading 'useMemo')`

### Root Cause
Line 1617-1623 in `UnifiedFlowEditor.tsx` was calling `useMemo` hook **outside the component function boundary**, violating React Hook Rules.

```typescript
// ❌ WRONG (line 1617) - Hook called at module level
const edgeTypes = useMemo<EdgeTypes>(() => ({
  custom: CustomEdge,
  // ...
}), []);

// Component starts here (line 1629) - TOO LATE!
const UnifiedFlowEditorInner: React.FC<...> = ({
```

### Fix
Changed `edgeTypes` from a `useMemo` hook to a static constant `staticEdgeTypes`:

```typescript
// ✅ CORRECT - Static constant (no hook needed)
const staticEdgeTypes: EdgeTypes = {
  custom: CustomEdge,
  conditional: ConditionalEdge,
  error: ErrorEdge,
  success: SuccessEdge,
  default: CustomEdge,
};
```

Updated usage at line 5671:
```typescript
<ReactFlow edgeTypes={staticEdgeTypes} />
```

### Why This Works
- Edge types are **truly static constants** - they never change at runtime
- No memoization needed (memoization is for values that depend on props/state)
- React Hook Rules require hooks to be called inside component functions only
- Static constants can be declared at module level without any issues

### Testing
- [x] Local build successful
- [x] TypeScript compilation passes
- [ ] Deployed to dev.meatscentral.com (will verify after merge)
- [ ] Workforms Editor loads without errors
- [ ] Flow preview, auto-layout, and keyboard shortcuts work

### Impact
- **Files Changed**: 1 (UnifiedFlowEditor.tsx)
- **Lines Changed**: 5 insertions, 4 deletions
- **Breaking Changes**: None
- **Backend Changes**: None
- **Migration Required**: None

### Related
- Introduced in: Phase 2 UI/UX Enhancements (PR #3166)
- Caused by: Over-zealous application of React Flow memoization best practices
- Lesson: Only memoize values that actually change - not static constants

### Deployment
After merge, this will automatically deploy to dev.meatscentral.com via Golden Pipeline.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>