### PR TITLE
Fix env audit + email integration log schema

### DIFF
--- a/backend/apps/email_integration/models/email_models.py
+++ b/backend/apps/email_integration/models/email_models.py
@@ -98,57 +98,6 @@ class EmailAccount(models.Model):
         return timezone.now() >= (self.webhook_expires_at - timezone.timedelta(days=1))
 
 
-class EmailLog(models.Model):
-    """Log of email events for debugging and audit trail"""
-    
-    EVENT_CHOICES = [
-        ('received', 'Email Received'),
-        ('sent', 'Email Sent'),
-        ('updated', 'Email Updated'),
-        ('error', 'Error'),
-    ]
-    
-    email_account = models.ForeignKey(
-        EmailAccount,
-        on_delete=models.CASCADE,
-        related_name='email_logs'
-    )
-    
-    event_type = models.CharField(max_length=20, choices=EVENT_CHOICES)
-    subject = models.CharField(max_length=500, blank=True)
-    from_address = models.EmailField(blank=True)
-    to_addresses = models.TextField(blank=True, help_text='Comma-separated list')
-    message_id = models.CharField(max_length=255, blank=True)
-    
-    # Full message data (JSON)
-    metadata = models.JSONField(default=dict, blank=True)
-    
-    created_at = models.DateTimeField(auto_now_add=True)
-    
-    class Meta:
-        db_table = 'email_logs'
-        ordering = ['-created_at']
-        indexes = [
-            models.Index(fields=['email_account', '-created_at']),
-            models.Index(fields=['event_type']),
-        ]
-    
-    def __str__(self):
-        return f'{self.event_type}: {self.subject}'
-
-
-# Placeholder models for workflow integration (to be implemented)
-class EmailTrigger(models.Model):
-    """Workflow trigger node for email events"""
-    # TODO: Implement full workflow integration
-    pass
-
-
-class EmailAction(models.Model):
-    """Workflow action node for sending emails"""
-    # TODO: Implement full workflow integration
-    pass
-
 
 class EmailTrigger(models.Model):
     """Email-based trigger configuration for workflow nodes"""

--- a/backend/apps/email_integration/views/webhook_views.py
+++ b/backend/apps/email_integration/views/webhook_views.py
@@ -360,18 +360,27 @@ def process_outlook_notification(account_id, user_id, resource, change_type, not
             if response.status_code == 200:
                 message_data = response.json()
                 
-                # Log the email event
+                # Log the webhook event (raw email payload stored for debugging)
                 EmailLog.objects.create(
                     email_account=email_account,
-                    event_type='received' if change_type == 'created' else 'updated',
+                    log_type='webhook',
+                    workflow_node_id='',
                     subject=message_data.get('subject', ''),
                     from_address=message_data.get('from', {}).get('emailAddress', {}).get('address', ''),
-                    to_addresses=', '.join([
-                        addr['emailAddress']['address'] 
+                    to_address=', '.join([
+                        addr.get('emailAddress', {}).get('address', '')
                         for addr in message_data.get('toRecipients', [])
+                        if addr.get('emailAddress', {}).get('address')
                     ]),
-                    message_id=message_data.get('id'),
-                    metadata=message_data
+                    success=True,
+                    raw_data={
+                        'change_type': change_type,
+                        'resource': resource,
+                        'message_id': message_data.get('id'),
+                        'message': message_data,
+                        'notification': notification_data,
+                        'subscription_id': notification_data.get('subscriptionId'),
+                    },
                 )
                 
                 # TODO: Trigger EmailTrigger workflow nodes
@@ -639,15 +648,21 @@ def process_gmail_notification(email_address, history_id):
                             for h in full_message['payload']['headers']
                         }
                         
-                        # Log the email event
+                        # Log the webhook event (raw email payload stored for debugging)
                         EmailLog.objects.create(
                             email_account=email_account,
-                            event_type='received',
+                            log_type='webhook',
+                            workflow_node_id='',
                             subject=headers.get('Subject', ''),
                             from_address=headers.get('From', ''),
-                            to_addresses=headers.get('To', ''),
-                            message_id=message['id'],
-                            metadata=full_message
+                            to_address=headers.get('To', ''),
+                            success=True,
+                            raw_data={
+                                'message_id': message.get('id'),
+                                'history_id': history_id,
+                                'headers': headers,
+                                'full_message': full_message,
+                            },
                         )
                         
                         logger.info(f"Processed Gmail email: {headers.get('Subject')}")

--- a/config/manage_env.py
+++ b/config/manage_env.py
@@ -1,22 +1,35 @@
 #!/usr/bin/env python3
-"""
-ProjectMeats Environment & Secret Manager (v4.0 - Environment-Aware)
-Source of Truth: config/env.manifest.json
+"""ProjectMeats Environment & Secret Manager.
 
-Features:
-- Audit: Environment-aware secret checking (Global + Environment Secrets)
-- Logic: Available Secrets = Environment Secrets + Global Secrets
+Canonical source of truth:
+- manifests/env.manifest.json (v5.x)
+
+Legacy fallback (supported for older checkouts):
+- config/env.manifest.json
+
+This tool audits GitHub Secrets (repository + environment-scoped) against the
+manifest requirements.
+
+Notes:
+- This tool never prints secret VALUES.
+- By default it prints only missing/zombie secret NAMES (actionable), not the
+  full inventory of configured secrets.
 """
 
+import argparse
 import json
 import subprocess
 import sys
-import argparse
 from pathlib import Path
-from typing import Dict, Set, List, Any
+from typing import Any, Dict, Optional, Set, Tuple
 
-# --- Configuration ---
-MANIFEST_PATH = Path(__file__).parent / "env.manifest.json"
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_CANDIDATES = [
+    REPO_ROOT / 'manifests' / 'env.manifest.json',  # canonical (v5.x)
+    Path(__file__).resolve().parent / 'env.manifest.json',  # legacy
+]
+
 
 class Colors:
     RED = '\033[91m'
@@ -26,29 +39,51 @@ class Colors:
     END = '\033[0m'
     BOLD = '\033[1m'
 
+
+def _parse_major_version(version_value: Any) -> int:
+    """Parse manifest version into a major integer (best effort)."""
+    if version_value is None:
+        return 0
+    try:
+        s = str(version_value).strip()
+        major = s.split('.', 1)[0]
+        return int(major)
+    except Exception:
+        return 0
+
+
 class EnvironmentManager:
-    def __init__(self):
-        self.manifest = self._load_manifest()
-        self.environments = self.manifest.get("environments", {})
-        self.variables = self.manifest.get("variables", {})
+    def __init__(self, manifest_path: Optional[Path] = None):
+        self.manifest_path, self.manifest = self._load_manifest(manifest_path)
+        self.manifest_version = self.manifest.get('version')
+        self.manifest_major = _parse_major_version(self.manifest_version)
 
-    def _load_manifest(self) -> Dict[str, Any]:
-        if not MANIFEST_PATH.exists():
-            print(f"{Colors.RED}CRITICAL: Manifest not found at {MANIFEST_PATH}{Colors.END}")
-            sys.exit(1)
-        with open(MANIFEST_PATH, 'r') as f:
-            return json.load(f)
+    def _load_manifest(self, manifest_path: Optional[Path]) -> Tuple[Path, Dict[str, Any]]:
+        candidates = [manifest_path] if manifest_path else []
+        candidates.extend(MANIFEST_CANDIDATES)
 
-    def _get_secrets(self, env_name: str = None) -> Set[str]:
+        for candidate in candidates:
+            if not candidate:
+                continue
+            if candidate.exists():
+                with candidate.open('r', encoding='utf-8') as f:
+                    return candidate, json.load(f)
+
+        print(f"{Colors.RED}CRITICAL: Manifest not found. Tried:{Colors.END}")
+        for c in MANIFEST_CANDIDATES:
+            print(f"  - {c}")
+        sys.exit(1)
+
+    def _get_secrets(self, env_name: Optional[str] = None) -> Set[str]:
+        """Fetch secret names from GitHub via gh.
+
+        - env_name=None => repository secrets
+        - env_name=str  => environment secrets for that environment
         """
-        Fetch secrets. 
-        If env_name is None, fetches Global Repository Secrets.
-        If env_name is provided, fetches Environment Secrets.
-        """
-        cmd = ["gh", "secret", "list", "--json", "name", "-q", ".[].name"]
+        cmd = ['gh', 'secret', 'list', '--json', 'name', '-q', '.[].name']
         if env_name:
-            cmd.extend(["--env", env_name])
-        
+            cmd.extend(['--env', env_name])
+
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
             return set(filter(None, result.stdout.strip().split('\n')))
@@ -59,171 +94,183 @@ class EnvironmentManager:
             print(f"{Colors.RED}Error: GitHub CLI ('gh') is not installed.{Colors.END}")
             sys.exit(1)
 
-    def _resolve_secret_name(self, env_name: str, var_name: str, var_def: Dict) -> str:
-        """Determines the expected GitHub Secret name."""
-        # 1. Explicit Mapping
-        if "ci_secret_mapping" in var_def:
-            if env_name in var_def["ci_secret_mapping"]:
-                return var_def["ci_secret_mapping"][env_name]
-        
-        # 2. Pattern Mapping
-        env_config = self.environments[env_name]
-        prefix = env_config.get("prefix", "DEV")
-        
-        pattern = var_def.get("ci_secret_pattern")
-        if pattern:
-            return pattern.replace("{PREFIX}", prefix)
-            
-        return f"{prefix}_{var_name}"
+    def _manifest_all_secret_names_v5(self) -> Tuple[Set[str], Set[str]]:
+        repo_defs = self.manifest.get('repository_secrets', {})
+        env_defs = self.manifest.get('environment_secrets', {})
 
-    def audit_secrets(self, exit_on_error: bool = True):
-        """
-        Comprehensive audit of GitHub Secrets against manifest requirements.
-        
-        Args:
-            exit_on_error: If True, exits with code 1 on missing secrets. 
-                          If False, returns audit results for programmatic use.
-        
-        Returns:
-            dict: Audit results with structure:
-                {
-                    'passed': bool,
-                    'global_secrets': set,
-                    'environments': {
-                        'env-name': {
-                            'env_secrets': set,
-                            'available_secrets': set,
-                            'missing': list,
-                            'required': list
-                        }
-                    }
-                }
-        """
-        print(f"{Colors.BOLD}Starting Environment-Aware Audit (Manifest v{self.manifest.get('version', '?.?')})...{Colors.END}\n")
-        
-        # 1. Fetch Global Secrets (Available to all)
-        global_secrets = self._get_secrets(None)
-        print(f"{Colors.CYAN}✓ Fetched {len(global_secrets)} Global Repository Secrets{Colors.END}")
-        
-        if global_secrets:
-            print(f"{Colors.CYAN}  Global Secrets:{Colors.END}")
-            for secret in sorted(global_secrets):
-                print(f"    - {secret}")
+        repo_names = set(repo_defs.keys())
+        env_names: Set[str] = set()
+        for category_vars in env_defs.values():
+            env_names |= set(category_vars.keys())
+        return repo_names, env_names
 
-        audit_results = {
-            'passed': True,
-            'global_secrets': global_secrets,
-            'environments': {}
-        }
-        
-        has_missing = False
-        all_missing_secrets = []
+    def _required_repo_secrets_v5(self) -> Set[str]:
+        repo_defs = self.manifest.get('repository_secrets', {})
+        return {name for name, d in repo_defs.items() if d.get('required', False)}
 
-        # 2. Audit Each Environment
-        for env_name, env_config in self.environments.items():
-            print(f"\n{Colors.BOLD}Environment: {env_name}{Colors.END}")
-            print(f"  Type: {env_config.get('type', 'backend')}")
-            print(f"  Prefix: {env_config.get('prefix', 'N/A')}")
-            
-            # Fetch Env-Specific Secrets
-            env_secrets = self._get_secrets(env_name)
-            # Effective access = Env Secrets + Global Secrets
-            available_secrets = env_secrets.union(global_secrets)
-            
-            missing_in_this_env = []
-            required_in_this_env = []
-            env_type = env_config.get("type", "backend")
-            
-            categories = ["infrastructure"]
-            if env_type == "backend":
-                categories.append("application")
-            elif env_type == "frontend":
-                categories.append("frontend_runtime")
+    def _required_env_secrets_for_env_v5(self, env_key: str, env_cfg: Dict[str, Any]) -> Set[str]:
+        env_type = env_cfg.get('type')
+        env_defs = self.manifest.get('environment_secrets', {})
 
-            print(f"  Checking categories: {', '.join(categories)}")
-            
-            for category in categories:
-                vars_in_cat = self.variables.get(category, {})
-                for var_name, var_def in vars_in_cat.items():
-                    # Skip if value comes from config (not a secret)
-                    if var_def.get("value_source") == "environment_config":
-                        continue
-                    
-                    secret_name = self._resolve_secret_name(env_name, var_name, var_def)
-                    required_in_this_env.append(secret_name)
-                    
-                    if secret_name not in available_secrets:
-                        missing_entry = {
-                            'var_name': var_name,
-                            'secret_name': secret_name,
-                            'category': category,
-                            'environment': env_name
-                        }
-                        missing_in_this_env.append(missing_entry)
-                        all_missing_secrets.append(missing_entry)
+        required: Set[str] = set()
+        for _category, vars_in_cat in env_defs.items():
+            for secret_name, secret_def in vars_in_cat.items():
+                if not secret_def.get('required', False):
+                    continue
 
-            # Store results for this environment
-            audit_results['environments'][env_name] = {
-                'env_secrets': env_secrets,
-                'available_secrets': available_secrets,
-                'missing': missing_in_this_env,
-                'required': required_in_this_env
+                applies_to = secret_def.get('applies_to')
+                if not applies_to:
+                    required.add(secret_name)
+                    continue
+
+                applies = False
+                for item in applies_to:
+                    if item == env_key:
+                        applies = True
+                        break
+                    if item == 'backend environments' and env_type == 'backend':
+                        applies = True
+                        break
+                    if item == 'frontend environments' and env_type == 'frontend':
+                        applies = True
+                        break
+
+                if applies:
+                    required.add(secret_name)
+
+        return required
+
+    def audit_secrets(self, exit_on_error: bool = True, verbose: bool = False):
+        """Audit GitHub secrets against manifest requirements."""
+        print(
+            f"{Colors.BOLD}Starting Secret Audit (manifest v{self.manifest_version}, "
+            f"loaded from {self.manifest_path})...{Colors.END}\n"
+        )
+
+        if self.manifest_major >= 5:
+            return self._audit_v5(exit_on_error=exit_on_error, verbose=verbose)
+
+        print(
+            f"{Colors.RED}Unsupported manifest version: {self.manifest_version}. "
+            f"Expected v5.x manifest at manifests/env.manifest.json.{Colors.END}"
+        )
+        if exit_on_error:
+            sys.exit(1)
+        return {'passed': False, 'reason': 'unsupported_manifest_version'}
+
+    def _audit_v5(self, exit_on_error: bool, verbose: bool):
+        environments = self.manifest.get('environments', {})
+        required_repo = self._required_repo_secrets_v5()
+        all_repo_names, all_env_names = self._manifest_all_secret_names_v5()
+        all_manifest_names = all_repo_names | all_env_names
+
+        repo_present = self._get_secrets(None)
+        print(f"{Colors.CYAN}✓ Fetched {len(repo_present)} repository secret(s){Colors.END}")
+
+        missing_any = False
+
+        missing_repo = sorted(required_repo - repo_present)
+        zombie_repo = sorted(repo_present - all_manifest_names)
+
+        if missing_repo:
+            missing_any = True
+            print(f"\n{Colors.RED}❌ Missing required repository secrets ({len(missing_repo)}):{Colors.END}")
+            for s in missing_repo:
+                print(f"  • {Colors.BOLD}{s}{Colors.END}")
+        else:
+            print(f"{Colors.GREEN}✓ Required repository secrets present ({len(required_repo)}){Colors.END}")
+
+        if zombie_repo:
+            print(f"\n{Colors.YELLOW}🧟 Zombie repository secrets (not in manifest) ({len(zombie_repo)}):{Colors.END}")
+            for s in zombie_repo:
+                print(f"  • {Colors.BOLD}{s}{Colors.END}")
+
+        env_results = {}
+        for env_key, env_cfg in environments.items():
+            gh_env = env_cfg.get('github_environment') or env_key
+            env_present = self._get_secrets(gh_env)
+
+            required_env = self._required_env_secrets_for_env_v5(env_key, env_cfg)
+            available = env_present | repo_present
+
+            missing_env = sorted(required_env - available)
+            zombie_env = sorted(env_present - all_env_names)
+
+            env_results[env_key] = {
+                'github_environment': gh_env,
+                'type': env_cfg.get('type'),
+                'required_env': sorted(required_env),
+                'missing': missing_env,
+                'zombie': zombie_env,
             }
 
-            if missing_in_this_env:
-                has_missing = True
-                audit_results['passed'] = False
-                print(f"\n  {Colors.RED}❌ MISSING SECRETS ({len(missing_in_this_env)}):{Colors.END}")
-                for item in missing_in_this_env:
-                    print(f"     {Colors.RED}•{Colors.END} {item['var_name']} → {Colors.BOLD}{item['secret_name']}{Colors.END}")
-                    print(f"       Category: {item['category']}")
-            else:
-                print(f"\n  {Colors.GREEN}✅ All Required Secrets Present{Colors.END}")
-                print(f"     Environment-specific: {len(env_secrets)}")
-                print(f"     Total available: {len(available_secrets)}")
+            print(f"\n{Colors.BOLD}Environment: {env_key}{Colors.END} (gh env: {gh_env})")
+            print(f"  Required env secrets: {len(required_env)}")
+            print(f"  Environment secrets present: {len(env_present)}")
 
-        # 3. Summary Report
+            if missing_env:
+                missing_any = True
+                print(f"  {Colors.RED}❌ Missing ({len(missing_env)}):{Colors.END}")
+                for s in missing_env:
+                    print(f"    • {Colors.BOLD}{s}{Colors.END}")
+            else:
+                print(f"  {Colors.GREEN}✅ All required secrets present{Colors.END}")
+
+            if zombie_env:
+                print(f"  {Colors.YELLOW}🧟 Zombie env secrets ({len(zombie_env)}):{Colors.END}")
+                for s in zombie_env:
+                    print(f"    • {Colors.BOLD}{s}{Colors.END}")
+
+            if verbose:
+                # Only in verbose mode do we print inventory-ish info.
+                print(f"  Available secrets (repo + env): {len(available)}")
+
         print(f"\n{Colors.BOLD}{'=' * 70}{Colors.END}")
-        print(f"{Colors.BOLD}AUDIT SUMMARY{Colors.END}")
-        print(f"{Colors.BOLD}{'=' * 70}{Colors.END}")
-        
-        if has_missing:
-            print(f"\n{Colors.RED}❌ AUDIT FAILED{Colors.END}")
-            print(f"\n{Colors.RED}Total Missing Secrets: {len(all_missing_secrets)}{Colors.END}\n")
-            
-            # Group by environment for clarity
-            for env_name, env_results in audit_results['environments'].items():
-                if env_results['missing']:
-                    print(f"{Colors.BOLD}{env_name}:{Colors.END}")
-                    for item in env_results['missing']:
-                        print(f"  • {Colors.BOLD}{item['secret_name']}{Colors.END}")
-                    print()
-            
-            print(f"{Colors.YELLOW}ACTION REQUIRED:{Colors.END}")
-            print(f"  1. Add missing secrets to GitHub:")
-            print(f"     {Colors.CYAN}https://github.com/Meats-Central/ProjectMeats/settings/secrets/actions{Colors.END}")
-            print(f"  2. Ensure secrets are added to the correct environment scope")
-            print(f"  3. Re-run audit: {Colors.CYAN}python config/manage_env.py audit{Colors.END}\n")
-            
+        if missing_any:
+            print(f"{Colors.RED}❌ AUDIT FAILED{Colors.END}")
             if exit_on_error:
                 sys.exit(1)
         else:
-            print(f"\n{Colors.GREEN}✅ AUDIT PASSED{Colors.END}")
-            print(f"\nAll required secrets are properly configured:")
-            for env_name, env_results in audit_results['environments'].items():
-                print(f"  • {env_name}: {len(env_results['required'])} secrets validated")
-            print()
-        
-        return audit_results
+            print(f"{Colors.GREEN}✅ AUDIT PASSED{Colors.END}")
+
+        return {
+            'passed': not missing_any,
+            'manifest_path': str(self.manifest_path),
+            'manifest_version': self.manifest_version,
+            'missing_repo': missing_repo,
+            'zombie_repo': zombie_repo,
+            'environments': env_results,
+        }
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Environment & Secret Manager")
-    parser.add_argument("command", choices=["audit"], help="Command to run")
+    parser = argparse.ArgumentParser(description='Environment & Secret Manager')
+    parser.add_argument('command', choices=['audit'], help='Command to run')
+    parser.add_argument(
+        '--no-exit',
+        action='store_true',
+        help='Do not exit non-zero on missing required secrets (report only).',
+    )
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Print additional diagnostic information (never prints secret values).',
+    )
+    parser.add_argument(
+        '--manifest',
+        type=str,
+        default=None,
+        help='Optional path to a manifest JSON file (overrides default search).',
+    )
+
     args = parser.parse_args()
 
-    manager = EnvironmentManager()
-    if args.command == "audit":
-        manager.audit_secrets()
+    manifest_path = Path(args.manifest).resolve() if args.manifest else None
+    manager = EnvironmentManager(manifest_path=manifest_path)
 
-if __name__ == "__main__":
+    if args.command == 'audit':
+        manager.audit_secrets(exit_on_error=not args.no_exit, verbose=args.verbose)
+
+
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
This batch fixes two recurring operational gaps:

1) Env secret audit
- config/manage_env.py now treats manifests/env.manifest.json (v5.1) as canonical (fallback to legacy config/env.manifest.json)
- Supports repository_secrets + environment_secrets, reports missing + zombie secrets
- Adds --no-exit / --verbose flags (default behavior unchanged)

2) Email integration runtime warnings + schema drift
- Removes duplicate model declarations in apps.email_integration that caused Django "already registered" RuntimeWarnings
- Updates webhook_views EmailLog writes to match 0001_initial schema (log_type/to_address/raw_data)

Verification:
- bash scripts/verify_golden_state.sh
- python verify_phase6.py