### PR TITLE
fix(floweditor): Phase 9 polish + remove axios

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -625,3 +625,18 @@ Deliverables:
 - ✅ Runtime Fixes: COMPLETE (PR #3584)
 - [x] Wired Cockpit Entity Tools (Smart Quote, Email Drafter) to dynamic workflow engine with record context.
 - [x] Integrated 'Configure Tools' UI for user-customizable action buttons.
+
+## Phase 9: Editor Polish & Optimization
+
+- [x] Audit & Destroy Legacy Code: remove direct axios imports under `frontend/src/components/FlowEditor/` (use `businessApi` / `workformsApi` only).
+  - [x] Replaced axios usage in `Modals/SharedTemplateDeleteModal.tsx` with `workformsApi` helpers.
+  - [x] Added `getTenantFormUsageInfo()` + `decrementTenantFormUsage()` to `frontend/src/services/workformsApi.ts`.
+
+- [x] Phase E.2 (Panel Migration): align panels to FlowEditorContext + shared StyledComponents.
+  - [x] `FormFieldConfigPanel.tsx`: imports standardized to `ConfigPanel/shared/StyledComponents.ts` (via explicit path).
+  - [x] `DocumentConfigPanel.tsx`: uses FlowEditorContext fallback for `availableFields` and replaces custom fixed wrapper with shared `Panel`.
+
+- [x] Edge semantics + performance tuning:
+  - [x] Enforced `MarkerType.ArrowClosed` marker color using CSS vars (no hardcoded hex).
+  - [x] Set `onlyRenderVisibleElements={true}` on the main ReactFlow instance.
+  - [x] Confirmed Monaco usage remains lazy via `React.lazy(() => import('@monaco-editor/react'))`.

--- a/frontend/src/components/FlowEditor/ConfigPanel/DocumentConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DocumentConfigPanel.tsx
@@ -11,6 +11,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { X, FileUp, Info, AlertCircle } from 'lucide-react';
 import { ConditionBuilder, ConditionRule, ConditionLogic } from './ConditionBuilder';
+import { useFlowEditor } from '../context';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -82,29 +83,6 @@ const FILE_TYPE_PRESETS = [
 // Styled Components
 // ============================================================================
 
-const Container = styled.div`
-  position: fixed;
-  top: 0;
-  right: 0;
-  width: 500px;
-  height: 100vh;
-  background: rgb(var(--color-surface));
-  border-left: 1px solid rgb(var(--color-border));
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
-  display: flex;
-  flex-direction: column;
-  z-index: 1000;
-  animation: slideIn 0.25s ease-out;
-
-  @keyframes slideIn {
-    from {
-      transform: translateX(100%);
-    }
-    to {
-      transform: translateX(0);
-    }
-  }
-`;
 
 
 
@@ -386,8 +364,15 @@ export const DocumentConfigPanel: React.FC<DocumentConfigPanelProps> = ({
   document,
   onChange,
   onClose,
-  availableFields = [],
+  availableFields: availableFieldsProp,
 }) => {
+  const { availableFields: ctxAvailableFields } = useFlowEditor();
+
+  const availableFields = (availableFieldsProp?.length
+    ? availableFieldsProp
+    : ctxAvailableFields.map((f) => ({ id: f.key, label: f.label, type: f.type }))
+  );
+
   const [formData, setFormData] = useState<DocumentData>({
     label: document.label || '',
     description: document.description || '',
@@ -449,7 +434,7 @@ export const DocumentConfigPanel: React.FC<DocumentConfigPanelProps> = ({
   };
 
   return (
-    <Container>
+    <Panel $width="500px">
       <PanelHeader>
         <PanelHeaderTitle>
           <IconBadge>
@@ -700,6 +685,6 @@ export const DocumentConfigPanel: React.FC<DocumentConfigPanelProps> = ({
           Save Upload Field
         </PrimaryButton>
       </PanelFooter>
-    </Container>
+    </Panel>
   );
 };

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
@@ -41,7 +41,7 @@ import {
   RequiredIndicator,
   PrimaryButton,
   SecondaryButton,
-} from './shared';
+} from './shared/StyledComponents';
 
 // ============================================================================
 // TypeScript Interfaces

--- a/frontend/src/components/FlowEditor/Modals/SharedTemplateDeleteModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/SharedTemplateDeleteModal.tsx
@@ -31,7 +31,10 @@ import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { AlertTriangle, Trash2, XCircle, Loader } from 'lucide-react';
 import { notify } from '../../../utils/notify';
-import axios from 'axios';
+import {
+  decrementTenantFormUsage,
+  getTenantFormUsageInfo,
+} from '../../../services/workformsApi';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -357,8 +360,8 @@ export const SharedTemplateDeleteModal: React.FC<SharedTemplateDeleteModalProps>
 
     setIsLoading(true);
     try {
-      const response = await axios.get(`/api/v1/system/tenant-forms/${template.formId}/usage/`);
-      setUsageInfo(response.data);
+      const data = await getTenantFormUsageInfo(template.formId);
+      setUsageInfo(data);
     } catch (error) {
       console.error('[SharedTemplateDeleteModal] Failed to fetch usage info:', error);
       notify.error('Failed to load template usage information');
@@ -377,7 +380,7 @@ export const SharedTemplateDeleteModal: React.FC<SharedTemplateDeleteModalProps>
 
     try {
       // Decrement usage count on backend
-      await axios.post(`/api/v1/system/tenant-forms/${template.formId}/decrement-usage/`);
+      await decrementTenantFormUsage(template.formId);
       
       // Remove node from workflow
       onRemoveFromWorkflow(template.nodeId);

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -5982,8 +5982,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         onSelectionChange={handleSelectionChange}
         nodeTypes={nodeTypes}
         edgeTypes={staticEdgeTypes}
-        // Phase 7.5: Performance optimizations for 1000+ nodes
-        onlyRenderVisibleElements={nodes.length > 100}
+        // Phase 7.5/9: Always render only visible elements for large-editor performance
+        onlyRenderVisibleElements={true}
         elevateNodesOnSelect={nodes.length < 200}
         maxZoom={4}
         minZoom={0.1}
@@ -5994,11 +5994,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             type: MarkerType.ArrowClosed,
             width: 20,
             height: 20,
-            color: '#94a3b8',
+            color: 'rgb(var(--color-border))',
           },
         }}
         connectionLineStyle={{
-          stroke: '#667eea',
+          stroke: 'rgb(var(--color-primary))',
           strokeWidth: 3,
           strokeDasharray: '5,5',
           animation: 'dash 0.5s linear infinite',

--- a/frontend/src/services/workformsApi.ts
+++ b/frontend/src/services/workformsApi.ts
@@ -85,6 +85,29 @@ export interface TenantForm {
   updated_by_name?: string;
 }
 
+// ---------------------------------------------------------------------------
+// System / TenantForm helpers (Phase 9: remove direct axios usage)
+// ---------------------------------------------------------------------------
+
+export interface TenantFormUsageInfo {
+  form_id: string;
+  usage_count: number;
+  workflows: Array<{
+    id: string;
+    name: string;
+    status: string;
+  }>;
+}
+
+export const getTenantFormUsageInfo = async (formId: string): Promise<TenantFormUsageInfo> => {
+  const response = await apiClient.get(`/system/tenant-forms/${formId}/usage/`);
+  return response.data;
+};
+
+export const decrementTenantFormUsage = async (formId: string): Promise<void> => {
+  await apiClient.post(`/system/tenant-forms/${formId}/decrement-usage/`);
+};
+
 export interface TenantWorkForm {
   id: string;
   tenant: string;


### PR DESCRIPTION
Implements Phase 9 editor polish and optimization tasks:

- FlowEditor: remove direct axios usage (SharedTemplateDeleteModal now uses workformsApi helpers).
- workformsApi: add TenantForm usage helper endpoints (system/tenant-forms usage + decrement).
- Panel migration: DocumentConfigPanel now uses FlowEditorContext fallback for availableFields and shared Panel wrapper; FormFieldConfigPanel imports explicitly from shared StyledComponents.
- UnifiedFlowEditor: enforce onlyRenderVisibleElements={true}; use CSS vars for arrow marker + connection line color.

Verification: frontend `npm run test:ci` (Vitest) passed.