### PR TITLE
Phase 7 UX: Sub-flows toolbars + smoothstep edges

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -27,6 +27,11 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 - 2026-03-19 — Fix: Catalog filtering shows hybrid WorkForms — Commit: TBD (PR: TBD)
   - WorkForms Catalog: refactored filtering/classification to deeply inspect flow_data.nodes, correctly categorizing hybrid WorkForms (Form Process Groups) and pure workflows so user-created flows are not hidden.
 
+- 2026-03-19 — Phase 7 UX: Sub-flows + toolbars + smoother edges — Commit: TBD (PR: TBD)
+  - FormProcessGroupNode: removed dimension transitions and force explicit width/height on expand/collapse to avoid ResizeObserver bounding-box glitches.
+  - BaseNode: replaced ad-hoc controls with React Flow NodeToolbar and added button-style output handle.
+  - Edges: default to smoothstep (via EnhancedConnectionEdge) with thicker strokes + larger arrow markers; added a hover EdgeToolbar with insert/delete affordances.
+
 - 2026-03-19 — Fix: Workforms Editor UI/config/publish polish — Commit: 25a56157 (PR: #3629)
   - PR: https://github.com/Meats-Central/ProjectMeats/pull/3629
   - DynamicConfigPanel: handle field.type=entityType and field.type=multiSelect to prevent "Unknown field type" rendering errors.

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -118,7 +118,7 @@ import {
   UtilityNode,
   TerminalNode,
 } from './nodes';
-import { CustomEdge, ConditionalEdge, ErrorEdge, SuccessEdge, InsertNodeEdge } from './edges';
+import { CustomEdge, ConditionalEdge, ErrorEdge, SuccessEdge, InsertNodeEdge, EnhancedConnectionEdge } from './edges';
 import { FormBuilder } from '../form-builder';
 import { useFormBuilder } from './hooks/useFormBuilder';
 import { ValidationDrawer } from './components/ValidationDrawer';
@@ -1682,6 +1682,7 @@ const staticEdgeTypes: EdgeTypes = {
   conditional: ConditionalEdge,
   error: ErrorEdge,
   success: SuccessEdge,
+  enhanced: EnhancedConnectionEdge,
   insert: InsertNodeEdge,
   default: CustomEdge, // Fallback to custom for untyped edges
 };
@@ -6698,13 +6699,16 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         elevateNodesOnSelect={nodes.length < 200}
         maxZoom={4}
         minZoom={0.1}
-        defaultEdgeOptions={{ 
-          type: 'insert',
-          pathOptions: { offset: 20 },
+        defaultEdgeOptions={{
+          type: 'enhanced',
+          style: {
+            strokeWidth: 3,
+            stroke: 'rgb(var(--color-border))',
+          },
           markerEnd: {
             type: MarkerType.ArrowClosed,
-            width: 20,
-            height: 20,
+            width: 24,
+            height: 24,
             color: 'rgb(var(--color-border))',
           },
         }}
@@ -6714,7 +6718,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           strokeDasharray: '5,5',
           animation: 'dash 0.5s linear infinite',
         }}
-        connectionLineType="step"
+        connectionLineType="smoothstep"
         fitView
         snapToGrid={snapToGrid}
         snapGrid={[gridSize, gridSize]}

--- a/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
@@ -15,13 +15,13 @@
 import React, { memo, useMemo, useState } from 'react';
 import {
   EdgeProps,
-  getBezierPath,
+  getSmoothStepPath,
   EdgeLabelRenderer,
   BaseEdge,
   useReactFlow,
 } from '@xyflow/react';
 import styled, { keyframes } from 'styled-components';
-import { CheckCircle, AlertCircle, XCircle, Info } from 'lucide-react';
+import { CheckCircle, AlertCircle, XCircle, Info, Edit2, Trash2, Plus } from 'lucide-react';
 
 // ============================================================================
 // Types
@@ -113,6 +113,35 @@ const EdgeLabel = styled.div<{ $status: ConnectionStatus }>`
   @media (prefers-reduced-motion: reduce) {
     animation: none;
     opacity: 0.8;
+  }
+`;
+
+const EdgeToolbarWrapper = styled.div`
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  gap: 4px;
+  background: rgb(var(--color-surface));
+  padding: 4px;
+  border-radius: 8px;
+  border: 1px solid rgb(var(--color-border));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  pointer-events: all;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+`;
+
+const EdgeBtn = styled.button`
+  padding: 4px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: rgb(var(--color-text-secondary));
+
+  &:hover {
+    background: rgba(var(--color-primary), 0.1);
+    color: rgb(var(--color-primary));
   }
 `;
 
@@ -238,6 +267,7 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
     targetY,
     sourcePosition,
     targetPosition,
+    markerEnd,
     data = {},
     selected,
   }) => {
@@ -249,13 +279,14 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
     } = data;
 
     // Calculate path
-    const [edgePath, labelX, labelY] = getBezierPath({
+    const [edgePath, labelX, labelY] = getSmoothStepPath({
       sourceX,
       sourceY,
       sourcePosition,
       targetX,
       targetY,
       targetPosition,
+      borderRadius: 16,
     });
 
     const edgeColor = getEdgeColor(status);
@@ -263,7 +294,26 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
 
     const [isHovered, setIsHovered] = useState(false);
 
-    const { getNode } = useReactFlow();
+    const { getNode, setEdges } = useReactFlow();
+
+    const handleInsertHere = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      window.dispatchEvent(
+        new CustomEvent('insert-node-between', {
+          detail: { edgeId: id },
+        })
+      );
+      window.dispatchEvent(
+        new CustomEvent('pm:openNodePalette', {
+          detail: { insertOnEdgeId: id },
+        })
+      );
+    };
+
+    const handleDeleteEdge = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setEdges((eds) => eds.filter((edge) => edge.id !== id));
+    };
 
     const dataKeys = useMemo(() => {
       const sourceNode = source ? getNode(source) : undefined;
@@ -309,6 +359,7 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
         <BaseEdge
           id={id}
           path={edgePath}
+          markerEnd={markerEnd}
           style={{
             stroke: edgeColor,
             strokeWidth,
@@ -364,6 +415,25 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
               {label && <span>{label}</span>}
             </EdgeLabel>
           )}
+
+          {/* Hover Toolbar */}
+          <EdgeToolbarWrapper
+            style={{
+              left: labelX,
+              top: labelY,
+              opacity: isHovered ? 1 : 0,
+            }}
+          >
+            <EdgeBtn title="Add Node Here" onClick={handleInsertHere}>
+              <Plus size={14} />
+            </EdgeBtn>
+            <EdgeBtn title="Edit Edge" onClick={(e) => e.stopPropagation()}>
+              <Edit2 size={14} />
+            </EdgeBtn>
+            <EdgeBtn title="Delete Edge" onClick={handleDeleteEdge}>
+              <Trash2 size={14} />
+            </EdgeBtn>
+          </EdgeToolbarWrapper>
         </EdgeLabelRenderer>
       </>
     );

--- a/frontend/src/components/FlowEditor/edges/index.ts
+++ b/frontend/src/components/FlowEditor/edges/index.ts
@@ -9,4 +9,5 @@ export { CustomEdge } from './CustomEdge';
 export { ConditionalEdge } from './ConditionalEdge';
 export { ErrorEdge } from './ErrorEdge';
 export { SuccessEdge } from './SuccessEdge';
+export { EnhancedConnectionEdge } from './EnhancedConnectionEdge';
 export { default as InsertNodeEdge } from './InsertNodeEdge';

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -11,7 +11,7 @@
  */
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Handle, Position } from '@xyflow/react';
+import { Handle, Position, NodeToolbar } from '@xyflow/react';
 import { Edit2, Trash2, ChevronDown, ChevronUp, Lock, Unlock } from 'lucide-react';
 import { NodeTypeDefinition } from '../nodeTypes';
 import type { NodeBadgeStatus } from '../components/NodeBadge';
@@ -254,6 +254,63 @@ const StyledHandle = styled(Handle)<{ $color: string }>`
   }
 `;
 
+const ToolbarCard = styled.div`
+  display: flex;
+  gap: 4px;
+  background: rgb(var(--color-surface));
+  padding: 6px;
+  border-radius: 8px;
+  border: 1px solid rgb(var(--color-border));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+`;
+
+const ToolbarBtn = styled.button<{ $danger?: boolean }>`
+  padding: 6px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: ${(props) => (props.$danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-text-secondary))')};
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${(props) =>
+      props.$danger ? 'rgba(239, 68, 68, 0.1)' : 'rgba(var(--color-primary), 0.1)'};
+    color: ${(props) => (props.$danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-primary))')};
+  }
+`;
+
+// Button Handle overrides standard dot
+const ButtonHandle = styled(Handle)`
+  width: 24px;
+  height: 24px;
+  background: rgb(var(--color-surface));
+  border: 2px solid rgb(var(--color-primary));
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  transition: transform 0.15s ease, background 0.15s ease;
+
+  &::after {
+    content: '+';
+    color: rgb(var(--color-primary));
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1;
+  }
+
+  &:hover {
+    transform: scale(1.1);
+    background: rgb(var(--color-primary));
+
+    &::after {
+      color: white;
+    }
+  }
+`;
+
 // Batch 3: Node Controls
 const NodeControls = styled.div`
   position: absolute;
@@ -449,42 +506,44 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
 
       {/* Status Indicator - REMOVED (confusing yellow dot) */}
       
-      {/* Node Controls (Batch 3 + Sprint 1 Pin) */}
-      <NodeControls className="nodrag">
-        {onPin && (
-          <ControlButton 
-            $variant="pin" 
-            onClick={handlePin}
-            title={isPinned ? "Unlock node (allow drag)" : "Lock node position (Cmd/Ctrl+L)"}
-          >
-            {isPinned ? <Lock /> : <Unlock />}
-          </ControlButton>
-        )}
-        {onEdit && (
-          <ControlButton 
-            $variant="edit" 
-            onClick={handleEdit}
-            title="Edit node configuration"
-            aria-label={`Edit ${data.label || 'node'} configuration`}
-            role="button"
-            tabIndex={0}
-          >
-            <Edit2 aria-hidden="true" />
-          </ControlButton>
-        )}
-        {onDelete && (
-          <ControlButton 
-            $variant="delete" 
-            onClick={handleDelete}
-            title="Delete node"
-            aria-label={`Delete ${data.label || 'node'}`}
-            role="button"
-            tabIndex={0}
-          >
-            <Trash2 aria-hidden="true" />
-          </ControlButton>
-        )}
-      </NodeControls>
+      <NodeToolbar isVisible={selected} position={Position.Top}>
+        <ToolbarCard className="nodrag">
+          {onPin && (
+            <ToolbarBtn
+              onClick={(e) => {
+                e.stopPropagation();
+                handlePin(e);
+              }}
+              title={isPinned ? 'Unlock node (allow drag)' : 'Lock node position (Cmd/Ctrl+L)'}
+            >
+              {isPinned ? <Lock size={16} /> : <Unlock size={16} />}
+            </ToolbarBtn>
+          )}
+          {data.onEdit && (
+            <ToolbarBtn
+              onClick={(e) => {
+                e.stopPropagation();
+                data.onEdit!();
+              }}
+              title="Edit Node"
+            >
+              <Edit2 size={16} />
+            </ToolbarBtn>
+          )}
+          {data.onDelete && (
+            <ToolbarBtn
+              $danger
+              onClick={(e) => {
+                e.stopPropagation();
+                data.onDelete!();
+              }}
+              title="Delete Node"
+            >
+              <Trash2 size={16} />
+            </ToolbarBtn>
+          )}
+        </ToolbarCard>
+      </NodeToolbar>
 
       {/* Header */}
       <NodeHeader className={headerDragHandleClass} $color={nodeType.color}>
@@ -559,16 +618,12 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
 
       {/* Output Handle */}
       {showOutputHandle && (
-        <StyledHandle
+        <ButtonHandle
           type="source"
-          position={Position.Bottom}
+          position={Position.Right}
           id="output"
-          $color={nodeType.color}
+          isConnectable={true}
           aria-label="Output connection handle"
-          style={{
-            left: 'unset',
-            right: '18px',
-          }}
         />
       )}
       

--- a/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
@@ -93,57 +93,49 @@ const spinAnimation = `
  * Adapts size based on expanded/collapsed state
  * Phase 3: Added drop zone indicator
  */
-const GroupContainer = styled.div<{ isExpanded: boolean; stepCount: number; pageCount: number; isDropTarget?: boolean }>`
+const GroupContainer = styled.div<{ isExpanded: boolean; isDropTarget?: boolean }>`
   ${spinAnimation}
-  
-  /* Expand horizontally based on the number of page nodes (form pages). */
-  min-width: ${(props) => (props.isExpanded ? `${Math.max(600, 140 + props.pageCount * 360)}px` : '280px')};
-  width: ${(props) => (props.isExpanded ? `${Math.max(600, 140 + props.pageCount * 360)}px` : '280px')};
-  min-height: ${props => props.isExpanded ? '360px' : 'auto'};
-  max-width: ${props => props.isExpanded ? 'none' : '320px'};
-  
-  background: ${props => {
-    if (props.isDropTarget) return 'rgba(139, 92, 246, 0.15)'; // Highlight when dragging over
-    return props.isExpanded 
-      ? 'rgba(139, 92, 246, 0.03)' 
-      : 'rgb(var(--color-background-secondary))';
-  }};
-  
-  /* FIX: Split border shorthand to prevent disappearing during collapse */
+
+  /* Removed min-width/min-height - sizing is now controlled directly via React Flow style prop */
+  width: 100%;
+  height: 100%;
+
+  background: ${(props) =>
+    props.isDropTarget
+      ? 'rgba(var(--color-primary), 0.15)'
+      : props.isExpanded
+        ? 'rgba(var(--color-primary), 0.03)'
+        : 'rgb(var(--color-background-secondary))'};
+
   border-width: 2px;
-  border-style: ${props => props.isExpanded ? 'dashed' : 'solid'};
-  border-color: ${props => 
-    props.isDropTarget ? 'rgba(139, 92, 246, 0.8)' : 'rgba(139, 92, 246, 0.5)'
-  };
+  border-style: ${(props) => (props.isExpanded ? 'dashed' : 'solid')};
+  border-color: ${(props) =>
+    props.isDropTarget ? 'rgba(var(--color-primary), 0.8)' : 'rgba(var(--color-primary), 0.5)'};
   border-radius: 12px;
-  overflow: ${props => props.isExpanded ? 'visible' : 'hidden'};
+  overflow: ${(props) => (props.isExpanded ? 'visible' : 'hidden')};
   position: relative;
-  
-  box-shadow: ${props => {
+
+  box-shadow: ${(props) => {
     if (!props.isExpanded) return 'none';
     return props.isDropTarget
-      ? '0 8px 24px rgba(139, 92, 246, 0.3), 0 0 0 6px rgba(139, 92, 246, 0.2)'
-      : '0 4px 12px rgba(0, 0, 0, 0.1), 0 0 0 4px rgba(139, 92, 246, 0.1)';
+      ? '0 8px 24px rgba(var(--color-primary), 0.3), 0 0 0 6px rgba(var(--color-primary), 0.2)'
+      : '0 4px 12px rgba(0, 0, 0, 0.1), 0 0 0 4px rgba(var(--color-primary), 0.1)';
   }};
-  
-  /* FIX: Only transition specific properties, not all */
-  transition: 
-    min-width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    min-height 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    border-style 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  
+
   &:hover {
-    box-shadow: ${props => {
+    box-shadow: ${(props) => {
       if (!props.isExpanded) return 'none';
-      return '0 6px 16px rgba(0, 0, 0, 0.15), 0 0 0 4px rgba(139, 92, 246, 0.2)';
+      return '0 6px 16px rgba(0, 0, 0, 0.15), 0 0 0 4px rgba(var(--color-primary), 0.2)';
     }};
   }
-  
+
+  /* ONLY transition colors/shadows, NEVER dimensions */
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+
   /* Group label indicator */
-  ${props => props.isExpanded && `
+  ${(props) =>
+    props.isExpanded &&
+    `
     &::after {
       content: '${props.isDropTarget ? 'DROP HERE TO ADD' : 'FORM PROCESS GROUP'}';
       position: absolute;
@@ -151,7 +143,7 @@ const GroupContainer = styled.div<{ isExpanded: boolean; stepCount: number; page
       right: 16px;
       font-size: 10px;
       font-weight: 600;
-      color: rgba(139, 92, 246, 0.4);
+      color: rgba(var(--color-primary), 0.4);
       text-transform: uppercase;
       letter-spacing: 1px;
       pointer-events: none;
@@ -262,22 +254,15 @@ const IconButton = styled.button<{ variant?: 'primary' | 'default'; isSaving?: b
   }
 `;
 
-/**
- * Body area for children (when expanded)
- * With smooth CSS transition animation
- */
 const GroupBody = styled.div<{ isExpanded: boolean }>`
-  padding: ${props => props.isExpanded ? '20px' : '0'};
-  min-height: ${props => props.isExpanded ? '300px' : '0'};
-  max-height: ${props => props.isExpanded ? '2000px' : '0'};
-  position: relative;
-  display: ${props => props.isExpanded ? 'flex' : 'block'};
+  /* Switch to horizontal track layout for "Book and Pages" paradigm */
+  display: ${(props) => (props.isExpanded ? 'flex' : 'none')};
   flex-direction: row;
   align-items: flex-start;
+  padding: 20px;
   gap: 40px;
-  overflow: ${props => props.isExpanded ? 'visible' : 'hidden'};
-  opacity: ${props => props.isExpanded ? 1 : 0};
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  height: 100%;
+  position: relative;
 `;
 
 /**
@@ -484,24 +469,19 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
    */
   const handleToggleExpand = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-
     const nextExpanded = !isExpanded;
 
     setNodes((nodes) =>
       nodes.map((node) => {
         if (node.id === id) {
-          const expandedWidth = Math.max(600, 140 + pageCount * 360);
-          const expandedHeight = 400;
-
+          // Horizontal calculation: 350px per step + padding
+          const expandedWidth = Math.max(600, stepCount * 350 + 100);
           return {
             ...node,
-            // IMPORTANT: React Flow can cache measured node width/height.
-            // When collapsing, explicitly shrink the wrapper so the expanded outline/shadow
-            // doesn't remain visible at the old dimensions.
             style: {
               ...(node.style || {}),
-              width: nextExpanded ? expandedWidth : 280,
-              height: nextExpanded ? expandedHeight : undefined,
+              width: nextExpanded ? expandedWidth : 320,
+              height: nextExpanded ? 450 : 80,
             },
             data: {
               ...node.data,
@@ -509,20 +489,25 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
             },
           };
         }
+
         // Hide/show children
         if (node.parentId === id) {
           return {
             ...node,
-            hidden: isExpanded, // Will hide when collapsing (isExpanded is currently true)
+            hidden: !nextExpanded,
           };
         }
+
         return node;
       })
     );
 
-    // Force a re-measure so React Flow doesn't keep the previous expanded bounds.
-    requestAnimationFrame(() => updateNodeInternals(id));
-  }, [id, isExpanded, setNodes, pageCount, updateNodeInternals]);
+    requestAnimationFrame(() => {
+      if (typeof updateNodeInternals === 'function') {
+        updateNodeInternals(id);
+      }
+    });
+  }, [id, isExpanded, setNodes, stepCount, updateNodeInternals]);
   
   /**
    * Save FormProcessGroup as TenantForm to backend
@@ -800,8 +785,6 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
   return (
     <GroupContainer 
       isExpanded={isExpanded} 
-      stepCount={stepCount}
-      pageCount={pageCount}
       isDropTarget={isDropTarget}
       data-node-id={id}
       data-node-type="formProcessGroup"


### PR DESCRIPTION
## Changes
- FormProcessGroupNode: remove size transitions and force explicit width/height during expand/collapse (prevents ResizeObserver bounding-box glitches).
- BaseNode: replace ad-hoc node controls with React Flow `NodeToolbar`; add a button-style output handle.
- UnifiedFlowEditor: new connections default to `enhanced` (smoothstep) edges with thicker strokes + larger arrow markers; connection line type is smoothstep.
- EnhancedConnectionEdge: add hover edge toolbar (insert/delete affordances) + markerEnd support.
- MASTER_PLAN: logged Phase 7 UX batch.

## Verification
- `npm --prefix frontend run build`