### PR TITLE
fix: Remove non-existent formsubmissionvalue table from migration 0015

### DIFF
--- a/backend/tenant_apps/workflows/migrations/0015_sync_workflow_rls_state.py
+++ b/backend/tenant_apps/workflows/migrations/0015_sync_workflow_rls_state.py
@@ -139,17 +139,7 @@ class Migration(migrations.Migration):
                         USING (tenant_id = current_setting('app.current_tenant', true)::uuid);
                 END IF;
 
-                -- FormSubmissionValue
-                IF NOT EXISTS (
-                    SELECT 1 FROM pg_policies 
-                    WHERE tablename = 'workflows_formsubmissionvalue' 
-                    AND policyname = 'formsubmissionvalue_tenant_isolation'
-                ) THEN
-                    ALTER TABLE workflows_formsubmissionvalue ENABLE ROW LEVEL SECURITY;
-                    ALTER TABLE workflows_formsubmissionvalue FORCE ROW LEVEL SECURITY;
-                    CREATE POLICY formsubmissionvalue_tenant_isolation ON workflows_formsubmissionvalue
-                        USING (tenant_id = current_setting('app.current_tenant', true)::uuid);
-                END IF;
+                -- FormSubmissionValue (REMOVED - table does not exist in current schema)
 
                 -- FormSubmissionFile
                 IF NOT EXISTS (
@@ -228,7 +218,7 @@ class Migration(migrations.Migration):
                 DROP POLICY IF EXISTS tenantworkflowaction_tenant_isolation ON workflows_tenantworkflowaction;
                 DROP POLICY IF EXISTS workflowexecutionlog_tenant_isolation ON workflows_workflowexecutionlog;
                 DROP POLICY IF EXISTS formsubmission_tenant_isolation ON workflows_formsubmission;
-                DROP POLICY IF EXISTS formsubmissionvalue_tenant_isolation ON workflows_formsubmissionvalue;
+                -- formsubmissionvalue table does not exist (skipped)
                 DROP POLICY IF EXISTS formsubmissionfile_tenant_isolation ON workflows_formsubmissionfile;
                 DROP POLICY IF EXISTS formsubmissionevent_tenant_isolation ON workflows_formsubmissionevent;
                 DROP POLICY IF EXISTS stepassignment_tenant_isolation ON workflows_stepassignment;
@@ -246,7 +236,7 @@ class Migration(migrations.Migration):
                 ALTER TABLE workflows_tenantworkflowaction DISABLE ROW LEVEL SECURITY;
                 ALTER TABLE workflows_workflowexecutionlog DISABLE ROW LEVEL SECURITY;
                 ALTER TABLE workflows_formsubmission DISABLE ROW LEVEL SECURITY;
-                ALTER TABLE workflows_formsubmissionvalue DISABLE ROW LEVEL SECURITY;
+                -- formsubmissionvalue table does not exist (skipped)
                 ALTER TABLE workflows_formsubmissionfile DISABLE ROW LEVEL SECURITY;
                 ALTER TABLE workflows_formsubmissionevent DISABLE ROW LEVEL SECURITY;
                 ALTER TABLE workflows_stepassignment DISABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Problem
Migration 0015 deployment failed with:
```
django.db.utils.ProgrammingError: relation "workflows_formsubmissionvalue" does not exist
CONTEXT: SQL statement "ALTER TABLE workflows_formsubmissionvalue ENABLE ROW LEVEL SECURITY"
```

## Root Cause
Migration 0015 attempted to apply RLS policies to `workflows_formsubmissionvalue` table, but this table does not exist in the current schema. It was likely removed in a prior migration.

## Solution
Removed all references to `workflows_formsubmissionvalue` from migration 0015:
- ✅ Removed RLS policy creation block (forward migration)
- ✅ Removed DROP POLICY statement (reverse migration)
- ✅ Removed DISABLE RLS statement (reverse migration)
- ✅ Added comments explaining the removal

## Verification
Actual workflow tables in schema (17 total):
```
workflows_tenantlist
workflows_tenantform
workflows_tenantformentity
workflows_tenantformfield
workflows_tenantformrule
workflows_tenantworkflow
workflows_tenantworkflowcondition
workflows_tenantworkflowaction
workflows_workflowexecutionlog
workflows_formsubmission
workflows_formstepsubmission
workflows_formsubmissionfile
workflows_formsubmissionevent
workflows_formstatushistory
workflows_stepassignment
workflows_usernotification
workflows_usernotificationpreferences
```

Note: `workflows_formsubmissionvalue` is **NOT** in this list.

## Testing
- [x] Migration 0014 already marked as applied via ops-db-surgery
- [ ] Migration 0015 will apply cleanly after this fix
- [ ] All 17 existing workflow tables will have RLS policies enabled

## Related
- Failed deployment: https://github.com/Meats-Central/ProjectMeats/actions/runs/22493925082
- Surgery workflow run: https://github.com/Meats-Central/ProjectMeats/actions/runs/22493672768
- PR #3325: Phase 6 completion (created migration 0015)
- PR #3327: Force deployment trigger