### PR TITLE
Fix: Catalog filtering for hybrid WorkForms

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -24,6 +24,11 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - DynamicConfigPanel: when an entity is selected (entityType/eventEntity/entity), load entity fields via schemaService and include them in ConditionBuilder available fields.
   - Resolves empty ConditionBuilder dropdowns for Database Event trigger nodes.
 
+- 2026-03-19 — Fix: Catalog correctly classifies hybrid WorkForms — Commit: TBD (PR: TBD)
+  - WorkForms/Catalog: refactored filtering to classify Workflows vs Forms by deeply inspecting flow_data.nodes (detects formProcessGroup + advanced nodes).
+  - Prevents newly-created hybrid WorkForms (Form Process Groups) and automation-heavy flows from being hidden under the wrong tab.
+  - WorkForms/InProgress + History: improved empty state copy to clarify why lists may be empty.
+
 - 2026-03-19 — Fix: Workforms Editor UI/config/publish polish — Commit: 25a56157 (PR: #3629)
   - PR: https://github.com/Meats-Central/ProjectMeats/pull/3629
   - DynamicConfigPanel: handle field.type=entityType and field.type=multiSelect to prevent "Unknown field type" rendering errors.

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -47,6 +47,7 @@ interface TenantForm {
   is_system_template: boolean;
   created_at: string;
   updated_at: string;
+  flow_data?: any; // Add flow_data for advanced filtering
   protein_type?: string; // NEW: Protein category (beef, pork, poultry, seafood, etc.)
   department?: string; // NEW: Department (receiving, processing, packaging, quality_control)
   can_quick_run?: boolean; // NEW: Flag if workflow supports one-click execution
@@ -529,6 +530,29 @@ const FormsFlowsCatalog: React.FC = () => {
     }
   }, [error]);
 
+  // Helper to determine if a form should be classified as a Workflow (Logic)
+  const isWorkflow = (form: TenantForm) => {
+    if (form.is_multi_entity) return true;
+    if (form.entity_count && form.entity_count > 1) return true;
+
+    // Inspect flow_data to see if it uses advanced workflow nodes
+    if (form.flow_data?.nodes && Array.isArray(form.flow_data.nodes)) {
+      const hasAdvancedNodes = form.flow_data.nodes.some((n: any) =>
+        n.type === 'formProcessGroup' ||
+        n.type === 'formProcess' ||
+        n.type === 'formMultiStepContainer' ||
+        n.type === 'conditionIf' ||
+        n.type === 'conditionSwitch' ||
+        (n.type && n.type.startsWith('action')) ||
+        (n.type && n.type.startsWith('trigger') && n.type !== 'triggerManual') ||
+        (n.type && n.type.startsWith('document'))
+      );
+      if (hasAdvancedNodes) return true;
+    }
+
+    return false;
+  };
+
   // Filter forms based on search, filter, and tab
   const filteredForms = React.useMemo(() => {
     // Safety check: ensure forms is an array
@@ -539,26 +563,15 @@ const FormsFlowsCatalog: React.FC = () => {
     
     let filtered = forms;
     
-    // Apply tab filter first (Phase 5: Separate Logic vs Data + Phase 2.2: Templates)
+    // Apply tab filter first
     if (activeTab === 'workflows') {
-      // Workflows: Forms with logic/automation nodes (exclude templates)
-      filtered = filtered.filter(form => 
-        !form.is_system_template && (
-          form.is_multi_entity === true || 
-          (form.entity_count && form.entity_count > 1)
-        )
-      );
+      // Workflows: Forms with logic/automation nodes or multi-step containers
+      filtered = filtered.filter(form => !form.is_system_template && isWorkflow(form));
     } else if (activeTab === 'forms') {
-      // Forms: Simple data capture forms (single entity or basic forms, exclude templates)
-      filtered = filtered.filter(form => 
-        !form.is_system_template && (
-          form.is_multi_entity === false || 
-          !form.entity_count || 
-          form.entity_count <= 1
-        )
-      );
+      // Forms: Simple single-step data capture forms
+      filtered = filtered.filter(form => !form.is_system_template && !isWorkflow(form));
     } else if (activeTab === 'templates') {
-      // Templates: Industry-standard system templates (Phase 2.2)
+      // Templates: Industry-standard system templates
       filtered = filtered.filter(form => form.is_system_template === true);
     }
     
@@ -601,12 +614,12 @@ const FormsFlowsCatalog: React.FC = () => {
   // Count forms by type for tab badges
   const workflowsCount = React.useMemo(() => {
     if (!forms || !Array.isArray(forms)) return 0;
-    return forms.filter(f => f.is_multi_entity === true || (f.entity_count && f.entity_count > 1)).length;
+    return forms.filter(f => !f.is_system_template && isWorkflow(f)).length;
   }, [forms]);
 
   const formsCount = React.useMemo(() => {
     if (!forms || !Array.isArray(forms)) return 0;
-    return forms.filter(f => f.is_multi_entity === false || !f.entity_count || f.entity_count <= 1).length;
+    return forms.filter(f => !f.is_system_template && !isWorkflow(f)).length;
   }, [forms]);
 
   // Handle template selection

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -721,7 +721,7 @@ const FormsFlowsHistory: React.FC = () => {
           <EmptyMessage>
             {searchQuery || startDate || endDate
               ? 'No matching records found. Try adjusting your filters.'
-              : 'Completed and cancelled forms will appear here.'}
+              : 'Completed and cancelled form submissions will appear here once a workflow finishes executing.'}
           </EmptyMessage>
         </EmptyState>
       ) : (

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -577,7 +577,7 @@ const FormsFlowsInProgress: React.FC = () => {
           <EmptyMessage>
             {searchQuery 
               ? 'No matching forms found. Try a different search term.'
-              : 'Start a new form from the Catalog to see it here.'}
+              : 'You have no active form submissions or workflow executions running right now. Start a new one from the Catalog.'}
           </EmptyMessage>
         </EmptyState>
       ) : (


### PR DESCRIPTION
## What
- Classify Workflows vs Forms by inspecting `flow_data.nodes` for advanced node types (incl. `formProcessGroup`).
- Update tab badge counts to match the new classification.
- Improve empty-state copy in In Progress + History.

## Why
Hybrid WorkForms (Form Process Groups) and automation-heavy flows were being hidden by shallow entity_count/is_multi_entity heuristics.

## Verification
- `npm --prefix frontend run build`