### PR TITLE
FlowEditor: node + opens palette

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2511,17 +2511,32 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   const [clipboardData, setClipboardData] = useState<Node[]>([]);
   const [isPaletteVisible, setIsPaletteVisible] = useState(true);
   const [pendingInsertEdgeId, setPendingInsertEdgeId] = useState<string | null>(null);
+  const [pendingInsertAnchorNodeId, setPendingInsertAnchorNodeId] = useState<string | null>(null);
 
   // Inline insertion: listen for "+" edge events to open palette with context
   useEffect(() => {
     const openPaletteForEdge = (edgeId: string | null) => {
       setPendingInsertEdgeId(edgeId);
+      setPendingInsertAnchorNodeId(null);
+      setIsPaletteVisible(true);
+      requestAnimationFrame(() => searchInputRef.current?.focus());
+    };
+
+    const openPaletteForNode = (nodeId: string | null) => {
+      setPendingInsertEdgeId(null);
+      setPendingInsertAnchorNodeId(nodeId);
+      setSelectedNodeId(nodeId);
+      setSelectedNode(null);
       setIsPaletteVisible(true);
       requestAnimationFrame(() => searchInputRef.current?.focus());
     };
 
     const handleOpenPalette = (event: Event) => {
-      const detail = (event as CustomEvent<{ insertOnEdgeId?: string }>).detail;
+      const detail = (event as CustomEvent<{ insertOnEdgeId?: string; anchorNodeId?: string }>).detail;
+      if (detail?.anchorNodeId) {
+        openPaletteForNode(detail.anchorNodeId);
+        return;
+      }
       openPaletteForEdge(detail?.insertOnEdgeId || null);
     };
 
@@ -3366,6 +3381,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
         setNodeIdCounter((prev) => prev + counterDelta);
         setPendingInsertEdgeId(null);
+        setPendingInsertAnchorNodeId(null);
         setSelectedNodeId(selectedId);
         setSelectedNode(null);
 
@@ -3375,11 +3391,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
       // Otherwise, insert directly below the selected node (or the bottom-most node)
       const selectedById = selectedNodeId ? nodes.find((n) => n.id === selectedNodeId) || null : null;
+      const pendingAnchor = pendingInsertAnchorNodeId ? nodes.find((n) => n.id === pendingInsertAnchorNodeId) || null : null;
       const bottomMost = [...nodes]
         .filter((n) => !n.hidden)
         .sort((a, b) => (b.position?.y ?? 0) - (a.position?.y ?? 0))[0];
 
-      const anchor = selectedNode || selectedById || nodes.find((n) => n.selected) || bottomMost || null;
+      const anchor = pendingAnchor || selectedNode || selectedById || nodes.find((n) => n.selected) || bottomMost || null;
 
       if (anchor) {
         // Preserve container context if inserting within a group
@@ -3441,6 +3458,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         const nextNodes = selectOnly([...nodes, ...nodesToAdd], selectedId);
 
         setNodeIdCounter((prev) => prev + counterDelta);
+        setPendingInsertAnchorNodeId(null);
         setSelectedNodeId(selectedId);
         setSelectedNode(null);
 
@@ -3451,6 +3469,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       readOnly,
       addToRecent,
       pendingInsertEdgeId,
+      pendingInsertAnchorNodeId,
       edges,
       nodes,
       nodeIdCounter,
@@ -6125,6 +6144,17 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           ? data.onTitleChange
           : (newTitle: string) => handleNodeTitleChange(node.id, newTitle);
 
+      const onInsertAfter =
+        typeof data.onInsertAfter === 'function'
+          ? data.onInsertAfter
+          : () => {
+              window.dispatchEvent(
+                new CustomEvent('pm:openNodePalette', {
+                  detail: { anchorNodeId: node.id },
+                })
+              );
+            };
+
       return {
         ...node,
         data: {
@@ -6133,6 +6163,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           onDelete,
           onSave,
           onTitleChange,
+          onInsertAfter,
         },
       };
     });

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -12,7 +12,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Handle, Position, NodeToolbar } from '@xyflow/react';
-import { Edit2, Trash2, ChevronDown, ChevronUp, Lock, Unlock } from 'lucide-react';
+import { Edit2, Trash2, ChevronDown, ChevronUp, Lock, Unlock, Plus } from 'lucide-react';
 import { NodeTypeDefinition } from '../nodeTypes';
 import type { NodeBadgeStatus } from '../components/NodeBadge';
 import { NodeIcon, NodeIconType } from '../components/NodeIcons';
@@ -32,6 +32,8 @@ export interface BaseNodeData {
   onEdit?: () => void; // Batch 3: Edit handler
   onDelete?: () => void; // Batch 3: Delete handler
   onTitleChange?: (newTitle: string) => void; // Batch 4: Title edit handler
+  /** Open the node palette in "insert after this node" context */
+  onInsertAfter?: () => void;
   // Phase 9.4: Breakpoints
   hasBreakpoint?: boolean;
   // Sprint 1 Task 1.2: Enhanced visuals
@@ -479,6 +481,17 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
               title={isPinned ? 'Unlock node (allow drag)' : 'Lock node position (Cmd/Ctrl+L)'}
             >
               {isPinned ? <Lock size={16} /> : <Unlock size={16} />}
+            </ToolbarBtn>
+          )}
+          {data.onInsertAfter && (
+            <ToolbarBtn
+              onClick={(e) => {
+                e.stopPropagation();
+                data.onInsertAfter!();
+              }}
+              title="Add next node"
+            >
+              <Plus size={16} />
             </ToolbarBtn>
           )}
           {data.onEdit && (


### PR DESCRIPTION
Unblocks node "+" behavior in the FlowEditor.

- Adds a "+" button to BaseNode toolbar that opens the node palette in **insert-after-this-node** context
- Extends the existing  event to support  and tracks 
- Clears insert state after insertion

Checks:
- eslint (changed files): PASS
- vitest subset: PASS