### PR TITLE
Fix: idempotent workflows migration 0022

### DIFF
--- a/backend/tenant_apps/workflows/migrations/0022_add_tenant_to_step_models.py
+++ b/backend/tenant_apps/workflows/migrations/0022_add_tenant_to_step_models.py
@@ -45,55 +45,142 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # Step 1: Add tenant field to FormStepSubmission (nullable for backfill)
-        migrations.AddField(
-            model_name='formstepsubmission',
-            name='tenant',
-            field=models.ForeignKey(
-                null=True,
-                blank=True,
-                on_delete=models.CASCADE,
-                related_name='form_step_submissions',
-                to='tenants.tenant',
-                help_text='Tenant owning this step submission'
-            ),
+        # Step 1: Ensure tenant_id exists (idempotent) and reflect it in Django state.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    DO $$
+                    BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1
+                            FROM information_schema.columns
+                            WHERE table_name = 'workflows_formstepsubmission'
+                              AND column_name = 'tenant_id'
+                        ) THEN
+                            ALTER TABLE workflows_formstepsubmission ADD COLUMN tenant_id uuid NULL;
+                        END IF;
+                    END $$;
+                    """,
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                    DO $$
+                    BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1
+                            FROM pg_constraint c
+                            JOIN pg_class t ON t.oid = c.conrelid
+                            WHERE t.relname = 'workflows_formstepsubmission'
+                              AND c.conname = 'workflows_formstepsubmission_tenant_id_fkey'
+                        ) THEN
+                            ALTER TABLE workflows_formstepsubmission
+                                ADD CONSTRAINT workflows_formstepsubmission_tenant_id_fkey
+                                FOREIGN KEY (tenant_id)
+                                REFERENCES tenants_tenant(id)
+                                ON DELETE CASCADE;
+                        END IF;
+                    END $$;
+                    """,
+                    reverse_sql="""
+                    ALTER TABLE workflows_formstepsubmission
+                        DROP CONSTRAINT IF EXISTS workflows_formstepsubmission_tenant_id_fkey;
+                    """,
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name='formstepsubmission',
+                    name='tenant',
+                    field=models.ForeignKey(
+                        null=True,
+                        blank=True,
+                        on_delete=models.CASCADE,
+                        related_name='form_step_submissions',
+                        to='tenants.tenant',
+                        help_text='Tenant owning this step submission',
+                    ),
+                ),
+            ],
         ),
-        
+
         # Step 2: Backfill tenant values from parent relationships
         migrations.RunPython(
             backfill_tenant_for_formstepsubmission,
             reverse_code=migrations.RunPython.noop,
         ),
+
         # Step 3: Make tenant required (after backfill)
-        migrations.AlterField(
-            model_name='formstepsubmission',
-            name='tenant',
-            field=models.ForeignKey(
-                on_delete=models.CASCADE,
-                related_name='form_step_submissions',
-                to='tenants.tenant',
-                help_text='Tenant owning this step submission'
-            ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    ALTER TABLE workflows_formstepsubmission
+                        ALTER COLUMN tenant_id SET NOT NULL;
+                    """,
+                    reverse_sql="""
+                    ALTER TABLE workflows_formstepsubmission
+                        ALTER COLUMN tenant_id DROP NOT NULL;
+                    """,
+                ),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name='formstepsubmission',
+                    name='tenant',
+                    field=models.ForeignKey(
+                        on_delete=models.CASCADE,
+                        related_name='form_step_submissions',
+                        to='tenants.tenant',
+                        help_text='Tenant owning this step submission',
+                    ),
+                ),
+            ],
         ),
-        # Step 4: Add database indexes for performance
-        migrations.AddIndex(
-            model_name='formstepsubmission',
-            index=models.Index(fields=['tenant', 'status'], name='fss_tenant_status_idx'),
+
+        # Step 4: Add database indexes for performance (idempotent)
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    CREATE INDEX IF NOT EXISTS fss_tenant_status_idx
+                        ON workflows_formstepsubmission (tenant_id, status);
+                    """,
+                    reverse_sql="""
+                    DROP INDEX IF EXISTS fss_tenant_status_idx;
+                    """,
+                ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name='formstepsubmission',
+                    index=models.Index(fields=['tenant', 'status'], name='fss_tenant_status_idx'),
+                ),
+            ],
         ),
-        # Step 5: Enable Row-Level Security (RLS) for tenant isolation
+
+        # Step 5: Enable Row-Level Security (RLS) for tenant isolation (idempotent)
         migrations.RunSQL(
             sql="""
-            -- Enable RLS on FormStepSubmission
             ALTER TABLE workflows_formstepsubmission ENABLE ROW LEVEL SECURITY;
-            
-            CREATE POLICY formstepsubmission_tenant_isolation ON workflows_formstepsubmission
-                USING (tenant_id = current_setting('app.current_tenant')::uuid);
-            
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_policies
+                    WHERE tablename = 'workflows_formstepsubmission'
+                      AND policyname = 'formstepsubmission_tenant_isolation'
+                ) THEN
+                    CREATE POLICY formstepsubmission_tenant_isolation ON workflows_formstepsubmission
+                        USING (tenant_id = current_setting('app.current_tenant')::uuid);
+                END IF;
+            END $$;
             """,
             reverse_sql="""
             DROP POLICY IF EXISTS formstepsubmission_tenant_isolation ON workflows_formstepsubmission;
             ALTER TABLE workflows_formstepsubmission DISABLE ROW LEVEL SECURITY;
-            
-            """
+            """,
         ),
     ]


### PR DESCRIPTION
Dev deploy failed in workflows.0022_add_tenant_to_step_models due to DuplicateColumn (tenant_id already exists on workflows_formstepsubmission).\n\nThis makes 0022 idempotent using SeparateDatabaseAndState + RunSQL guards (column/FK/index/policy) so migrations succeed even with partial/schema-drifted environments.