### PR TITLE
🔧 Fix: Trigger/Action Node Visibility Conditions

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -85,6 +85,41 @@ export interface DynamicConfigPanelProps {
 }
 
 // ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Helper to aggressively check all known condition aliases and support functions
+ * 
+ * Checks for: conditional, visibilityCondition, showIf
+ * Supports: function conditions and standard condition objects
+ * 
+ * @param item - Section or field to check
+ * @param data - Current form data
+ * @returns true if item should be visible, false otherwise
+ */
+const checkIsVisible = (item: any, data: any): boolean => {
+  // Check all known aliases for condition properties
+  const cond = item.conditional || item.visibilityCondition || item.showIf;
+  
+  // No condition = always visible
+  if (!cond) return true;
+  
+  // Support functional conditions
+  if (typeof cond === 'function') {
+    try {
+      return cond(data);
+    } catch (error) {
+      console.warn('[DynamicConfigPanel] Functional condition error:', error);
+      return true; // Default to visible on error
+    }
+  }
+  
+  // Use standard evaluator for object conditions
+  return evaluateCondition(cond, data);
+};
+
+// ============================================================================
 // Main Component
 // ============================================================================
 
@@ -181,14 +216,14 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     const visible = new Set<string>();
     
     schema.sections.forEach(section => {
-      // Check section-level conditional
-      if (section.conditional && !evaluateCondition(section.conditional, formData)) {
+      // Check section-level conditional (using robust helper)
+      if (!checkIsVisible(section, formData)) {
         return; // Hide entire section
       }
 
       section.fields.forEach(field => {
-        // Check field-level conditional
-        if (!field.conditional || evaluateCondition(field.conditional, formData)) {
+        // Check field-level conditional (using robust helper)
+        if (checkIsVisible(field, formData)) {
           visible.add(field.id);
         }
       });
@@ -541,8 +576,8 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
 
   // Render a section
   const renderSection = (section: ConfigSection) => {
-    // Check section-level conditional
-    if (section.conditional && !evaluateCondition(section.conditional, formData)) {
+    // Check section-level conditional (using robust helper)
+    if (!checkIsVisible(section, formData)) {
       return null;
     }
 

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -1090,7 +1090,7 @@ export const triggerSchema: NodeConfigSchema = {
       icon: Webhook,
       defaultExpanded: true,
       description: 'Configure webhook endpoint and authentication',
-      visibilityCondition: {
+      conditional: {
         field: 'type',
         operator: 'equals',
         value: 'webhook'
@@ -1125,7 +1125,7 @@ export const triggerSchema: NodeConfigSchema = {
           placeholder: 'Auto-generated',
           helpText: 'Secret key for validating incoming requests (auto-generated)',
           readOnly: true,
-          visibilityCondition: {
+          conditional: {
             field: 'webhookAuth',
             operator: 'notEquals',
             value: 'none'
@@ -1153,7 +1153,7 @@ export const triggerSchema: NodeConfigSchema = {
       icon: Calendar,
       defaultExpanded: true,
       description: 'Configure when the workflow should run',
-      visibilityCondition: {
+      conditional: {
         field: 'type',
         operator: 'equals',
         value: 'schedule'
@@ -1177,7 +1177,7 @@ export const triggerSchema: NodeConfigSchema = {
           placeholder: 'e.g., 15',
           helpText: 'How often to run',
           defaultValue: 15,
-          visibilityCondition: {
+          conditional: {
             field: 'scheduleType',
             operator: 'equals',
             value: 'simple'
@@ -1198,7 +1198,7 @@ export const triggerSchema: NodeConfigSchema = {
             { value: 'weeks', label: 'Weeks' },
           ],
           defaultValue: 'minutes',
-          visibilityCondition: {
+          conditional: {
             field: 'scheduleType',
             operator: 'equals',
             value: 'simple'
@@ -1210,7 +1210,7 @@ export const triggerSchema: NodeConfigSchema = {
           label: 'Cron Expression',
           placeholder: '0 0 * * *',
           helpText: 'Unix cron syntax (minute hour day month weekday)',
-          visibilityCondition: {
+          conditional: {
             field: 'scheduleType',
             operator: 'equals',
             value: 'cron'
@@ -1246,7 +1246,7 @@ export const triggerSchema: NodeConfigSchema = {
       icon: Database,
       defaultExpanded: true,
       description: 'Configure database event triggers',
-      visibilityCondition: {
+      conditional: {
         field: 'type',
         operator: 'equals',
         value: 'event'
@@ -1290,7 +1290,7 @@ export const triggerSchema: NodeConfigSchema = {
       icon: FileText,
       defaultExpanded: true,
       description: 'Configure form submission trigger',
-      visibilityCondition: {
+      conditional: {
         field: 'type',
         operator: 'equals',
         value: 'formSubmit'
@@ -1315,7 +1315,7 @@ export const triggerSchema: NodeConfigSchema = {
       icon: Zap,
       defaultExpanded: true,
       description: 'Configure manual trigger button',
-      visibilityCondition: {
+      conditional: {
         field: 'type',
         operator: 'equals',
         value: 'manual'
@@ -1404,7 +1404,7 @@ export const documentGenerateSchema: NodeConfigSchema = {
               disabled: true,
             },
           ],
-          visibilityCondition: {
+          conditional: {
             field: 'templateSource',
             operator: 'equals',
             value: 'library'
@@ -1496,7 +1496,7 @@ export const documentSignSchema: NodeConfigSchema = {
           placeholder: 'Select document from previous step...',
           helpText: 'Document to be signed',
           required: true,
-          visibilityCondition: {
+          conditional: {
             field: 'documentSource',
             operator: 'equals',
             value: 'upstream'
@@ -1698,7 +1698,7 @@ export const documentStoreSchema: NodeConfigSchema = {
           label: 'Record ID',
           placeholder: 'Select record ID...',
           helpText: 'ID of the related entity record',
-          visibilityCondition: {
+          conditional: {
             field: 'relatedEntity',
             operator: 'notEmpty',
           }
@@ -1777,7 +1777,7 @@ export const conditionIfSchema: NodeConfigSchema = {
           label: 'Right Value',
           placeholder: 'Select value or enter text...',
           helpText: 'Value to compare against',
-          visibilityCondition: {
+          conditional: {
             field: 'operator',
             operator: 'notIn',
             value: ['isEmpty', 'isNotEmpty']
@@ -2974,7 +2974,7 @@ const actionHTTPSchema: NodeConfigSchema = {
           language: 'json',
           placeholder: '{\n  "key": "value"\n}',
           helpText: 'Request body for POST/PUT/PATCH. Supports {{variable}} substitution.',
-          showIf: {
+          conditional: {
             field: 'method',
             operator: 'in',
             value: ['POST', 'PUT', 'PATCH']
@@ -3016,7 +3016,7 @@ const actionHTTPSchema: NodeConfigSchema = {
           label: 'Bearer Token',
           placeholder: 'your-api-token',
           helpText: 'Token will be sent as "Authorization: Bearer {token}"',
-          showIf: {
+          conditional: {
             field: 'authType',
             operator: 'equals',
             value: 'bearer'
@@ -3027,7 +3027,7 @@ const actionHTTPSchema: NodeConfigSchema = {
           type: 'text',
           label: 'Username',
           placeholder: 'username',
-          showIf: {
+          conditional: {
             field: 'authType',
             operator: 'equals',
             value: 'basic'
@@ -3038,7 +3038,7 @@ const actionHTTPSchema: NodeConfigSchema = {
           type: 'password',
           label: 'Password',
           placeholder: 'password',
-          showIf: {
+          conditional: {
             field: 'authType',
             operator: 'equals',
             value: 'basic'
@@ -3049,7 +3049,7 @@ const actionHTTPSchema: NodeConfigSchema = {
           type: 'text',
           label: 'API Key Header Name',
           placeholder: 'X-API-Key',
-          showIf: {
+          conditional: {
             field: 'authType',
             operator: 'equals',
             value: 'apiKey'
@@ -3060,7 +3060,7 @@ const actionHTTPSchema: NodeConfigSchema = {
           type: 'text',
           label: 'API Key Value',
           placeholder: 'your-api-key',
-          showIf: {
+          conditional: {
             field: 'authType',
             operator: 'equals',
             value: 'apiKey'
@@ -3109,7 +3109,7 @@ const actionHTTPSchema: NodeConfigSchema = {
           defaultValue: 3,
           min: 1,
           max: 10,
-          showIf: {
+          conditional: {
             field: 'errorHandling',
             operator: 'equals',
             value: 'retry'
@@ -3441,7 +3441,7 @@ const dataTransformSchema: NodeConfigSchema = {
           helpText: 'Map input fields to output fields',
           placeholder: { key: 'Output field', value: 'Input field (e.g., {{item.name}})' },
           addButtonText: '+ Add Mapping',
-          showIf: {
+          conditional: {
             field: 'operation',
             operator: 'equals',
             value: 'map'
@@ -3454,7 +3454,7 @@ const dataTransformSchema: NodeConfigSchema = {
           placeholder: 'e.g., {{item.status}} == "active"',
           helpText: 'Items matching this condition will be included',
           rows: 3,
-          showIf: {
+          conditional: {
             field: 'operation',
             operator: 'equals',
             value: 'filter'
@@ -3468,7 +3468,7 @@ const dataTransformSchema: NodeConfigSchema = {
           placeholder: '// Transform logic\nreturn data.map(item => ({\n  id: item.id,\n  name: item.name.toUpperCase()\n}));',
           helpText: 'Full JavaScript control. Input available as "data" variable.',
           rows: 8,
-          showIf: {
+          conditional: {
             field: 'operation',
             operator: 'equals',
             value: 'custom'
@@ -3549,7 +3549,7 @@ const setVariableSchema: NodeConfigSchema = {
           label: 'Value',
           placeholder: 'Enter value...',
           helpText: 'Static value to assign',
-          showIf: {
+          conditional: {
             field: 'valueType',
             operator: 'equals',
             value: 'static'
@@ -3561,7 +3561,7 @@ const setVariableSchema: NodeConfigSchema = {
           label: 'Upstream Field',
           placeholder: 'e.g., {{customer.email}} or {{response.data.id}}',
           helpText: 'Select field from previous node output',
-          showIf: {
+          conditional: {
             field: 'valueType',
             operator: 'equals',
             value: 'upstream'
@@ -3575,7 +3575,7 @@ const setVariableSchema: NodeConfigSchema = {
           placeholder: '// Calculate value\nreturn {{quantity}} * {{price}};',
           helpText: 'JavaScript expression to calculate value. Return the result.',
           rows: 4,
-          showIf: {
+          conditional: {
             field: 'valueType',
             operator: 'equals',
             value: 'expression'
@@ -3623,7 +3623,7 @@ const setVariableSchema: NodeConfigSchema = {
           label: 'Persist to Database',
           defaultValue: false,
           helpText: 'Save variable value to database for future workflow runs',
-          showIf: {
+          conditional: {
             field: 'scope',
             operator: 'equals',
             value: 'global'
@@ -4164,7 +4164,7 @@ export const subWorkflowSchema: NodeConfigSchema = {
           min: 1,
           max: 10,
           defaultValue: 3,
-          visibilityCondition: (data) => data.errorHandling === 'retry',
+          conditional: (data) => data.errorHandling === 'retry',
         },
       ]
     }


### PR DESCRIPTION
## Issue Fixed
Trigger and action nodes were showing all configuration options simultaneously instead of conditionally showing/hiding sections based on selected type.

## Root Cause
Property name mismatches between schema definitions and DynamicConfigPanel:
- Schemas used: `visibilityCondition:`, `showIf:`, `conditional:`
- DynamicConfigPanel only checked: `conditional:`
- Result: Sections with aliases treated as having no conditions → all visible

## Solution

### 1. Standardized Schema Properties
- Replaced all `visibilityCondition:` → `conditional:`
- Replaced all `showIf:` → `conditional:`
- **28 replacements** across nodeConfigSchemas.ts

### 2. Enhanced DynamicConfigPanel
Added `checkIsVisible()` helper function that:
- ✅ Checks all aliases: `conditional`, `visibilityCondition`, `showIf`
- ✅ Supports functional conditions: `conditional: (data) => data.field === 'value'`
- ✅ Error handling with graceful fallback
- ✅ Uses standard evaluateCondition for object conditions

### 3. Updated Visibility Logic
- `visibleFields` useMemo now uses `checkIsVisible()`
- `renderSection()` now uses `checkIsVisible()`
- Consistent behavior across section and field-level conditionals

## Files Modified
- `frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts` (28 replacements)
- `frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx` (+47 lines)

## Impact
- ✅ Trigger nodes now properly toggle between webhook/schedule/event configurations
- ✅ Action nodes with conditional fields work correctly
- ✅ Backward compatible (all condition aliases still work)
- ✅ Future-proof (functional conditions supported)

## Testing
1. Drop a Trigger node on canvas
2. Change trigger type dropdown (webhook/schedule/event)
3. Verify only relevant section shows (not all sections simultaneously)
4. Test with Action nodes that have conditional fields

## Related
- Phase 7 Stabilization - FlowEditor Config UX
- Follows WSOD hotfix (#3569)