### PR TITLE
fix: Add BackgroundVariant to React Flow mock (Complete Vitest Migration)

### DIFF
--- a/frontend/src/components/FlowEditor/__tests__/UnifiedFlowEditor.integration.test.tsx
+++ b/frontend/src/components/FlowEditor/__tests__/UnifiedFlowEditor.integration.test.tsx
@@ -40,6 +40,11 @@ vi.mock('@xyflow/react', () => ({
     Left: 'left',
     Right: 'right',
   },
+  BackgroundVariant: {
+    Lines: 'lines',
+    Dots: 'dots',
+    Cross: 'cross',
+  },
   useReactFlow: () => ({
     fitView: vi.fn(),
     setNodes: vi.fn(),


### PR DESCRIPTION
## 🐛 Problem

Deployment failure in run 22426323085 - ANOTHER missing React Flow export:
```
Error: [vitest] No "BackgroundVariant" export is defined on the "@xyflow/react" mock.
```

## ✅ Solution

Added missing `BackgroundVariant` enum to complete the React Flow mock:
```typescript
BackgroundVariant: {
  Lines: 'lines',
  Dots: 'dots',
  Cross: 'cross',
},
```

## 📋 Complete Mock Now Includes

**Components:**
- ReactFlow, ReactFlowProvider
- Background, Controls, MiniMap, Panel

**Enums:**
- Position (Top, Bottom, Left, Right)
- BackgroundVariant (Lines, Dots, Cross) ← NEW

**Hooks:**
- useReactFlow, useNodesState, useEdgesState

**Helpers:**
- addEdge, applyNodeChanges, applyEdgeChanges, Handle

## ✅ Testing

Local build passes - all React Flow dependencies now mocked.

## 🔗 Related

- Fixes: https://github.com/Meats-Central/ProjectMeats/actions/runs/22426323085
- Follows: PR #3280 (jest→vi), #3281 (Handle/Position), #3284 (ReactFlowProvider)

This should be the **final** piece for complete Vitest migration.