### PR TITLE
Fix: workflows.0022 backfill tenant via TenantForm

### DIFF
--- a/backend/tenant_apps/workflows/migrations/0022_add_tenant_to_step_models.py
+++ b/backend/tenant_apps/workflows/migrations/0022_add_tenant_to_step_models.py
@@ -12,8 +12,9 @@ def backfill_tenant_for_formstepsubmission(apps, schema_editor):
     # Use raw SQL for efficiency with large datasets
     schema_editor.execute("""
         UPDATE workflows_formstepsubmission fss
-        SET tenant_id = fs.tenant_id
+        SET tenant_id = tf.tenant_id
         FROM workflows_formsubmission fs
+        JOIN workflows_tenantform tf ON tf.id = fs.form_id
         WHERE fss.submission_id = fs.id
         AND fss.tenant_id IS NULL;
     """)


### PR DESCRIPTION
Deployment is failing inside workflows.0022 backfill with: column fs.tenant_id does not exist.\n\nAdjust backfill to derive tenant_id via workflows_tenantform (fs.form_id -> tf.tenant_id) instead of relying on workflows_formsubmission.tenant_id being present.