### PR TITLE
fix: Use robust line-by-line parser for .env loading

### DIFF
--- a/.github/workflows/98-ops-db-surgery.yml
+++ b/.github/workflows/98-ops-db-surgery.yml
@@ -84,11 +84,19 @@ jobs:
           sshpass -e ssh -o StrictHostKeyChecking=no $USER@$HOST << 'ENDSSH'
           set -euo pipefail
           
-          # Load database credentials from backend .env (Golden Standard pattern)
-          # This handles quoted values correctly, unlike xargs
-          set -a
-          [ -f /root/projectmeats/backend/.env ] && . /root/projectmeats/backend/.env
-          set +a
+          # Load database credentials from backend .env (Robust parser)
+          # Handles quoted values, comments, and malformed lines
+          while IFS='=' read -r key value; do
+            # Skip empty lines and comments
+            [[ -z "$key" || "$key" =~ ^#.*$ ]] && continue
+            # Remove quotes from value if present
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            # Export the variable
+            export "$key=$value"
+          done < <(grep -v '^#' /root/projectmeats/backend/.env | grep '=' || true)
           
           # Execute SQL with PGPASSWORD
           export PGPASSWORD="$DB_PASSWORD"


### PR DESCRIPTION
## Problem  
The ops-db-surgery workflow still fails even after switching from `xargs` to `set -a`:

```
/root/projectmeats/backend/.env: line 1: unexpected EOF while looking for matching quote
```

**Root Cause**: The .env file on the server has a **malformed quote** (likely an unclosed string or special character).

## Why Previous Fixes Failed

1. **xargs**: Can't parse quoted strings at all
2. **set -a + source**: Relies on shell's parser, which fails on syntax errors

Both require perfectly valid shell syntax.

## Solution: Line-by-Line Parser

Parse the .env file **manually** without relying on shell interpretation:

```bash
while IFS='=' read -r key value; do
  # Skip empty lines and comments
  [[ -z "$key" || "$key" =~ ^#.*$ ]] && continue
  
  # Remove quotes from value (both " and ')
  value="${value%\"}"
  value="${value#\"}"
  value="${value%\'}"
  value="${value#\'}"
  
  # Export the variable
  export "$key=$value"
done < <(grep -v '^#' /root/projectmeats/backend/.env | grep '=' || true)
```

### Why This Works
- **Manual parsing**: Doesn't rely on shell's quote interpreter
- **Quote stripping**: Removes both " and ' from values
- **Graceful failures**: `|| true` prevents errors on malformed lines
- **Flexible**: Handles real-world .env files with inconsistent formatting

## Testing
After merge, will re-run the final RLS audit query.

## Related
- PR #3330: First fix attempt (xargs → set -a)
- Failed run: #22495189972
- Original issue: Server .env has malformed quotes