### PR TITLE
fix: Cockpit Navigation Integration - SmartSearch + BreadcrumbBar

### DIFF
--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -23,6 +23,7 @@ import {
   Users, Building2, Package, TrendingUp, X, Home 
 } from 'lucide-react';
 import { apiClient } from '../../services/apiService';
+import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -472,10 +473,12 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
   onSelectEntity,
   onClose,
 }) => {
+  // Use global navigation context instead of local breadcrumbs
+  const navigation = useCockpitNavigation();
+  
   const [query, setQuery] = useState(initialQuery);
   const [results, setResults] = useState<Record<string, SearchEntity[]>>({});
   const [relationalChunks, setRelationalChunks] = useState<RelationalChunk[]>([]);
-  const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([{ id: 'home', label: 'Search' }]);
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(false);
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -677,14 +680,16 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
   }, []);
 
   /**
-   * Handle entity selection
+   * Handle entity selection - Push to navigation stack
    */
   const handleSelectEntity = useCallback((entity: SearchEntity) => {
-    // Add to breadcrumbs
-    setBreadcrumbs(prev => [
-      ...prev,
-      { id: entity.id, label: entity.name, entity },
-    ]);
+    // Add to navigation stack (replaces breadcrumbs)
+    navigation.addStep({
+      id: parseInt(entity.id),
+      type: entity.type,
+      label: entity.name,
+      subtitle: entity.subtitle,
+    });
 
     // Load relational chunks
     loadRelationalChunks(entity);
@@ -693,29 +698,36 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
     if (onSelectEntity) {
       onSelectEntity(entity);
     }
-  }, [loadRelationalChunks, onSelectEntity]);
+  }, [navigation, loadRelationalChunks, onSelectEntity]);
 
   /**
-   * Navigate breadcrumb
+   * Navigate to a specific step in the path
    */
-  const handleBreadcrumbClick = useCallback((index: number) => {
-    const newBreadcrumbs = breadcrumbs.slice(0, index + 1);
-    setBreadcrumbs(newBreadcrumbs);
+  const handleNavigateToStep = useCallback((index: number) => {
+    // Use navigation context to jump to step
+    navigation.goToStep(index);
 
-    // If navigating back to home, show search results
-    if (index === 0) {
+    // If navigating back to root (no steps), show search results
+    if (index === -1 || navigation.path.length === 0) {
       setRelationalChunks([]);
       if (query) {
         searchEntities(query);
       }
     } else {
-      // Load relational chunks for the selected entity
-      const entity = newBreadcrumbs[index].entity;
-      if (entity) {
+      // Load relational chunks for the selected step
+      const step = navigation.path[index];
+      if (step) {
+        // Convert NavigationStep back to SearchEntity format
+        const entity: SearchEntity = {
+          id: step.id.toString(),
+          type: step.type as any,
+          name: step.label,
+          subtitle: step.subtitle,
+        };
         loadRelationalChunks(entity);
       }
     }
-  }, [breadcrumbs, query, loadRelationalChunks, searchEntities]);
+  }, [navigation, query, loadRelationalChunks, searchEntities]);
 
   /**
    * Handle quick action click
@@ -912,17 +924,27 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
           )}
         </SearchInputWrapper>
 
-        {breadcrumbs.length > 1 && (
+        {/* Breadcrumbs now use navigation.path from context */}
+        {navigation.path.length > 0 && (
           <Breadcrumbs>
-            {breadcrumbs.map((crumb, index) => (
-              <React.Fragment key={crumb.id}>
-                {index > 0 && <BreadcrumbSeparator size={14} />}
+            {/* Always show "Home" root */}
+            <BreadcrumbItem
+              $isActive={navigation.path.length === 0}
+              onClick={() => handleNavigateToStep(-1)}
+            >
+              <Home size={12} />
+              Search
+            </BreadcrumbItem>
+            
+            {/* Render navigation path */}
+            {navigation.path.map((step, index) => (
+              <React.Fragment key={`${step.type}-${step.id}`}>
+                <BreadcrumbSeparator size={14} />
                 <BreadcrumbItem
-                  $isActive={index === breadcrumbs.length - 1}
-                  onClick={() => handleBreadcrumbClick(index)}
+                  $isActive={index === navigation.path.length - 1}
+                  onClick={() => handleNavigateToStep(index)}
                 >
-                  {index === 0 && <Home size={12} />}
-                  {crumb.label}
+                  {step.label}
                 </BreadcrumbItem>
               </React.Fragment>
             ))}
@@ -938,7 +960,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
             </EmptyIcon>
             <EmptyTitle>Searching...</EmptyTitle>
           </EmptyState>
-        ) : breadcrumbs.length > 1 ? (
+        ) : navigation.path.length > 0 ? (
           renderRelationalChunks()
         ) : (
           renderSearchResults()

--- a/frontend/src/components/Cockpit/index.ts
+++ b/frontend/src/components/Cockpit/index.ts
@@ -5,6 +5,7 @@
  */
 export { CommandBar } from './CommandBar';
 export { SmartSearch } from './SmartSearch';
+export { BreadcrumbBar } from './BreadcrumbBar';
 export { CockpitTour, resetCockpitTour, hasCompletedTour } from './CockpitTour';
 export type { SearchEntity, RelationalChunk, BreadcrumbItem, SmartSearchProps } from './SmartSearch';
 export type { CommandBarProps } from './CommandBar';

--- a/frontend/src/pages/Cockpit/CockpitDashboard.tsx
+++ b/frontend/src/pages/Cockpit/CockpitDashboard.tsx
@@ -35,7 +35,7 @@ import {
   EmailIntegrationWidget,
   EmailIngestionMonitorWidget,
 } from '../../components/Widgets';
-import { CommandBar, CockpitTour, SmartSearch } from '../../components/Cockpit';
+import { CommandBar, CockpitTour, SmartSearch, BreadcrumbBar } from '../../components/Cockpit';
 import { CommandPalette } from '../../components/Navigation/CommandPalette';
 import { useCommandPalette } from '../../hooks/useCommandPalette';
 import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
@@ -655,15 +655,21 @@ export const CockpitDashboard: React.FC = () => {
       {/* Command Palette Modal - Keep for ⌘K shortcut */}
       <CommandPalette isOpen={isPaletteOpen} onClose={closePalette} />
 
-      {/* NEW: Embedded Search View */}
+      {/* NEW: Embedded Search View with BreadcrumbBar */}
       {isSearchView && (
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', padding: '16px' }}>
-          <div style={{ marginBottom: '16px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '16px' }}>
             <ActionButton onClick={() => setIsSearchView(false)}>
               <ArrowLeft size={16} />
               Back to Widgets
             </ActionButton>
+            
+            {/* Breadcrumb navigation bar */}
+            {navigation.path.length > 0 && (
+              <BreadcrumbBar />
+            )}
           </div>
+          
           <SmartSearch 
             onSelectEntity={(entity) => {
               navigation.addStep({


### PR DESCRIPTION
## Problem

**Gap 1 & 2**: SmartSearch was using its own internal breadcrumbs state instead of the global CockpitNavigationContext, and BreadcrumbBar component was not being rendered in CockpitDashboard.

This prevented:
- Shared navigation state across components
- Visual breadcrumb trail for drill-down exploration
- "Continuous browsing" experience (no modals, no page refreshes)

## Solution

### SmartSearch.tsx
- ✅ Import and use `useCockpitNavigation()` hook
- ✅ Remove local `breadcrumbs` state (line 479)
- ✅ Replace `setBreadcrumbs` with `navigation.addStep()`
- ✅ Update `handleBreadcrumbClick` → `handleNavigateToStep` using `navigation.goToStep()`
- ✅ Render breadcrumbs from `navigation.path` instead of local state
- ✅ Update dependency arrays to use navigation context

### CockpitDashboard.tsx
- ✅ Import `BreadcrumbBar` component
- ✅ Render `BreadcrumbBar` in search view header (alongside Back button)
- ✅ Only show when `navigation.path.length > 0`
- ✅ Provides visual navigation trail

### Cockpit/index.ts
- ✅ Export `BreadcrumbBar` for use across Cockpit pages

## Benefits

1. **Global Navigation State**: All Cockpit components share same navigation context
2. **Visual Breadcrumb Trail**: Users see exactly where they are in drill-down
3. **Back Navigation**: Click any breadcrumb to jump back to that entity
4. **Continuous Browsing**: No modals, no page refreshes, seamless UX
5. **Persistence**: Navigation path saved in sessionStorage

## Testing Checklist

- [ ] Search for customer → breadcrumb appears
- [ ] Click customer → new breadcrumb added for that customer
- [ ] Click order within customer → another breadcrumb added
- [ ] Click customer breadcrumb → jumps back to customer view
- [ ] Click "Back to Widgets" → clears navigation path
- [ ] Refresh page → navigation path restored from sessionStorage (if within same session)

## Related

- Implements DELEGATION 1 from user requirements
- Resolves Gap 1 & 2 from `remaining-gaps.md`
- Builds on PR #3436 (Fuzzy Discovery)