### PR TITLE
FlowEditor: horizontal form pages + in-situ field editor

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -14,6 +14,12 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - Container edges: strict container edge isolation remains removed to support Form → Action → Form workflows across permeable boundaries.
   - Layout: steps sequence horizontally (wider spacing) and non-form child nodes are not repositioned by container auto-layout.
 
+- 2026-03-19 — Phase 7 — Initiative: WorkForm Visual Evolution: Interleaved Action Containers and Horizontal Page Layout — Commit: TBD
+  - FormProcessGroupNode: pages (type `form`) lay out horizontally while other node types remain free-positioned within the container.
+  - Group container sizing: width expands with page count ("book" grows as pages are added).
+  - FormNode UX: selected pages support a lightweight in-canvas field editor (add/reorder) to reduce side-panel dependency.
+  - Connectivity: plan to introduce virtual handles for collapsed groups so edges can cross the container boundary cleanly without breaking `extent: 'parent'` visually.
+
 - 2026-03-19 — Fix: Workforms Editor UI/config/publish polish — Commit: 25a56157 (PR: #3629)
   - PR: https://github.com/Meats-Central/ProjectMeats/pull/3629
   - DynamicConfigPanel: handle field.type=entityType and field.type=multiSelect to prevent "Unknown field type" rendering errors.

--- a/frontend/src/components/FlowEditor/nodes/FormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormNode.tsx
@@ -5,9 +5,9 @@
  * This intentionally does NOT rely on BaseNode so we can fully customize the UI.
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Handle, Position, useReactFlow, type NodeProps } from '@xyflow/react';
 
 type PreviewField = {
   id: string;
@@ -100,6 +100,97 @@ const FieldPreview = styled.div`
   gap: 6px;
 `;
 
+const InlineEditor = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const EditorHint = styled.div`
+  font-size: 11px;
+  color: rgb(var(--color-text-tertiary));
+  text-align: center;
+`;
+
+const EditorRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 90px 26px auto;
+  gap: 6px;
+  align-items: center;
+  padding: 8px;
+  border: 1px solid rgb(var(--color-border));
+  border-radius: 8px;
+  background: rgb(var(--color-background));
+`;
+
+const SmallInput = styled.input`
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  border: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-text-primary));
+
+  &:focus {
+    outline: none;
+    border-color: rgb(var(--color-primary));
+  }
+`;
+
+const SmallSelect = styled.select`
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  border: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-text-primary));
+
+  &:focus {
+    outline: none;
+    border-color: rgb(var(--color-primary));
+  }
+`;
+
+const IconBtn = styled.button`
+  border: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-text-secondary));
+  border-radius: 6px;
+  padding: 4px 6px;
+  font-size: 12px;
+  cursor: pointer;
+
+  &:hover {
+    border-color: rgb(var(--color-primary));
+    color: rgb(var(--color-text-primary));
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const AddFieldBtn = styled.button`
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px dashed rgb(var(--color-border));
+  background: transparent;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: rgb(var(--color-text-secondary));
+  cursor: pointer;
+
+  &:hover {
+    border-color: rgb(var(--color-primary));
+    color: rgb(var(--color-primary));
+    background: rgba(var(--color-primary), 0.06);
+  }
+`;
+
 const FieldStub = styled.div`
   display: grid;
   grid-template-columns: 1fr;
@@ -161,6 +252,8 @@ const StyledHandle = styled(Handle)<{ $role: 'in' | 'out' }>`
 `;
 
 export const FormNode: React.FC<NodeProps<FormNodeData>> = React.memo(({ id, data, selected }) => {
+  const { setNodes } = useReactFlow();
+
   const fields = (data?.fields as PreviewField[] | undefined) ?? [];
   const title =
     (data?.stepTitle as string | undefined) ||
@@ -168,8 +261,69 @@ export const FormNode: React.FC<NodeProps<FormNodeData>> = React.memo(({ id, dat
     'Form';
 
   const entityType = (data?.entityType as string | undefined) || '';
-
   const preview = fields.slice(0, 4);
+  const showInSituEditor = Boolean(selected);
+
+  const mutateFields = useCallback(
+    (mutator: (prev: PreviewField[]) => PreviewField[]) => {
+      setNodes((nodes) =>
+        nodes.map((n) => {
+          if (n.id !== id) return n;
+          const prevFields = ((n.data as any)?.fields as PreviewField[] | undefined) ?? [];
+          const nextFields = mutator([...prevFields]);
+          return {
+            ...n,
+            data: {
+              ...(n.data as any),
+              fields: nextFields,
+            },
+          };
+        })
+      );
+    },
+    [id, setNodes]
+  );
+
+  const handleAddField = useCallback(() => {
+    mutateFields((prev) => [
+      ...prev,
+      {
+        id: `field-${Date.now()}`,
+        label: `Field ${prev.length + 1}`,
+        type: 'text',
+        required: false,
+      },
+    ]);
+  }, [mutateFields]);
+
+  const handleRemoveField = useCallback(
+    (fieldId: string) => {
+      mutateFields((prev) => prev.filter((f) => f.id !== fieldId));
+    },
+    [mutateFields]
+  );
+
+  const handleMoveField = useCallback(
+    (fieldId: string, dir: -1 | 1) => {
+      mutateFields((prev) => {
+        const idx = prev.findIndex((f) => f.id === fieldId);
+        if (idx === -1) return prev;
+        const nextIdx = idx + dir;
+        if (nextIdx < 0 || nextIdx >= prev.length) return prev;
+        const next = [...prev];
+        [next[idx], next[nextIdx]] = [next[nextIdx], next[idx]];
+        return next;
+      });
+    },
+    [mutateFields]
+  );
+
+  const handleUpdateField = useCallback(
+    (fieldId: string, patch: Partial<PreviewField>) => {
+      mutateFields((prev) => prev.map((f) => (f.id === fieldId ? { ...f, ...patch } : f)));
+    },
+    [mutateFields]
+  );
 
   return (
     <Page $selected={Boolean(selected)} role="article" aria-label={`Form node: ${title}`} aria-selected={selected}>
@@ -186,7 +340,75 @@ export const FormNode: React.FC<NodeProps<FormNodeData>> = React.memo(({ id, dat
       </Header>
 
       <Body className="nodrag">
-        {preview.length === 0 ? (
+        {showInSituEditor ? (
+          <InlineEditor aria-label="In-situ form field editor">
+            {fields.length === 0 ? (
+              <Empty>Add fields directly on the canvas</Empty>
+            ) : null}
+
+            {fields.map((f, idx) => (
+              <EditorRow key={f.id} onMouseDown={(e) => e.stopPropagation()}>
+                <SmallInput
+                  value={f.label || ''}
+                  placeholder="Field label"
+                  onChange={(e) => handleUpdateField(f.id, { label: e.target.value })}
+                />
+
+                <SmallSelect
+                  value={f.type || 'text'}
+                  onChange={(e) => handleUpdateField(f.id, { type: e.target.value })}
+                >
+                  <option value="text">Text</option>
+                  <option value="textarea">Textarea</option>
+                  <option value="number">Number</option>
+                  <option value="email">Email</option>
+                  <option value="phone">Phone</option>
+                  <option value="url">URL</option>
+                  <option value="date">Date</option>
+                  <option value="datetime">DateTime</option>
+                  <option value="select">Select</option>
+                  <option value="radio">Radio</option>
+                  <option value="checkbox">Checkbox</option>
+                  <option value="file">File</option>
+                </SmallSelect>
+
+                <input
+                  type="checkbox"
+                  checked={Boolean(f.required)}
+                  onChange={(e) => handleUpdateField(f.id, { required: e.target.checked })}
+                  aria-label={`Required: ${f.label || f.id}`}
+                  onMouseDown={(e) => e.stopPropagation()}
+                />
+
+                <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
+                  <IconBtn
+                    onClick={() => handleMoveField(f.id, -1)}
+                    disabled={idx === 0}
+                    aria-label="Move field up"
+                  >
+                    ↑
+                  </IconBtn>
+                  <IconBtn
+                    onClick={() => handleMoveField(f.id, 1)}
+                    disabled={idx === fields.length - 1}
+                    aria-label="Move field down"
+                  >
+                    ↓
+                  </IconBtn>
+                  <IconBtn onClick={() => handleRemoveField(f.id)} aria-label="Delete field">
+                    ✕
+                  </IconBtn>
+                </div>
+              </EditorRow>
+            ))}
+
+            <AddFieldBtn onClick={handleAddField} onMouseDown={(e) => e.stopPropagation()}>
+              + Add field
+            </AddFieldBtn>
+
+            <EditorHint>Advanced options are available in the side panel</EditorHint>
+          </InlineEditor>
+        ) : preview.length === 0 ? (
           <Empty>Click “Fields” in the config panel to add fields</Empty>
         ) : (
           <FieldPreview>

--- a/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
@@ -145,6 +145,18 @@ export function calculateChildYPosition(
 }
 
 /**
+ * Calculate horizontal position for a child node based on its index.
+ * Used for the horizontal “page row” layout inside form process groups.
+ */
+export function calculateChildXPosition(
+  stepIndex: number,
+  baseX: number = 30,
+  spacing: number = 360
+): number {
+  return baseX + (stepIndex * spacing);
+}
+
+/**
  * Calculate horizontal position for a child node based on its index
  * 
  * Book+Pages: steps flow left-to-right like pages on a track.

--- a/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
@@ -27,9 +27,9 @@ import { logger } from '@/utils/logger';
 
 import styled from 'styled-components';
 import { NodeProps, Node, Edge, useReactFlow, useNodes, useEdges } from '@xyflow/react';
-import { BaseNode, BaseNodeData } from './BaseNode';
+import type { BaseNodeData } from './BaseNode';
 import { ChevronDown, ChevronRight, Plus, Settings, Save, Check } from 'lucide-react';
-import { autoLayoutChildren, calculateChildXPosition } from './FormProcessChildWrapper';
+import { calculateChildXPosition } from './FormProcessChildWrapper';
 import { saveFormProcessGroup } from '../../../services/tenantFormService';
 import toast from 'react-hot-toast';
 
@@ -64,6 +64,8 @@ export interface FormProcessGroupData extends BaseNodeData {
   isDropTarget?: boolean;
   /** Sequential execution order enabled (Phase 3) */
   sequentialExecution?: boolean;
+  /** Stable horizontal ordering for page nodes (computed, additive-only) */
+  pageOrder?: string[];
   /** Edit handler from UnifiedFlowEditor */
   onEdit?: () => void;
   /** Delete handler from UnifiedFlowEditor */
@@ -91,10 +93,12 @@ const spinAnimation = `
  * Adapts size based on expanded/collapsed state
  * Phase 3: Added drop zone indicator
  */
-const GroupContainer = styled.div<{ isExpanded: boolean; stepCount: number; isDropTarget?: boolean }>`
+const GroupContainer = styled.div<{ isExpanded: boolean; stepCount: number; pageCount: number; isDropTarget?: boolean }>`
   ${spinAnimation}
   
-  min-width: ${props => props.isExpanded ? `${Math.max(600, props.stepCount * 300 + 100)}px` : '280px'};
+  /* Expand horizontally based on the number of page nodes (form pages). */
+  min-width: ${(props) => (props.isExpanded ? `${Math.max(600, 140 + props.pageCount * 360)}px` : '280px')};
+  width: ${(props) => (props.isExpanded ? `${Math.max(600, 140 + props.pageCount * 360)}px` : '280px')};
   min-height: ${props => props.isExpanded ? '360px' : 'auto'};
   max-width: ${props => props.isExpanded ? 'none' : '320px'};
   
@@ -396,7 +400,6 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
   // Local state for save operations
   const [isSaving, setIsSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   
   // Debug logging
   logger.debug('[FormProcessGroup] Rendered with ID:', id, 'Data:', data);
@@ -414,6 +417,12 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
     return children;
   }, [allNodes, id]);
   
+  const isPageNodeType = (type?: string) =>
+    type === 'form' || type === 'formStepSingle' || type === 'formStep' || type === 'formReference';
+
+  const pageNodes = useMemo(() => childNodes.filter((n) => isPageNodeType(n.type)), [childNodes]);
+  const pageCount = pageNodes.length;
+
   const stepCount = childNodes.length;
   const containerName = data.containerName || 'Untitled Form Process';
   const containerDescription = data.containerDescription;
@@ -445,7 +454,7 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
     setNodes((nodes) =>
       nodes.map((node) => {
         if (node.id === id) {
-          const expandedWidth = Math.max(600, stepCount * 300 + 100);
+          const expandedWidth = Math.max(600, 140 + pageCount * 360);
           const expandedHeight = 400;
 
           return {
@@ -477,7 +486,7 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
 
     // Force a re-measure so React Flow doesn't keep the previous expanded bounds.
     requestAnimationFrame(() => updateNodeInternals(id));
-  }, [id, isExpanded, setNodes, stepCount, updateNodeInternals]);
+  }, [id, isExpanded, setNodes, pageCount, updateNodeInternals]);
   
   /**
    * Save FormProcessGroup as TenantForm to backend
@@ -528,7 +537,6 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
       );
       
       setLastSaved(new Date());
-      setHasUnsavedChanges(false);
 
       if (typeof data.onSave === 'function') {
         data.onSave();
@@ -550,147 +558,192 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
   }, [id, isSaving, childNodes.length, allNodes, allEdges, setNodes, data]);
   
   /**
-   * Auto-layout children when they change
-   * Triggers vertical re-positioning when steps are added/removed/reordered
+   * Auto-layout pages (form nodes) horizontally.
+   * Non-form child nodes remain free-positioned inside the container.
    */
   useEffect(() => {
-    if (!isExpanded || childNodes.length === 0) return;
+    if (!isExpanded || pageNodes.length === 0) return;
 
-    // Apply auto-layout to children
-    const layoutedChildren = autoLayoutChildren(childNodes);
+    const existingOrder = Array.isArray(data.pageOrder) ? data.pageOrder : undefined;
+    const pageIdSet = new Set(pageNodes.map((n) => n.id));
+
+    const normalizedExisting = existingOrder ? existingOrder.filter((pid) => pageIdSet.has(pid)) : [];
+    const missing = pageNodes
+      .filter((n) => !normalizedExisting.includes(n.id))
+      .sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0) || (a.position?.y || 0) - (b.position?.y || 0))
+      .map((n) => n.id);
+
+    const nextOrder = [...normalizedExisting, ...missing];
+
+    const PAGE_START_X = 30;
+    const PAGE_ROW_Y = 90;
+    const PAGE_SPACING_X = 360;
+
+    const desiredPositions = new Map(
+      nextOrder.map((pid, index) => [pid, { x: PAGE_START_X + index * PAGE_SPACING_X, y: PAGE_ROW_Y }])
+    );
+
+    const needsOrderUpdate = !existingOrder || JSON.stringify(existingOrder) !== JSON.stringify(nextOrder);
+    const needsPositionUpdate = pageNodes.some((n) => {
+      const desired = desiredPositions.get(n.id);
+      if (!desired) return false;
+      return n.position?.x !== desired.x || n.position?.y !== desired.y;
+    });
+
+    if (!needsOrderUpdate && !needsPositionUpdate) return;
 
     setNodes((nodes) =>
       nodes.map((node) => {
-        const layouted = layoutedChildren.find((child) => child.id === node.id);
-        if (layouted && node.parentId === id) {
+        if (node.id === id) {
+          const expandedWidth = Math.max(600, 140 + pageCount * 360);
           return {
             ...node,
-            position: layouted.position,
+            style: {
+              ...(node.style || {}),
+              width: expandedWidth,
+            },
+            data: needsOrderUpdate
+              ? {
+                  ...node.data,
+                  pageOrder: nextOrder,
+                }
+              : node.data,
           };
         }
+
+        const desired = desiredPositions.get(node.id);
+        if (desired && node.parentId === id) {
+          return {
+            ...node,
+            position: desired,
+          };
+        }
+
         return node;
       })
     );
 
-    // Ensure internals account for any layout-driven size changes.
     requestAnimationFrame(() => updateNodeInternals(id));
-  }, [childNodes.length, id, isExpanded, setNodes, updateNodeInternals]); // Only trigger on count/visibility change
-  
-  /**
-   * Auto-connect children in sequential order (Phase 3)
-   * Creates edges between consecutive child nodes based on Y position
-   * 
-   * FIX: Prevents infinite loop by memoizing edge IDs and only updating when needed
-   */
-  useEffect(() => {
-    if (!sequentialExecution || childNodes.length < 2) return;
-    
-    // Sort children by X position (left to right execution order)
-    const sortedChildren = [...childNodes].sort((a, b) => a.position.x - b.position.x);
-    
-    // Generate expected edge IDs for this configuration
-    const expectedEdgeIds = new Set<string>();
-    for (let i = 0; i < sortedChildren.length - 1; i++) {
-      const edgeId = `${sortedChildren[i].id}-to-${sortedChildren[i + 1].id}`;
-      expectedEdgeIds.add(edgeId);
-    }
-    
-    // Check current edges to see if update is needed (prevents infinite loop)
-    const childIds = new Set(sortedChildren.map(c => c.id));
-    const currentAutoEdges = allEdges.filter(edge => 
-      childIds.has(edge.source) && childIds.has(edge.target)
-    );
-    const currentEdgeIds = new Set(currentAutoEdges.map(e => e.id));
-    
-    // Only update if the edge configuration changed
-    const needsUpdate = 
-      expectedEdgeIds.size !== currentEdgeIds.size ||
-      [...expectedEdgeIds].some(id => !currentEdgeIds.has(id));
-    
-    if (!needsUpdate) {
-      logger.debug(`[FormProcessGroup] Auto-connect: edges already correct, skipping update`);
-      return;
-    }
-    
-    logger.debug(`[FormProcessGroup] Auto-connect: updating ${expectedEdgeIds.size} edges`);
-    
-    // Create edges between consecutive nodes
-    const newEdges: Edge[] = [];
-    for (let i = 0; i < sortedChildren.length - 1; i++) {
-      const sourceNode = sortedChildren[i];
-      const targetNode = sortedChildren[i + 1];
-      const edgeId = `${sourceNode.id}-to-${targetNode.id}`;
-      
-      newEdges.push({
-        id: edgeId,
-        source: sourceNode.id,
-        target: targetNode.id,
-        type: 'smoothstep',
-        animated: true,
-        style: { 
-          stroke: 'rgba(139, 92, 246, 0.6)',
-          strokeWidth: 2,
-        },
-        label: `Step ${i + 1} → ${i + 2}`,
-        labelStyle: {
-          fill: 'rgb(139, 92, 246)',
-          fontWeight: 600,
-          fontSize: 11,
-        },
-        labelBgStyle: {
-          fill: 'rgb(var(--color-surface))',
-        },
-      });
-    }
-    
-    if (newEdges.length > 0) {
-      setEdges((edges) => {
-        // Remove old auto-generated edges between these children
-        const filteredEdges = edges.filter(edge => {
-          const isAutoEdge = childIds.has(edge.source) && childIds.has(edge.target);
-          return !isAutoEdge;
-        });
-        return [...filteredEdges, ...newEdges];
-      });
-    }
   }, [
-    // CRITICAL: Only depend on node count and positions, NOT allEdges
-    // Depending on allEdges causes infinite loop: update edges → allEdges changes → useEffect runs → update edges...
-    childNodes.length,
-    sequentialExecution,
-    // Memoize child positions to detect actual changes
+    id,
+    isExpanded,
+    pageCount,
+    pageNodes.length,
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    JSON.stringify(childNodes.map(c => ({ id: c.id, x: c.position.x }))),
-    setEdges
+    JSON.stringify(pageNodes.map((n) => n.id).sort()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    JSON.stringify(data.pageOrder || []),
+    setNodes,
+    updateNodeInternals,
   ]);
   
   /**
-   * Add new step to this group
-   * Creates a formStepSingle node as child
+   * Auto-connect pages in sequential order.
+   * Only connects page nodes (form / legacy form types) and never deletes manual edges.
    */
-  const handleAddStep = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    
-    // Create new step node at calculated position
-    const newStepId = `step-${Date.now()}`;
-    const newStep: Node = {
-      id: newStepId,
-      type: 'formStepSingle',
-      position: { 
-        x: calculateChildXPosition(stepCount),
-        y: 80,
-      },
-      data: {
-        label: `Step ${stepCount + 1}`,
-        formFields: [],
-      },
-      parentId: id,
-      extent: 'parent' as const, // Constrain to parent bounds
-      draggable: true,
-    };
-    
-    setNodes((nodes) => [...nodes, newStep]);
-  }, [id, stepCount, setNodes]);
+  useEffect(() => {
+    if (!sequentialExecution || pageNodes.length < 2) return;
+
+    const existingOrder = Array.isArray(data.pageOrder) ? data.pageOrder : undefined;
+    const pageIdSet = new Set(pageNodes.map((n) => n.id));
+
+    const normalizedExisting = existingOrder ? existingOrder.filter((pid) => pageIdSet.has(pid)) : [];
+    const missing = pageNodes
+      .filter((n) => !normalizedExisting.includes(n.id))
+      .sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0) || (a.position?.y || 0) - (b.position?.y || 0))
+      .map((n) => n.id);
+
+    const orderedPageIds = [...normalizedExisting, ...missing];
+
+    setEdges((prevEdges) => {
+      const isThisAutoEdge = (edge: Edge) =>
+        edge.data?.auto === true && edge.data?.containerId === id && edge.data?.kind === 'pageSequence';
+
+      const prevAutoEdges = prevEdges.filter(isThisAutoEdge);
+      const preservedEdges = prevEdges.filter((e) => !isThisAutoEdge(e));
+
+      const nextAutoEdges: Edge[] = [];
+      for (let i = 0; i < orderedPageIds.length - 1; i++) {
+        const sourceId = orderedPageIds[i];
+        const targetId = orderedPageIds[i + 1];
+
+        // Don’t auto-generate an edge if a manual edge already exists.
+        const manualExists = preservedEdges.some(
+          (e) => e.source === sourceId && e.target === targetId && e.data?.auto !== true
+        );
+        if (manualExists) continue;
+
+        nextAutoEdges.push({
+          id: `auto-page-${id}-${sourceId}-${targetId}`,
+          source: sourceId,
+          target: targetId,
+          type: 'smoothstep',
+          animated: true,
+          data: {
+            auto: true,
+            containerId: id,
+            kind: 'pageSequence',
+          },
+          style: {
+            stroke: 'rgba(139, 92, 246, 0.6)',
+            strokeWidth: 2,
+          },
+        });
+      }
+
+      const prevIds = new Set(prevAutoEdges.map((e) => e.id));
+      const nextIds = new Set(nextAutoEdges.map((e) => e.id));
+      const same = prevIds.size === nextIds.size && [...nextIds].every((x) => prevIds.has(x));
+
+      if (same) return prevEdges;
+
+      logger.debug(`[FormProcessGroup] Auto-connect: updating ${nextAutoEdges.length} page edges`);
+      return [...preservedEdges, ...nextAutoEdges];
+    });
+  }, [
+    id,
+    sequentialExecution,
+    pageNodes.length,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    JSON.stringify(pageNodes.map((n) => ({ id: n.id, x: n.position?.x, y: n.position?.y }))),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    JSON.stringify(data.pageOrder || []),
+    setEdges,
+  ]);
+  
+  /**
+   * Add new page to this group.
+   * Creates a `form` node as a child; page nodes are laid out horizontally.
+   */
+  const handleAddStep = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+
+      const newPageIndex = pageCount;
+      const newPageId = `page-${Date.now()}`;
+
+      const newPage: Node = {
+        id: newPageId,
+        type: 'form',
+        position: {
+          x: calculateChildXPosition(newPageIndex),
+          y: 90,
+        },
+        data: {
+          stepTitle: `Page ${newPageIndex + 1}`,
+          label: `Page ${newPageIndex + 1}`,
+          fields: [],
+        },
+        parentId: id,
+        extent: 'parent' as const,
+        expandParent: true,
+        draggable: true,
+      };
+
+      setNodes((nodes) => [...nodes, newPage]);
+    },
+    [id, pageCount, setNodes]
+  );
   
   /**
    * Open configuration panel
@@ -712,6 +765,7 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
     <GroupContainer 
       isExpanded={isExpanded} 
       stepCount={stepCount}
+      pageCount={pageCount}
       isDropTarget={isDropTarget}
       data-node-id={id}
       data-node-type="formProcessGroup"

--- a/frontend/src/components/FlowEditor/utils/containerLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/containerLayout.ts
@@ -83,11 +83,13 @@ export function calculateContainerLayout(
   }
   
   // Separate nodes by type
-  const formSteps = childNodes.filter(node => node.type === 'formStep' || node.type === 'formReference');
-  const otherNodes = childNodes.filter(node => 
-    node.type !== 'formStep' && 
-    node.type !== 'formReference' &&
-    node.type !== 'formMultiStepContainer' // Don't layout nested containers
+  // Pages (form nodes) should be laid out in a horizontal row; other child nodes remain free-positioned.
+  const isPageNodeType = (type?: string) =>
+    type === 'form' || type === 'formReference' || type === 'formStepSingle' || type === 'formStep';
+
+  const formSteps = childNodes.filter((node) => isPageNodeType(node.type));
+  const otherNodes = childNodes.filter(
+    (node) => !isPageNodeType(node.type) && node.type !== 'formMultiStepContainer' // Don't layout nested containers
   );
   
   logger.debug(`[Layout] Found \${formSteps.length} form steps, \${otherNodes.length} non-form child nodes`);
@@ -184,8 +186,11 @@ export function autoConnectSequentialSteps(
   const childNodes = allNodes.filter(node => node.parentId === containerId);
   
   // Get only form steps and sort by x-position (left-to-right)
+  const isPageNodeType = (type?: string) =>
+    type === 'form' || type === 'formReference' || type === 'formStepSingle' || type === 'formStep';
+
   const formSteps = childNodes
-    .filter(node => node.type === 'formStep' || node.type === 'formReference')
+    .filter((node) => isPageNodeType(node.type))
     .sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0));
   
   logger.debug(`[AutoConnect] Found ${formSteps.length} form steps to connect`);


### PR DESCRIPTION
Implements horizontal page row layout for form pages inside FormProcessGroup, expands container width by page count, and adds a lightweight in-canvas field editor for FormNode when selected.

Notes:
- Frontend type-check requires increased Node heap in this environment (e.g. NODE_OPTIONS=--max-old-space-size=8192).
- type-check currently reports TS2322 in frontend/src/App.tsx (not modified by this PR), suggesting a pre-existing baseline type issue.
