### PR TITLE
Phase 8.0: System products in Inquiry UI

### DIFF
--- a/frontend/src/components/Inquiry/CreateInquiryModal.tsx
+++ b/frontend/src/components/Inquiry/CreateInquiryModal.tsx
@@ -11,12 +11,11 @@
  */
 import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
-import { apiClient } from '../../services/apiService';
-import { 
-  Inquiry, 
-  InquirySource, 
+import { businessApi } from '../../services/businessApi';
+import {
+  Inquiry,
+  InquirySource,
   InquiryEntityType,
-  Product 
 } from '../../types';
 
 // ============================================================================
@@ -47,6 +46,17 @@ interface ContactOption {
   phone?: string;
   position?: string;
   company?: string;
+}
+
+interface ProductOption {
+  id: string;
+  product_code: string;
+  name?: string;
+  description?: string;
+  description_of_product_item?: string;
+  protein_type?: string;
+  type_of_protein?: string;
+  is_active?: boolean;
 }
 
 interface ProductLineItem {
@@ -476,8 +486,8 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
   // Options
   const [entityOptions, setEntityOptions] = useState<EntityOption[]>([]);
   const [contactOptions, setContactOptions] = useState<ContactOption[]>([]);
-  const [productOptions, setProductOptions] = useState<Product[]>([]);
-  const [suggestedProducts, setSuggestedProducts] = useState<Product[]>([]);  // Products based on customer preferences
+  const [productOptions, setProductOptions] = useState<ProductOption[]>([]);
+  const [suggestedProducts, setSuggestedProducts] = useState<ProductOption[]>([]);  // Products based on customer preferences
   const [selectedContact, setSelectedContact] = useState<ContactOption | null>(null);
   
   // Loading states
@@ -538,7 +548,7 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
 
   const loadCallData = async (callId: string) => {
     try {
-      const response = await apiClient.get(`inquiries/from-call/${callId}/`);
+      const response = await businessApi.get(`inquiries/from-call/${callId}/`);
       const data = response.data;
       
       if (data.entity_type) setEntityType(data.entity_type);
@@ -563,7 +573,7 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
     setLoadingEntities(true);
     try {
       const endpoint = type === 'supplier' ? 'suppliers/' : 'customers/';
-      const response = await apiClient.get(endpoint);
+      const response = await businessApi.get(endpoint);
       const data = response.data.results || response.data;
       
       setEntityOptions(data.map((item: any) => ({
@@ -581,7 +591,9 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
   const fetchContacts = async (type: InquiryEntityType, id: string) => {
     setLoadingContacts(true);
     try {
-      const response = await apiClient.get(`contacts/?entity_type=${type}&entity_id=${id}`);
+      const response = await businessApi.get('contacts/', {
+        params: { entity_type: type, entity_id: id },
+      });
       const data = response.data.results || response.data;
       
       setContactOptions(data.map((item: any) => ({
@@ -603,9 +615,11 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
   const fetchProducts = async () => {
     setLoadingProducts(true);
     try {
-      const response = await apiClient.get('products/?is_active=true&page_size=500');
+      const response = await businessApi.get('system/products/', {
+        params: { is_active: true, page_size: 500 },
+      });
       const data = response.data.results || response.data;
-      setProductOptions(data);
+      setProductOptions(data as ProductOption[]);
     } catch (err) {
       console.error('Failed to fetch products:', err);
       setProductOptions([]);
@@ -623,7 +637,7 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
     
     try {
       // First, get customer's preferred protein types
-      const customerResponse = await apiClient.get(`customers/${customerId}/`);
+      const customerResponse = await businessApi.get(`customers/${customerId}/`);
       const customer = customerResponse.data;
       const preferredTypes = customer.preferred_protein_types || [];
       
@@ -633,10 +647,19 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
       }
       
       // Fetch products matching those protein types
-      const proteinParams = preferredTypes.map((t: string) => `type_of_protein=${encodeURIComponent(t)}`).join('&');
-      const productsResponse = await apiClient.get(`products/?is_active=true&${proteinParams}`);
+      const normalizedProteins = preferredTypes
+        .map((t: string) => String(t).toLowerCase().trim())
+        .filter(Boolean);
+
+      const productsResponse = await businessApi.get('system/products/', {
+        params: {
+          is_active: true,
+          protein: normalizedProteins,
+          page_size: 500,
+        },
+      });
       const data = productsResponse.data.results || productsResponse.data;
-      setSuggestedProducts(data);
+      setSuggestedProducts(data as ProductOption[]);
     } catch (err) {
       console.error('Failed to fetch suggested products:', err);
       setSuggestedProducts([]);
@@ -678,7 +701,7 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
     updateProductLine(tempId, {
       product: productId,
       productCode: product?.product_code,
-      productDescription: product?.description_of_product_item,
+      productDescription: product?.description_of_product_item ?? product?.description ?? product?.name,
     });
   };
 
@@ -756,7 +779,7 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
         })),
       };
 
-      const response = await apiClient.post('inquiries/', payload);
+      const response = await businessApi.post('inquiries/', payload);
       
       resetForm();
       onSuccess(response.data);
@@ -955,7 +978,7 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
                           <optgroup label="📌 Suggested (Based on Customer Preferences)">
                             {suggestedProducts.map(product => (
                               <option key={`suggested-${product.id}`} value={product.id}>
-                                ⭐ {product.product_code} - {product.description_of_product_item}
+                                ⭐ {product.product_code} - {product.description_of_product_item ?? product.description ?? product.name ?? ''}
                               </option>
                             ))}
                           </optgroup>
@@ -966,7 +989,7 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
                             .filter(p => !suggestedProducts.some(s => s.id === p.id))
                             .map(product => (
                               <option key={product.id} value={product.id}>
-                                {product.product_code} - {product.description_of_product_item}
+                                {product.product_code} - {product.description_of_product_item ?? product.description ?? product.name ?? ''}
                               </option>
                             ))}
                         </optgroup>
@@ -1033,7 +1056,7 @@ export const CreateInquiryModal: React.FC<CreateInquiryModalProps> = ({
                         tempId: `temp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
                         product: product.id.toString(),
                         productCode: product.product_code,
-                        productDescription: product.description_of_product_item,
+                        productDescription: product.description_of_product_item ?? product.description ?? product.name,
                         quantity: 1,
                         desired_uom: 'LBS',
                         actual_uom: 'LBS',

--- a/frontend/src/components/Inquiry/InquiryTemplateModal.tsx
+++ b/frontend/src/components/Inquiry/InquiryTemplateModal.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
+import { businessApi } from '../../services/businessApi';
 import { InquiryTemplate, InquiryEntityType } from '../../types';
 
 // ============================================================================
@@ -332,7 +332,7 @@ export const InquiryTemplateModal: React.FC<InquiryTemplateModalProps> = ({
   // Load products list
   useEffect(() => {
     if (isOpen) {
-      axios.get('/api/v1/products/', { params: { page_size: 500 } })
+      businessApi.get('system/products/', { params: { page_size: 500, is_active: true } })
         .then(res => {
           const data = res.data.results || res.data;
           setAvailableProducts(data);
@@ -431,9 +431,9 @@ export const InquiryTemplateModal: React.FC<InquiryTemplateModalProps> = ({
       
       let response;
       if (isEditing && template) {
-        response = await axios.put(`/api/v1/inquiry-templates/${template.id}/`, payload);
+        response = await businessApi.put(`inquiry-templates/${template.id}/`, payload);
       } else {
-        response = await axios.post('/api/v1/inquiry-templates/', payload);
+        response = await businessApi.post('inquiry-templates/', payload);
       }
       
       onSave(response.data);

--- a/frontend/src/components/Inquiry/SmartProductAutocomplete.tsx
+++ b/frontend/src/components/Inquiry/SmartProductAutocomplete.tsx
@@ -14,7 +14,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { debounce } from 'lodash';
-import { apiClient } from '../../services/apiService';
+import { businessApi } from '../../services/businessApi';
 import { Product } from '../../types';
 import { Search as SearchIcon, Star, Package, DollarSign, X } from 'lucide-react';
 
@@ -35,10 +35,13 @@ interface SmartProductAutocompleteProps {
 interface SearchResult {
   id: string;
   product_code: string;
-  description_of_product_item: string;
+  name?: string;
+  description?: string;
+  description_of_product_item?: string;
+  protein_type?: string;
   type_of_protein?: string;
   avg_price?: number;
-  is_active: boolean;
+  is_active?: boolean;
   is_suggested?: boolean;
 }
 
@@ -316,7 +319,7 @@ export const SmartProductAutocomplete: React.FC<SmartProductAutocompleteProps> =
   
   const fetchProductById = async (productId: string) => {
     try {
-      const response = await apiClient.get(`products/${productId}/`);
+      const response = await businessApi.get(`system/products/${productId}/`);
       setSelectedProduct(response.data);
       setSearchTerm(response.data.product_code);
     } catch (err) {
@@ -337,7 +340,7 @@ export const SmartProductAutocomplete: React.FC<SmartProductAutocompleteProps> =
         setLoading(true);
         
         // Use Cockpit search endpoint for unified search
-        const response = await apiClient.get('system/search/', {
+        const response = await businessApi.get('system/search/', {
           params: {
             query: query,
             types: 'product',
@@ -500,11 +503,11 @@ export const SmartProductAutocomplete: React.FC<SmartProductAutocompleteProps> =
                   )}
                 </ResultHeader>
                 <ProductDescription>
-                  {product.description_of_product_item}
+                  {product.description_of_product_item ?? product.description ?? product.name ?? ''}
                 </ProductDescription>
                 <ProductMeta>
-                  {product.type_of_protein && (
-                    <span>🥩 {product.type_of_protein}</span>
+                  {(product.type_of_protein ?? product.protein_type) && (
+                    <span>🥩 {product.type_of_protein ?? product.protein_type}</span>
                   )}
                 </ProductMeta>
               </ResultItem>
@@ -536,11 +539,11 @@ export const SmartProductAutocomplete: React.FC<SmartProductAutocompleteProps> =
                     )}
                   </ResultHeader>
                   <ProductDescription>
-                    {product.description_of_product_item}
+                    {product.description_of_product_item ?? product.description ?? product.name ?? ''}
                   </ProductDescription>
                   <ProductMeta>
-                    {product.type_of_protein && (
-                      <span>🥩 {product.type_of_protein}</span>
+                    {(product.type_of_protein ?? product.protein_type) && (
+                      <span>🥩 {product.type_of_protein ?? product.protein_type}</span>
                     )}
                   </ProductMeta>
                 </ResultItem>

--- a/frontend/src/components/Layout/Header.test.tsx
+++ b/frontend/src/components/Layout/Header.test.tsx
@@ -158,7 +158,7 @@ describe('Header', () => {
         </MemoryRouter>
       );
 
-      expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /global search/i })).toBeInTheDocument();
     });
 
     it('renders quick actions button', () => {
@@ -220,46 +220,43 @@ describe('Header', () => {
         </MemoryRouter>
       );
 
-      const searchInput = screen.getByPlaceholderText('Search...');
+      const searchInput = screen.getByRole('textbox', { name: /global search/i });
       fireEvent.change(searchInput, { target: { value: 'test query' } });
 
       expect(searchInput).toHaveValue('test query');
     });
 
     it('handles search form submission', () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-      
       render(
         <MemoryRouter>
           <Header />
         </MemoryRouter>
       );
 
-      const searchInput = screen.getByPlaceholderText('Search...');
+      const searchInput = screen.getByRole('textbox', { name: /global search/i });
       fireEvent.change(searchInput, { target: { value: 'test query' } });
-      
+
+      // onChange triggers a debounced navigation; we only want to assert the explicit submit behavior.
+      mockNavigate.mockClear();
+
       const form = searchInput.closest('form')!;
       fireEvent.submit(form);
 
-      expect(consoleSpy).toHaveBeenCalledWith('Search query:', 'test query');
-      consoleSpy.mockRestore();
+      expect(mockNavigate).toHaveBeenCalledWith('/cockpit?q=test%20query');
     });
 
     it('does not submit empty search', () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-      
       render(
         <MemoryRouter>
           <Header />
         </MemoryRouter>
       );
 
-      const searchInput = screen.getByPlaceholderText('Search...');
+      const searchInput = screen.getByRole('textbox', { name: /global search/i });
       const form = searchInput.closest('form')!;
       fireEvent.submit(form);
 
-      expect(consoleSpy).not.toHaveBeenCalled();
-      consoleSpy.mockRestore();
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     it('search input has accessible label', () => {

--- a/frontend/src/components/Widgets/MyTasksWidget.test.tsx
+++ b/frontend/src/components/Widgets/MyTasksWidget.test.tsx
@@ -7,6 +7,15 @@ import { MemoryRouter } from 'react-router-dom';
 import { MyTasksWidget } from './MyTasksWidget';
 import * as NotificationsContext from '../../contexts/NotificationsContext';
 
+vi.mock('../../contexts/CockpitPinnedToolsContext', () => ({
+  useCockpitPinnedTools: () => ({
+    pinned: [],
+    pinWidget: vi.fn(),
+    unpin: vi.fn(),
+    isWidgetPinned: vi.fn(() => false),
+  }),
+}));
+
 // Mock useNavigate
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {

--- a/frontend/src/components/Widgets/WidgetCard.test.tsx
+++ b/frontend/src/components/Widgets/WidgetCard.test.tsx
@@ -15,6 +15,15 @@ import userEvent from '@testing-library/user-event';
 import { WidgetCard } from './WidgetCard';
 import { Activity } from 'lucide-react';
 
+vi.mock('../../contexts/CockpitPinnedToolsContext', () => ({
+  useCockpitPinnedTools: () => ({
+    pinned: [],
+    pinWidget: vi.fn(),
+    unpin: vi.fn(),
+    isWidgetPinned: vi.fn(() => false),
+  }),
+}));
+
 describe('WidgetCard', () => {
   describe('Basic Rendering', () => {
     it('should render title', () => {

--- a/frontend/src/contexts/CockpitPinnedToolsContext.tsx
+++ b/frontend/src/contexts/CockpitPinnedToolsContext.tsx
@@ -19,10 +19,16 @@ export interface CockpitPinnedToolsContextType {
 
 const CockpitPinnedToolsContext = createContext<CockpitPinnedToolsContextType | undefined>(undefined);
 
+const FALLBACK_CTX: CockpitPinnedToolsContextType = {
+  pinned: [],
+  pinWidget: () => {},
+  unpin: () => {},
+  isWidgetPinned: () => false,
+};
+
 export const useCockpitPinnedTools = () => {
   const ctx = useContext(CockpitPinnedToolsContext);
-  if (!ctx) throw new Error('useCockpitPinnedTools must be used within CockpitPinnedToolsProvider');
-  return ctx;
+  return ctx ?? FALLBACK_CTX;
 };
 
 const getStorageKey = () => {

--- a/frontend/src/hooks/useCustomerProducts.ts
+++ b/frontend/src/hooks/useCustomerProducts.ts
@@ -16,35 +16,7 @@
  *   } = useCustomerProducts(customerId);
  */
 import { useState, useCallback, useEffect } from 'react';
-import axios from 'axios';
-import { config } from '../config/runtime';
-
-const API_BASE_URL = config.API_BASE_URL;
-
-// Create axios instance
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  timeout: 15000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-  xsrfCookieName: 'csrftoken',
-  xsrfHeaderName: 'X-CSRFToken',
-});
-
-// Request interceptor
-apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('authToken');
-  if (token) {
-    config.headers.Authorization = `Token ${token}`;
-  }
-  const tenantId = localStorage.getItem('tenantId');
-  if (tenantId) {
-    config.headers['X-Tenant-ID'] = tenantId;
-  }
-  return config;
-});
+import { businessApi } from '../services/businessApi';
 
 // Types
 export interface Product {
@@ -109,8 +81,11 @@ export function useCustomerProducts(
   // Fetch all products
   const fetchAllProducts = useCallback(async () => {
     try {
-      const response = await apiClient.get<Product[]>('/products/');
-      const products = Array.isArray(response.data) ? response.data : [];
+      const response = await businessApi.get('system/products/', {
+        params: { is_active: true, page_size: 500 },
+      });
+      const data = response.data.results || response.data;
+      const products = Array.isArray(data) ? data : [];
       setAllProducts(products);
       return products;
     } catch (err: any) {
@@ -128,10 +103,19 @@ export function useCustomerProducts(
 
     try {
       // Build query string with multiple protein parameters
-      const proteinParams = proteinTypes.map(type => `protein=${encodeURIComponent(type)}`).join('&');
-      const response = await apiClient.get<Product[]>(`/products/?${proteinParams}`);
-      const products = Array.isArray(response.data) ? response.data : [];
-      return products;
+      const normalizedProteins = proteinTypes
+        .map((t) => String(t).toLowerCase().trim())
+        .filter(Boolean);
+
+      const response = await businessApi.get<Product[]>('system/products/', {
+        params: {
+          is_active: true,
+          protein: normalizedProteins,
+          page_size: 500,
+        },
+      });
+      const data = response.data.results || response.data;
+      return Array.isArray(data) ? data : [];
     } catch (err: any) {
       console.error('Failed to fetch products by protein types:', err);
       return [];
@@ -146,14 +130,15 @@ export function useCustomerProducts(
 
     try {
       // Fetch customer details
-      const customerResponse = await apiClient.get<Customer>(`/customers/${custId}/`);
+      const customerResponse = await businessApi.get<Customer>(`customers/${custId}/`);
       const customer = customerResponse.data;
       const preferences = customer.preferred_protein_types || [];
       setCustomerPreferences(preferences);
 
       // Fetch associated products
-      const associatedResponse = await apiClient.get<Product[]>(`/customers/${custId}/products/`);
-      const associated = Array.isArray(associatedResponse.data) ? associatedResponse.data : [];
+      const associatedResponse = await businessApi.get<Product[]>(`customers/${custId}/products/`);
+      const associatedData = associatedResponse.data.results || associatedResponse.data;
+      const associated = Array.isArray(associatedData) ? associatedData : [];
       setAssociatedProducts(associated);
 
       // Fetch suggested products based on preferences
@@ -183,10 +168,11 @@ export function useCustomerProducts(
     }
 
     try {
-      const response = await apiClient.get<Product[]>(`/products/`, {
-        params: { search: query }
+      const response = await businessApi.get<Product[]>('system/products/', {
+        params: { search: query, is_active: true, page_size: 50 },
       });
-      return Array.isArray(response.data) ? response.data : [];
+      const data = response.data.results || response.data;
+      return Array.isArray(data) ? data : [];
     } catch (err: any) {
       console.error('Failed to search products:', err);
       return [];
@@ -213,11 +199,11 @@ export function useCustomerProducts(
 
   // Initial load
   useEffect(() => {
-    fetchAllProducts();
+    void fetchAllProducts();
     if (initialCustomerId) {
-      fetchProductsForCustomer(initialCustomerId);
+      void fetchProductsForCustomer(initialCustomerId);
     }
-  }, []);
+  }, [fetchAllProducts, fetchProductsForCustomer, initialCustomerId]);
 
   return {
     allProducts,


### PR DESCRIPTION
Frontend P0 for Three-Tier Products:\n\n- Inquiry create flow: product options + suggested products now fetched from /api/v1/system/products/ via businessApi\n- Protein cascade: uses system endpoint query params (protein=*) with normalization\n- SmartProductAutocomplete: fetches product detail from system products; search results render both legacy and new fields\n- Remove ad-hoc axios client from useCustomerProducts; use businessApi consistently\n- Safety: useCockpitPinnedTools now falls back to no-op context if provider not mounted (prevents isolated widget renders/tests from crashing)\n\nTest: cd frontend && NODE_OPTIONS=--max-old-space-size=6144 npm test -- --run\n\nFollow-up: migrate remaining tenant product pages (Customers/Suppliers Products) to system products endpoint.