### PR TITLE
fix(workforms): prevent 500 on workflow save

### DIFF
--- a/backend/apps/system/models/tenant_workform.py
+++ b/backend/apps/system/models/tenant_workform.py
@@ -193,33 +193,48 @@ class TenantWorkForm(models.Model):
         return f"{self.name} (v{self.version}) - {self.tenant.name}"
     
     def extract_form_references(self):
+        """Extract TenantForm UUIDs referenced by this workform.
+
+        This is intentionally defensive:
+        - tolerate malformed workflow_definition shapes
+        - ignore non-UUID tenantFormId values (prevents 500s on save)
         """
-        Extract TenantForm IDs from workflow nodes.
-        
-        Scans all nodes in workflow_definition and collects tenantFormId
-        references from Form Step nodes and Form Multi-Step Containers.
-        
-        Returns:
-            list: List of UUID strings
-        """
+
+        def _coerce_uuid(value):
+            if not value:
+                return None
+            try:
+                return str(uuid.UUID(str(value)))
+            except (ValueError, AttributeError, TypeError):
+                return None
+
         form_ids = set()
         nodes = self.workflow_definition.get('nodes', [])
-        
+        if not isinstance(nodes, list):
+            return []
+
         for node in nodes:
-            node_data = node.get('data', {})
-            
-            # Form Step node
-            if node.get('type') == 'formStep' and node_data.get('tenantFormId'):
-                form_ids.add(node_data['tenantFormId'])
-            
-            # Form Multi-Step Container (if implemented)
-            if node.get('type') == 'formMultiStepContainer' and node_data.get('tenantFormId'):
-                form_ids.add(node_data['tenantFormId'])
-            
-            # Form Reference node
-            if node.get('type') == 'formReference' and node_data.get('tenantFormId'):
-                form_ids.add(node_data['tenantFormId'])
-        
+            if not isinstance(node, dict):
+                continue
+
+            node_type = node.get('type')
+            node_data = node.get('data') or {}
+            if not isinstance(node_data, dict):
+                continue
+
+            candidate = node_data.get('tenantFormId')
+            coerced = _coerce_uuid(candidate)
+            if not coerced:
+                continue
+
+            # Form nodes
+            if node_type in {'formStep', 'formReference', 'form', 'formStepSingle'}:
+                form_ids.add(coerced)
+
+            # Form containers (legacy + canonical)
+            if node_type in {'formMultiStepContainer', 'formProcessGroup', 'formProcess'}:
+                form_ids.add(coerced)
+
         return list(form_ids)
     
     def update_form_references(self):

--- a/backend/apps/system/workform_serializers.py
+++ b/backend/apps/system/workform_serializers.py
@@ -199,7 +199,28 @@ class TenantWorkFormSerializer(serializers.ModelSerializer):
         return None
     
     def create(self, validated_data):
-        """Create workflow and extract form references."""
+        """Create workflow and extract form references.
+
+        Defensive improvements:
+        - Avoid 500s when creating a new workform with a duplicate name by auto-suffixing
+          (common with the default "Untitled Workflow").
+        """
+        tenant = validated_data.get('tenant')
+        name = validated_data.get('name')
+
+        if tenant and name:
+            # The DB constraint is (tenant, name, version). New workforms start at version=1,
+            # so duplicate names would raise IntegrityError and surface as 500.
+            base_name = name
+            candidate = base_name
+            suffix = 2
+
+            while TenantWorkForm.objects.filter(tenant=tenant, name=candidate, version=1).exists():
+                candidate = f"{base_name} ({suffix})"
+                suffix += 1
+
+            validated_data['name'] = candidate
+
         workform = super().create(validated_data)
         workform.update_form_references()
         return workform

--- a/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
+++ b/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
@@ -214,7 +214,13 @@ export const saveWorkflow = async (
     
     return response.data;
   } catch (error: any) {
-    logger.error('❌ Error saving workflow:', error);
+    logger.error('❌ Error saving workflow:', {
+      message: error?.message,
+      status: error?.response?.status,
+      url: error?.config?.url,
+      method: error?.config?.method,
+      data: error?.response?.data,
+    });
     
     // Enhanced error handling with user-friendly messages
     if (error.response?.status === 401) {


### PR DESCRIPTION
Fixes POST /api/v1/tenant-workforms/ returning 500 in common scenarios:\n\n- Backend: make TenantWorkForm.extract_form_references defensive (ignore malformed shapes + non-UUID tenantFormId values; include canonical container types)\n- Backend: auto-suffix duplicate workflow names on create to avoid IntegrityError (e.g., "Untitled Workflow" → "Untitled Workflow (2)")\n- Frontend: improve saveWorkflow error logging to include status + response body for quicker diagnosis\n