### PR TITLE
fix: Convert subWorkflow Arrow Function to Object Conditional

### DIFF
--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -4164,7 +4164,7 @@ export const subWorkflowSchema: NodeConfigSchema = {
           min: 1,
           max: 10,
           defaultValue: 3,
-          conditional: (data) => data.errorHandling === 'retry',
+          conditional: { field: 'errorHandling', operator: 'equals', value: 'retry' },
         },
       ]
     }


### PR DESCRIPTION
## 🐛 Schema Validation Fix

Resolves console errors for subWorkflow node

## Issue
Arrow function in conditional field causes validation error

## Solution
```diff
-  conditional: (data) => data.errorHandling === 'retry',
+  conditional: { field: 'errorHandling', operator: 'equals', value: 'retry' },
```

## Impact
Resolves schema validation console errors