### PR TITLE
Fix: frontend deploy tolerates unset SENTRY vars

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -1125,8 +1125,8 @@ jobs:
           window.ENV = {
             API_BASE_URL: "${API_BASE_URL}",
             ENVIRONMENT: "${ENVIRONMENT}",
-            SENTRY_DSN: "${SENTRY_DSN}",
-            SENTRY_ENABLED: "${SENTRY_ENABLED}"
+            SENTRY_DSN: "${SENTRY_DSN:-}",
+            SENTRY_ENABLED: "${SENTRY_ENABLED:-false}"
           };
           ENVJS
           


### PR DESCRIPTION
Dev deploy failed because frontend remote script runs with set -u and env-config.js references SENTRY_DSN/SENTRY_ENABLED when unset.\n\nUse safe parameter expansion defaults in reusable-deploy.yml:  and false.