### PR TITLE
Fix cockpit breadcrumb and quick actions

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -79,12 +79,14 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - Objective: BreadcrumbBar must sit above the hero search area and persist regardless of search/grid view state.
   - Action: Move BreadcrumbBar rendering out of `showSearchView` block and place directly beneath Toolbar/CockpitTour for continuous context.
   - Verification: Drilling into entities shows breadcrumbs at top of workspace above search results and search hint.
+  - Status: Implemented on branch `feature/cockpit-actions-breadcrumb` — BreadcrumbBar now renders immediately below the toolbar/CockpitTour and outside the search block.
 
 - 2026-03-17 — Cockpit Quick Actions routing + PinnedTools event bus — Commit: TBD (PR: TBD)
   - Objective: Replace placeholder `alert` quick actions with real navigation + tool triggers.
   - Action: Wire quick actions to `useNavigate` routes (PO/SO create/history) and dispatch `pm:open-tool` so “Send Email” opens the PinnedToolsBar email drafter.
   - Hardening: Add global `pm:open-tool` listener to PinnedToolsBar to accept external tool open requests.
   - Verification: Quick Actions open correct routes with entity ids, and Send Email opens the mail drawer without manual click.
+  - Status: Implemented on branch `feature/cockpit-actions-breadcrumb` — Quick Actions now route via React Router and dispatch `pm:open-tool`; PinnedToolsBar listens and opens tools.
 
 ---
 

--- a/frontend/src/components/Cockpit/PinnedToolsBar.tsx
+++ b/frontend/src/components/Cockpit/PinnedToolsBar.tsx
@@ -145,6 +145,20 @@ export const PinnedToolsBar: React.FC = () => {
     }
   }, [openPinnedId, activeRecord, loadActiveRecord]);
 
+  useEffect(() => {
+    if (!isCockpit) return;
+
+    const handleOpenTool = (event: Event) => {
+      const toolId = (event as CustomEvent<{ toolId?: string }>).detail?.toolId;
+      if (typeof toolId === 'string' && toolId.length > 0) {
+        setOpenPinnedId(toolId);
+      }
+    };
+
+    window.addEventListener('pm:open-tool', handleOpenTool as EventListener);
+    return () => window.removeEventListener('pm:open-tool', handleOpenTool as EventListener);
+  }, [isCockpit]);
+
   if (!isCockpit) return null;
 
   const drawerTitle = openPinned?.title ?? openBuiltin?.title ?? '';

--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -23,6 +23,7 @@ import {
   Users, Building2, Package, TrendingUp, X
 } from 'lucide-react';
 import debounce from 'lodash/debounce';
+import { useNavigate } from 'react-router-dom';
 import { businessApi } from '../../services/businessApi';
 import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
 import { EntityProfileHeader } from './EntityProfileHeader';
@@ -439,6 +440,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
 
   // Use global navigation context instead of local breadcrumbs
   const navigation = useCockpitNavigation();
+  const navigate = useNavigate();
   
   const [internalQuery, setInternalQuery] = useState(initialQuery);
   const query = controlledQuery ?? internalQuery;
@@ -670,15 +672,35 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
    * Handle quick action click
    */
   const handleQuickAction = useCallback((action: SearchEntity) => {
-    const actionType = action.metadata?.action;
+    const actionType = action.metadata?.action as string | undefined;
     const entityId = action.metadata?.entityId;
-    
-    console.log('[SmartSearch] Quick action triggered:', actionType, entityId);
-    
-    // TODO: Implement actual action handlers (create invoice, schedule call, etc.)
-    // For now, just log the action
-    alert(`Quick Action: ${action.name}\nAction: ${actionType}\nEntity ID: ${entityId}`);
-  }, []);
+
+    if (!actionType) {
+      console.warn('[SmartSearch] Quick action missing actionType', action);
+      return;
+    }
+
+    switch (actionType) {
+      case 'create_po':
+        navigate(`/purchase-orders?action=create&supplier_id=${entityId}`);
+        break;
+      case 'view_purchase_history':
+      case 'view_history':
+        navigate(`/purchase-orders?supplier_id=${entityId}`);
+        break;
+      case 'send_email':
+        window.dispatchEvent(new CustomEvent('pm:open-tool', { detail: { toolId: 'tool:email' } }));
+        break;
+      case 'create_so':
+        navigate(`/sales-orders?action=create&customer_id=${entityId}`);
+        break;
+      case 'view_sales_history':
+        navigate(`/sales-orders?customer_id=${entityId}`);
+        break;
+      default:
+        console.warn('Unhandled quick action:', actionType, 'for entity', entityId);
+    }
+  }, [navigate]);
 
   /**
    * Toggle favorite

--- a/frontend/src/pages/Cockpit/CockpitDashboard.tsx
+++ b/frontend/src/pages/Cockpit/CockpitDashboard.tsx
@@ -640,17 +640,16 @@ export const CockpitDashboard: React.FC = () => {
       
       {/* Guided Tour */}
       <CockpitTour enabled={true} />
-      
+
+      {/* Breadcrumb navigation bar - Elevated above search and grid */}
+      {navigation.path.length > 0 && (
+        <div style={{ padding: '16px 24px 0 24px' }}>
+          <BreadcrumbBar />
+        </div>
+      )}
 
       {/* EMBEDDED SEARCH - Always Visible */}
       <div style={{ padding: '16px 16px 0 16px' }}>
-        {/* Breadcrumb navigation bar */}
-        {navigation.path.length > 0 && (
-          <div style={{ marginBottom: '12px' }}>
-            <BreadcrumbBar />
-          </div>
-        )}
-        
         <SmartSearch query={cockpitQuery} />
       </div>
 


### PR DESCRIPTION
## Summary
- move cockpit BreadcrumbBar above search block to keep navigation visible
- wire SmartSearch quick actions to router and pm:open-tool, add PinnedToolsBar listener
- log changes in master plan

## Testing
- not run (manual verification recommended)