### PR TITLE
feat(workforms): Phase 10 WYSIWYG form flow

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -3080,56 +3080,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       
       if (!sourceNode || !targetNode) return;
       
-      // Phase 6.1: Container isolation validation (HIGHEST PRIORITY)
-      // Block connections from child node to external node
-      if (sourceNode.parentNode && !targetNode.parentNode) {
-        logger.warn('[Connection] ❌ Cannot connect child node to external node (container isolation)');
-        toast.error('Cannot connect nodes across container boundaries', {
-          duration: 4000,
-          icon: '🚫',
-        });
-        Sentry.captureMessage('Container isolation: child → external blocked', {
-          level: 'info',
-          extra: { sourceNode: sourceNode.id, targetNode: targetNode.id },
-        });
-        return;
-      }
-      
-      // Block connections from external node to child node
-      if (!sourceNode.parentNode && targetNode.parentNode) {
-        logger.warn('[Connection] ❌ Cannot connect external node to child node (container isolation)');
-        toast.error('Cannot connect nodes across container boundaries', {
-          duration: 4000,
-          icon: '🚫',
-        });
-        Sentry.captureMessage('Container isolation: external → child blocked', {
-          level: 'info',
-          extra: { sourceNode: sourceNode.id, targetNode: targetNode.id },
-        });
-        return;
-      }
-      
-      // Block connections between nodes in different containers
-      if (sourceNode.parentNode && targetNode.parentNode && sourceNode.parentNode !== targetNode.parentNode) {
-        logger.warn('[Connection] ❌ Cannot connect nodes from different containers');
-        toast.error('Cannot connect nodes between different containers', {
-          duration: 4000,
-          icon: '🚫',
-        });
-        Sentry.captureMessage('Container isolation: different containers blocked', {
-          level: 'info',
-          extra: { 
-            sourceNode: sourceNode.id, 
-            targetNode: targetNode.id,
-            sourceContainer: sourceNode.parentNode,
-            targetContainer: targetNode.parentNode,
-          },
-        });
-        return;
-      }
-      
-      logger.debug('[Connection] ✅ Container isolation check passed');
-      
+      // Phase 10: WYSIWYG Form Flow
+      // Container boundaries are permeable: allow edges to leave/re-enter containers.
       // Type-aware validation
       const typeCheck = isValidConnectionType(sourceNode.type || '', targetNode.type || '');
       if (!typeCheck.valid) {
@@ -3272,11 +3224,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
   const applyAutoLayoutImmediate = useCallback(
     (nextNodes: Node[], nextEdges: Edge[]) => {
-      const hasFormProcessContainer = nextNodes.some((n) => isFormProcessContainerType(n.type));
-      const layoutDirection: 'TB' | 'LR' = hasFormProcessContainer ? 'LR' : 'TB';
-
       const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(nextNodes, nextEdges, {
-        direction: layoutDirection,
+        direction: 'TB',
         nodeSpacing: 60,
         rankSpacing: 120,
       });
@@ -3296,12 +3245,14 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
       const insertEdge = pendingInsertEdgeId ? edges.find((e) => e.id === pendingInsertEdgeId) : null;
 
-      const newNodeId = `node-${nodeIdCounter}`;
+      const isNewContainer = isFormProcessContainerType(nodeTypeId);
+
+      const containerNodeId = `node-${nodeIdCounter}`;
+      const newNodeId = containerNodeId;
       const reactFlowType = getReactFlowNodeType(nodeTypeId);
 
       // Ensure default dimensions upfront (prevents React Flow dimension errors)
-      const isContainerNode = isFormProcessContainerType(nodeTypeId);
-      const defaultDimensions = isContainerNode ? { width: 600, height: 400 } : undefined;
+      const defaultDimensions = isNewContainer ? { width: 600, height: 400 } : undefined;
 
       const newNode: Node = {
         id: newNodeId,
@@ -3317,7 +3268,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       };
 
       // Upgrade legacy container types to the canonical group container
-      if (nodeTypeId === 'formMultiStepContainer' || isFormProcessContainerType(nodeTypeId)) {
+      if (isNewContainer) {
         newNode.style = {
           width: 600,
           height: 400,
@@ -3330,7 +3281,36 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         (newNode as any).type = 'formProcessGroup';
       }
 
-      const withOnlyNewSelected = (ns: Node[]) => ns.map((n) => ({ ...n, selected: n.id === newNodeId }));
+      const spawnDefaultFormPage = (parentId: string) => {
+        const pageId = `node-${nodeIdCounter + 1}`;
+
+        const pageNode: Node = {
+          id: pageId,
+          type: 'form',
+          parentId,
+          extent: 'parent',
+          expandParent: true,
+          position: { x: 30, y: 90 },
+          data: {
+            label: NODE_TYPE_REGISTRY.form?.name || 'Form',
+            status: 'draft',
+            fields: [],
+            ...getDefaultNodeData('form'),
+          },
+          selected: true,
+        };
+
+        const edge: Edge = {
+          id: `edge-${parentId}-${pageId}`,
+          source: parentId,
+          target: pageId,
+          type: 'insert',
+        };
+
+        return { pageNode, edge, pageId };
+      };
+
+      const selectOnly = (ns: Node[], selectedId: string) => ns.map((n) => ({ ...n, selected: n.id === selectedId }));
 
       // If we're in "insert between edge" mode, split the target edge
       if (insertEdge) {
@@ -3353,7 +3333,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           };
         }
 
-        const nextNodes = withOnlyNewSelected([...nodes, newNode]);
         const nextEdges: Edge[] = [
           ...edges.filter((e) => e.id !== insertEdge.id),
           {
@@ -3370,9 +3349,23 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           },
         ];
 
-        setNodeIdCounter((prev) => prev + 1);
+        const nodesToAdd: Node[] = [newNode];
+        let selectedId = newNodeId;
+        let counterDelta = 1;
+
+        if (isNewContainer) {
+          const { pageNode, edge, pageId } = spawnDefaultFormPage(newNodeId);
+          nodesToAdd.push(pageNode);
+          nextEdges.push(edge);
+          selectedId = pageId;
+          counterDelta = 2;
+        }
+
+        const nextNodes = selectOnly([...nodes, ...nodesToAdd], selectedId);
+
+        setNodeIdCounter((prev) => prev + counterDelta);
         setPendingInsertEdgeId(null);
-        setSelectedNodeId(newNodeId);
+        setSelectedNodeId(selectedId);
         setSelectedNode(null);
 
         applyAutoLayoutImmediate(nextNodes, nextEdges);
@@ -3400,7 +3393,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           y: anchor.position.y + 150,
         };
 
-        const nextNodes = withOnlyNewSelected([...nodes, newNode]);
         const nextEdges: Edge[] = [
           ...edges,
           {
@@ -3411,19 +3403,47 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           },
         ];
 
-        setNodeIdCounter((prev) => prev + 1);
-        setSelectedNodeId(newNodeId);
+        const nodesToAdd: Node[] = [newNode];
+        let selectedId = newNodeId;
+        let counterDelta = 1;
+
+        if (isNewContainer) {
+          const { pageNode, edge, pageId } = spawnDefaultFormPage(newNodeId);
+          nodesToAdd.push(pageNode);
+          nextEdges.push(edge);
+          selectedId = pageId;
+          counterDelta = 2;
+        }
+
+        const nextNodes = selectOnly([...nodes, ...nodesToAdd], selectedId);
+
+        setNodeIdCounter((prev) => prev + counterDelta);
+        setSelectedNodeId(selectedId);
         setSelectedNode(null);
 
         applyAutoLayoutImmediate(nextNodes, nextEdges);
       } else {
-        const nextNodes = withOnlyNewSelected([newNode]);
+        const nextEdges: Edge[] = [...edges];
 
-        setNodeIdCounter((prev) => prev + 1);
-        setSelectedNodeId(newNodeId);
+        const nodesToAdd: Node[] = [newNode];
+        let selectedId = newNodeId;
+        let counterDelta = 1;
+
+        if (isNewContainer) {
+          const { pageNode, edge, pageId } = spawnDefaultFormPage(newNodeId);
+          nodesToAdd.push(pageNode);
+          nextEdges.push(edge);
+          selectedId = pageId;
+          counterDelta = 2;
+        }
+
+        const nextNodes = selectOnly([...nodes, ...nodesToAdd], selectedId);
+
+        setNodeIdCounter((prev) => prev + counterDelta);
+        setSelectedNodeId(selectedId);
         setSelectedNode(null);
 
-        applyAutoLayoutImmediate(nextNodes, edges);
+        applyAutoLayoutImmediate(nextNodes, nextEdges);
       }
     },
     [
@@ -3914,9 +3934,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       }
       
       // Normal drop on main canvas
-      const insertEdge = pendingInsertEdgeId
-        ? edges.find((e) => e.id === pendingInsertEdgeId)
-        : null;
+      const insertEdge = pendingInsertEdgeId ? edges.find((e) => e.id === pendingInsertEdgeId) : null;
 
       if (insertEdge) {
         const sourceNode = nodes.find((n) => n.id === insertEdge.source);
@@ -3930,13 +3948,43 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         }
       }
 
-      const updatedNodes = nodes.concat(newNode);
-      setNodes(updatedNodes);
-      setNodeIdCounter((prev) => prev + 1);
-      
+      const nodesToAdd: Node[] = [newNode];
+      const edgesToAdd: Edge[] = [];
+      let counterDelta = 1;
+
+      // Phase 10: Auto-spawn a default Form page inside a new formProcessGroup
+      if (isContainerNode && newNode.type === 'formProcessGroup') {
+        const pageId = `node-${nodeIdCounter + 1}`;
+        const pageNode: Node = {
+          id: pageId,
+          type: 'form',
+          parentId: newNode.id,
+          extent: 'parent',
+          expandParent: true,
+          position: { x: 30, y: 90 },
+          data: {
+            label: NODE_TYPE_REGISTRY.form?.name || 'Form',
+            status: 'draft',
+            fields: [],
+            ...getDefaultNodeData('form'),
+          },
+        };
+
+        nodesToAdd.push(pageNode);
+        edgesToAdd.push({
+          id: `edge-${newNode.id}-${pageId}`,
+          source: newNode.id,
+          target: pageId,
+          type: 'insert',
+        });
+        counterDelta = 2;
+      }
+
+      const updatedNodes = nodes.concat(nodesToAdd);
+
       // Mark drop as succeeded
       dropSucceededRef.current = true;
-      
+
       // Auto-connect to nearby node if found (only for main canvas drops)
       let updatedEdges = edges;
       if (insertEdge && !targetContainer) {
@@ -3956,7 +4004,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             type: 'insert',
           },
         ];
-        setEdges(updatedEdges);
         setPendingInsertEdgeId(null);
       } else if (nearby && !targetContainer) {
         const newEdge = {
@@ -3966,14 +4013,36 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           type: 'insert',
         };
         updatedEdges = [...edges, newEdge];
-        setEdges(updatedEdges);
       }
-      
+
+      updatedEdges = [...updatedEdges, ...edgesToAdd];
+
+      if (isContainerNode && newNode.type === 'formProcessGroup') {
+        applyAutoLayoutImmediate(updatedNodes, updatedEdges);
+      } else {
+        setNodes(updatedNodes);
+        setEdges(updatedEdges);
+        setHasUnsavedChanges(true);
+      }
+
+      setNodeIdCounter((prev) => prev + counterDelta);
+
       // Clear nearby node state
       setNearbyNode(null);
       setPendingInsertEdgeId(null);
     },
-    [nodeIdCounter, setNodes, reactFlowInstance, nodes, edges, findNearbyNode, setEdges, findContainerAtPosition, pendingInsertEdgeId]
+    [
+      nodeIdCounter,
+      setNodes,
+      reactFlowInstance,
+      nodes,
+      edges,
+      findNearbyNode,
+      setEdges,
+      findContainerAtPosition,
+      pendingInsertEdgeId,
+      applyAutoLayoutImmediate,
+    ]
   );
 
   const onDragOver = useCallback((event: React.DragEvent) => {
@@ -4583,14 +4652,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
    * Phase 2: UI/UX Enhancements
    */
   const handleAutoLayout = useCallback(() => {
-    const hasFormProcessContainer = nodes.some((n) => isFormProcessContainerType(n.type));
-    const layoutDirection: 'TB' | 'LR' = hasFormProcessContainer ? 'LR' : 'TB';
-    
-    const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
-      nodes,
-      edges,
-      { direction: layoutDirection, nodeSpacing: 60, rankSpacing: 120 }
-    );
+    const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(nodes, edges, {
+      direction: 'TB',
+      nodeSpacing: 60,
+      rankSpacing: 120,
+    });
     setNodes(layoutedNodes);
     setHasUnsavedChanges(true);
     toast.success('Layout applied successfully');
@@ -4611,14 +4677,9 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       e => selectedNodeIds.includes(e.source) && selectedNodeIds.includes(e.target)
     );
 
-    const hasFormProcessContainer = selectedNodes.some((n) => isFormProcessContainerType(n.type));
-    const layoutDirection: 'TB' | 'LR' = hasFormProcessContainer ? 'LR' : 'TB';
-
-    const { nodes: layoutedSelected } = getLayoutedElements(
-      selectedNodes,
-      relevantEdges,
-      { direction: layoutDirection }
-    );
+    const { nodes: layoutedSelected } = getLayoutedElements(selectedNodes, relevantEdges, {
+      direction: 'TB',
+    });
 
     // Merge layouted nodes back
     const updatedNodes = nodes.map(node => {

--- a/frontend/src/components/FlowEditor/nodes/FormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormNode.tsx
@@ -1,292 +1,222 @@
 /**
- * Form Node Component
- * 
- * Single-page form for data collection and entity interaction.
- * Displays field summary and validation status.
- * Can be used standalone or inside Form Process containers.
- * 
- * Created: 2026-02-04 - Phase 2.1 Visual Editor Foundation
- * Updated: 2026-02-04 - Phase 5 Field/Step/Mapping Enhancements
- * Renamed: 2026-02-14 - Phase 2: FormStep → FormStepSingle
- * Renamed: 2026-02-19 - Phase E: FormStepSingle → Form (simplified naming)
+ * Form Node Component (Phase 10: WYSIWYG Form Flow)
+ *
+ * Visual metaphor: a "ripped page" that can live inside a "book" (formProcessGroup).
+ * This intentionally does NOT rely on BaseNode so we can fully customize the UI.
  */
+
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps } from '@xyflow/react';
-import { BaseNode, BaseNodeData } from './BaseNode';
-import { getNodeTypeDefinition } from '../nodeTypes';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
 
-// ============================================================================
-// TypeScript Interfaces (Updated for Phase 5)
-// ============================================================================
-
-export type FormFieldType = 
-  | 'text'
-  | 'textarea'
-  | 'number'
-  | 'email'
-  | 'phone'
-  | 'url'
-  | 'date'
-  | 'datetime'
-  | 'select'
-  | 'multi-select'
-  | 'checkbox'
-  | 'radio'
-  | 'file';
-
-export interface ValidationRule {
+type PreviewField = {
   id: string;
-  type: string;
-  value?: any;
-  errorMessage?: string;
-}
+  label?: string;
+  type?: string;
+  required?: boolean;
+};
 
-export interface ConditionRule {
-  id: string;
-  field: string;
-  operator: string;
-  value?: any;
-}
-
-export interface FormField {
-  id: string;
-  type: FormFieldType;
-  label: string;
-  required: boolean;
-  placeholder?: string;
-  defaultValue?: any;
-  helpText?: string;
-  validationRules: ValidationRule[];
-  visibility?: {
-    mode: 'always' | 'conditional';
-    conditions?: ConditionRule[];
-    logic?: 'and' | 'or';
-  };
-  options?: {
-    source: 'manual' | 'tenant-list' | 'entity';
-    manualOptions?: string[];
-    tenantListId?: string;
-    entityType?: string;
-    entityField?: string;
-  };
-  dependencies?: Array<{
-    field: string;
-    action: 'enable' | 'disable' | 'show' | 'hide';
-    condition: ConditionRule;
-  }>;
-}
-
-export interface FieldMapping {
-  id: string;
-  formFieldId: string;
-  entityField: string;
-  transformation: {
-    type: 'direct' | 'lookup' | 'format' | 'calculated';
-    format?: string;
-    formula?: string;
-    lookupEntity?: string;
-  };
-  autoPopulate?: {
-    sourceStep: string;
-    sourceField: string;
-    mode: 'copy' | 'lookup';
-  };
-}
-
-export interface FormStepNodeData extends BaseNodeData {
+export type FormNodeData = {
+  label?: string;
   stepTitle?: string;
-  stepDescription?: string;
-  fields?: FormField[];
-  visibility?: {
-    mode: 'always' | 'conditional';
-    conditions?: ConditionRule[];
-    logic?: 'and' | 'or';
-  };
-  navigation?: {
-    allowBack: boolean;
-    allowSkip: boolean;
-    autoAdvance: boolean;
-    backLabel?: string;
-    nextLabel?: string;
-    skipLabel?: string;
-  };
-  validation?: {
-    mode: 'all' | 'minimum';
-    minimumRequired?: number;
-    customMessage?: string;
-  };
-  fieldMappings?: FieldMapping[];
-  targetEntity?: string;
-  validationRules?: Record<string, any>; // Legacy - kept for backward compatibility
-}
+  fields?: PreviewField[];
+  entityType?: string;
+} & Record<string, unknown>;
 
-// ============================================================================
-// Styled Components
-// ============================================================================
+const Page = styled.div<{ $selected: boolean }>`
+  position: relative;
+  min-width: 220px;
+  max-width: 320px;
+  background: rgb(var(--color-surface));
+  border-radius: 8px;
+  border: 1px solid rgb(var(--color-border));
+  box-shadow: 0 4px 14px rgb(var(--color-text-primary) / 0.08);
+  overflow: hidden;
+  transition: box-shadow 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
 
-const FieldList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-top: 8px;
+  ${(p) =>
+    p.$selected
+      ? `
+    border-color: rgb(var(--color-primary));
+    box-shadow: 0 6px 18px rgb(var(--color-text-primary) / 0.12);
+  `
+      : ''}
+
+  &:hover {
+    box-shadow: 0 6px 18px rgb(var(--color-text-primary) / 0.12);
+  }
 `;
 
-const FieldItem = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
+const Header = styled.div`
+  padding: 10px 12px;
   background: rgb(var(--color-background));
-  border-radius: var(--radius-sm);
-  font-size: 11px;
+  border-bottom: 1px solid rgb(var(--color-border));
+  border-top: 4px solid rgb(var(--color-primary));
+
+  /* Drag handle for ReactFlow: configured via nodeDragHandle in UnifiedFlowEditor */
+  &.custom-drag-handle {
+    cursor: grab;
+  }
+  &.custom-drag-handle:active {
+    cursor: grabbing;
+  }
 `;
 
-const FieldIcon = styled.span`
-  font-size: 14px;
+const TitleRow = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
 `;
 
-const FieldLabel = styled.span`
-  flex: 1;
+const Title = styled.div`
+  font-weight: 800;
+  font-size: 13px;
+  letter-spacing: 0.2px;
+  color: rgb(var(--color-text-primary));
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: rgb(var(--color-text-primary));
 `;
 
-const RequiredBadge = styled.span`
-  color: rgb(239, 68, 68);
-  font-weight: 700;
-`;
-
-const EmptyState = styled.div`
-  text-align: center;
-  padding: 12px;
-  color: rgb(var(--color-text-tertiary));
-  font-size: 11px;
-  font-style: italic;
-`;
-
-const FieldCount = styled.div`
-  margin-top: 8px;
-  text-align: center;
+const Meta = styled.div`
+  margin-top: 4px;
   font-size: 11px;
   color: rgb(var(--color-text-secondary));
-  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
-// ============================================================================
-// Field Type Icons (Updated for Phase 5)
-// ============================================================================
+const Body = styled.div`
+  padding: 10px 12px 12px;
+  background: rgb(var(--color-surface));
+`;
 
-const FIELD_TYPE_ICONS: Record<FormFieldType, string> = {
-  text: '📝',
-  number: '🔢',
-  email: '📧',
-  select: '📋',
-  textarea: '📄',
-  checkbox: '☑️',
-  radio: '🔘',
-  date: '📅',
-  file: '📎',
-  phone: '📱',
-  url: '🔗',
-  datetime: '🕐',
-  'multi-select': '✅',
-};
+const FieldPreview = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
 
-// ============================================================================
-// Component
-// ============================================================================
+const FieldStub = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 4px;
+  padding: 8px 8px;
+  border: 1px solid rgb(var(--color-border));
+  border-radius: 6px;
+  background: rgb(var(--color-background));
+`;
 
-export const FormNode = React.memo<NodeProps<FormStepNodeData>>((props) => {
-  const { data, selected, id } = props;
-  const nodeTypeDef = getNodeTypeDefinition('form');
-  
-  // Safety check: provide fallback if nodeType is undefined
-  const nodeType = nodeTypeDef || {
-    id: 'form',
-    name: 'Form',
-    category: 'form' as const,
-    color: 'rgb(59, 130, 246)', // blue
-    icon: 'ListChecks',
-    maxInputs: 1,
-    maxOutputs: 1,
-    config: {},
-  };
-  
-  const { stepTitle, fields = [] } = data;
-  const title = stepTitle || (data as any).name || (data as any).displayTitle;
-  const entityType = (data as any).entityType || (data as any).targetEntity;
-  const fieldCount = fields.length;
-  const requiredCount = fields.filter(f => f.required).length;
+const FieldLabel = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  color: rgb(var(--color-text-primary));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const Required = styled.span`
+  font-size: 11px;
+  font-weight: 800;
+  color: rgb(var(--color-error));
+`;
+
+const InputStub = styled.div`
+  height: 10px;
+  border-radius: 4px;
+  background: rgb(var(--color-border));
+  opacity: 0.55;
+`;
+
+const Empty = styled.div`
+  padding: 10px 0;
+  font-size: 11px;
+  color: rgb(var(--color-text-tertiary));
+  font-style: italic;
+  text-align: center;
+`;
+
+const StyledHandle = styled(Handle)<{ $role: 'in' | 'out' }>`
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  border: 2px solid rgb(var(--color-surface));
+  background: ${(p) => (p.$role === 'in' ? 'rgb(var(--color-primary))' : 'rgb(var(--color-success))')};
+  z-index: 20;
+
+  &.react-flow__handle-top {
+    top: -14px;
+  }
+  &.react-flow__handle-bottom {
+    bottom: -14px;
+  }
+`;
+
+export const FormNode: React.FC<NodeProps<FormNodeData>> = React.memo(({ id, data, selected }) => {
+  const fields = (data?.fields as PreviewField[] | undefined) ?? [];
+  const title =
+    (data?.stepTitle as string | undefined) ||
+    (data?.label as string | undefined) ||
+    'Form';
+
+  const entityType = (data?.entityType as string | undefined) || '';
+
+  const preview = fields.slice(0, 5);
 
   return (
-    <BaseNode
-      id={id}
-      data={data}
-      selected={selected}
-      nodeType={nodeType}
-    >
-      <div>
-        {title && (
-          <div style={{ 
-            fontWeight: 600, 
-            marginBottom: 6,
-            color: 'rgb(var(--color-text-primary))',
-          }}>
-            {title}
-          </div>
-        )}
+    <Page $selected={Boolean(selected)} role="article" aria-label={`Form node: ${title}`} aria-selected={selected}>
+      <StyledHandle id="input" type="target" position={Position.Top} $role="in" aria-label="Input handle" />
 
-        {entityType && (
-          <div style={{
-            marginBottom: 8,
-            fontSize: 11,
-            color: 'rgb(var(--color-text-secondary))',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}>
-            Entity: {String(entityType)}
+      <Header className="custom-drag-handle">
+        <TitleRow>
+          <Title title={title}>{title}</Title>
+          <div style={{ fontSize: 11, color: 'rgb(var(--color-text-secondary))', fontWeight: 700 }}>
+            {fields.length} field{fields.length === 1 ? '' : 's'}
           </div>
-        )}
-        
-        {fields.length === 0 ? (
-          <EmptyState>
-            Click to add fields
-          </EmptyState>
+        </TitleRow>
+        {entityType && <Meta>Entity: {entityType}</Meta>}
+      </Header>
+
+      <Body className="nodrag">
+        {preview.length === 0 ? (
+          <Empty>Click “Fields” in the config panel to add fields</Empty>
         ) : (
-          <>
-            <FieldList>
-              {fields.slice(0, 3).map(field => (
-                <FieldItem key={field.id}>
-                  <FieldIcon>
-                    {FIELD_TYPE_ICONS[field.type] || '📝'}
-                  </FieldIcon>
-                  <FieldLabel>{field.label}</FieldLabel>
-                  {field.required && <RequiredBadge>*</RequiredBadge>}
-                </FieldItem>
-              ))}
-            </FieldList>
-            
-            {fields.length > 3 && (
-              <FieldCount>
-                +{fields.length - 3} more field{fields.length - 3 > 1 ? 's' : ''}
-              </FieldCount>
-            )}
-            
-            <FieldCount>
-              {fieldCount} field{fieldCount !== 1 ? 's' : ''}
-              {requiredCount > 0 && ` • ${requiredCount} required`}
-            </FieldCount>
-          </>
+          <FieldPreview>
+            {preview.map((f) => (
+              <FieldStub key={f.id}>
+                <FieldLabel title={f.label || f.id}>
+                  <span>{f.label || 'Untitled field'}</span>
+                  {f.required ? <Required>*</Required> : null}
+                </FieldLabel>
+                <InputStub />
+              </FieldStub>
+            ))}
+            {fields.length > preview.length ? (
+              <div style={{ fontSize: 11, color: 'rgb(var(--color-text-tertiary))', textAlign: 'center' }}>
+                +{fields.length - preview.length} more
+              </div>
+            ) : null}
+          </FieldPreview>
         )}
+      </Body>
+
+      <StyledHandle id="output" type="source" position={Position.Bottom} $role="out" aria-label="Output handle" />
+
+      {/* Keep node identity stable for debugging */}
+      <div style={{ position: 'absolute', bottom: 6, right: 10, fontSize: 10, color: 'rgb(var(--color-text-tertiary))' }}>
+        {id}
       </div>
-    </BaseNode>
+    </Page>
   );
 });
 
-// Export with both names for backward compatibility during migration
-export { FormNode as FormStepSingleNode };
+FormNode.displayName = 'FormNode';
+
 export default FormNode;

--- a/frontend/src/components/FlowEditor/utils/autoLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/autoLayout.ts
@@ -51,12 +51,12 @@ export const getLayoutedElements = (
   const layoutDagre = (
     inputNodes: Node[],
     inputEdges: Edge[],
-    normalize: { x: number; y: number },
-    rankdir: 'TB' | 'LR'
+    normalize: { x: number; y: number }
   ) => {
-    const dagreGraph = new dagre.graphlib.Graph();
+    const dagreGraph = new dagre.graphlib.Graph({ compound: true });
     dagreGraph.setGraph({
-      rankdir,
+      // Phase 10: Always Top-to-Bottom for compound clusters
+      rankdir: 'TB',
       align: opts.align,
       ranker: 'longest-path',
       nodesep: opts.nodeSpacing,
@@ -67,9 +67,20 @@ export const getLayoutedElements = (
     });
     dagreGraph.setDefaultEdgeLabel(() => ({}));
 
+    const nodeById = new Map<string, Node>();
     inputNodes.forEach((n) => {
+      nodeById.set(n.id, n);
       const { width, height } = getDims(n);
       dagreGraph.setNode(n.id, { width, height });
+    });
+
+    // Compound graph: attach children to their parent formProcessGroup nodes
+    inputNodes.forEach((n) => {
+      if (!n.parentId) return;
+      const parent = nodeById.get(n.parentId);
+      if (!parent) return;
+      if (parent.type !== 'formProcessGroup') return;
+      dagreGraph.setParent(n.id, parent.id);
     });
 
     inputEdges.forEach((e) => {
@@ -79,43 +90,66 @@ export const getLayoutedElements = (
 
     dagre.layout(dagreGraph);
 
-    const laidOut = inputNodes.map((n) => {
+    const absTopLeft = new Map<string, { x: number; y: number }>();
+
+    // Pass 1: compute absolute top-left positions for all nodes
+    inputNodes.forEach((n) => {
       const p = dagreGraph.node(n.id);
       const { width, height } = getDims(n);
+      absTopLeft.set(n.id, {
+        x: p.x - width / 2,
+        y: p.y - height / 2,
+      });
+    });
+
+    const isRootLike = (n: Node) => {
+      if (!n.parentId) return true;
+      const parent = nodeById.get(n.parentId);
+      return !(parent && parent.type === 'formProcessGroup');
+    };
+
+    // Pass 2: convert compound children into parent-relative coordinates
+    const laidOut = inputNodes.map((n) => {
+      const pos = absTopLeft.get(n.id) ?? { x: 0, y: 0 };
+
+      if (n.parentId) {
+        const parent = nodeById.get(n.parentId);
+        if (parent && parent.type === 'formProcessGroup') {
+          const parentAbs = absTopLeft.get(parent.id);
+          if (parentAbs) {
+            return {
+              ...n,
+              position: {
+                x: pos.x - parentAbs.x,
+                y: pos.y - parentAbs.y,
+              },
+            };
+          }
+        }
+      }
+
       return {
         ...n,
-        position: {
-          x: p.x - width / 2,
-          y: p.y - height / 2,
-        },
+        position: pos,
       };
     });
 
-    const minX = Math.min(...laidOut.map((n) => n.position.x));
-    const minY = Math.min(...laidOut.map((n) => n.position.y));
+    // Normalize only root-level nodes. Child nodes are relative to their parent.
+    const rootNodes = laidOut.filter(isRootLike);
+    const minX = Math.min(...rootNodes.map((n) => n.position.x));
+    const minY = Math.min(...rootNodes.map((n) => n.position.y));
 
-    return laidOut.map((n) => ({
-      ...n,
-      position: {
-        x: n.position.x - minX + normalize.x,
-        y: n.position.y - minY + normalize.y,
-      },
-    }));
+    return laidOut.map((n) => {
+      if (!isRootLike(n)) return n;
+      return {
+        ...n,
+        position: {
+          x: n.position.x - minX + normalize.x,
+          y: n.position.y - minY + normalize.y,
+        },
+      };
+    });
   };
-
-  // Group nodes by parentId
-  const childrenByParent = new Map<string, Node[]>();
-  const nodeById = new Map<string, Node>();
-  nodes.forEach((n) => {
-    nodeById.set(n.id, n);
-    if (n.parentId) {
-      const arr = childrenByParent.get(n.parentId) ?? [];
-      arr.push(n);
-      childrenByParent.set(n.parentId, arr);
-    }
-  });
-
-  const updates = new Map<string, Node>();
 
   const PADDING_X = 30;
   const PADDING_Y = 30;
@@ -123,74 +157,65 @@ export const getLayoutedElements = (
   const MIN_CONTAINER_WIDTH = 500;
   const MIN_CONTAINER_HEIGHT = 300;
 
-  const layoutContainerRecursive = (containerId: string) => {
-    const children = childrenByParent.get(containerId) ?? [];
-    if (children.length === 0) return;
+  // Phase 10: Single-pass compound layout across the whole graph.
+  // Dagre routes edges that leave and re-enter compound parents.
+  const laidOutAll = layoutDagre(nodes, edges, { x: 50, y: 50 });
 
-    // Layout nested containers first so their dims are updated before parent layout
-    for (const child of children) {
-      if (childrenByParent.has(child.id)) layoutContainerRecursive(child.id);
+  // Update container dimensions to comfortably fit their children.
+  const byId = new Map<string, Node>(laidOutAll.map((n) => [n.id, n]));
+
+  for (const parent of laidOutAll) {
+    if (parent.type !== 'formProcessGroup') continue;
+
+    const children = laidOutAll.filter((n) => n.parentId === parent.id);
+    if (children.length === 0) {
+      // Keep a sensible minimum size for empty containers
+      byId.set(parent.id, {
+        ...parent,
+        style: {
+          ...(parent.style as any),
+          width: Math.max(MIN_CONTAINER_WIDTH, (parent.style as any)?.width || 0),
+          height: Math.max(MIN_CONTAINER_HEIGHT, (parent.style as any)?.height || 0),
+        },
+      });
+      continue;
     }
 
-    const childIds = new Set(children.map((c) => c.id));
-    const childEdges = edges.filter((e) => childIds.has(e.source) && childIds.has(e.target));
-
-    const mergedChildren = children.map((c) => updates.get(c.id) ?? c);
-    // Container children are laid out Left-to-Right (LR)
-    const laidOutChildren = layoutDagre(
-      mergedChildren,
-      childEdges,
-      {
-        x: PADDING_X,
-        y: HEADER_HEIGHT + PADDING_Y,
-      },
-      'LR'
-    );
-
-    // Compute container bounds to fit children
     let maxRight = 0;
     let maxBottom = 0;
-    for (const c of laidOutChildren) {
+
+    for (const c of children) {
       const { width, height } = getDims(c);
       maxRight = Math.max(maxRight, c.position.x + width);
       maxBottom = Math.max(maxBottom, c.position.y + height);
     }
 
     const containerWidth = Math.max(MIN_CONTAINER_WIDTH, maxRight + PADDING_X);
-    const containerHeight = Math.max(MIN_CONTAINER_HEIGHT, maxBottom + PADDING_Y);
+    const containerHeight = Math.max(MIN_CONTAINER_HEIGHT, maxBottom + PADDING_Y + HEADER_HEIGHT);
 
-    for (const c of laidOutChildren) {
-      updates.set(c.id, c);
-    }
+    byId.set(parent.id, {
+      ...parent,
+      style: {
+        ...(parent.style as any),
+        width: containerWidth,
+        height: containerHeight,
+      },
+    });
 
-    const container = nodeById.get(containerId);
-    if (container) {
-      updates.set(containerId, {
-        ...container,
-        style: {
-          ...(container.style as any),
-          width: containerWidth,
-          height: containerHeight,
+    // Apply consistent inset within the container for readability
+    for (const c of children) {
+      byId.set(c.id, {
+        ...c,
+        position: {
+          x: c.position.x + PADDING_X,
+          y: c.position.y + HEADER_HEIGHT + PADDING_Y,
         },
       });
     }
-  };
-
-  // Layout all containers (deepest-first via recursion)
-  for (const containerId of childrenByParent.keys()) {
-    layoutContainerRecursive(containerId);
   }
 
-  // Final pass: layout root nodes/containers Top-to-Bottom (TB)
-  const rootNodes = nodes.filter((n) => !n.parentId).map((n) => updates.get(n.id) ?? n);
-  const rootIds = new Set(rootNodes.map((n) => n.id));
-  const rootEdges = edges.filter((e) => rootIds.has(e.source) && rootIds.has(e.target));
-
-  const laidOutTop = layoutDagre(rootNodes, rootEdges, { x: 50, y: 50 }, 'TB');
-  for (const n of laidOutTop) updates.set(n.id, n);
-
   // Merge back into original order (order-preserving)
-  const merged = nodes.map((n) => updates.get(n.id) ?? n);
+  const merged = nodes.map((n) => byId.get(n.id) ?? n);
 
   return {
     nodes: merged,


### PR DESCRIPTION
Phase 10: WYSIWYG Form Flow (books + ripped pages)\n\n- Lifted container isolation in UnifiedFlowEditor onConnect: edges can leave/re-enter containers\n- Auto-spawn: creating a formProcessGroup now also creates a default child Form (page) inside it (drop + click-to-add)\n- FormNode visual overhaul: custom ripped-page UI with mini read-only field preview + top/bottom handles\n- autoLayout: dagre compound graph support + setParent for formProcessGroup children, rankdir TB\n