### PR TITLE
Harden FlowEditor handler injection

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -85,6 +85,8 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - Action: Wire quick actions to `useNavigate` routes (PO/SO create/history) and dispatch `pm:open-tool` so “Send Email” opens the PinnedToolsBar email drafter.
   - Hardening: Add global `pm:open-tool` listener to PinnedToolsBar to accept external tool open requests.
   - Verification: Quick Actions open correct routes with entity ids, and Send Email opens the mail drawer without manual click.
+- 2026-03-17 — FlowEditor handler injection hardening — Commit: TBD (branch: `feature/wf-handler-injection`, PR: TBD)
+  - Inject safe defaults for `onEdit`/`onDelete`/`onSave`/`onTitleChange` across all node data objects to prevent missing-callback crashes.
 
 ---
 

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -5536,16 +5536,37 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Batch 3: Inject edit/delete handlers into node data
   // Batch 4: Also inject title change handler
   const nodesWithHandlers = useMemo(() => {
-    return nodes.map(node => ({
-      ...node,
-      data: {
-        ...node.data,
-        onEdit: () => handleNodeEdit(node.id),
-        onDelete: () => handleNodeDelete(node.id),
-        onSave: () => handleSaveWorkflow(),
-        onTitleChange: (newTitle: string) => handleNodeTitleChange(node.id, newTitle),
-      },
-    }));
+    return nodes.map((node) => {
+      const data = node.data ?? {};
+
+      const onEdit =
+        typeof data.onEdit === 'function'
+          ? data.onEdit
+          : () => handleNodeEdit(node.id);
+      const onDelete =
+        typeof data.onDelete === 'function'
+          ? data.onDelete
+          : () => handleNodeDelete(node.id);
+      const onSave =
+        typeof data.onSave === 'function'
+          ? data.onSave
+          : () => handleSaveWorkflow();
+      const onTitleChange =
+        typeof data.onTitleChange === 'function'
+          ? data.onTitleChange
+          : (newTitle: string) => handleNodeTitleChange(node.id, newTitle);
+
+      return {
+        ...node,
+        data: {
+          ...data,
+          onEdit,
+          onDelete,
+          onSave,
+          onTitleChange,
+        },
+      };
+    });
   }, [nodes, handleNodeEdit, handleNodeDelete, handleNodeTitleChange, handleSaveWorkflow]);
 
   return (


### PR DESCRIPTION
## Summary\n- guard node data handlers with safe defaults so onEdit/onDelete/onSave/onTitleChange always exist\n- preserve existing handler overrides when provided by node data\n- update master plan PR log entry for handler hardening\n\n## Testing\n- not run (frontend change only)