### PR TITLE
fix: Replace xargs with set -a pattern in ops-db-surgery

### DIFF
--- a/.github/workflows/98-ops-db-surgery.yml
+++ b/.github/workflows/98-ops-db-surgery.yml
@@ -84,8 +84,11 @@ jobs:
           sshpass -e ssh -o StrictHostKeyChecking=no $USER@$HOST << 'ENDSSH'
           set -euo pipefail
           
-          # Load database credentials from backend .env
-          export $(grep -v '^#' /root/projectmeats/backend/.env | xargs)
+          # Load database credentials from backend .env (Golden Standard pattern)
+          # This handles quoted values correctly, unlike xargs
+          set -a
+          [ -f /root/projectmeats/backend/.env ] && . /root/projectmeats/backend/.env
+          set +a
           
           # Execute SQL with PGPASSWORD
           export PGPASSWORD="$DB_PASSWORD"


### PR DESCRIPTION
## Problem
The ops-db-surgery workflow fails when the server's `.env` file contains quoted values:

```bash
export $(grep -v '^#' /root/projectmeats/backend/.env | xargs)
# ERROR: xargs: unmatched double quote
```

This causes:
1. **Unmatched Quote Error**: `xargs` cannot parse quoted strings like `DB_PASSWORD="secret123"`
2. **Unbound Variable Error**: Variables never get exported, so `$DB_PASSWORD` is undefined

## Root Cause
The `xargs` command splits on whitespace and doesn't understand shell quoting rules.

## Solution
Use the **Golden Standard env loader pattern** with `set -a` (allexport):

```bash
set -a
[ -f /root/projectmeats/backend/.env ] && . /root/projectmeats/backend/.env
set +a
```

### Why This Works
- `set -a`: Automatically exports all variables as they're set
- `. /path/to/.env`: Sources the file using shell's native parser (handles quotes correctly)
- `set +a`: Disables auto-export after loading
- `[ -f ... ] &&`: Safe check to prevent errors if file doesn't exist

## Testing
After merge, will run final RLS audit query:
```sql
SELECT relname, relrowsecurity 
FROM pg_class 
WHERE relname LIKE 'workflows_%' AND relkind = 'r' 
ORDER BY relname ASC;
```

Expected: All 17 workflow tables show `t` for `relrowsecurity`

## Related
- Failed run: #22494886958
- Migration 0015 successfully deployed (Run #22494406445)
- Phase 6 completion: PR #3325