### PR TITLE
Hotfix: frontend build duplicate export

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
@@ -156,18 +156,6 @@ export function calculateChildXPosition(
   return baseX + (stepIndex * spacing);
 }
 
-/**
- * Calculate horizontal position for a child node based on its index
- * 
- * Book+Pages: steps flow left-to-right like pages on a track.
- */
-export function calculateChildXPosition(
-  stepIndex: number,
-  baseX: number = 20,
-  spacing: number = 350
-): number {
-  return baseX + (stepIndex * spacing);
-}
 
 /**
  * Auto-layout children within a container


### PR DESCRIPTION
Fix deployment failure: Vite build was failing with a duplicated export calculateChildXPosition in frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx.

This removes the duplicate export so npm run build succeeds.

Evidence: Actions run 23282971239 failing job Build & Push Frontend Image reported PARSE_ERROR Duplicated export calculateChildXPosition.