### PR TITLE
Hotfix: Remove duplicate ErrorBoundary closing tag

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -6835,7 +6835,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         }}
       />
     </EditorContainer>
-    </ErrorBoundary>
   );
 };
 


### PR DESCRIPTION
## Problem
Build failure in deployment run #22463563663 due to syntax error:
- Line 6838 had erroneous `</ErrorBoundary>` closing tag  
- UnifiedFlowEditorInner component should close with `</EditorContainer>`
- Outer `ErrorBoundary` wrapper is in separate parent component

## Solution
- Removed duplicate `</ErrorBoundary>` tag at line 6838
- Frontend build now succeeds

## Impact  
- ✅ Fixes frontend build error blocking deployment
- ✅ Unblocks Phase 6 commits from deploying successfully

## Testing
```bash
cd frontend && npm run build  
# ✅ Build successful in 25.70s
```