### PR TITLE
fix: Restore correct Form Process node (Group variant)

### DIFF
--- a/frontend/src/components/FlowEditor/nodeTypes.ts
+++ b/frontend/src/components/FlowEditor/nodeTypes.ts
@@ -132,30 +132,31 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
     hidden: true, // Deprecated - use 'form' instead
   },
   
+  // DEPRECATED: FormProcess (Basic) - Use formProcessGroup instead
   formProcess: {
     id: 'formProcess',
-    name: 'Form Process',
+    name: 'Form Process (Basic - Deprecated)',
     category: 'form',
     icon: '📦',
     color: '#8b5cf6', // purple - distinct from regular form blue
-    description: 'Multi-step form container - drag Form nodes here to create a sequential workflow',
-    maxInputs: 1,
-    maxOutputs: 1,
-    requiresConfig: true,
-  },
-  
-  // DEPRECATED: FormProcessGroup - Use regular formProcess instead
-  formProcessGroup: {
-    id: 'formProcessGroup',
-    name: 'Form Process (Multi-Step - Deprecated)',
-    category: 'form',
-    icon: '📂',
-    color: '#a78bfa', // lighter purple - group variant
-    description: 'DEPRECATED: Use Form Process node instead. This multi-step container has been consolidated.',
+    description: 'DEPRECATED: Use Form Process Group node instead. This basic container has been superseded by the advanced group implementation.',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
     hidden: true, // Hide from node palette
+  },
+  
+  // Advanced Form Process with React Flow grouping
+  formProcessGroup: {
+    id: 'formProcessGroup',
+    name: 'Form Process',
+    category: 'form',
+    icon: '📂',
+    color: '#a78bfa', // lighter purple - group variant
+    description: 'Advanced form container with labeled header, automatic step sequencing, and React Flow grouping',
+    maxInputs: 1,
+    maxOutputs: 1,
+    requiresConfig: true,
   },
   
   // DEPRECATED: Phase 2 - Backward compatibility aliases (2026-02-14)

--- a/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
@@ -105,7 +105,10 @@ const GroupContainer = styled.div<{ isExpanded: boolean; stepCount: number; isDr
       : 'rgb(var(--color-background-secondary))';
   }};
   
-  border: 2px ${props => props.isExpanded ? 'dashed' : 'solid'} ${props => 
+  /* FIX: Split border shorthand to prevent disappearing during collapse */
+  border-width: 2px;
+  border-style: ${props => props.isExpanded ? 'dashed' : 'solid'};
+  border-color: ${props => 
     props.isDropTarget ? 'rgba(139, 92, 246, 0.8)' : 'rgba(139, 92, 246, 0.5)'
   };
   border-radius: 12px;
@@ -117,7 +120,14 @@ const GroupContainer = styled.div<{ isExpanded: boolean; stepCount: number; isDr
     : '0 4px 12px rgba(0, 0, 0, 0.1), 0 0 0 4px rgba(139, 92, 246, 0.1)'
   };
   
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  /* FIX: Only transition specific properties, not all */
+  transition: 
+    min-width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    min-height 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    border-style 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   
   &:hover {
     box-shadow: 


### PR DESCRIPTION
## Problem

PR #3437 deprecated the **wrong** Form Process node. It hid `formProcessGroup` (the advanced implementation) instead of `formProcess` (the basic implementation).

## Analysis

There are two Form Process implementations:

1. **`formProcess`** (📦) - Basic multi-step container (created Feb 12)
2. **`formProcessGroup`** (📂) - Advanced container with React Flow grouping (created Feb 19)

The `formProcessGroup` node is:
- Newer implementation (7 days later)
- Marked as "IDEAL container implementation" in code comments
- Has more features: labeled headers, auto-layout, database persistence
- Uses React Flow's native grouping behavior

## Solution

This PR corrects the deprecation:

✅ **Kept**: `formProcessGroup` - Advanced Form Process with React Flow grouping
❌ **Deprecated**: `formProcess` - Basic Form Process (simpler implementation)

## Changes

1. **frontend/src/components/FlowEditor/nodeTypes.ts**
   - Deprecated `formProcess` (basic) instead of `formProcessGroup`
   - Updated descriptions to clarify which is the preferred implementation
   - `formProcessGroup` now shows as "Form Process" in the palette

2. **frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx**
   - Applied CSS border fix (split shorthand border property)
   - Prevents border from disappearing during collapse/expand animations
   - Split `border` into `border-width`, `border-style`, `border-color`
   - Updated transition to specific properties (not `all`)

## Testing

- [ ] Verify "Form Process" node (📂) appears in palette
- [ ] Verify basic "Form Process (Basic - Deprecated)" (📦) is hidden
- [ ] Test collapse/expand animation - border should remain visible
- [ ] Verify existing workflows with `formProcess` nodes still work (backward compatibility)

## Related

- Fixes issue from PR #3437
- Ensures CSS fix is applied to the correct (preferred) implementation