### PR TITLE
fix(workforms): topological upstream traversal + edge payload visualization

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/VariablePicker.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VariablePicker.tsx
@@ -41,6 +41,7 @@ import {
   List, 
   FileText,
   ArrowRight,
+  AlertTriangle,
 } from 'lucide-react';
 import { WorkflowContext, AvailableDataNode } from '../../FormSubmission/hooks/useWorkflowContext';
 import {
@@ -149,6 +150,24 @@ export const VariablePicker: React.FC<VariablePickerProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isOpen, onClose]);
   
+  const nodeIndexById = useMemo(() => {
+    const m = new Map<string, number>();
+    context.nodes.forEach((n, idx) => m.set(n.id, idx));
+    return m;
+  }, [context.nodes]);
+
+  const currentNodeIndex = useMemo(() => {
+    if (!context.currentNodeId) return -1;
+    return nodeIndexById.get(context.currentNodeId) ?? -1;
+  }, [context.currentNodeId, nodeIndexById]);
+
+  const isPotentiallyOutOfScope = (nodeId: string) => {
+    if (currentNodeIndex < 0) return false;
+    const idx = nodeIndexById.get(nodeId);
+    if (typeof idx !== 'number') return true;
+    return idx >= currentNodeIndex;
+  };
+
   // Filter and flatten available variables
   const filteredVariables = useMemo(() => {
     const variables: Array<{
@@ -159,6 +178,7 @@ export const VariablePicker: React.FC<VariablePickerProps> = ({
       fieldLabel: string;
       fieldType: string;
       template: string;
+      potentiallyOutOfScope: boolean;
     }> = [];
     
     context.availableData.forEach(node => {
@@ -181,12 +201,13 @@ export const VariablePicker: React.FC<VariablePickerProps> = ({
           fieldLabel: field.label || field.key,
           fieldType: field.type || 'string',
           template,
+          potentiallyOutOfScope: isPotentiallyOutOfScope(node.nodeId),
         });
       });
     });
     
     return variables;
-  }, [context.availableData, search]);
+  }, [context.availableData, search, currentNodeIndex, nodeIndexById]);
   
   // Group variables by node
   const groupedVariables = useMemo(() => {
@@ -294,6 +315,13 @@ export const VariablePicker: React.FC<VariablePickerProps> = ({
                         <VariableLabel>{variable.fieldLabel}</VariableLabel>
                         <VariableKey>{variable.fieldKey}</VariableKey>
                       </VariableContent>
+                      {variable.potentiallyOutOfScope && (
+                        <ScopeWarning
+                          title="Warning: This variable may not be evaluated before this step executes."
+                        >
+                          <AlertTriangle size={14} />
+                        </ScopeWarning>
+                      )}
                       <ArrowRight size={14} style={{ opacity: 0.3 }} />
                     </VariableItem>
                   );
@@ -449,6 +477,13 @@ const VariableKey = styled.div`
   font-family: 'Monaco', 'Menlo', monospace;
   color: rgb(var(--color-text-secondary));
   opacity: 0.7;
+`;
+
+const ScopeWarning = styled.span`
+  display: flex;
+  align-items: center;
+  color: rgb(234, 179, 8);
+  opacity: 0.9;
 `;
 
 const PickerFooter = styled.div`

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -5860,31 +5860,48 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Get previous step fields for conditional logic
   const getPreviousStepFields = useCallback((currentNodeId: string) => {
     const allFields: any[] = [];
-    
-    // Find all FormStep nodes before the current one
-    const currentNode = nodes.find(n => n.id === currentNodeId);
+
+    const currentNode = nodes.find((n) => n.id === currentNodeId);
     if (!currentNode) return allFields;
-    
-    // Simple heuristic: nodes with lower Y position are "before" current node
-    const previousNodes = nodes.filter(n => 
-      n.type === 'formStep' && 
-      n.id !== currentNodeId &&
-      n.position.y < currentNode.position.y
+
+    // Phase 11: Use true graph traversal instead of Y-coordinate heuristics.
+    // Trace ancestors by following incoming edges (target -> source).
+    const upstreamNodeIds = new Set<string>();
+    const visited = new Set<string>();
+    const queue: string[] = [currentNodeId];
+
+    while (queue.length > 0) {
+      const nodeId = queue.shift()!;
+      if (visited.has(nodeId)) continue;
+      visited.add(nodeId);
+
+      const incoming = edges.filter((e) => e.target === nodeId);
+      for (const e of incoming) {
+        if (!upstreamNodeIds.has(e.source)) {
+          upstreamNodeIds.add(e.source);
+          queue.push(e.source);
+        }
+      }
+    }
+
+    const upstreamFormNodes = nodes.filter(
+      (n) =>
+        upstreamNodeIds.has(n.id) &&
+        (n.type === 'formStep' || n.type === 'formStepSingle' || n.type === 'form')
     );
-    
-    // Extract fields from previous FormStep nodes
-    previousNodes.forEach(node => {
-      const fields = node.data.fields || [];
+
+    upstreamFormNodes.forEach((node) => {
+      const fields = node.data?.fields || [];
       fields.forEach((field: any) => {
         allFields.push({
           ...field,
-          stepTitle: node.data.stepTitle || node.data.label || 'Unnamed Step',
+          stepTitle: node.data?.stepTitle || node.data?.label || 'Unnamed Step',
         });
       });
     });
-    
+
     return allFields;
-  }, [nodes]);
+  }, [nodes, edges]);
   
   const handleAddField = useCallback(() => {
     // Create new blank field and open field editor

--- a/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
@@ -12,12 +12,13 @@
  * Created: 2026-02-27
  */
 
-import React, { memo } from 'react';
+import React, { memo, useMemo, useState } from 'react';
 import {
   EdgeProps,
   getBezierPath,
   EdgeLabelRenderer,
   BaseEdge,
+  useReactFlow,
 } from '@xyflow/react';
 import styled, { keyframes } from 'styled-components';
 import { CheckCircle, AlertCircle, XCircle, Info } from 'lucide-react';
@@ -125,6 +126,44 @@ const AnimatedPath = styled.path<{ $animated: boolean }>`
   }
 `;
 
+const DataKeysTooltip = styled.div`
+  position: absolute;
+  transform: translate(-50%, -50%);
+  background: rgba(var(--color-background-primary), 0.95);
+  border: 1px solid rgb(var(--color-border));
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: rgb(var(--color-text-primary));
+  max-width: 260px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+`;
+
+const DataKeysTitle = styled.div`
+  font-size: 11px;
+  font-weight: 600;
+  color: rgb(var(--color-text-secondary));
+  margin-bottom: 4px;
+`;
+
+const DataKeysList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+`;
+
+const DataKeyChip = styled.span`
+  font-size: 11px;
+  font-family: var(--font-family-mono);
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgb(var(--color-surface));
+  border: 1px solid rgb(var(--color-border));
+  color: rgb(var(--color-text-secondary));
+`;
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -192,6 +231,7 @@ function getStatusIcon(status: ConnectionStatus): React.ReactNode {
 export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = memo(
   ({
     id,
+    source,
     sourceX,
     sourceY,
     targetX,
@@ -221,17 +261,48 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
     const edgeColor = getEdgeColor(status);
     const strokeWidth = selected ? 3 : status !== 'default' ? 2.5 : 2;
 
+    const [isHovered, setIsHovered] = useState(false);
+
+    const { getNode } = useReactFlow();
+
+    const dataKeys = useMemo(() => {
+      const sourceNode = source ? getNode(source) : undefined;
+      const keys: string[] = [];
+
+      const outputFields = sourceNode?.data?.outputSchema?.outputFields;
+      if (Array.isArray(outputFields)) {
+        for (const f of outputFields) {
+          const key = f?.fieldName || f?.fieldId;
+          if (typeof key === 'string' && key.trim()) keys.push(key);
+        }
+      }
+
+      if (keys.length === 0) {
+        const fields = sourceNode?.data?.fields || sourceNode?.data?.selectedFields;
+        if (Array.isArray(fields)) {
+          for (const f of fields) {
+            const key = typeof f === 'string' ? f : (f?.name || f?.id || f?.key);
+            if (typeof key === 'string' && key.trim()) keys.push(key);
+          }
+        }
+      }
+
+      // Unique + stable order
+      return Array.from(new Set(keys));
+    }, [getNode, source]);
+
+    const visibleKeys = dataKeys.slice(0, 6);
+    const remainingCount = Math.max(0, dataKeys.length - visibleKeys.length);
+
     return (
       <>
         {/* Invisible thick hitbox under the visible edge to stabilize hover/interaction */}
-        <BaseEdge
-          id={`${id}-hitbox`}
-          path={edgePath}
-          style={{
-            stroke: 'transparent',
-            strokeWidth: 30,
-            strokeOpacity: 0,
-          }}
+        <path
+          d={edgePath}
+          style={{ stroke: 'transparent', strokeWidth: 30, strokeOpacity: 0 }}
+          pointerEvents="stroke"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         />
 
         {/* Base Edge */}
@@ -258,20 +329,42 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
           />
         )}
 
-        {/* Label with Icon */}
-        {(label || showIcon) && (
-          <EdgeLabelRenderer>
+        <EdgeLabelRenderer>
+          {/* Phase 11: Edge payload / data-key visualization */}
+          {visibleKeys.length > 0 && (
+            <DataKeysTooltip
+              style={{
+                transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY - 22}px)`,
+                opacity: isHovered ? 1 : 0,
+              }}
+            >
+              <DataKeysTitle>Data Keys</DataKeysTitle>
+              <DataKeysList>
+                {visibleKeys.map((k) => (
+                  <DataKeyChip key={k}>{k}</DataKeyChip>
+                ))}
+                {remainingCount > 0 && <DataKeyChip>+{remainingCount}</DataKeyChip>}
+              </DataKeysList>
+            </DataKeysTooltip>
+          )}
+
+          {/* Label with Icon */}
+          {(label || showIcon) && (
             <EdgeLabel
               $status={status}
               style={{
                 transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+                opacity: isHovered ? 1 : undefined,
+                animation: isHovered ? 'none' : undefined,
               }}
+              onMouseEnter={() => setIsHovered(true)}
+              onMouseLeave={() => setIsHovered(false)}
             >
               {showIcon && getStatusIcon(status)}
               {label && <span>{label}</span>}
             </EdgeLabel>
-          </EdgeLabelRenderer>
-        )}
+          )}
+        </EdgeLabelRenderer>
       </>
     );
   }

--- a/frontend/src/components/FlowEditor/hooks/useUpstreamVariables.ts
+++ b/frontend/src/components/FlowEditor/hooks/useUpstreamVariables.ts
@@ -141,6 +141,29 @@ function findUpstreamNodes(
 }
 
 /**
+ * Returns upstream node distances (1 = direct parent, 2 = grandparent, ...)
+ * using true graph traversal over edges (target -> source).
+ */
+export function getUpstreamNodeDistances(
+  currentNodeId: string,
+  edges: Edge[],
+  maxDistance: number = 10
+): Map<string, number> {
+  return findUpstreamNodes(currentNodeId, edges, maxDistance);
+}
+
+/**
+ * Convenience helper: set of upstream node IDs for currentNodeId.
+ */
+export function getUpstreamNodeIdSet(
+  currentNodeId: string,
+  edges: Edge[],
+  maxDistance: number = 10
+): Set<string> {
+  return new Set(getUpstreamNodeDistances(currentNodeId, edges, maxDistance).keys());
+}
+
+/**
  * Extract field definitions from a Form Step Single node
  */
 function extractFieldsFromFormStep(node: Node): Array<{


### PR DESCRIPTION
Phase 11: Data Flow Tracing\n\n- Replace upstream field logic that relied on Y-position with true edge-based traversal (target -> source).\n- UnifiedFlowEditor getPreviousStepFields now uses graph traversal over edges.\n- EnhancedConnectionEdge shows Data Keys on hover (from source outputSchema / fields) with a stable hitbox to avoid flicker.\n- Variable picker shows a scope warning indicator for variables that may not be evaluated before this step executes.\n\nVerification:\n- cd frontend && npm run build\n\nNote: frontend lint script currently fails due to ESLint config mismatch (pre-existing); build passes.