### PR TITLE
fix: Correct typo in App.tsx import statement

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tantml:query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
 import { NavigationProvider } from './contexts/NavigationContext';
 import { ThemeProvider } from './contexts/ThemeContext';


### PR DESCRIPTION
## Hotfix: Import Typo Breaking Frontend Build

**Fixes deployment failure from run #22503842528**

### Issue
Frontend build failed with:
```
error during build:
[vite]: Rollup failed to resolve import "@tantml:query" from "/workspaces/ProjectMeats/frontend/src/App.tsx".
```

### Root Cause
Typo introduced in PR #3366 when adding i18n initialization:
- ❌ Used: `@tantml:query`
- ✅ Should be: `@tanstack/react-query`

### Fix
- Corrected import statement in frontend/src/App.tsx
- All imports now resolve correctly

### Testing
```bash
npm run build
# ✓ built in 24.96s
# All chunks generated successfully
```

### Impact
- ✅ Frontend builds successfully
- ✅ Deployment can proceed
- ✅ No other changes needed

### Checklist
- [x] Build tested locally
- [x] Import statement corrected
- [x] No other typos in file
- [x] Single-line fix (surgical)
