### PR TITLE
Admin workspace: fix API client usage

### DIFF
--- a/frontend/src/pages/Admin/Activity/index.tsx
+++ b/frontend/src/pages/Admin/Activity/index.tsx
@@ -21,7 +21,7 @@ import {
   FileText,
   Loader
 } from 'lucide-react';
-import axios from 'axios';
+import { apiClient } from '../../../services/apiService';
 
 // Types
 interface ActivityLog {
@@ -54,7 +54,6 @@ interface ActivityFilters {
   end_date: string;
 }
 
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
 
 // Action type configuration
 const ACTION_TYPES = [
@@ -101,26 +100,23 @@ const ActivityPage: React.FC = () => {
       setLoading(true);
       setError('');
 
-      const params = new URLSearchParams({
-        page: pageNum.toString(),
-        page_size: '20',
+      const params: Record<string, string | number> = {
+        page: pageNum,
+        page_size: 20,
         ordering: '-created_at',
-      });
+      };
 
       // Add filters
-      if (filters.search) params.append('search', filters.search);
-      if (filters.action) params.append('action', filters.action);
-      if (filters.entity_type) params.append('entity_type', filters.entity_type);
-      if (filters.start_date) params.append('created_at__gte', filters.start_date);
-      if (filters.end_date) params.append('created_at__lte', filters.end_date);
+      if (filters.search) params.search = filters.search;
+      if (filters.action) params.action = filters.action;
+      if (filters.entity_type) params.entity_type = filters.entity_type;
+      if (filters.start_date) params.created_at__gte = filters.start_date;
+      if (filters.end_date) params.created_at__lte = filters.end_date;
 
-      const token = localStorage.getItem('access_token');
-      const response = await axios.get(`${API_BASE_URL}/api/v1/activity-logs/?${params}`, {
-        headers: { Authorization: `Bearer ${token}` }
-      });
+      const response = await apiClient.get('/activity-logs/', { params });
 
       // Ensure response.data.results is always an array
-      const results = Array.isArray(response.data.results) ? response.data.results : [];
+      const results = Array.isArray((response.data as any)?.results) ? (response.data as any).results : [];
       
       if (appendMode) {
         setLogs(prev => [...prev, ...results]);
@@ -128,7 +124,7 @@ const ActivityPage: React.FC = () => {
         setLogs(results);
       }
 
-      setHasMore(!!response.data.next);
+      setHasMore(Boolean((response.data as any)?.next));
       setPage(pageNum);
     } catch (err: any) {
       setError(err.response?.data?.detail || 'Failed to load activity logs');
@@ -167,24 +163,22 @@ const ActivityPage: React.FC = () => {
     try {
       setExporting(true);
 
-      const params = new URLSearchParams();
-      if (filters.search) params.append('search', filters.search);
-      if (filters.action) params.append('action', filters.action);
-      if (filters.entity_type) params.append('entity_type', filters.entity_type);
-      if (filters.start_date) params.append('created_at__gte', filters.start_date);
-      if (filters.end_date) params.append('created_at__lte', filters.end_date);
+      const params: Record<string, string> = {};
+      if (filters.search) params.search = filters.search;
+      if (filters.action) params.action = filters.action;
+      if (filters.entity_type) params.entity_type = filters.entity_type;
+      if (filters.start_date) params.created_at__gte = filters.start_date;
+      if (filters.end_date) params.created_at__lte = filters.end_date;
 
-      const token = localStorage.getItem('access_token');
-      const response = await axios.get(
-        `${API_BASE_URL}/api/v1/activity-logs/export/?${params}`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          responseType: 'blob',
-        }
-      );
+      const response = await apiClient.get('/activity-logs/export/', {
+        params,
+        responseType: 'blob',
+      });
 
       // Create download link
-      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const data = response.data as any;
+      const blob = data instanceof Blob ? data : new Blob([data]);
+      const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
       link.setAttribute('download', `activity_logs_${new Date().toISOString().split('T')[0]}.csv`);

--- a/frontend/src/pages/Admin/Configurations/index.tsx
+++ b/frontend/src/pages/Admin/Configurations/index.tsx
@@ -9,7 +9,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
+import { apiClient } from '../../../services/apiService';
 
 // Types
 interface Configuration {
@@ -55,7 +55,7 @@ const ConfigurationsPage: React.FC = () => {
   const loadConfigurations = async () => {
     try {
       setLoading(true);
-      const response = await axios.get('/api/v1/configurations/');
+      const response = await apiClient.get('/configurations/');
       // Ensure response.data is always an array
       const data = Array.isArray(response.data) ? response.data : [];
       setConfigurations(data);
@@ -90,8 +90,8 @@ const ConfigurationsPage: React.FC = () => {
         value
       }));
 
-      await axios.post('/api/v1/configurations/bulk_update/', {
-        configurations: configurationsToUpdate
+      await apiClient.post('/configurations/bulk_update/', {
+        configurations: configurationsToUpdate,
       });
 
       showMessage('success', `Saved ${configurationsToUpdate.length} configuration(s)`);
@@ -112,8 +112,8 @@ const ConfigurationsPage: React.FC = () => {
 
     try {
       setSaving(true);
-      await axios.post('/api/v1/configurations/reset_category/', {
-        category: activeCategory
+      await apiClient.post('/configurations/reset_category/', {
+        category: activeCategory,
       });
       
       showMessage('success', `Reset ${activeCategory} configurations to defaults`);

--- a/frontend/src/pages/Admin/Profile/index.tsx
+++ b/frontend/src/pages/Admin/Profile/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import { apiClient } from '@/services/apiService';
 import { useToast } from '@/hooks/useToast';
 import { LoadingSkeleton } from '@/components/Admin/LoadingSkeleton';
 import styles from './Profile.module.css';
@@ -42,7 +42,7 @@ export const Profile: React.FC = () => {
   const { data: tenant, isLoading } = useQuery<Tenant>({
     queryKey: ['tenant'],
     queryFn: async () => {
-      const response = await axios.get('/api/tenants/current/');
+      const response = await apiClient.get('/tenants/current/');
       return response.data;
     },
   });
@@ -79,7 +79,7 @@ export const Profile: React.FC = () => {
 
   const updateProfileMutation = useMutation({
     mutationFn: async (data: FormData) => {
-      const response = await axios.patch(`/api/tenants/${tenant?.id}/`, data, {
+      const response = await apiClient.patch(`/tenants/${tenant?.id}/`, data, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
       return response.data;

--- a/frontend/src/pages/Admin/README.md
+++ b/frontend/src/pages/Admin/README.md
@@ -22,7 +22,7 @@ frontend/src/pages/Admin/
 ## ✨ Features
 
 ### 1. Users & Invitations (Phase 1)
-**Route**: `/admin/users`
+**Route**: `/workspace/users`
 
 - View all tenant users
 - Invite new users via email
@@ -34,7 +34,7 @@ frontend/src/pages/Admin/
 **Permissions**: Owners and admins only
 
 ### 2. Profile & Branding (Phase 2)
-**Route**: `/admin/profile`
+**Route**: `/workspace/profile`
 
 - Organization information (name, description, address, website)
 - Logo upload with preview
@@ -45,7 +45,7 @@ frontend/src/pages/Admin/
 **Permissions**: Owners and admins only
 
 ### 3. Option Lists Management (Phase 3)
-**Route**: `/admin/option-lists`
+**Route**: `/workspace/option-lists`
 
 - View all system choice lists
 - Create custom option lists
@@ -57,7 +57,7 @@ frontend/src/pages/Admin/
 **Permissions**: Owners and admins only
 
 ### 4. Configurations (Phase 4)
-**Route**: `/admin/configurations`
+**Route**: `/workspace/configurations`
 
 - Category-based organization (6 categories)
   - General
@@ -76,7 +76,7 @@ frontend/src/pages/Admin/
 **Permissions**: Owners and admins only
 
 ### 5. Activity & Audit Logs (Phase 5)
-**Route**: `/admin/activity`
+**Route**: `/workspace/activity`
 
 - Timeline view of all admin actions
 - Color-coded action types (create/update/delete)
@@ -94,7 +94,7 @@ frontend/src/pages/Admin/
 **Permissions**: Owners and admins only
 
 ### 6. Billing (Placeholder)
-**Route**: `/admin/billing`
+**Route**: `/workspace/billing`
 
 - Subscription management (coming soon)
 - Payment methods (coming soon)
@@ -103,7 +103,7 @@ frontend/src/pages/Admin/
 **Permissions**: Owners only
 
 ### 7. Customizations (Placeholder)
-**Route**: `/admin/customizations`
+**Route**: `/workspace/customizations`
 
 - UI customization options (coming soon)
 - Custom fields (coming soon)


### PR DESCRIPTION
Admin workspace pages were bypassing authenticated API clients, causing broken requests in production.

Changes:
- Admin Profile, Configurations, Activity now use apiClient (correct baseURL, auth, tenant headers)
- Removed hardcoded /api paths and removed process.env-based base URL logic
- Updated admin workspace docs routes to /workspace/... (App redirects /admin/... to /workspace/...)

Checks:
- vitest (Admin): PASS
- eslint (changed files): PASS
- frontend build: PASS