### PR TITLE
refactor: Phase 2 Standardization - Unify Terminology

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx
@@ -1,13 +1,14 @@
 /**
  * FormSelectionPanel Component
  * 
- * First panel shown when configuring Form Step or Form Multi-Step Container nodes.
+ * First panel shown when configuring Form or Form Process nodes.
  * Allows user to choose between:
  * - Creating a new form (shows name input)
  * - Using an existing form (shows cascading dropdown)
  * 
  * Phase 2.2 of WF-ENH-2026-Q1
  * Created: 2026-02-06
+ * Updated: 2026-02-25 - Phase 2 Standardization
  */
 
 import React, { useState, useEffect } from 'react';
@@ -271,7 +272,7 @@ export const FormSelectionPanel: React.FC<FormSelectionPanelProps> = ({
 
   const canProceed = mode === 'new' ? newFormName.trim().length > 0 : !!selectedExistingFormId;
 
-  const nodeTypeLabel = nodeType === 'formStep' ? 'Form Step' : 'Multi-Step Form Container';
+  const nodeTypeLabel = nodeType === 'formStep' ? 'Form' : 'Form Process';
 
   return (
     <Container>
@@ -280,7 +281,7 @@ export const FormSelectionPanel: React.FC<FormSelectionPanelProps> = ({
         <Description>
           {nodeType === 'formStep' 
             ? 'Choose whether to create a new form or use an existing one from your library.'
-            : 'Choose whether to create a new multi-step form container or use an existing one.'}
+            : 'Choose whether to create a new form process or use an existing one.'}
         </Description>
       </div>
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
@@ -1,23 +1,24 @@
 /**
- * Form Step Configuration Panel
+ * Form Configuration Panel
  * 
- * Configuration panel for form steps (multi-step form containers).
- * Manages step-level settings including visibility, navigation, and validation.
+ * Configuration panel for forms and form processes.
+ * Manages form-level settings including visibility, navigation, and validation.
  * 
  * Features:
- * - Step title and description editing
- * - Conditional visibility for entire step
+ * - Form title and description editing
+ * - Conditional visibility for entire form
  * - Navigation controls (back/skip/auto-advance)
- * - Step-level validation rules
+ * - Form-level validation rules
  * - Field list management (add/edit/delete/reorder)
  * 
  * Phase E.2: Panel Migration - Batch 1 (1 of 3)
- * Migrated to use shared styled components from ConfigPanel/shared
+ * Updated: 2026-02-25 - Phase 2 Standardization
  * 
  * Changes:
  * - Replaced 30+ local styled components with shared components
  * - Massive code reduction expected (40%+)
  * - Maintained exact same functionality
+ * - Updated terminology: "Form Step" → "Form"
  * 
  * Created: 2026-02-04 - Phase 5 Field/Step/Mapping Enhancements
  * Last Updated: 2026-02-18 - Phase E.2 Panel Migration

--- a/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
@@ -674,7 +674,7 @@ export const FormProcessModal: React.FC<ContainerModalProps> = ({
           <HeaderLeft>
             <ContainerIcon>📦</ContainerIcon>
             <div>
-              <ModalTitle>Configure Multi-Step Container</ModalTitle>
+              <ModalTitle>Configure Form Process</ModalTitle>
             </div>
           </HeaderLeft>
           <CloseButton onClick={onClose} aria-label="Close modal">

--- a/frontend/src/components/FlowEditor/nodeTypes.ts
+++ b/frontend/src/components/FlowEditor/nodeTypes.ts
@@ -138,7 +138,7 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
     category: 'form',
     icon: '📦',
     color: '#8b5cf6', // purple - distinct from regular form blue
-    description: 'DROP ZONE: Drag form steps and nodes here to create a multi-step flow',
+    description: 'Multi-step form container - drag Form nodes here to create a sequential workflow',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
@@ -146,11 +146,11 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
   
   formProcessGroup: {
     id: 'formProcessGroup',
-    name: 'Form Process Group',
+    name: 'Form Process',
     category: 'form',
     icon: '📂',
     color: '#a78bfa', // lighter purple - group variant
-    description: 'LABELED CONTAINER: Resizable group with labeled header and vertical auto-layout for child steps',
+    description: 'Advanced form container with labeled header and automatic step sequencing',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
@@ -160,11 +160,11 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
   // These map to the new node types but are marked as deprecated
   formStep: {
     id: 'formStep',
-    name: 'Form Step (DEPRECATED - use formStepSingle)',
+    name: 'Form Step (Deprecated)',
     category: 'form',
     icon: '📋',
     color: '#9ca3af', // gray - deprecated
-    description: '[DEPRECATED] This node type has been renamed to formStepSingle. Existing workflows will continue to work.',
+    description: '[DEPRECATED] This node type has been renamed to "Form". Existing workflows will continue to work.',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,


### PR DESCRIPTION
## 🔄 Phase 2: Standardization - Terminology Unification

### Summary
Implements Phase 2 of the Master Plan by standardizing workflow editor terminology for clarity and consistency.

### Changes

**Terminology Updates**:
- ✅ "Form Process Group" → "Form Process" (simplified)
- ✅ "Multi-Step Form Container" → "Form Process" (user-facing labels)
- ✅ "Form Step" → "Form" (in documentation/comments)

**Files Changed** (4 files, +18, -16):
1. `nodeTypes.ts`: Updated node names and descriptions
2. `FormSelectionPanel.tsx`: Updated UI labels and help text
3. `FormStepConfigPanel.tsx`: Updated comments and documentation
4. `FormProcessModal.tsx`: Updated modal title

### Backward Compatibility ✅

**No Breaking Changes**:
- ✅ Old type IDs (`formMultiStepContainer`, `formStep`) still work
- ✅ Existing workflows load without modification
- ✅ Deprecated aliases remain hidden but functional
- ✅ Backend persistence already handles both old and new names

### Benefits

**User Experience**:
- 📝 Clearer terminology ("Form Process" vs "Multi-Step Container")
- 🎯 Consistent naming across UI
- 💡 Better describes what the node does (orchestrates a sequence)

**Developer Experience**:
- 🧹 Cleaner codebase with unified terminology
- 📚 Updated documentation reflects new standards
- 🔧 Foundation for Phase 3 (Data Architecture)

### Verification

**Build Status**:
```bash
npm run build
# ✅ Passed (23.48s, 6727 modules transformed)
```

**Changes Summary**:
```
frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx  |  7 ++++---
frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx | 15 ++++++++-------
frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx         |  2 +-
frontend/src/components/FlowEditor/nodeTypes.ts                        | 10 +++++-----
4 files changed, 18 insertions(+), 16 deletions(-)
```

### Testing Checklist

**Manual Testing Required**:
- [ ] Open UnifiedFlowEditor
- [ ] Drag "Form Process" node to canvas
- [ ] Verify node label shows "Form Process"
- [ ] Open config modal → title shows "Configure Form Process"
- [ ] Drag "Form" node inside process container
- [ ] Verify selection panel shows "Form" terminology
- [ ] Load existing workflow with old `formMultiStepContainer` → still works

### Related Work

- **Master Plan**: Phase 2 of 7 (Standardization)
- **Next**: Phase 3 (Data Architecture - Virtual Schema + Choice Engine)
- **Previous**: PR #3260 (Error fixes), PR #3256 (Agent B Persistence)

### Risk Assessment

**Very Low Risk**:
- Frontend-only changes (no database migrations)
- No API changes (backend already handles aliases)
- Backward compatible (old workflows unaffected)
- Small scope (4 files, terminology only)

---

**Ready for review and merge to developmentecho ___BEGIN___COMMAND_OUTPUT_MARKER___ ; PS1= ; PS2= ; unset HISTFILE ; EC=0 ; echo ___BEGIN___COMMAND_DONE_MARKER___0 ; }*