### PR TITLE
fix(settings): purge rogue axios clients causing phantom logouts

### DIFF
--- a/frontend/src/components/Integrations/EmailConnection.tsx
+++ b/frontend/src/components/Integrations/EmailConnection.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
+import { apiClient as axios } from '../../services/apiService';
 import { toast } from 'react-hot-toast';
 import { Mail, CheckCircle, AlertCircle, ExternalLink } from 'lucide-react';
 
@@ -54,7 +54,7 @@ export const EmailConnection: React.FC<EmailConnectionProps> = ({
     setIsConnecting(true);
     
     try {
-      const response = await axios.get('/api/integrations/oauth/authorize/', {
+      const response = await axios.get('/integrations/oauth/authorize/', {
         params: { provider },
       });
       window.location.href = response.data.auth_url;

--- a/frontend/src/pages/Settings/IntegrationSettings.tsx
+++ b/frontend/src/pages/Settings/IntegrationSettings.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { AlertCircle, CheckCircle, Mail, ExternalLink } from 'lucide-react';
-import axios from 'axios';
+import { apiClient as axios } from '../../services/apiService';
 
 interface Connection {
   provider: string;
@@ -52,7 +52,7 @@ export const IntegrationSettings: React.FC = () => {
     setError(null);
 
     try {
-      const response = await axios.get<ConnectionStatus>('/api/v1/integrations/oauth/status/');
+      const response = await axios.get<ConnectionStatus>('/integrations/oauth/status/');
       setConnections(response.data.connections);
     } catch (err: any) {
       setError(err.response?.data?.error || 'Failed to fetch connection status');
@@ -64,7 +64,7 @@ export const IntegrationSettings: React.FC = () => {
   const handleConnect = async (provider: string) => {
     try {
       setError(null);
-      const response = await axios.get(`/api/v1/integrations/oauth/authorize/?provider=${provider}`);
+      const response = await axios.get(`/integrations/oauth/authorize/?provider=${provider}`);
       
       // Redirect to OAuth authorization URL
       window.location.href = response.data.auth_url;
@@ -82,7 +82,7 @@ export const IntegrationSettings: React.FC = () => {
     setError(null);
 
     try {
-      await axios.post('/api/v1/integrations/oauth/disconnect/', { provider });
+      await axios.post('/integrations/oauth/disconnect/', { provider });
       setSuccess('Email account disconnected successfully');
       fetchConnectionStatus();
     } catch (err: any) {

--- a/frontend/src/services/tenantService.ts
+++ b/frontend/src/services/tenantService.ts
@@ -3,53 +3,7 @@
  *
  * Handles tenant-related API calls including branding and logo management.
  */
-import axios from 'axios';
-import { config } from '../config/runtime';
-
-// API Configuration
-const API_BASE_URL = config.API_BASE_URL;
-
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  timeout: 30000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true, // Allow cookies for authentication
-  xsrfCookieName: 'csrftoken', // Django's CSRF cookie name
-  xsrfHeaderName: 'X-CSRFToken', // Django's expected CSRF header
-});
-
-// Request interceptor for authentication and tenant context
-apiClient.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem('authToken');
-    if (token) {
-      config.headers.Authorization = `Token ${token}`;
-    }
-    
-    // Add tenant ID header if available
-    const tenantId = localStorage.getItem('tenantId');
-    if (tenantId) {
-      config.headers['X-Tenant-ID'] = tenantId;
-    }
-    
-    return config;
-  },
-  (error) => Promise.reject(error)
-);
-
-// Response interceptor for error handling
-apiClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      localStorage.removeItem('authToken');
-      window.location.href = '/login';
-    }
-    return Promise.reject(error);
-  }
-);
+import { apiClient } from './apiService';
 
 export interface Tenant {
   id: string;


### PR DESCRIPTION
Removes rogue axios clients/interceptors bypassing the centralized JWT-aware apiClient (fixes phantom logout redirects).\n\nChanges:\n- tenantService: remove local axios.create + interceptors, use centralized apiClient\n- IntegrationSettings: use apiClient and remove /api/v1 prefix from endpoints\n- EmailConnection: use apiClient and remove /api prefix from OAuth authorize endpoint\n\nVerification: cd frontend && npm run build