### PR TITLE
fix(workforms): editor UI/config/publish polish

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -412,6 +412,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       
       case 'select':
       case 'multiselect':
+      case 'multiSelect': // FIX: Added exact match for schema
         renderedField = renderSelectField(commonProps);
         break;
       
@@ -420,6 +421,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
         break;
       
       // Phase E: Dynamic entity type select (replaces old entity-selector usage)
+      case 'entityType': // FIX: Added entityType field
       case 'entity-selector':
         // Use simple select dropdown for entity TYPE selection
         renderedField = renderEntityTypeSelect(commonProps);

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1544,7 +1544,7 @@ const AlignmentGuide = styled.div<{ $orientation: 'horizontal' | 'vertical'; $po
 // Sprint 1 Task 1.4: Background & Grid Settings Panel
 const SettingsPanel = styled.div`
   position: absolute;
-  top: 12px;
+  bottom: 60px; /* FIX: Changed from top: 12px to pop up above the toolbar */
   left: 12px;
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
@@ -6513,6 +6513,23 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
       {/* Viewport Controls */}
       <ViewportToolbar>
+        {/* NEW: Explicit Node Palette Toggle */}
+        {!readOnly && normalizedEditorMode === 'visual' && (
+          <>
+            <ViewportButton 
+              onClick={() => setIsPaletteVisible(!isPaletteVisible)} 
+              title={isPaletteVisible ? 'Hide Node Palette (Tab)' : 'Show Node Palette (Tab)'}
+              style={isPaletteVisible ? {
+                background: 'rgb(var(--color-primary))',
+                color: 'white',
+                borderColor: 'rgb(var(--color-primary))'
+              } : {}}
+            >
+              <Plus />
+            </ViewportButton>
+            <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
+          </>
+        )}
         <ViewportButton 
           onClick={() => setIsSettingsPanelOpen(!isSettingsPanelOpen)} 
           title="Canvas Settings (Grid, Background)"
@@ -6525,7 +6542,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           <Settings />
         </ViewportButton>
         <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
-        <ViewportButton onClick={toggleFullscreen} title={isFullscreen ? "Exit Fullscreen (ESC)" : "Enter Fullscreen"}>
+        <ViewportButton onClick={toggleFullscreen} title={isFullscreen ? 'Exit Fullscreen (ESC)' : 'Enter Fullscreen'}>
           {isFullscreen ? <Minimize2 /> : <Maximize2 />}
         </ViewportButton>
         <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
@@ -6541,7 +6558,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
         <ViewportButton 
           onClick={() => setIsMinimapVisible(!isMinimapVisible)} 
-          title={isMinimapVisible ? "Hide Minimap (M)" : "Show Minimap (M)"}
+          title={isMinimapVisible ? 'Hide Minimap (M)' : 'Show Minimap (M)'}
           style={isMinimapVisible ? {
             background: 'rgb(var(--color-primary))',
             color: 'white',
@@ -6551,7 +6568,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           <Map />
         </ViewportButton>
         <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
-        <ViewportButton onClick={() => setIsHelpModalOpen(true)} title="Help & Keyboard Shortcuts (?)">
+        {/* FIX: Wired Help button directly to Keyboard Shortcuts state */}
+        <ViewportButton onClick={() => setShowKeyboardShortcuts(true)} title="Help & Keyboard Shortcuts (?)">
           <HelpCircle />
         </ViewportButton>
       </ViewportToolbar>

--- a/frontend/src/pages/WorkForms/Editor.tsx
+++ b/frontend/src/pages/WorkForms/Editor.tsx
@@ -730,6 +730,7 @@ export const WorkFormsEditor: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [showSavedIndicator, setShowSavedIndicator] = useState(false);
   const [flowName, setFlowName] = useState('New Flow');
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [initialNodes, setInitialNodes] = useState<Node[]>([]);
   const [initialEdges, setInitialEdges] = useState<Edge[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -1281,7 +1282,40 @@ export const WorkFormsEditor: React.FC = () => {
             ← Back
           </BackButton>
           <div>
-            <PageTitle>{flowName}</PageTitle>
+            {isEditingTitle ? (
+              <input
+                value={flowName}
+                onChange={(e) => {
+                  setFlowName(e.target.value);
+                  setHasUnsavedChanges(true);
+                }}
+                onBlur={() => setIsEditingTitle(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') setIsEditingTitle(false);
+                }}
+                autoFocus
+                style={{
+                  fontSize: '24px',
+                  fontWeight: 700,
+                  background: 'transparent',
+                  border: '1px dashed rgb(var(--color-primary))',
+                  color: 'rgb(var(--color-text-primary))',
+                  borderRadius: '4px',
+                  padding: '2px 8px',
+                  outline: 'none',
+                  minWidth: '250px'
+                }}
+              />
+            ) : (
+              <PageTitle 
+                onClick={() => setIsEditingTitle(true)}
+                title="Click to edit flow name"
+                style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '8px' }}
+              >
+                {flowName}
+                <Eye size={14} style={{ opacity: 0.5 }} />
+              </PageTitle>
+            )}
           </div>
         </HeaderLeft>
         
@@ -1389,8 +1423,8 @@ export const WorkFormsEditor: React.FC = () => {
           <ActionButton 
             $variant="primary" 
             onClick={handlePublish}
-            disabled={!permissions.can_publish || status === 'active' || !id || publishMutation.isPending || permissionsLoading}
-            title={!permissions.can_publish ? getUpgradeMessage('publish', permissions.role) : ''}
+            disabled={!permissions.can_publish || status === 'active' || hasUnsavedChanges || !id || publishMutation.isPending || permissionsLoading}
+            title={!permissions.can_publish ? getUpgradeMessage('publish', permissions.role) : (hasUnsavedChanges ? 'Save changes before publishing' : '')}
           >
             {publishMutation.isPending ? 'Publishing...' : status === 'active' ? 'Published' : 'Publish'}
           </ActionButton>


### PR DESCRIPTION
- DynamicConfigPanel: handle field.type=multiSelect and entityType to avoid "Unknown field type"
- UnifiedFlowEditor: move settings panel to bottom-left; add explicit node palette toggle; wire Help (?) to keyboard shortcuts modal
- WorkForms Editor: inline click-to-edit flow title; disable Publish when unsaved changes exist

Build: frontend `npm run build`