### PR TITLE
fix: Add ReactFlowProvider to React Flow mock (Final Vitest Fix)

### DIFF
--- a/frontend/src/components/FlowEditor/__tests__/UnifiedFlowEditor.integration.test.tsx
+++ b/frontend/src/components/FlowEditor/__tests__/UnifiedFlowEditor.integration.test.tsx
@@ -27,6 +27,7 @@ vi.mock('@xyflow/react', () => ({
       {children}
     </div>
   ),
+  ReactFlowProvider: ({ children }: any) => <div data-testid="reactflow-provider">{children}</div>,
   Background: () => <div data-testid="background" />,
   Controls: () => <div data-testid="controls" />,
   MiniMap: () => <div data-testid="minimap" />,


### PR DESCRIPTION
## 🐛 Problem

Deployment failure in run 22424324096:
```
Error: [vitest] No "ReactFlowProvider" export is defined on the "@xyflow/react" mock.
```

## ✅ Solution

Added missing `ReactFlowProvider` export to React Flow mock at line 29:
```typescript
ReactFlowProvider: ({ children }: any) => <div data-testid="reactflow-provider">{children}</div>,
```

## 📍 Root Cause

UnifiedFlowEditor.tsx line 6955 wraps components in ReactFlowProvider, but the mock in PR #3281 only included Handle/Position exports.

## ✅ Testing

- Local frontend build: ✅ Passes
- Mock now complete with all required exports

## 🔗 Related

- Fixes deployment failure: https://github.com/Meats-Central/ProjectMeats/actions/runs/22424324096
- Completes Vitest migration started in PR #3280, #3281

This is the final piece to fully unblock CI/CD pipeline.