### PR TITLE
fix: migration 0021 - rename timestamps to match model inheritance (v2)

### DIFF
--- a/backend/tenant_apps/workflows/migrations/0021_remove_tenantformfield_computed_validation_and_more.py
+++ b/backend/tenant_apps/workflows/migrations/0021_remove_tenantformfield_computed_validation_and_more.py
@@ -1,6 +1,7 @@
 # Generated to fix Phase 2 migration issues
 # - Remove Phase 2.5 fields from TenantFormField (never added to model)
-# - Add missing inherited fields to TenantFormVersion (created_on, modified_on, custom_data)
+# - Rename TenantFormVersion timestamps to match TenantAwareModel inheritance
+# - Add missing custom_data field to TenantFormVersion
 
 from django.db import migrations, models
 import django.db.models.deletion
@@ -28,19 +29,20 @@ class Migration(migrations.Migration):
             name='strict_type_checking',
         ),
         
-        # Add missing inherited fields to TenantFormVersion
-        # (These come from TenantAwareModel -> TimestampModel)
-        migrations.AddField(
+        # Rename timestamp fields to match TenantAwareModel inheritance
+        # This preserves existing data while aligning with TimestampModel
+        migrations.RenameField(
             model_name='tenantformversion',
-            name='created_on',
-            field=models.DateTimeField(auto_now_add=True, default='2026-01-01T00:00:00Z'),
-            preserve_default=False,
+            old_name='created_at',
+            new_name='created_on',
         ),
-        migrations.AddField(
+        migrations.RenameField(
             model_name='tenantformversion',
-            name='modified_on',
-            field=models.DateTimeField(auto_now=True),
+            old_name='updated_at',
+            new_name='modified_on',
         ),
+        
+        # Add missing custom_data field (inherited from TenantAwareModel)
         migrations.AddField(
             model_name='tenantformversion',
             name='custom_data',
@@ -52,15 +54,5 @@ class Migration(migrations.Migration):
             model_name='tenantformversion',
             name='tenant',
             field=models.ForeignKey(help_text='Tenant this entity belongs to', on_delete=django.db.models.deletion.CASCADE, to='tenants.tenant'),
-        ),
-        
-        # Remove incorrectly named fields from migration 0019
-        migrations.RemoveField(
-            model_name='tenantformversion',
-            name='created_at',
-        ),
-        migrations.RemoveField(
-            model_name='tenantformversion',
-            name='updated_at',
         ),
     ]

--- a/backend/tenant_apps/workflows/models.py
+++ b/backend/tenant_apps/workflows/models.py
@@ -301,8 +301,7 @@ class TenantFormVersion(TenantAwareModel):
         help_text="Whether this is the current active version"
     )
     
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # NOTE: created_on, modified_on, tenant, and custom_data are inherited from TenantAwareModel
     
     class Meta:
         verbose_name = "Form Version"


### PR DESCRIPTION
## Problem
PR #3417 merged migration 0021 but it still fails CI:
```
Migrations for 'workflows':
  tenant_apps/workflows/migrations/0022_tenantformversion_created_at_and_more.py
    + Add field created_at to tenantformversion
    + Add field updated_at to tenantformversion
❌ ERROR: Unapplied model changes detected!
```

## Root Cause
TenantFormVersion had BOTH:
1. **Explicit fields**: `created_at`, `updated_at` (lines 304-305)
2. **Inherited fields**: `created_on`, `modified_on` (from TenantAwareModel)

Migration 0021 (PR #3417) used RemoveField + AddField, but model still had explicit definitions.

## Solution
1. **Removed explicit timestamp fields** from TenantFormVersion model
2. **Changed migration 0021** to use **RenameField** instead:
   - `created_at` → `created_on`
   - `updated_at` → `modified_on`
3. **Preserves existing data** while aligning with inheritance

## Key Difference from #3417
- **Old**: RemoveField(created_at) + AddField(created_on) - loses data!
- **New**: RenameField(created_at → created_on) - preserves data!

## References
- Supersedes: #3418 (had merge conflicts)
- Previous attempt: #3417 (wrong approach)
- Failed deployment: https://github.com/Meats-Central/ProjectMeats/actions/runs/22643114356