### PR TITLE
fix(deploy): restore FormStepSingleNode export

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/index.ts
+++ b/frontend/src/components/FlowEditor/nodes/index.ts
@@ -13,9 +13,10 @@
 export { BaseNode } from './BaseNode';
 export type { BaseNodeData, BaseNodeProps } from './BaseNode';
 
-// Form nodes - Phase E (2026-02-19): FormNode is the new name, FormStepSingleNode exported for backward compat
-export { FormNode, FormStepSingleNode } from './FormNode';
-export type { FormStepNodeData, FormField } from './FormNode';
+// Form nodes - Phase E (2026-02-19): FormNode is the new name, FormStepSingleNode retained for backward compat
+export { FormNode } from './FormNode';
+export { FormStepSingleNode } from './FormStepSingleNode';
+export type { FormStepNodeData, FormField } from './FormStepSingleNode';
 
 export { FormReferenceNode } from './FormReferenceNode';
 export type { FormReferenceNodeData } from './FormReferenceNode';


### PR DESCRIPTION
Fixes dev deployment failure (Actions run 23280685372) where Vite build fails due to missing export FormStepSingleNode after Phase 10 FormNode rewrite.

- Re-export FormStepSingleNode from legacy module in nodes index
- Keep existing FormNode WYSIWYG implementation intact

Verification: cd frontend && npm run build