### PR TITLE
Support LR auto-layout for formProcess

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -85,6 +85,8 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - Action: Wire quick actions to `useNavigate` routes (PO/SO create/history) and dispatch `pm:open-tool` so “Send Email” opens the PinnedToolsBar email drafter.
   - Hardening: Add global `pm:open-tool` listener to PinnedToolsBar to accept external tool open requests.
   - Verification: Quick Actions open correct routes with entity ids, and Send Email opens the mail drawer without manual click.
+- 2026-03-17 — FormProcess left-to-right auto-layout — Commit: TBD (branch: `feature/implement-lr-layout`, PR: TBD)
+  - Auto-layout now honors left-to-right orientation for workflows containing formProcess/formProcessGroup containers; dagre utility uses caller-specified direction instead of forcing top-to-bottom.
 
 ---
 

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -4275,10 +4275,15 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
    * Phase 2: UI/UX Enhancements
    */
   const handleAutoLayout = useCallback(() => {
+    const hasFormProcessContainer = nodes.some(
+      (n) => n.type === 'formProcess' || n.type === 'formProcessGroup'
+    );
+    const layoutDirection: 'TB' | 'LR' = hasFormProcessContainer ? 'LR' : 'TB';
+    
     const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
       nodes,
       edges,
-      { direction: 'TB', nodeSpacing: 60, rankSpacing: 120 }
+      { direction: layoutDirection, nodeSpacing: 60, rankSpacing: 120 }
     );
     setNodes(layoutedNodes);
     setHasUnsavedChanges(true);
@@ -4300,10 +4305,15 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       e => selectedNodeIds.includes(e.source) && selectedNodeIds.includes(e.target)
     );
 
+    const hasFormProcessContainer = selectedNodes.some(
+      (n) => n.type === 'formProcess' || n.type === 'formProcessGroup'
+    );
+    const layoutDirection: 'TB' | 'LR' = hasFormProcessContainer ? 'LR' : 'TB';
+
     const { nodes: layoutedSelected } = getLayoutedElements(
       selectedNodes,
       relevantEdges,
-      { direction: 'TB' }
+      { direction: layoutDirection }
     );
 
     // Merge layouted nodes back

--- a/frontend/src/components/FlowEditor/utils/autoLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/autoLayout.ts
@@ -24,8 +24,8 @@ export interface LayoutOptions {
   align?: 'UL' | 'UR' | 'DL' | 'DR';
 }
 
-const DEFAULT_OPTIONS: Required<Omit<LayoutOptions, 'direction'>> & { direction: 'TB' } = {
-  direction: 'TB', // Force Top to Bottom
+const DEFAULT_OPTIONS: Required<LayoutOptions> = {
+  direction: 'TB', // Default Top to Bottom; callers can override
   nodeSpacing: 50,
   rankSpacing: 100,
   edgeSpacing: 20,
@@ -40,14 +40,15 @@ export const getLayoutedElements = (
   edges: Edge[],
   options: LayoutOptions = {}
 ): { nodes: Node[]; edges: Edge[] } => {
-  const opts = { ...DEFAULT_OPTIONS, ...options, direction: 'TB' };
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const direction = opts.direction ?? 'TB';
   
   // Create a new dagre graph
   const dagreGraph = new dagre.graphlib.Graph();
   
   // Set graph options
   dagreGraph.setGraph({
-    rankdir: 'TB',
+    rankdir: direction,
     align: opts.align,
     ranker: 'longest-path',
     nodesep: opts.nodeSpacing,
@@ -94,25 +95,44 @@ export const getLayoutedElements = (
     };
   });
   
-  // Center align graph horizontally for consistent top-to-bottom layout
-  const minX = Math.min(...layoutedNodes.map((n) => n.position.x));
-  const maxX = Math.max(...layoutedNodes.map((n) => n.position.x + (n.width || 280)));
-  const centerOffset = (minX + maxX) / 2;
+  let alignedNodes = layoutedNodes;
 
-  const alignedNodes = layoutedNodes.map((node) => ({
-    ...node,
-    position: {
-      x: node.position.x - centerOffset,
-      y: node.position.y,
-    },
-  }));
+  if (direction === 'TB' || direction === 'BT') {
+    // Center horizontally for top-to-bottom layout
+    const minX = Math.min(...layoutedNodes.map((n) => n.position.x));
+    const maxX = Math.max(...layoutedNodes.map((n) => n.position.x + (n.width || 280)));
+    const centerOffset = (minX + maxX) / 2;
 
+    alignedNodes = layoutedNodes.map((node) => ({
+      ...node,
+      position: {
+        x: node.position.x - centerOffset,
+        y: node.position.y,
+      },
+    }));
+  } else {
+    // Center vertically for left-to-right layout
+    const minY = Math.min(...layoutedNodes.map((n) => n.position.y));
+    const maxY = Math.max(...layoutedNodes.map((n) => n.position.y + (n.height || 100)));
+    const centerOffsetY = (minY + maxY) / 2;
+
+    alignedNodes = layoutedNodes.map((node) => ({
+      ...node,
+      position: {
+        x: node.position.x,
+        y: node.position.y - centerOffsetY,
+      },
+    }));
+  }
+
+  // Normalize to keep positions positive with a small margin
   const normalizedMinX = Math.min(...alignedNodes.map((n) => n.position.x));
+  const normalizedMinY = Math.min(...alignedNodes.map((n) => n.position.y));
   const normalizedNodes = alignedNodes.map((node) => ({
     ...node,
     position: {
-      x: node.position.x - normalizedMinX + 50, // add slight margin for viewport
-      y: node.position.y,
+      x: node.position.x - normalizedMinX + 50,
+      y: node.position.y - normalizedMinY + 50,
     },
   }));
 


### PR DESCRIPTION
## Summary\n- allow dagre autoLayout to honor requested direction instead of forcing top-to-bottom\n- auto-layout switches to left-to-right when formProcess/formProcessGroup containers are present\n- update master plan log with new PR entry\n\n## Testing\n- not run (frontend layout change only)