### PR TITLE
hotfix: add debug endpoint for superuser permissions diagnosis

### DIFF
--- a/backend/tenant_apps/workflows/debug_permissions.py
+++ b/backend/tenant_apps/workflows/debug_permissions.py
@@ -1,0 +1,33 @@
+"""
+Debug helper for permissions issues.
+Temporary file to diagnose superuser permissions.
+"""
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+
+
+class DebugPermissionsView(APIView):
+    """
+    Debug endpoint to check user authentication state.
+    GET /api/v1/workflows/debug-permissions/
+    """
+    permission_classes = [IsAuthenticated]
+    
+    def get(self, request):
+        user = request.user
+        tenant = getattr(request, 'tenant', None)
+        
+        return Response({
+            'user_id': user.id if user else None,
+            'username': user.username if user else None,
+            'email': user.email if user and hasattr(user, 'email') else None,
+            'is_authenticated': user.is_authenticated if user else False,
+            'is_superuser': user.is_superuser if user else False,
+            'is_staff': user.is_staff if user and hasattr(user, 'is_staff') else False,
+            'tenant_id': tenant.id if tenant else None,
+            'tenant_name': tenant.name if tenant else None,
+            'tenant_slug': tenant.slug if tenant else None,
+            'has_tenant': tenant is not None,
+            'request_user_type': type(user).__name__,
+        })

--- a/backend/tenant_apps/workflows/urls.py
+++ b/backend/tenant_apps/workflows/urls.py
@@ -37,6 +37,9 @@ from .views import (
     WorkFormPermissionsAPIView
 )
 
+# Debug helper (temporary)
+from .debug_permissions import DebugPermissionsView
+
 # Phase 5: Workflow Trigger API Views
 from .views_triggers import (
     WorkflowWebhookAPIView,
@@ -129,6 +132,9 @@ urlpatterns = [
     
     # Phase 4.2: WorkForms Permissions endpoint
     path('permissions/', WorkFormPermissionsAPIView.as_view(), name='workforms-permissions'),
+    
+    # Debug endpoint (temporary - for diagnosing superuser permissions issue)
+    path('debug-permissions/', DebugPermissionsView.as_view(), name='debug-permissions'),
     
     # Phase 5: Workflow Trigger API endpoints
     path('workflows/<uuid:workflow_id>/webhooks/', WorkflowWebhookAPIView.as_view(), name='workflow-webhooks'),


### PR DESCRIPTION
## 🎯 Purpose
Add temporary debug endpoint to diagnose why superusers are getting `can_edit: false` in WorkForms permissions.

## 🐛 Issue
Console logs show:
```
can_edit: false, readOnly: true
```

Even for authenticated superusers. Backend code checks `user.is_superuser` correctly, so this suggests:
1. User object not properly authenticated
2. Tenant context missing
3. Request not reaching the permission check

## 🔧 Changes
- Created `DebugPermissionsView` at `/api/v1/workflows/debug-permissions/`
- Returns comprehensive user state:
  - user_id, username, email
  - is_authenticated, is_superuser, is_staff
  - tenant_id, tenant_name, tenant_slug
  - request_user_type (helps identify proxy issues)

## ✅ Testing
After deployment, call:
```bash
curl -H "Authorization: Bearer $TOKEN" https://dev.meatscentral.com/api/v1/workflows/debug-permissions/
```

Expected output for superuser:
```json
{
  "is_superuser": true,
  "is_authenticated": true,
  "has_tenant": true
}
```

## 🗑️ Cleanup
This is a TEMPORARY endpoint - will be removed once root cause identified and fixed.

## 📋 Related
- PR #3171 (added debug logging to permissions helper)
- PR #3174 (fixed config modal rendering)