### PR TITLE
FlowEditor: Book & Pages (subflows/toolbars)

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -6700,25 +6700,18 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         maxZoom={4}
         minZoom={0.1}
         defaultEdgeOptions={{
+          // Keep our enhanced edge component, but render it with thicker step-like styling.
           type: 'enhanced',
-          style: {
-            strokeWidth: 3,
-            stroke: 'rgb(var(--color-border))',
-          },
-          markerEnd: {
-            type: MarkerType.ArrowClosed,
-            width: 24,
-            height: 24,
-            color: 'rgb(var(--color-border))',
-          },
+          style: { strokeWidth: 3, stroke: 'rgb(148, 163, 184)' },
+          markerEnd: { type: MarkerType.ArrowClosed, width: 24, height: 24, color: 'rgb(148, 163, 184)' },
         }}
         connectionLineStyle={{
-          stroke: 'rgb(var(--color-primary))',
+          stroke: 'rgb(148, 163, 184)',
           strokeWidth: 3,
           strokeDasharray: '5,5',
           animation: 'dash 0.5s linear infinite',
         }}
-        connectionLineType="smoothstep"
+        connectionLineType="step"
         fitView
         snapToGrid={snapToGrid}
         snapGrid={[gridSize, gridSize]}

--- a/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
@@ -118,7 +118,7 @@ const EdgeLabel = styled.div<{ $status: ConnectionStatus }>`
 
 const EdgeToolbarWrapper = styled.div`
   position: absolute;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%) scale(0.9);
   display: flex;
   gap: 4px;
   background: rgb(var(--color-surface));
@@ -128,7 +128,7 @@ const EdgeToolbarWrapper = styled.div`
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   pointer-events: all;
   opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease, transform 0.2s ease;
 `;
 
 const EdgeBtn = styled.button`
@@ -441,6 +441,7 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
               left: labelX,
               top: labelY,
               opacity: isHovered ? 1 : 0,
+              transform: `translate(-50%, -50%) scale(${isHovered ? 1 : 0.9})`,
             }}
             onMouseEnter={setHoverOn}
             onMouseLeave={scheduleHoverOff}

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -311,6 +311,26 @@ const ButtonHandle = styled(Handle)`
   }
 `;
 
+const ControlButton = styled.button`
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  border: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-text-secondary));
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: rgba(var(--color-primary), 0.08);
+    border-color: rgb(var(--color-primary));
+    color: rgb(var(--color-primary));
+  }
+`;
 
 const ExpandButton = styled(ControlButton)`
   position: absolute;

--- a/frontend/src/components/FlowEditor/nodes/FormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormNode.tsx
@@ -25,15 +25,35 @@ export type FormNodeData = {
 
 const Page = styled.div<{ $selected: boolean }>`
   position: relative;
-  min-width: 240px;
-  max-width: 340px;
-  min-height: 260px;
+  width: 280px;
+  min-width: 280px;
+  max-width: 280px;
+  min-height: 300px;
   background: rgb(var(--color-surface));
   border-radius: 10px;
   border: 1px solid rgb(var(--color-border));
   box-shadow: 0 4px 14px rgb(var(--color-text-primary) / 0.08);
   overflow: hidden;
   transition: box-shadow 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
+
+  /* Subtle "ripped page" hint along the bottom edge */
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 10px;
+    background:
+      linear-gradient(
+        135deg,
+        transparent 0,
+        transparent 6px,
+        rgb(var(--color-surface)) 6px
+      );
+    opacity: 0.6;
+    pointer-events: none;
+  }
 
   ${(p) =>
     p.$selected
@@ -94,10 +114,47 @@ const Body = styled.div`
   background: rgb(var(--color-surface));
 `;
 
-const FieldPreview = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+const PreviewCard = styled.div`
+  padding: 12px;
+  background: rgb(var(--color-background-secondary));
+  border-radius: 6px;
+  margin-top: 12px;
+`;
+
+const PreviewTitle = styled.div`
+  font-size: 10px;
+  font-weight: 700;
+  color: rgb(var(--color-text-secondary));
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+`;
+
+const PreviewFieldRow = styled.div`
+  margin-bottom: 8px;
+`;
+
+const PreviewFieldLabel = styled.div`
+  font-size: 11px;
+  color: rgb(var(--color-text-primary));
+  margin-bottom: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const PreviewFieldBox = styled.div`
+  height: 24px;
+  background: rgb(var(--color-surface));
+  border: 1px solid rgb(var(--color-border));
+  border-radius: 6px;
+`;
+
+const PreviewMore = styled.div`
+  font-size: 10px;
+  color: rgb(var(--color-text-secondary));
+  text-align: center;
+  margin-top: 2px;
 `;
 
 const InlineEditor = styled.div`
@@ -189,42 +246,6 @@ const AddFieldBtn = styled.button`
     color: rgb(var(--color-primary));
     background: rgba(var(--color-primary), 0.06);
   }
-`;
-
-const FieldStub = styled.div`
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 4px;
-  padding: 8px 8px;
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 6px;
-  background: rgb(var(--color-background));
-`;
-
-const FieldLabel = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  font-size: 11px;
-  font-weight: 700;
-  color: rgb(var(--color-text-primary));
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
-const Required = styled.span`
-  font-size: 11px;
-  font-weight: 800;
-  color: rgb(var(--color-error));
-`;
-
-const MockBox = styled.div<{ $type?: string }>`
-  height: ${(p) => (p.$type === 'textarea' ? '16px' : '10px')};
-  border-radius: 4px;
-  background: rgb(var(--color-border));
-  opacity: 0.55;
 `;
 
 const Empty = styled.div`
@@ -411,22 +432,16 @@ export const FormNode: React.FC<NodeProps<FormNodeData>> = React.memo(({ id, dat
         ) : preview.length === 0 ? (
           <Empty>Click “Fields” in the config panel to add fields</Empty>
         ) : (
-          <FieldPreview>
-            {preview.map((f) => (
-              <FieldStub key={f.id}>
-                <FieldLabel title={f.label || f.id}>
-                  <span>{f.label || 'Untitled field'}</span>
-                  {f.required ? <Required>*</Required> : null}
-                </FieldLabel>
-                <MockBox $type={f.type} />
-              </FieldStub>
+          <PreviewCard aria-label="Field preview">
+            <PreviewTitle>Field Preview</PreviewTitle>
+            {(fields || []).slice(0, 4).map((field) => (
+              <PreviewFieldRow key={field.id}>
+                <PreviewFieldLabel title={field.label || field.id}>{field.label || 'Untitled field'}</PreviewFieldLabel>
+                <PreviewFieldBox />
+              </PreviewFieldRow>
             ))}
-            {(fields || []).length > 4 && (
-              <div style={{ fontSize: 11, color: 'rgb(var(--color-text-tertiary))', textAlign: 'center' }}>
-                + {(fields.length - 4)} more fields...
-              </div>
-            )}
-          </FieldPreview>
+            {(fields || []).length > 4 && <PreviewMore>+ {(fields.length - 4)} more fields...</PreviewMore>}
+          </PreviewCard>
         )}
       </Body>
 

--- a/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
@@ -489,7 +489,8 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
             style: {
               ...(node.style || {}),
               width: nextExpanded ? expandedWidth : 320,
-              height: nextExpanded ? 320 : 80,
+              // Explicit bounds prevent ResizeObserver "glitch" during expand/collapse
+              height: nextExpanded ? 450 : 80,
             },
             data: {
               ...node.data,


### PR DESCRIPTION
Fixes urgent FlowEditor crash and advances Book & Pages UI.\n\nChanges:\n- BaseNode: define missing ControlButton (fixes runtime error on dev.meatscentral.com)\n- FormProcessGroup: enforce explicit expanded/collapsed bounds (ResizeObserver glitch fix)\n- FormNode: page-like styling (280x300) + 4-field preview block\n- UnifiedFlowEditor: thicker step-style edges + step connection line (keeps enhanced edge type)\n- EnhancedConnectionEdge: hover toolbar scale/opacity polish\n\nNotes:\n- Container edge isolation block was already removed; onConnect already allows cross-container connections.