### PR TITLE
fix: show dynamic config sections for all nodes

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -169,6 +169,11 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - LiveFormPreview: normalize `field.validation` to an array before iterating.
   - Verified: GitHub Actions run 23112951974 succeeded (dev deploy green). Deployed tags: `development-5b9e5f34da6f80c51f807483caa3910de6d339d9` (pm-frontend + pm-backend).
 
+- 2026-03-17 — FlowEditor: restore dynamic config sections (PR pending)
+  - Fix TabbedConfigPanel strict whitelist that hid non-form node sections (triggers, actions, conditions).
+  - General tab now shows all non-advanced sections; Advanced tab shows only advanced sections.
+  - Impact: All node types render their schema-driven configuration panels again.
+
 ---
 
 ## Consolidated Execution Plan (2026-03-13)

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
@@ -140,10 +140,21 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
                   onApply={onApply}
                   onDiscard={onDiscard}
                   sectionFilter={(section) => {
-                    // Show only basic sections in General tab
-                    // Advanced sections go to Advanced tab
-                    const basicSectionIds = ['basic', 'entity', 'fields', 'appearance', 'behavior'];
-                    return basicSectionIds.includes(section.id);
+                    // Show everything by default in General, except sections intended for Advanced
+                    const advancedSectionIds = [
+                      'advanced',
+                      'validation',
+                      'conditional',
+                      'integration',
+                      'webhooks',
+                      'email',
+                      'notifications',
+                      'errorHandling',
+                      'http-auth',
+                      'advanced-settings',
+                    ].map((s) => s.toLowerCase());
+                    const id = (section.id || '').toLowerCase();
+                    return !advancedSectionIds.includes(id) && !id.includes('advanced');
                   }}
                 />
               </TabPanel>
@@ -209,9 +220,21 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
                   onApply={onApply}
                   onDiscard={onDiscard}
                   sectionFilter={(section) => {
-                    // Show advanced sections: validation, conditional logic, integration, etc.
-                    const advancedSectionIds = ['advanced', 'validation', 'conditional', 'integration', 'webhooks', 'email', 'notifications'];
-                    return advancedSectionIds.includes(section.id);
+                    // Show only advanced sections here
+                    const advancedSectionIds = [
+                      'advanced',
+                      'validation',
+                      'conditional',
+                      'integration',
+                      'webhooks',
+                      'email',
+                      'notifications',
+                      'errorHandling',
+                      'http-auth',
+                      'advanced-settings',
+                    ].map((s) => s.toLowerCase());
+                    const id = (section.id || '').toLowerCase();
+                    return advancedSectionIds.includes(id) || id.includes('advanced');
                   }}
                 />
               </TabPanel>


### PR DESCRIPTION
## Summary
Fix TabbedConfigPanel filters so non-form nodes show their schema sections.

## Changes
- General tab now excludes only advanced-designated sections (exclusion-based).
- Advanced tab shows only advanced sections or ids containing 'advanced'.
- Restores trigger/action/condition node configuration panels.
- Logged change in .github/MASTER_PLAN.md.

## Testing
- Manual: verified non-form nodes render their configuration sections under General; advanced-only sections stay in Advanced.