### PR TITLE
Cockpit: record pivot + pinned tools bar

### DIFF
--- a/backend/apps/system/urls.py
+++ b/backend/apps/system/urls.py
@@ -57,7 +57,7 @@ urlpatterns = [
     ),
     path(
         'entities/<str:type>/<str:pk>/',
-        EntityViewSet.as_view({'get': 'retrieve'}),
+        EntityViewSet.as_view({'get': 'retrieve', 'patch': 'partial_update'}),
         name='entity-detail',
     ),
 

--- a/backend/apps/system/views/entity_viewset.py
+++ b/backend/apps/system/views/entity_viewset.py
@@ -11,20 +11,22 @@ from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.exceptions import PermissionDenied
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
 
 
 class EntityViewSet(viewsets.ViewSet):
-    """
-    Unified entity relationship API for the Cockpit.
-    
+    """Unified entity relationship API for the Cockpit.
+
     Endpoints:
     - GET /api/v1/system/entities/{type}/{id}/relationships/ - Get related entities
-    - GET /api/v1/system/entities/{type}/{id}/ - Get single entity details
+    - GET /api/v1/system/entities/{type}/{id}/ - Get single entity details (record profile payload)
+    - PATCH /api/v1/system/entities/{type}/{id}/ - Update a single field (inline editing)
     """
+
     permission_classes = [IsAuthenticated]
-    
+
     # Map entity types to (app_label, model_name)
     MODEL_MAP = {
         'customer': ('customers', 'Customer'),
@@ -119,41 +121,143 @@ class EntityViewSet(viewsets.ViewSet):
         })
     
     def retrieve(self, request, pk=None, type=None):
+        """Get single entity details for record-centric Cockpit UI."""
+        try:
+            entity, entity_type, Model = self._get_entity_or_404(request, type=type, pk=pk)
+        except ValueError as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except LookupError as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_404_NOT_FOUND)
+        except ObjectDoesNotExist:
+            return Response({'error': 'Entity not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        can_edit = bool(getattr(request.user, 'is_staff', False) or getattr(request.user, 'is_superuser', False))
+        return Response(self._serialize_entity_detail(entity, entity_type, can_edit=can_edit))
+
+    def partial_update(self, request, pk=None, type=None):
+        """Inline editing endpoint used by Cockpit EntityProfileHeader.
+
+        Payload (minimal): {"field": "name", "value": "Acme"}
         """
-        Get single entity details.
-        
-        Example: GET /api/v1/system/entities/customer/123/
-        """
+        if not (getattr(request.user, 'is_staff', False) or getattr(request.user, 'is_superuser', False)):
+            raise PermissionDenied('You do not have permission to edit records')
+
+        try:
+            entity, entity_type, Model = self._get_entity_or_404(request, type=type, pk=pk)
+        except ValueError as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except LookupError as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_404_NOT_FOUND)
+        except ObjectDoesNotExist:
+            return Response({'error': 'Entity not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        field_name = str(request.data.get('field') or '').strip()
+        if not field_name:
+            return Response({'error': 'Missing field'}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Block known-dangerous or non-editable fields
+        blocked = {
+            'id', 'pk', 'tenant', 'tenant_id', 'custom_data',
+            'created_at', 'updated_at', 'created_on', 'updated_on',
+        }
+        if field_name in blocked:
+            return Response({'error': f'Field not editable: {field_name}'}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Only allow direct model fields (no reverse relations / m2m)
+        model_fields = {f.name: f for f in Model._meta.get_fields() if getattr(f, 'concrete', False) and not getattr(f, 'many_to_many', False)}
+        if field_name not in model_fields:
+            return Response({'error': f'Unknown field: {field_name}'}, status=status.HTTP_400_BAD_REQUEST)
+
+        field = model_fields[field_name]
+        raw_value = request.data.get('value', None)
+
+        try:
+            if getattr(field, 'is_relation', False) and getattr(field, 'many_to_one', False):
+                # FK: accept id or null
+                if raw_value in ('', None):
+                    setattr(entity, field.attname, None)
+                else:
+                    setattr(entity, field.attname, field.target_field.to_python(raw_value))
+            else:
+                setattr(entity, field.name, field.to_python(raw_value))
+
+            entity.save(update_fields=[field_name])
+        except Exception as exc:
+            return Response({'error': f'Failed to update {field_name}: {exc}'}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(self._serialize_entity_detail(entity, entity_type, can_edit=True))
+
+    def _get_entity_or_404(self, request, *, type, pk):
         tenant = request.tenant
-        
+
         if type not in self.MODEL_MAP:
-            return Response(
-                {"error": f"Unknown entity type: {type}"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
+            raise ValueError(f'Unknown entity type: {type}')
+
         app_label, model_name = self.MODEL_MAP[type]
-        
         try:
             Model = apps.get_model(app_label, model_name)
-        except LookupError:
-            return Response(
-                {"error": f"Model not found: {app_label}.{model_name}"},
-                status=status.HTTP_404_NOT_FOUND
-            )
-        
-        try:
-            if hasattr(Model, 'tenant'):
-                entity = Model.objects.filter(tenant=tenant).get(pk=pk)
+        except LookupError as exc:
+            raise LookupError(f'Model not found: {app_label}.{model_name}') from exc
+
+        if hasattr(Model, 'tenant'):
+            entity = Model.objects.filter(tenant=tenant).get(pk=pk)
+        else:
+            entity = Model.objects.get(pk=pk)
+
+        return entity, type, Model
+
+    def _entity_type_for_model(self, model):
+        """Best-effort mapping from Django model to Cockpit entity type string."""
+        if not model:
+            return None
+        for entity_type, (app_label, model_name) in self.MODEL_MAP.items():
+            if model._meta.app_label == app_label and model.__name__ == model_name:
+                return entity_type
+        return None
+
+    def _serialize_entity_detail(self, entity, entity_type, *, can_edit=False):
+        """Serialize an entity for record profile display.
+
+        Returns base identity + a safe 'fields' dict with scalar values and FK references.
+        """
+        base = self._serialize_entity(entity, entity_type)
+        Model = entity.__class__
+
+        blocked = {
+            'tenant', 'custom_data',
+        }
+        fields_payload = {}
+        for field in Model._meta.get_fields():
+            # Only include forward concrete fields
+            if not getattr(field, 'concrete', False) or getattr(field, 'many_to_many', False):
+                continue
+            if field.name in blocked:
+                continue
+
+            if getattr(field, 'is_relation', False) and getattr(field, 'many_to_one', False):
+                fk_id = getattr(entity, field.attname, None)
+                if fk_id is None:
+                    fields_payload[field.name] = None
+                    continue
+
+                rel_obj = getattr(entity, field.name, None)
+                rel_type = self._entity_type_for_model(getattr(rel_obj, '__class__', None))
+                rel_title = None
+                if rel_obj is not None:
+                    # Reuse minimal serializer to produce a stable title
+                    rel_title = self._serialize_entity(rel_obj, rel_type or field.related_model.__name__.lower()).get('title')
+
+                fields_payload[field.name] = {
+                    'id': fk_id,
+                    'type': rel_type,
+                    'title': rel_title,
+                }
             else:
-                entity = Model.objects.get(pk=pk)
-        except ObjectDoesNotExist:
-            return Response(
-                {"error": f"{model_name} not found"},
-                status=status.HTTP_404_NOT_FOUND
-            )
-        
-        return Response(self._serialize_entity(entity, type))
+                fields_payload[field.name] = getattr(entity, field.name, None)
+
+        base['fields'] = fields_payload
+        base['can_edit'] = bool(can_edit)
+        return base
     
     def _get_default_relationships(self, entity_type):
         """Return default relationship types for each entity."""

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { NotificationsProvider } from './contexts/NotificationsContext';
 import { ActionItemsProvider } from './contexts/ActionItemsContext';
 import { SessionManagerProvider } from './contexts/SessionManagerContext';
 import { CockpitNavigationProvider } from './contexts/CockpitNavigationContext';
+import { CockpitPinnedToolsProvider } from './contexts/CockpitPinnedToolsContext';
 import { ToastProvider } from './hooks/useToast';
 import Layout from './components/Layout/Layout';
 import './i18n/config'; // Initialize i18n
@@ -221,12 +222,13 @@ const App: React.FC = () => {
                 <ActionItemsProvider>
                   <QuickActionsProvider>
                     <CockpitNavigationProvider>
-                      <Router
-                        future={{
-                          v7_startTransition: true,
-                          v7_relativeSplatPath: true,
-                        }}
-                      >
+                      <CockpitPinnedToolsProvider>
+                        <Router
+                          future={{
+                            v7_startTransition: true,
+                            v7_relativeSplatPath: true,
+                          }}
+                        >
                         <SessionManagerProvider>
                           <NavigationProvider>
                     <Routes>
@@ -361,6 +363,7 @@ const App: React.FC = () => {
                           </NavigationProvider>
                         </SessionManagerProvider>
                       </Router>
+                    </CockpitPinnedToolsProvider>
                     </CockpitNavigationProvider>
                   </QuickActionsProvider>
                 </ActionItemsProvider>

--- a/frontend/src/components/Cockpit/EntityProfileHeader.tsx
+++ b/frontend/src/components/Cockpit/EntityProfileHeader.tsx
@@ -1,0 +1,247 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Spin, Typography, message, Tag } from 'antd';
+import debounce from 'lodash/debounce';
+import { businessApi } from '../../services/businessApi';
+
+const { Text } = Typography;
+
+export interface EntityReference {
+  id: string | number;
+  type?: string | null;
+  title?: string | null;
+}
+
+export interface EntityDetailResponse {
+  id: string | number;
+  type: string;
+  title: string;
+  metadata?: Record<string, unknown>;
+  created_at?: string;
+  fields?: Record<string, unknown>;
+  can_edit?: boolean;
+}
+
+export interface EntityProfileHeaderProps {
+  entityType: string;
+  entityId: string;
+  onNavigateToEntity: (entityType: string, entityId: string, label: string) => void;
+}
+
+const Container = styled.div`
+  background: rgb(var(--color-surface));
+  border: 1px solid rgb(var(--color-border));
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  margin-bottom: 12px;
+`;
+
+const TitleRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+`;
+
+const TitleBlock = styled.div`
+  min-width: 0;
+`;
+
+const Title = styled.div`
+  font-size: 18px;
+  font-weight: 700;
+  color: rgb(var(--color-text-primary));
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const Subtitle = styled.div`
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgb(var(--color-text-tertiary));
+`;
+
+const FieldsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px 16px;
+
+  @media (max-width: 1024px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const FieldRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+`;
+
+const FieldLabel = styled.div`
+  font-size: 11px;
+  font-weight: 600;
+  color: rgb(var(--color-text-tertiary));
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`;
+
+const FieldValue = styled.div`
+  font-size: 13px;
+  color: rgb(var(--color-text-primary));
+  min-width: 0;
+`;
+
+const LinkButton = styled.button`
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgb(var(--color-primary));
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const formatScalar = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+};
+
+const isEntityReference = (value: unknown): value is EntityReference => {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as any;
+  return 'id' in v && (typeof v.id === 'string' || typeof v.id === 'number');
+};
+
+export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
+  entityType,
+  entityId,
+  onNavigateToEntity,
+}) => {
+  const [data, setData] = useState<EntityDetailResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const resp = await businessApi.get(`/system/entities/${encodeURIComponent(entityType)}/${encodeURIComponent(entityId)}/`);
+      setData(resp.data as EntityDetailResponse);
+    } catch (err: any) {
+      console.error('[EntityProfileHeader] Failed to load entity:', err);
+      message.error('Failed to load record details');
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [entityType, entityId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const canEdit = Boolean(data?.can_edit);
+
+  const debouncedPatch = useMemo(
+    () => debounce(async (field: string, value: unknown) => {
+      try {
+        await businessApi.patch(
+          `/system/entities/${encodeURIComponent(entityType)}/${encodeURIComponent(entityId)}/`,
+          { field, value }
+        );
+      } catch (err: any) {
+        console.error('[EntityProfileHeader] Failed to update field:', err);
+        message.error('Failed to update field');
+        void load();
+      }
+    }, 300),
+    [entityType, entityId, load]
+  );
+
+  useEffect(() => {
+    return () => debouncedPatch.cancel();
+  }, [debouncedPatch]);
+
+  const fieldEntries = useMemo(() => {
+    const fields = data?.fields ?? {};
+    return Object.entries(fields)
+      .filter(([key]) => !['id'].includes(key))
+      .sort(([a], [b]) => a.localeCompare(b));
+  }, [data]);
+
+  return (
+    <Container>
+      <TitleRow>
+        <TitleBlock>
+          <Title title={data?.title || ''}>{data?.title || 'Record'}</Title>
+          <Subtitle>
+            <Tag color="blue">{entityType}</Tag>
+            <span style={{ marginLeft: 8 }}>ID: {entityId}</span>
+          </Subtitle>
+        </TitleBlock>
+      </TitleRow>
+
+      {loading ? (
+        <div style={{ padding: 12 }}><Spin /></div>
+      ) : (
+        <FieldsGrid>
+          {fieldEntries.map(([key, value]) => {
+            if (isEntityReference(value) && value.type && value.id !== null && value.id !== undefined) {
+              const label = value.title || `${value.type} ${value.id}`;
+              return (
+                <FieldRow key={key}>
+                  <FieldLabel>{key}</FieldLabel>
+                  <FieldValue>
+                    <LinkButton
+                      onClick={() => onNavigateToEntity(String(value.type), String(value.id), label)}
+                      title="Navigate"
+                    >
+                      {label}
+                    </LinkButton>
+                  </FieldValue>
+                </FieldRow>
+              );
+            }
+
+            const scalar = formatScalar(value);
+            const isEditable = canEdit && typeof value === 'string' && scalar.length <= 200;
+
+            return (
+              <FieldRow key={key}>
+                <FieldLabel>{key}</FieldLabel>
+                <FieldValue>
+                  {isEditable ? (
+                    <Text
+                      editable={{
+                        onChange: (next) => debouncedPatch(key, next),
+                        tooltip: 'Click to edit',
+                      }}
+                    >
+                      {scalar || <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>—</span>}
+                    </Text>
+                  ) : (
+                    scalar || <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>—</span>
+                  )}
+                </FieldValue>
+              </FieldRow>
+            );
+          })}
+        </FieldsGrid>
+      )}
+    </Container>
+  );
+};
+
+export default EntityProfileHeader;

--- a/frontend/src/components/Cockpit/PinnedToolsBar.tsx
+++ b/frontend/src/components/Cockpit/PinnedToolsBar.tsx
@@ -1,0 +1,244 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Drawer, Button, Spin } from 'antd';
+import { Calculator, Mail, PinOff, Search } from 'lucide-react';
+import { useLocation } from 'react-router-dom';
+import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
+import { useCockpitPinnedTools } from '../../contexts/CockpitPinnedToolsContext';
+import { businessApi } from '../../services/businessApi';
+import {
+  ActionItemsWidget,
+  CalendarWidget,
+  EmailIngestionMonitorWidget,
+  EmailIntegrationWidget,
+  EntityExplorerWidget,
+  MyTasksWidget,
+  QuickActionsWidget,
+  QuickStatsWidget,
+  RecentActivityWidget,
+  TodaysNumbersWidget,
+  UpcomingCallsWidget,
+} from '../Widgets';
+
+const Bar = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgb(var(--color-surface));
+  border-bottom: 1px solid rgb(var(--color-border));
+  padding: 8px 12px;
+`;
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow-x: auto;
+`;
+
+const ToolButton = styled.button<{ $active?: boolean }>`
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid rgb(var(--color-border));
+  background: ${(p) => (p.$active ? 'rgb(var(--color-primary) / 0.1)' : 'rgb(var(--color-background))')};
+  color: rgb(var(--color-text-primary));
+  cursor: pointer;
+  flex: 0 0 auto;
+
+  &:hover {
+    border-color: rgb(var(--color-primary));
+  }
+`;
+
+const ToolLabel = styled.div`
+  font-size: 11px;
+  color: rgb(var(--color-text-tertiary));
+  margin-left: 8px;
+  white-space: nowrap;
+`;
+
+const normalizeWidgetType = (type: string) =>
+  type.includes('-')
+    ? type
+        .split('-')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join('') + 'Widget'
+    : type;
+
+const renderWidget = (type: string) => {
+  switch (normalizeWidgetType(type)) {
+    case 'QuickStatsWidget':
+      return <QuickStatsWidget />;
+    case 'RecentActivityWidget':
+      return <RecentActivityWidget />;
+    case 'UpcomingCallsWidget':
+      return <UpcomingCallsWidget />;
+    case 'QuickActionsWidget':
+      return <QuickActionsWidget />;
+    case 'EntityExplorerWidget':
+      return <EntityExplorerWidget />;
+    case 'MyTasksWidget':
+      return <MyTasksWidget />;
+    case 'TodaysNumbersWidget':
+      return <TodaysNumbersWidget />;
+    case 'ActionItemsWidget':
+      return <ActionItemsWidget />;
+    case 'CalendarWidget':
+    case 'calendar':
+      return <CalendarWidget />;
+    case 'EmailIntegrationWidget':
+      return <EmailIntegrationWidget />;
+    case 'EmailIngestionMonitorWidget':
+      return <EmailIngestionMonitorWidget />;
+    default:
+      return (
+        <div style={{ padding: 16, color: 'rgb(var(--color-text-tertiary))' }}>
+          Unknown widget: {type}
+        </div>
+      );
+  }
+};
+
+export const PinnedToolsBar: React.FC = () => {
+  const location = useLocation();
+  const { path } = useCockpitNavigation();
+  const { pinned, unpin } = useCockpitPinnedTools();
+
+  const isCockpit = location.pathname.startsWith('/cockpit');
+  const activeRecord = path[path.length - 1];
+
+  const [openPinnedId, setOpenPinnedId] = useState<string | null>(null);
+  const [recordDetail, setRecordDetail] = useState<any>(null);
+  const [recordLoading, setRecordLoading] = useState(false);
+
+  const openPinned = useMemo(
+    () => pinned.find((p) => p.id === openPinnedId) ?? null,
+    [pinned, openPinnedId]
+  );
+
+  const openBuiltin = useMemo(() => {
+    if (!openPinnedId) return null;
+    if (openPinnedId === 'tool:record') return { id: openPinnedId, title: 'Record Context', icon: <Search size={14} /> };
+    if (openPinnedId === 'tool:email') return { id: openPinnedId, title: 'Email Drafter', icon: <Mail size={14} /> };
+    if (openPinnedId === 'tool:quote') return { id: openPinnedId, title: 'Smart Quote', icon: <Calculator size={14} /> };
+    return null;
+  }, [openPinnedId]);
+
+  const loadActiveRecord = useCallback(async () => {
+    if (!activeRecord) return;
+    setRecordLoading(true);
+    try {
+      const resp = await businessApi.get(`/system/entities/${encodeURIComponent(activeRecord.type)}/${encodeURIComponent(String(activeRecord.id))}/`);
+      setRecordDetail(resp.data);
+    } catch (e) {
+      console.warn('[PinnedToolsBar] Failed to load active record context:', e);
+      setRecordDetail(null);
+    } finally {
+      setRecordLoading(false);
+    }
+  }, [activeRecord]);
+
+  useEffect(() => {
+    if (openPinnedId === 'tool:record' && activeRecord) {
+      void loadActiveRecord();
+    }
+  }, [openPinnedId, activeRecord, loadActiveRecord]);
+
+  if (!isCockpit) return null;
+
+  const drawerTitle = openPinned?.title ?? openBuiltin?.title ?? '';
+  const isDrawerOpen = Boolean(openPinned || openBuiltin);
+
+  return (
+    <Bar>
+      <Row>
+        <ToolButton
+          $active={openPinnedId === 'tool:record'}
+          onClick={() => setOpenPinnedId(openPinnedId === 'tool:record' ? null : 'tool:record')}
+          title="Record Context"
+          aria-label="Record Context"
+          disabled={!activeRecord}
+        >
+          <Search size={16} />
+        </ToolButton>
+        <ToolButton
+          $active={openPinnedId === 'tool:email'}
+          onClick={() => setOpenPinnedId(openPinnedId === 'tool:email' ? null : 'tool:email')}
+          title="Email Drafter"
+          aria-label="Email Drafter"
+          disabled={!activeRecord}
+        >
+          <Mail size={16} />
+        </ToolButton>
+        <ToolButton
+          $active={openPinnedId === 'tool:quote'}
+          onClick={() => setOpenPinnedId(openPinnedId === 'tool:quote' ? null : 'tool:quote')}
+          title="Smart Quote"
+          aria-label="Smart Quote"
+          disabled={!activeRecord}
+        >
+          <Calculator size={16} />
+        </ToolButton>
+
+        {pinned.map((p) => (
+          <ToolButton
+            key={p.id}
+            $active={openPinnedId === p.id}
+            onClick={() => setOpenPinnedId(openPinnedId === p.id ? null : p.id)}
+            title={p.title}
+            aria-label={p.title}
+          >
+            📌
+          </ToolButton>
+        ))}
+
+        {activeRecord && <ToolLabel>Active: {activeRecord.label}</ToolLabel>}
+      </Row>
+
+      <Drawer
+        open={isDrawerOpen}
+        onClose={() => setOpenPinnedId(null)}
+        width={520}
+        title={drawerTitle}
+        extra={
+          openPinned ? (
+            <Button
+              icon={<PinOff size={14} /> as any}
+              onClick={() => {
+                unpin(openPinned.id);
+                setOpenPinnedId(null);
+              }}
+            >
+              Unpin
+            </Button>
+          ) : null
+        }
+      >
+        {openPinned?.kind === 'widget' && openPinned.widget ? (
+          renderWidget(openPinned.widget.type)
+        ) : openPinnedId === 'tool:record' ? (
+          recordLoading ? (
+            <Spin />
+          ) : (
+            <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              {JSON.stringify(recordDetail, null, 2)}
+            </pre>
+          )
+        ) : openPinnedId === 'tool:email' ? (
+          <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
+            Drafting from active record: <b>{activeRecord?.label}</b>. (Template + rules TBD.)
+          </div>
+        ) : openPinnedId === 'tool:quote' ? (
+          <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
+            Smart Quote for: <b>{activeRecord?.label}</b>. (Formula TBD.)
+          </div>
+        ) : (
+          <div style={{ color: 'rgb(var(--color-text-tertiary))' }}>No content</div>
+        )}
+      </Drawer>
+    </Bar>
+  );
+};
+
+export default PinnedToolsBar;

--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -16,15 +16,16 @@
  * @module SmartSearch
  */
 
-import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import styled from 'styled-components';
 import {
-  Search, Star, Clock, Phone, FileText,
+  Search, Star, Clock, FileText,
   Users, Building2, Package, TrendingUp, X
 } from 'lucide-react';
 import debounce from 'lodash/debounce';
 import { businessApi } from '../../services/businessApi';
 import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
+import { EntityProfileHeader } from './EntityProfileHeader';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -435,6 +436,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
   onSelectEntity,
   onClose,
 }) => {
+
   // Use global navigation context instead of local breadcrumbs
   const navigation = useCockpitNavigation();
   
@@ -709,23 +711,33 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
     setResults({});
     setRelationalChunks([]);
     navigation.clearPath();
-  }, [controlledQuery, navigation, onQueryChange]);
+    onClose?.();
+  }, [controlledQuery, navigation, onQueryChange, onClose]);
+
+  const activeStep = navigation.path[navigation.path.length - 1];
+
+  const handleNavigateToEntity = useCallback((nextType: string, nextId: string, label: string) => {
+    navigation.addStep({
+      id: nextId,
+      type: nextType,
+      label,
+    });
+  }, [navigation]);
 
   // Continuous browsing: whenever the breadcrumb path changes, load the active entity's relations.
   useEffect(() => {
-    const active = navigation.path[navigation.path.length - 1];
-    if (!active) {
+    if (!activeStep) {
       setRelationalChunks([]);
       return;
     }
 
     loadRelationalChunks({
-      id: active.id,
-      type: active.type,
-      name: active.label,
-      subtitle: active.subtitle,
+      id: activeStep.id,
+      type: activeStep.type,
+      name: activeStep.label,
+      subtitle: activeStep.subtitle,
     });
-  }, [navigation.path, loadRelationalChunks]);
+  }, [activeStep, loadRelationalChunks]);
 
   /**
    * Render search results (top-5 per type)
@@ -884,14 +896,22 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
       )}
 
       <ContentArea>
+        {activeStep && (
+          <EntityProfileHeader
+            entityType={activeStep.type}
+            entityId={String(activeStep.id)}
+            onNavigateToEntity={handleNavigateToEntity}
+          />
+        )}
+
         {isLoading ? (
           <EmptyState>
             <EmptyIcon>
               <Search size={48} />
             </EmptyIcon>
-            <EmptyTitle>Searching...</EmptyTitle>
+            <EmptyTitle>{activeStep ? 'Loading record context…' : 'Searching…'}</EmptyTitle>
           </EmptyState>
-        ) : navigation.path.length > 0 ? (
+        ) : activeStep ? (
           renderRelationalChunks()
         ) : (
           renderSearchResults()

--- a/frontend/src/components/Cockpit/index.ts
+++ b/frontend/src/components/Cockpit/index.ts
@@ -6,6 +6,7 @@
 export { CommandBar } from './CommandBar';
 export { SmartSearch } from './SmartSearch';
 export { BreadcrumbBar } from './BreadcrumbBar';
+export { EntityProfileHeader } from './EntityProfileHeader';
 export { CockpitTour, resetCockpitTour, hasCompletedTour } from './CockpitTour';
-export type { SearchEntity, RelationalChunk, BreadcrumbItem, SmartSearchProps } from './SmartSearch';
+export type { SearchEntity, RelationalChunk, SmartSearchProps } from './SmartSearch';
 export type { CommandBarProps } from './CommandBar';

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 import Sidebar from './Sidebar';
 import Header from './Header';
+import { PinnedToolsBar } from '../Cockpit/PinnedToolsBar';
 import Breadcrumb from '../Navigation/Breadcrumb';
 import Omnibox from '../AIAssistant/Omnibox';
 import { CommandPalette } from '../Navigation/CommandPalette';
@@ -61,6 +62,7 @@ const Layout: React.FC = () => {
       <Sidebar isOpen={sidebarOpen} onToggle={toggleSidebar} onHoverChange={handleSidebarHoverChange} />
       <MainArea $sidebarOpen={sidebarOpen} $sidebarHovered={sidebarHovered}>
         <Header />
+        <PinnedToolsBar />
         <Content $theme={theme}>
           <CenteredContainer>
             <Breadcrumb />

--- a/frontend/src/components/Widgets/WidgetCard.tsx
+++ b/frontend/src/components/Widgets/WidgetCard.tsx
@@ -14,7 +14,9 @@
  */
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
-import { RefreshCw, MoreVertical } from 'lucide-react';
+import { Pin, RefreshCw } from 'lucide-react';
+import { useCockpitPinnedTools } from '../../contexts/CockpitPinnedToolsContext';
+import { useWidgetInstance } from './WidgetInstanceContext';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -179,6 +181,11 @@ export const WidgetCard: React.FC<WidgetCardProps> = ({
   badge,
   badgeVariant = 'default',
 }) => {
+  const widgetInstance = useWidgetInstance();
+  const pinnedTools = useCockpitPinnedTools();
+
+  const isPinned = widgetInstance?.widget ? pinnedTools.isWidgetPinned(widgetInstance.widget.id) : false;
+
   return (
     <CardContainer className={className}>
       <CardHeader>
@@ -188,6 +195,16 @@ export const WidgetCard: React.FC<WidgetCardProps> = ({
           {badge && <HeaderBadge $variant={badgeVariant}>{badge}</HeaderBadge>}
         </HeaderLeft>
         <HeaderActions>
+          {widgetInstance?.onPinWidget && widgetInstance.widget && (
+            <IconButton
+              onClick={() => widgetInstance.onPinWidget?.(widgetInstance.widget)}
+              title={isPinned ? 'Pinned' : 'Pin to tools'}
+              aria-label={isPinned ? 'Pinned' : 'Pin to tools'}
+              disabled={isPinned}
+            >
+              <Pin size={14} />
+            </IconButton>
+          )}
           {actions}
           {onRefresh && (
             <IconButton onClick={onRefresh} disabled={loading} title="Refresh">

--- a/frontend/src/components/Widgets/WidgetGrid.tsx
+++ b/frontend/src/components/Widgets/WidgetGrid.tsx
@@ -13,11 +13,12 @@
  * Theme Compliance:
  * - Uses CSS custom properties
  */
-import React, { useState, useCallback, useEffect } from 'react';
-import GridLayout, { Layout } from 'react-grid-layout';
+import React, { useCallback } from 'react';
+import GridLayout, { LayoutItem } from 'react-grid-layout';
 import styled from 'styled-components';
 import { X } from 'lucide-react';
 import 'react-grid-layout/css/styles.css';
+import { WidgetInstanceProvider } from './WidgetInstanceContext';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -30,15 +31,14 @@ export interface WidgetConfig {
   props?: Record<string, any>;
 }
 
-export interface WidgetLayout extends Layout {
-  i: string;
-}
+export type WidgetLayout = LayoutItem;
 
 export interface WidgetGridProps {
   widgets: WidgetConfig[];
   layout: WidgetLayout[];
   onLayoutChange: (layout: WidgetLayout[]) => void;
   onRemoveWidget?: (widgetId: string) => void;
+  onPinWidget?: (widget: WidgetConfig) => void;
   renderWidget: (widget: WidgetConfig) => React.ReactNode;
   cols?: number;
   rowHeight?: number;
@@ -152,6 +152,7 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
   layout,
   onLayoutChange,
   onRemoveWidget,
+  onPinWidget,
   renderWidget,
   cols = 12,
   rowHeight = 100,
@@ -160,7 +161,7 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
   isEditing = false,
 }) => {
   const handleLayoutChange = useCallback(
-    (newLayout: Layout[]) => {
+    (newLayout: LayoutItem[]) => {
       onLayoutChange(newLayout as WidgetLayout[]);
     },
     [onLayoutChange]
@@ -203,7 +204,9 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
                 <X size={14} />
               </RemoveButton>
             )}
-            {renderWidget(widget)}
+            <WidgetInstanceProvider widget={widget} onPinWidget={onPinWidget}>
+              {renderWidget(widget)}
+            </WidgetInstanceProvider>
           </WidgetWrapper>
         ))}
       </GridLayout>

--- a/frontend/src/components/Widgets/WidgetInstanceContext.tsx
+++ b/frontend/src/components/Widgets/WidgetInstanceContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext } from 'react';
+import type { WidgetConfig } from './WidgetGrid';
+
+export interface WidgetInstanceContextValue {
+  widget: WidgetConfig;
+  onPinWidget?: (widget: WidgetConfig) => void;
+}
+
+const WidgetInstanceContext = createContext<WidgetInstanceContextValue | undefined>(undefined);
+
+export const useWidgetInstance = () => useContext(WidgetInstanceContext);
+
+export const WidgetInstanceProvider: React.FC<{
+  widget: WidgetConfig;
+  onPinWidget?: (widget: WidgetConfig) => void;
+  children: React.ReactNode;
+}> = ({ widget, onPinWidget, children }) => {
+  return (
+    <WidgetInstanceContext.Provider value={{ widget, onPinWidget }}>
+      {children}
+    </WidgetInstanceContext.Provider>
+  );
+};

--- a/frontend/src/contexts/CockpitPinnedToolsContext.tsx
+++ b/frontend/src/contexts/CockpitPinnedToolsContext.tsx
@@ -1,0 +1,86 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { WidgetConfig } from '../components/Widgets/WidgetGrid';
+
+export type PinnedToolKind = 'widget' | 'tool';
+
+export interface PinnedTool {
+  id: string;
+  kind: PinnedToolKind;
+  title: string;
+  widget?: WidgetConfig;
+}
+
+export interface CockpitPinnedToolsContextType {
+  pinned: PinnedTool[];
+  pinWidget: (widget: WidgetConfig) => void;
+  unpin: (pinnedId: string) => void;
+  isWidgetPinned: (widgetId: string) => boolean;
+}
+
+const CockpitPinnedToolsContext = createContext<CockpitPinnedToolsContextType | undefined>(undefined);
+
+export const useCockpitPinnedTools = () => {
+  const ctx = useContext(CockpitPinnedToolsContext);
+  if (!ctx) throw new Error('useCockpitPinnedTools must be used within CockpitPinnedToolsProvider');
+  return ctx;
+};
+
+const getStorageKey = () => {
+  const tenantId = localStorage.getItem('tenantId') || 'unknown';
+  return `cockpit_pinned_tools_${tenantId}`;
+};
+
+export const CockpitPinnedToolsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [pinned, setPinned] = useState<PinnedTool[]>([]);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(getStorageKey());
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) setPinned(parsed);
+    } catch (e) {
+      console.warn('[CockpitPinnedTools] Failed to load pinned tools:', e);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(getStorageKey(), JSON.stringify(pinned));
+    } catch (e) {
+      console.warn('[CockpitPinnedTools] Failed to persist pinned tools:', e);
+    }
+  }, [pinned]);
+
+  const pinWidget = useCallback((widget: WidgetConfig) => {
+    setPinned((prev) => {
+      const already = prev.some((p) => p.kind === 'widget' && p.widget?.id === widget.id);
+      if (already) return prev;
+      return [
+        ...prev,
+        {
+          id: `widget:${widget.id}`,
+          kind: 'widget',
+          title: widget.title,
+          widget,
+        },
+      ];
+    });
+  }, []);
+
+  const unpin = useCallback((pinnedId: string) => {
+    setPinned((prev) => prev.filter((p) => p.id !== pinnedId));
+  }, []);
+
+  const isWidgetPinned = useCallback(
+    (widgetId: string) => pinned.some((p) => p.kind === 'widget' && p.widget?.id === widgetId),
+    [pinned]
+  );
+
+  const value = useMemo<CockpitPinnedToolsContextType>(
+    () => ({ pinned, pinWidget, unpin, isWidgetPinned }),
+    [pinned, pinWidget, unpin, isWidgetPinned]
+  );
+
+  return <CockpitPinnedToolsContext.Provider value={value}>{children}</CockpitPinnedToolsContext.Provider>;
+};

--- a/frontend/src/pages/Cockpit/CockpitDashboard.tsx
+++ b/frontend/src/pages/Cockpit/CockpitDashboard.tsx
@@ -16,8 +16,8 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import styled from 'styled-components';
 import { 
-  LayoutGrid, Lock, Unlock, Plus, 
-  RotateCcw, X, ArrowLeft, Search
+  LayoutGrid, Lock, Unlock, Plus,
+  RotateCcw, X
 } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { 
@@ -39,6 +39,7 @@ import {
 import { CockpitTour, SmartSearch, BreadcrumbBar } from '../../components/Cockpit';
 import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
 import { businessApi } from '../../services/businessApi';
+import { useCockpitPinnedTools } from '../../contexts/CockpitPinnedToolsContext';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -70,13 +71,14 @@ const DEFAULT_WIDGETS: WidgetConfig[] = [
 
 // Default layout configuration
 const DEFAULT_LAYOUT: WidgetLayout[] = [
-  { i: 'todays-numbers', x: 0, y: 0, w: 6, h: 4 },
-  { i: 'my-tasks', x: 6, y: 0, w: 6, h: 4 },
-  { i: 'quick-stats', x: 0, y: 4, w: 4, h: 3 },
-  { i: 'quick-actions', x: 4, y: 4, w: 4, h: 3 },
-  { i: 'recent-activity', x: 8, y: 4, w: 4, h: 3 },
-  { i: 'upcoming-calls', x: 0, y: 7, w: 6, h: 3 },
-  { i: 'entity-explorer', x: 6, y: 7, w: 6, h: 3 },
+  // Wider defaults to reduce horizontal overflow and improve scanability
+  { i: 'todays-numbers', x: 0, y: 0, w: 8, h: 4 },
+  { i: 'my-tasks', x: 8, y: 0, w: 4, h: 4 },
+  { i: 'quick-stats', x: 0, y: 4, w: 6, h: 3 },
+  { i: 'quick-actions', x: 6, y: 4, w: 6, h: 3 },
+  { i: 'recent-activity', x: 0, y: 7, w: 6, h: 3 },
+  { i: 'upcoming-calls', x: 6, y: 7, w: 6, h: 3 },
+  { i: 'entity-explorer', x: 0, y: 10, w: 12, h: 3 },
 ];
 
 // Widget catalog for adding new widgets - organized by category
@@ -421,6 +423,7 @@ export const CockpitDashboard: React.FC = () => {
   
   // Cockpit navigation context
   const navigation = useCockpitNavigation();
+  const pinnedTools = useCockpitPinnedTools();
 
   // Load saved layout from backend API with localStorage fallback
   useEffect(() => {
@@ -547,6 +550,13 @@ export const CockpitDashboard: React.FC = () => {
     setLayout(prev => prev.filter(l => l.i !== widgetId));
   }, []);
 
+  // Pin widget into the tools bar (and remove from grid)
+  const handlePinWidget = useCallback((widget: WidgetConfig) => {
+    pinnedTools.pinWidget(widget);
+    setWidgets(prev => prev.filter(w => w.id !== widget.id));
+    setLayout(prev => prev.filter(l => l.i !== widget.id));
+  }, [pinnedTools]);
+
   // Render widget based on type
   const renderWidget = useCallback((widget: WidgetConfig) => {
     // Handle both old format (widget id as type) and new format (widget type)
@@ -644,32 +654,35 @@ export const CockpitDashboard: React.FC = () => {
         <SmartSearch query={cockpitQuery} />
       </div>
 
-      {/* Widget Grid - Always show */}
-      <GridWrapper ref={containerRef} data-tour="search-results">
-        {widgets.length === 0 ? (
-          <EmptyState>
-            <LayoutGrid size={48} />
-            <h3>No widgets configured</h3>
-            <p>Add widgets to build your personalized dashboard</p>
-            <ActionButton $variant="primary" onClick={() => setIsEditing(true)}>
-              <Plus size={16} />
-              Get Started
-            </ActionButton>
-          </EmptyState>
-        ) : (
-          <WidgetGrid
-            widgets={widgets}
-            layout={layout}
-            onLayoutChange={handleLayoutChange}
-            onRemoveWidget={handleRemoveWidget}
-            renderWidget={renderWidget}
-            width={gridWidth}
-            cols={12}
-            rowHeight={100}
-            isEditing={isEditing}
-          />
-        )}
-      </GridWrapper>
+      {/* Widget Grid (hidden when a record is active) */}
+      {navigation.path.length === 0 && (
+        <GridWrapper ref={containerRef} data-tour="search-results">
+          {widgets.length === 0 ? (
+            <EmptyState>
+              <LayoutGrid size={48} />
+              <h3>No widgets configured</h3>
+              <p>Add widgets to build your personalized dashboard</p>
+              <ActionButton $variant="primary" onClick={() => setIsEditing(true)}>
+                <Plus size={16} />
+                Get Started
+              </ActionButton>
+            </EmptyState>
+          ) : (
+            <WidgetGrid
+              widgets={widgets}
+              layout={layout}
+              onLayoutChange={handleLayoutChange}
+              onRemoveWidget={handleRemoveWidget}
+              onPinWidget={handlePinWidget}
+              renderWidget={renderWidget}
+              width={gridWidth}
+              cols={12}
+              rowHeight={100}
+              isEditing={isEditing}
+            />
+          )}
+        </GridWrapper>
+      )}
 
       {/* Widget Catalog Modal */}
       <ModalOverlay $isOpen={isCatalogOpen} onClick={() => setIsCatalogOpen(false)}>

--- a/frontend/src/types/lodash-debounce.d.ts
+++ b/frontend/src/types/lodash-debounce.d.ts
@@ -1,0 +1,4 @@
+declare module 'lodash/debounce' {
+  const debounce: any;
+  export default debounce;
+}


### PR DESCRIPTION
Implements record-centric Cockpit pivot:

- Backend: expand /api/v1/system/entities/{type}/{id}/ to include safe field payload + inline-edit PATCH support (staff/superuser only).
- Frontend: EntityProfileHeader (record profile) + hide widget grid when a record is active.
- Add pinned tools bar under global Header and per-widget Pin-to-Tools action (pins + removes widget from grid).
- Widen DEFAULT_LAYOUT to reduce horizontal overflow.

Verified: frontend vite build passes (NODE_OPTIONS increased locally).