### PR TITLE
docs: add cockpit breadcrumb + quick actions plan

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -75,6 +75,17 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - CockpitDashboard becomes a results view driven by URL `?q=` (SmartSearch controlled query + hideInput).
   - SmartSearch now debounces via `lodash/debounce` (no setTimeout).
 
+- 2026-03-17 — Cockpit BreadcrumbBar elevation — Commit: TBD (PR: TBD)
+  - Objective: BreadcrumbBar must sit above the hero search area and persist regardless of search/grid view state.
+  - Action: Move BreadcrumbBar rendering out of `showSearchView` block and place directly beneath Toolbar/CockpitTour for continuous context.
+  - Verification: Drilling into entities shows breadcrumbs at top of workspace above search results and search hint.
+
+- 2026-03-17 — Cockpit Quick Actions routing + PinnedTools event bus — Commit: TBD (PR: TBD)
+  - Objective: Replace placeholder `alert` quick actions with real navigation + tool triggers.
+  - Action: Wire quick actions to `useNavigate` routes (PO/SO create/history) and dispatch `pm:open-tool` so “Send Email” opens the PinnedToolsBar email drafter.
+  - Hardening: Add global `pm:open-tool` listener to PinnedToolsBar to accept external tool open requests.
+  - Verification: Quick Actions open correct routes with entity ids, and Send Email opens the mail drawer without manual click.
+
 ---
 
 ## Consolidated Execution Plan (2026-03-13)


### PR DESCRIPTION
Add master plan entries for Cockpit breadcrumb elevation and Quick Actions routing/pinned tools event bus. Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>