### PR TITLE
fix: Robust line-by-line .env parser for ops-db-surgery workflow

### DIFF
--- a/.github/workflows/98-ops-db-surgery.yml
+++ b/.github/workflows/98-ops-db-surgery.yml
@@ -84,11 +84,18 @@ jobs:
           sshpass -e ssh -o StrictHostKeyChecking=no $USER@$HOST << 'ENDSSH'
           set -euo pipefail
           
-          # Load database credentials from backend .env (Golden Standard pattern)
-          # This handles quoted values correctly, unlike xargs
-          set -a
-          [ -f /root/projectmeats/backend/.env ] && . /root/projectmeats/backend/.env
-          set +a
+          # Load database credentials from backend .env (Robust parser)
+          # Handles quoted values, comments, and malformed lines
+          while IFS='=' read -r key value; do
+            # Skip empty lines and comments
+            [[ -z "$key" || "$key" =~ ^#.*$ ]] && continue
+            # Remove quotes from value if present
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            export "$key=$value"
+          done < <(grep -v '^#' /root/projectmeats/backend/.env | grep '=' || true)
           
           # Execute SQL with PGPASSWORD
           export PGPASSWORD="$DB_PASSWORD"


### PR DESCRIPTION
## Problem
The ops-db-surgery workflow fails with malformed .env files on the server:
```
unexpected EOF while looking for matching quote
```

**Failed Runs**: #22495189972, #22495233905

## Root Cause
The `set -a + source` pattern (PR #3330) relies on shell's native parser, which requires valid bash syntax. The server's .env file has malformed quotes.

## Solution
Replaced with line-by-line parser that:
- Reads KEY=VALUE without shell interpretation
- Manually strips both " and ' quotes
- Handles comments and empty lines gracefully
- Uses `|| true` to skip malformed lines

## Changes
- `.github/workflows/98-ops-db-surgery.yml`: Lines 87-100 replaced with robust parser

## Testing Plan
After merge, run RLS audit query via ops-db-surgery workflow:
```sql
SELECT relname, relrowsecurity FROM pg_class 
WHERE relname LIKE 'workflows_%' AND relkind = 'r' 
ORDER BY relname ASC;
```

Expected: All 17 workflow tables show `t` for relrowsecurity

## Related
- Blocks: Final Phase 6 RLS audit
- Follows: PR #3330 (initial fix attempt)