### PR TITLE
Phase 8.0: FlowEditor schema bridge supports affinity fields

### DIFF
--- a/backend/apps/system/urls.py
+++ b/backend/apps/system/urls.py
@@ -36,13 +36,24 @@ router.register(r'field-schemas', SystemFieldSchemaViewSet, basename='field-sche
 router.register(r'tenant-configs', TenantConfigViewSet, basename='tenant-config')
 router.register(r'config', ConfigResolverView, basename='config')
 router.register(r'audit-logs', ConfigAuditLogViewSet, basename='audit-log')
-router.register(r'entities-introspect', EntityIntrospectionViewSet, basename='entity-introspect')
-router.register(r'entities', EntityViewSet, basename='entity-graph')
+# IMPORTANT:
+# - `/api/v1/system/entities/` is reserved for Schema Bridge entity introspection (FlowEditor, admin-form builder parity).
+# - Cockpit record/relationship APIs use typed routes: `/api/v1/system/entities/<type>/<id>/...` (see custom paths below).
+#
+# Keep an alias at `entities-introspect` for backward compatibility, but the canonical path is `entities`.
+router.register(r'entities', EntityIntrospectionViewSet, basename='entity-introspect')
+router.register(r'entities-introspect', EntityIntrospectionViewSet, basename='entity-introspect-alias')
 router.register(r'products', SystemProductViewSet, basename='product')
 router.register(r'product-preferences', TenantProductPreferenceViewSet, basename='product-preference')
 router.register(r'search/ranked', RankedSearchViewSet, basename='ranked-search')
 
 urlpatterns = [
+    # IMPORTANT: include router first so Schema Bridge routes work:
+    # - /api/v1/system/entities/<entity_id>/fields/
+    # - /api/v1/system/entities/<entity_id>/display-fields/
+    # (These would otherwise be captured by the typed Cockpit routes below.)
+    path('', include(router.urls)),
+
     # Cockpit Entity Graph (typed URLs)
     # The DefaultRouter only supports /entities/<pk>/..., but Cockpit uses /entities/<type>/<id>/...
     path(
@@ -60,6 +71,4 @@ urlpatterns = [
         EntityViewSet.as_view({'get': 'retrieve', 'patch': 'partial_update'}),
         name='entity-detail',
     ),
-
-    path('', include(router.urls)),
 ]

--- a/backend/apps/system/views/choice_viewsets.py
+++ b/backend/apps/system/views/choice_viewsets.py
@@ -444,16 +444,19 @@ class ConfigAuditLogViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class EntityIntrospectionViewSet(viewsets.ViewSet):
-    """
-    ViewSet for entity introspection and field metadata.
-    
-    Phase 3: Schema Bridge
+    """ViewSet for entity introspection and field metadata.
+
+    Phase 3: Schema Bridge.
     Provides entity types and field definitions from Django models.
-    
-    GET /api/v1/system/entities/ - List all business entities
-    GET /api/v1/system/entities/{entity_id}/fields/ - Get fields for entity
-    GET /api/v1/system/entities/{entity_id}/display-fields/ - Get display fields
+
+    Note: entity IDs are dotted strings (e.g., `tenant_apps.locations.location`). DRF routers
+    default to `lookup_value_regex = [^/.]+`, which would truncate at dots and break
+    `/api/v1/system/entities/<entity_id>/fields/`.
     """
+
+    # Allow dots in the entity id URL segment (DRF DefaultRouter uses this regex)
+    lookup_value_regex = r'[^/]+'
+
     permission_classes = [permissions.IsAuthenticated]
     
     def list(self, request):


### PR DESCRIPTION
Fix System Schema Bridge routing so FlowEditor can fetch entity fields via /api/v1/system/entities/<entity_id>/fields/ (supports dotted entity IDs). This unblocks selecting Plant/Location associated_products in Form node field picker.