### PR TITLE
feat(workforms): book and pages hybrid paradigm

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/FormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormNode.tsx
@@ -25,10 +25,11 @@ export type FormNodeData = {
 
 const Page = styled.div<{ $selected: boolean }>`
   position: relative;
-  min-width: 220px;
-  max-width: 320px;
+  min-width: 240px;
+  max-width: 340px;
+  min-height: 260px;
   background: rgb(var(--color-surface));
-  border-radius: 8px;
+  border-radius: 10px;
   border: 1px solid rgb(var(--color-border));
   box-shadow: 0 4px 14px rgb(var(--color-text-primary) / 0.08);
   overflow: hidden;
@@ -128,8 +129,8 @@ const Required = styled.span`
   color: rgb(var(--color-error));
 `;
 
-const InputStub = styled.div`
-  height: 10px;
+const MockBox = styled.div<{ $type?: string }>`
+  height: ${(p) => (p.$type === 'textarea' ? '16px' : '10px')};
   border-radius: 4px;
   background: rgb(var(--color-border));
   opacity: 0.55;
@@ -168,7 +169,7 @@ export const FormNode: React.FC<NodeProps<FormNodeData>> = React.memo(({ id, dat
 
   const entityType = (data?.entityType as string | undefined) || '';
 
-  const preview = fields.slice(0, 5);
+  const preview = fields.slice(0, 4);
 
   return (
     <Page $selected={Boolean(selected)} role="article" aria-label={`Form node: ${title}`} aria-selected={selected}>
@@ -195,14 +196,14 @@ export const FormNode: React.FC<NodeProps<FormNodeData>> = React.memo(({ id, dat
                   <span>{f.label || 'Untitled field'}</span>
                   {f.required ? <Required>*</Required> : null}
                 </FieldLabel>
-                <InputStub />
+                <MockBox $type={f.type} />
               </FieldStub>
             ))}
-            {fields.length > preview.length ? (
+            {(fields || []).length > 4 && (
               <div style={{ fontSize: 11, color: 'rgb(var(--color-text-tertiary))', textAlign: 'center' }}>
-                +{fields.length - preview.length} more
+                + {(fields.length - 4)} more fields...
               </div>
-            ) : null}
+            )}
           </FieldPreview>
         )}
       </Body>

--- a/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
@@ -134,10 +134,7 @@ const ContentArea = styled.div`
 /**
  * Calculate vertical position for a child node based on its index
  * 
- * @param stepIndex - Zero-based index of step in container
- * @param baseY - Base Y offset from container top
- * @param spacing - Vertical spacing between steps
- * @returns Y position for this step
+ * (Kept for backward compatibility; the Book+Pages paradigm prefers horizontal sequencing.)
  */
 export function calculateChildYPosition(
   stepIndex: number,
@@ -148,26 +145,35 @@ export function calculateChildYPosition(
 }
 
 /**
- * Auto-layout children within a container
- * Updates node positions to follow vertical stack pattern
+ * Calculate horizontal position for a child node based on its index
  * 
- * @param childNodes - Array of child nodes to layout
- * @param containerWidth - Width of parent container
- * @returns Updated nodes with new positions
+ * Book+Pages: steps flow left-to-right like pages on a track.
+ */
+export function calculateChildXPosition(
+  stepIndex: number,
+  baseX: number = 20,
+  spacing: number = 350
+): number {
+  return baseX + (stepIndex * spacing);
+}
+
+/**
+ * Auto-layout children within a container
+ * Updates node positions to follow horizontal "pages" sequencing
  */
 export function autoLayoutChildren(
   childNodes: any[],
-  containerWidth: number = 560
+  _containerWidth: number = 560
 ): any[] {
   const baseX = 20; // Left margin
-  const baseY = 60; // Top margin (below header)
-  const spacing = 120; // Vertical spacing between steps
-  
+  const baseY = 80; // Row position (below header)
+  const spacingX = 350; // Horizontal spacing between pages
+
   return childNodes.map((node, index) => ({
     ...node,
     position: {
-      x: baseX,
-      y: calculateChildYPosition(index, baseY, spacing),
+      x: calculateChildXPosition(index, baseX, spacingX),
+      y: baseY,
     },
     data: {
       ...node.data,

--- a/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
@@ -29,7 +29,7 @@ import styled from 'styled-components';
 import { NodeProps, Node, Edge, useReactFlow, useNodes, useEdges } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { ChevronDown, ChevronRight, Plus, Settings, Save, Check } from 'lucide-react';
-import { autoLayoutChildren, calculateChildYPosition } from './FormProcessChildWrapper';
+import { autoLayoutChildren, calculateChildXPosition } from './FormProcessChildWrapper';
 import { saveFormProcessGroup } from '../../../services/tenantFormService';
 import toast from 'react-hot-toast';
 
@@ -94,9 +94,9 @@ const spinAnimation = `
 const GroupContainer = styled.div<{ isExpanded: boolean; stepCount: number; isDropTarget?: boolean }>`
   ${spinAnimation}
   
-  min-width: ${props => props.isExpanded ? '600px' : '280px'};
-  min-height: ${props => props.isExpanded ? `${Math.max(400, props.stepCount * 120 + 80)}px` : 'auto'};
-  max-width: ${props => props.isExpanded ? '1200px' : '320px'};
+  min-width: ${props => props.isExpanded ? `${Math.max(600, props.stepCount * 300 + 100)}px` : '280px'};
+  min-height: ${props => props.isExpanded ? '360px' : 'auto'};
+  max-width: ${props => props.isExpanded ? 'none' : '320px'};
   
   background: ${props => {
     if (props.isDropTarget) return 'rgba(139, 92, 246, 0.15)'; // Highlight when dragging over
@@ -267,7 +267,10 @@ const GroupBody = styled.div<{ isExpanded: boolean }>`
   min-height: ${props => props.isExpanded ? '300px' : '0'};
   max-height: ${props => props.isExpanded ? '2000px' : '0'};
   position: relative;
-  display: block;
+  display: ${props => props.isExpanded ? 'flex' : 'block'};
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 40px;
   overflow: ${props => props.isExpanded ? 'visible' : 'hidden'};
   opacity: ${props => props.isExpanded ? 1 : 0};
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -442,7 +445,8 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
     setNodes((nodes) =>
       nodes.map((node) => {
         if (node.id === id) {
-          const expandedHeight = Math.max(400, stepCount * 120 + 80);
+          const expandedWidth = Math.max(600, stepCount * 300 + 100);
+          const expandedHeight = 400;
 
           return {
             ...node,
@@ -451,7 +455,7 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
             // doesn't remain visible at the old dimensions.
             style: {
               ...(node.style || {}),
-              width: nextExpanded ? 600 : 280,
+              width: nextExpanded ? expandedWidth : 280,
               height: nextExpanded ? expandedHeight : undefined,
             },
             data: {
@@ -581,8 +585,8 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
   useEffect(() => {
     if (!sequentialExecution || childNodes.length < 2) return;
     
-    // Sort children by Y position (top to bottom execution order)
-    const sortedChildren = [...childNodes].sort((a, b) => a.position.y - b.position.y);
+    // Sort children by X position (left to right execution order)
+    const sortedChildren = [...childNodes].sort((a, b) => a.position.x - b.position.x);
     
     // Generate expected edge IDs for this configuration
     const expectedEdgeIds = new Set<string>();
@@ -656,7 +660,7 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
     sequentialExecution,
     // Memoize child positions to detect actual changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    JSON.stringify(childNodes.map(c => ({ id: c.id, y: c.position.y }))),
+    JSON.stringify(childNodes.map(c => ({ id: c.id, x: c.position.x }))),
     setEdges
   ]);
   
@@ -673,8 +677,8 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
       id: newStepId,
       type: 'formStepSingle',
       position: { 
-        x: 20, 
-        y: calculateChildYPosition(stepCount) // Use auto-layout calculation
+        x: calculateChildXPosition(stepCount),
+        y: 80,
       },
       data: {
         label: `Step ${stepCount + 1}`,
@@ -799,7 +803,7 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
           {stepCount > 0 && (
             <CollapsedStepList>
               {childNodes
-                .sort((a, b) => a.position.y - b.position.y) // Sort by Y position for flow order
+                .sort((a, b) => a.position.x - b.position.x) // Sort by X position for flow order
                 .slice(0, 5)
                 .map((child, index) => (
                   <StepPreview key={child.id}>

--- a/frontend/src/components/FlowEditor/utils/containerLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/containerLayout.ts
@@ -5,7 +5,7 @@
  * 
  * This module handles automatic positioning of nodes within containers:
  * - Form steps arrange horizontally (left-to-right)
- * - Action nodes stack vertically below connected form steps
+ * - Non-form nodes are NOT repositioned by container layout (prevents forcing actions inside the book)
  * - Maintains consistent spacing and alignment
  */
 
@@ -20,7 +20,7 @@ import { logger } from '@/utils/logger';
 export const LAYOUT_CONSTANTS = {
   // Horizontal layout for form steps
   START_X: 50,           // Starting x position for first form step
-  STEP_SPACING: 250,     // Horizontal spacing between form steps
+  STEP_SPACING: 350,     // Horizontal spacing between form steps
   STEP_Y: 80,            // Y position for form step row
   
   // Vertical layout for action nodes
@@ -84,13 +84,13 @@ export function calculateContainerLayout(
   
   // Separate nodes by type
   const formSteps = childNodes.filter(node => node.type === 'formStep' || node.type === 'formReference');
-  const actionNodes = childNodes.filter(node => 
+  const otherNodes = childNodes.filter(node => 
     node.type !== 'formStep' && 
     node.type !== 'formReference' &&
     node.type !== 'formMultiStepContainer' // Don't layout nested containers
   );
   
-  logger.debug(`[Layout] Found \${formSteps.length} form steps, \${actionNodes.length} action nodes`);
+  logger.debug(`[Layout] Found \${formSteps.length} form steps, \${otherNodes.length} non-form child nodes`);
   
   // Sort form steps by current x-position to preserve rough order
   formSteps.sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0));
@@ -114,49 +114,8 @@ export function calculateContainerLayout(
     };
   });
   
-  // Layout action nodes below their connected form steps
-  const updatedActionNodes = actionNodes.map(action => {
-    // Find which form step this action is connected to
-    const connectedStep = findConnectedFormStep(action, updatedFormSteps, allEdges);
-    
-    if (connectedStep) {
-      // Position below the connected form step
-      const actionsAtThisStep = actionNodes.filter(a => 
-        findConnectedFormStep(a, updatedFormSteps, allEdges)?.id === connectedStep.id
-      );
-      const actionIndex = actionsAtThisStep.indexOf(action);
-      
-      const newPosition: NodePosition = {
-        x: connectedStep.position.x,
-        y: connectedStep.position.y + LAYOUT_CONSTANTS.ACTION_OFFSET_Y + 
-           (actionIndex * LAYOUT_CONSTANTS.ACTION_SPACING_Y),
-      };
-      
-      logger.debug(`[Layout] Action \${action.id} positioned below step \${connectedStep.id} at (\${newPosition.x}, \${newPosition.y})`);
-      
-      return {
-        ...action,
-        position: newPosition,
-      };
-    } else {
-      // No connected form step - position at the end
-      const defaultX = LAYOUT_CONSTANTS.START_X + (formSteps.length * LAYOUT_CONSTANTS.STEP_SPACING);
-      const newPosition: NodePosition = {
-        x: defaultX,
-        y: LAYOUT_CONSTANTS.STEP_Y,
-      };
-      
-      logger.debug(`[Layout] Orphaned action \${action.id} positioned at end (\${newPosition.x}, \${newPosition.y})`);
-      
-      return {
-        ...action,
-        position: newPosition,
-      };
-    }
-  });
-  
-  // Combine updated nodes
-  const updatedChildNodes = [...updatedFormSteps, ...updatedActionNodes];
+  // Book+Pages: only reposition form steps; leave other child nodes unchanged
+  const updatedChildNodes = [...updatedFormSteps, ...otherNodes];
   
   // Calculate required container dimensions
   const maxX = Math.max(
@@ -186,43 +145,6 @@ export function calculateContainerLayout(
   };
 }
 
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * Find the form step that an action node is connected to
- * 
- * @param actionNode - The action node to check
- * @param formSteps - Array of form step nodes
- * @param edges - All edges in the editor
- * @returns The connected form step node, or null if none found
- */
-function findConnectedFormStep(
-  actionNode: Node,
-  formSteps: Node[],
-  edges: Edge[]
-): Node | null {
-  // Check incoming edges (action is target)
-  const incomingEdge = edges.find(edge => edge.target === actionNode.id);
-  if (incomingEdge) {
-    const sourceNode = formSteps.find(step => step.id === incomingEdge.source);
-    if (sourceNode) {
-      return sourceNode;
-    }
-  }
-  
-  // Check outgoing edges (action is source)
-  const outgoingEdge = edges.find(edge => edge.source === actionNode.id);
-  if (outgoingEdge) {
-    const targetNode = formSteps.find(step => step.id === outgoingEdge.target);
-    if (targetNode) {
-      return targetNode;
-    }
-  }
-  
-  return null;
-}
 
 /**
  * Check if a node should trigger auto-layout


### PR DESCRIPTION
- Container edges: already permeable (no strict container edge isolation); this PR continues that direction for Form → Action → Form flows
- FormProcessGroupNode: horizontal swimlane sizing and left-to-right step ordering (auto-layout + sequential connect uses x)
- FormProcessChildWrapper: horizontal page sequencing utilities
- FormNode: "ripped page" UI now previews up to 4 fields with "+ N more" indicator
- containerLayout: STEP_SPACING widened (350) and only form steps are repositioned (non-form child nodes left untouched)

Build: frontend `npm run build`