### PR TITLE
Fix Settings: mount Email Integrations + auth API client

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -48,6 +48,10 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - tenantService: removed rogue axios.create + interceptors (incl. 401 hard redirect to /login); now uses centralized JWT-aware apiClient.
   - IntegrationSettings + EmailConnection: switched to apiClient and removed hardcoded /api/v1 (or /api) prefixes to avoid double-stacking baseURL.
 
+- 2026-03-19 — Email Integrations UI mounted (Settings) — Commit: TBD (PR: TBD)
+  - Settings: mounted IntegrationsSection below Tenant Branding.
+  - IntegrationsSection + EmailConnection: OAuth calls now use authenticated apiClient (no raw axios, no hardcoded /api prefix).
+
 - 2026-03-19 — Phase 11: Data Flow Tracing — Commit: c02d4d2d (PR: #3623)
   - PR: https://github.com/Meats-Central/ProjectMeats/pull/3623
   - FlowEditor: upstream context is now derived from true graph traversal (edges), not Y-position heuristics.

--- a/frontend/src/components/Integrations/EmailConnection.tsx
+++ b/frontend/src/components/Integrations/EmailConnection.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { apiClient as axios } from '../../services/apiService';
+import { apiClient } from '../../services/apiService'; // FIX: Use authenticated client
 import { toast } from 'react-hot-toast';
 import { Mail, CheckCircle, AlertCircle, ExternalLink } from 'lucide-react';
 
@@ -54,7 +54,7 @@ export const EmailConnection: React.FC<EmailConnectionProps> = ({
     setIsConnecting(true);
     
     try {
-      const response = await axios.get('/integrations/oauth/authorize/', {
+      const response = await apiClient.get('/integrations/oauth/authorize/', { // FIX: Use apiClient
         params: { provider },
       });
       window.location.href = response.data.auth_url;

--- a/frontend/src/components/Integrations/IntegrationsSection.tsx
+++ b/frontend/src/components/Integrations/IntegrationsSection.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
+import { apiClient } from '../../services/apiService'; // FIX: Use authenticated client
 import { toast } from 'react-hot-toast';
-import { Plug, Trash2, RefreshCw } from 'lucide-react';
+import { Trash2, RefreshCw } from 'lucide-react';
 import { EmailConnection } from './EmailConnection';
 import { IngestionMonitor } from './IngestionMonitor';
 
@@ -22,7 +22,7 @@ export const IntegrationsSection: React.FC = () => {
 
   const loadConnections = useCallback(async () => {
     try {
-      const response = await axios.get('/api/integrations/oauth/status/');
+      const response = await apiClient.get('/integrations/oauth/status/'); // FIX: Use apiClient
       setConnections(response.data.connections || []);
     } catch (error: any) {
       console.error('[IntegrationsSection] Failed to load connections:', error);
@@ -58,7 +58,7 @@ export const IntegrationsSection: React.FC = () => {
 
     setIsDisconnecting(provider);
     try {
-      await axios.post('/api/integrations/oauth/disconnect/', { provider });
+      await apiClient.post('/integrations/oauth/disconnect/', { provider }); // FIX: Use apiClient
       toast.success(`${provider} disconnected successfully`);
       loadConnections();
     } catch (error: any) {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import { ChromePicker, ColorResult } from 'react-color';
 import { extractBrandColors, rgbToHex, hexToRgb } from '../utils/themeUtils';
 import { injectTenantColors } from '../config/theme';
 import { getRuntimeConfig } from '../config/runtime';
+import { IntegrationsSection } from '../components/Integrations/IntegrationsSection';
 
 // Renamed to avoid collision with component name (ESLint no-redeclare warning)
 interface UserSettings {
@@ -533,6 +534,9 @@ const Settings: React.FC = () => {
             </SettingGroup>
           </SettingsSection>
         )}
+
+        {/* Email Integrations Section */}
+        <IntegrationsSection />
 
         {/* Notification Settings */}
         <SettingsSection>


### PR DESCRIPTION
Mounts the Email Integrations section in Settings and updates Integrations OAuth calls to use the authenticated apiClient (no raw axios, no hardcoded /api prefix). Also logs the change in .github/MASTER_PLAN.md.