### PR TITLE
Cockpit: single global search input

### DIFF
--- a/frontend/src/pages/Cockpit/CockpitDashboard.tsx
+++ b/frontend/src/pages/Cockpit/CockpitDashboard.tsx
@@ -651,7 +651,7 @@ export const CockpitDashboard: React.FC = () => {
           </div>
         )}
         
-        <SmartSearch query={cockpitQuery} />
+        <SmartSearch query={cockpitQuery} hideInput={true} />
       </div>
 
       {/* Widget Grid (hidden when a record is active) */}


### PR DESCRIPTION
Remove duplicate Cockpit-embedded search input by rendering SmartSearch with hideInput=true. Global Header search remains the single entrypoint (Ctrl/Cmd+K).