### PR TITLE
fix: DRF Spectacular E001 - read_only_fields must be list

### DIFF
--- a/backend/tenant_apps/workflows/serializers.py
+++ b/backend/tenant_apps/workflows/serializers.py
@@ -319,7 +319,12 @@ class WorkflowExecutionLogSerializer(serializers.ModelSerializer):
             'actions_executed', 'actions_failed', 'error_message',
             'execution_log', 'triggered_by'
         ]
-        read_only_fields = '__all__'
+        read_only_fields = [
+            'id', 'workflow', 'workflow_name', 'trigger_type', 'trigger_data',
+            'status', 'started_at', 'completed_at', 'duration_ms',
+            'actions_executed', 'actions_failed', 'error_message',
+            'execution_log', 'triggered_by'
+        ]
     
     def get_duration_ms(self, obj):
         if obj.completed_at and obj.started_at:
@@ -375,7 +380,11 @@ class FormSubmissionListSerializer(serializers.ModelSerializer):
             'created_by', 'created_by_name', 'progress',
             'created_at', 'updated_at', 'completed_at'
         ]
-        read_only_fields = '__all__'
+        read_only_fields = [
+            'id', 'form', 'form_name', 'form_icon', 'status',
+            'created_by', 'created_by_name', 'progress',
+            'created_at', 'updated_at', 'completed_at'
+        ]
     
     def get_created_by_name(self, obj):
         if obj.created_by:


### PR DESCRIPTION
## 🔧 Backend Serializer Fix

### Summary
Fixes DRF Spectacular schema generation error caused by invalid `read_only_fields` format.

### Error Fixed

**DRF Spectacular E001**:
```
ERRORS:
?: (drf_spectacular.E001) Schema generation threw exception "The `read_only_fields` option must be a list or tuple. Got str."
```

**Root Cause**: Lines 322 and 378 in `workflows/serializers.py`:
```python
class WorkflowExecutionLogSerializer(serializers.ModelSerializer):
    class Meta:
        read_only_fields = '__all__'  # ❌ String not allowed by DRF

class FormSubmissionListSerializer(serializers.ModelSerializer):
    class Meta:
        read_only_fields = '__all__'  # ❌ String not allowed by DRF
```

**Fix Applied**:
```python
class WorkflowExecutionLogSerializer(serializers.ModelSerializer):
    class Meta:
        read_only_fields = [
            'id', 'workflow', 'workflow_name', 'trigger_type', ...
        ]  # ✅ Proper list format

class FormSubmissionListSerializer(serializers.ModelSerializer):
    class Meta:
        read_only_fields = [
            'id', 'form', 'form_name', 'form_icon', ...
        ]  # ✅ Proper list format
```

---

### Changes

**File**: `backend/tenant_apps/workflows/serializers.py`
- Line 322: WorkflowExecutionLogSerializer - convert to list
- Line 378: FormSubmissionListSerializer - convert to list

---

### Verification

**Before**:
```bash
python manage.py check --deploy
# SystemCheckError: System check identified some issues
```

**After**:
```bash
python manage.py check --deploy
# System check identified 188 issues (0 silenced)  # All warnings, no ERRORS
```

---

### Testing

**Backend Validation**:
```bash
cd backend
python manage.py check --deploy  # ✅ No errors
python -m py_compile tenant_apps/workflows/serializers.py  # ✅ Syntax OK
```

---

### Benefits

✅ **Schema Generation**: API documentation now generates successfully
✅ **Deployment**: System checks pass without errors
✅ **Standards**: Follows DRF best practices (explicit field lists)

---

### Notes

- Session Expired Modal files already exist in upstream (PR #3254, commit 0789b3b9)
- This PR contains ONLY the serializer fix
- No database migrations needed
- No frontend changes
- Low risk - standard DRF pattern

---

**Ready for immediate mergeecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*