### PR TITLE
Frontend: remove raw axios usage (tenant/auth safe)

### DIFF
--- a/frontend/src/components/Admin/ChoiceListEditor.tsx
+++ b/frontend/src/components/Admin/ChoiceListEditor.tsx
@@ -31,17 +31,17 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { 
-  PlusIcon, 
-  TrashIcon, 
-  PencilIcon,
-  GripVerticalIcon,
-  EyeOffIcon,
-  EyeIcon,
-  CheckIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline';
-import axios from 'axios';
+import {
+  Plus,
+  Trash2,
+  Pencil,
+  GripVertical,
+  EyeOff,
+  Eye,
+  Check,
+  X,
+} from 'lucide-react';
+import { apiClient } from '@/services/apiService';
 
 interface ChoiceItem {
   id: string;
@@ -109,7 +109,7 @@ const SortableItem: React.FC<SortableItemProps> = ({
           {...listeners}
           className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600"
         >
-          <GripVerticalIcon className="w-5 h-5" />
+          <GripVertical className="w-5 h-5" />
         </button>
       )}
 
@@ -152,9 +152,9 @@ const SortableItem: React.FC<SortableItemProps> = ({
             title={item.is_active ? 'Hide for tenant' : 'Show for tenant'}
           >
             {item.is_active ? (
-              <EyeIcon className="w-5 h-5" />
+              <Eye className="w-5 h-5" />
             ) : (
-              <EyeOffIcon className="w-5 h-5" />
+              <EyeOff className="w-5 h-5" />
             )}
           </button>
         ) : (
@@ -165,14 +165,14 @@ const SortableItem: React.FC<SortableItemProps> = ({
               className="p-2 text-blue-600 hover:text-blue-700 rounded"
               title="Edit"
             >
-              <PencilIcon className="w-5 h-5" />
+              <Pencil className="w-5 h-5" />
             </button>
             <button
               onClick={() => onDelete(item)}
               className="p-2 text-red-600 hover:text-red-700 rounded"
               title="Delete"
             >
-              <TrashIcon className="w-5 h-5" />
+              <Trash2 className="w-5 h-5" />
             </button>
           </>
         )}
@@ -210,14 +210,14 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
   const loadChoiceList = async () => {
     try {
       setLoading(true);
-      const response = await axios.get(
-        `/api/v1/system/choice-lists/${choiceListSlug}/`
+      const response = await apiClient.get(
+        `/system/choice-lists/${choiceListSlug}/`
       );
       setChoiceList(response.data);
       
       // Load items with tenant filtering
-      const itemsResponse = await axios.get(
-        `/api/v1/system/choice-lists/${choiceListSlug}/items/`
+      const itemsResponse = await apiClient.get(
+        `/system/choice-lists/${choiceListSlug}/items/`
       );
       // Ensure itemsResponse.data is always an array
       const itemsData = Array.isArray(itemsResponse.data) ? itemsResponse.data : [];
@@ -251,8 +251,8 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
         order: (index + 1) * 10,
       }));
 
-      await axios.post(
-        `/api/v1/system/choice-lists/${choiceListSlug}/reorder/`,
+      await apiClient.post(
+        `/system/choice-lists/${choiceListSlug}/reorder/`,
         { items: updates }
       );
     } catch (err: any) {
@@ -268,8 +268,8 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
     }
 
     try {
-      await axios.post(
-        `/api/v1/system/choice-lists/${choiceListSlug}/items/`,
+      await apiClient.post(
+        `/system/choice-lists/${choiceListSlug}/items/`,
         {
           value: newItem.value.toUpperCase(),
           label: newItem.label,
@@ -288,8 +288,8 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
     if (!editingItem) return;
 
     try {
-      await axios.patch(
-        `/api/v1/system/choice-items/${editingItem.id}/`,
+      await apiClient.patch(
+        `/system/choice-items/${editingItem.id}/`,
         {
           label: editingItem.label,
           is_active: editingItem.is_active,
@@ -306,7 +306,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
     if (!confirm(`Delete "${item.label}"?`)) return;
 
     try {
-      await axios.delete(`/api/v1/system/choice-items/${item.id}/`);
+      await apiClient.delete(`/system/choice-items/${item.id}/`);
       loadChoiceList();
     } catch (err: any) {
       setError('Failed to delete item');
@@ -317,7 +317,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
     // For system items, we need to use choice overrides
     // This is a simplified implementation - full version would use TenantChoiceOverride
     try {
-      await axios.patch(`/api/v1/system/choice-items/${item.id}/`, {
+      await apiClient.patch(`/system/choice-items/${item.id}/`, {
         is_active: !item.is_active,
       });
       loadChoiceList();
@@ -382,7 +382,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
             onClick={() => setIsAddingItem(true)}
             className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
           >
-            <PlusIcon className="w-5 h-5" />
+            <Plus className="w-5 h-5" />
             Add Custom Item
           </button>
         )}
@@ -427,7 +427,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
               onClick={handleAddItem}
               className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
             >
-              <CheckIcon className="w-5 h-5" />
+              <Check className="w-5 h-5" />
               Save
             </button>
             <button
@@ -437,7 +437,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
               }}
               className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300"
             >
-              <XMarkIcon className="w-5 h-5" />
+              <X className="w-5 h-5" />
               Cancel
             </button>
           </div>

--- a/frontend/src/contexts/ThemeContext.test.tsx
+++ b/frontend/src/contexts/ThemeContext.test.tsx
@@ -52,7 +52,6 @@ const TestConsumer: React.FC = () => {
 };
 
 describe('ThemeContext', () => {
-  let originalBody: HTMLElement;
   let originalMatchMedia: typeof window.matchMedia | undefined;
   let localStorageMock: { [key: string]: string };
 
@@ -84,9 +83,6 @@ describe('ThemeContext', () => {
     vi.spyOn(Storage.prototype, 'removeItem').mockImplementation((key) => {
       delete localStorageMock[key];
     });
-    
-    // Store original body reference
-    originalBody = document.body;
     
     // Mock axios responses (no auth token by default)
     mockedAxios.get.mockRejectedValue(new Error('No token'));

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -13,10 +13,11 @@
  */
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { ConfigProvider } from 'antd';
-import { Theme, themes, lightTheme, darkTheme, injectTenantColors } from '../config/theme';
+import { Theme, themes, injectTenantColors } from '../config/theme';
 import { getThemeConfig, applyCanvasTheme } from '../theme/themeConfig';
 import { getRuntimeConfig } from '../config/runtime';
-import axios from 'axios';
+import { apiClient } from '../services/apiService';
+import { getAuthHeader } from '../services/jwtService';
 
 type ThemeName = 'light' | 'dark' | 'high-contrast';
 
@@ -66,35 +67,24 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   
   const [tenantBranding, setTenantBranding] = useState<TenantBranding | null>(null);
 
-  // NEW: Always use CSS variable-based themes (no custom theme object needed)
-  const theme = themes[themeName];
+  const cssThemeMode: 'light' | 'dark' = themeName === 'dark' ? 'dark' : 'light';
 
-  // Apply theme to document body (now sets data-theme attribute for CSS variable switching)
+  // CSS-variable theme object only supports light/dark
+  const theme = themes[cssThemeMode];
+
+  // Apply theme to document body (data-theme powers global CSS variables)
   useEffect(() => {
-    document.body.setAttribute('data-theme', themeName);
+    document.body.setAttribute('data-theme', cssThemeMode);
     applyCanvasTheme(themeName);
-    // Background and text color are now controlled by CSS variables
-    // No need to manually set body styles here
-  }, [themeName]);
+  }, [cssThemeMode, themeName]);
 
   // Sync theme to backend when it changes
   useEffect(() => {
     const syncThemeToBackend = async () => {
-      const token = localStorage.getItem('authToken');
-      if (!token) return;
+      if (!getAuthHeader()) return;
 
       try {
-        const apiBaseUrl = getRuntimeConfig('API_BASE_URL', 'http://localhost:8000/api/v1');
-        await axios.patch(
-          `${apiBaseUrl}/preferences/me/`,
-          { theme: themeName },
-          {
-            headers: {
-              Authorization: `Token ${token}`,
-              'Content-Type': 'application/json',
-            },
-          }
-        );
+        await apiClient.patch('/preferences/me/', { theme: themeName });
       } catch (error) {
         console.error('Failed to sync theme to backend:', error);
       }
@@ -106,19 +96,11 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   // Load tenant branding from backend on mount (only once)
   useEffect(() => {
     const loadTenantBranding = async () => {
-      const token = localStorage.getItem('authToken');
-      if (!token) return;
+      if (!getAuthHeader()) return;
 
       try {
         const apiBaseUrl = getRuntimeConfig('API_BASE_URL', 'http://localhost:8000/api/v1');
-        const response = await axios.get(
-          `${apiBaseUrl}/tenants/current_theme/`,
-          {
-            headers: {
-              Authorization: `Token ${token}`,
-            },
-          }
-        );
+        const response = await apiClient.get('/tenants/current_theme/');
 
         const branding = {
           logoUrl: response.data.logo_url,
@@ -168,27 +150,18 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
       injectTenantColors(
         tenantBranding.primaryColorLight,
         tenantBranding.primaryColorDark,
-        themeName
+        cssThemeMode
       );
     }
-  }, [themeName, tenantBranding]);
+  }, [cssThemeMode, themeName, tenantBranding]);
 
   // Load theme from backend on mount
   useEffect(() => {
     const loadThemeFromBackend = async () => {
-      const token = localStorage.getItem('authToken');
-      if (!token) return;
+      if (!getAuthHeader()) return;
 
       try {
-        const apiBaseUrl = getRuntimeConfig('API_BASE_URL', 'http://localhost:8000/api/v1');
-        const response = await axios.get(
-          `${apiBaseUrl}/preferences/me/`,
-          {
-            headers: {
-              Authorization: `Token ${token}`,
-            },
-          }
-        );
+        const response = await apiClient.get('/preferences/me/');
 
         const backendTheme = response.data.theme;
         if (backendTheme === 'light' || backendTheme === 'dark' || backendTheme === 'high-contrast') {

--- a/frontend/src/pages/Workflows/WorkflowExecutionDetails.tsx
+++ b/frontend/src/pages/Workflows/WorkflowExecutionDetails.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import axios from 'axios';
+import { adminClient } from '../../services/apiService';
 import { Clock, CheckCircle, Activity, AlertCircle, ChevronDown, ChevronRight } from 'lucide-react';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'https://dev.meatscentral.com';
 
 interface StepDetail {
   index: number;
@@ -39,14 +38,7 @@ export const WorkflowExecutionDetails: React.FC = () => {
 
   const fetchRunDetails = async () => {
     try {
-      const response = await axios.get(
-        `${API_BASE}/admin/system-config/api/runs/${runId}/`,
-        {
-          headers: {
-            Authorization: `Token ${localStorage.getItem('authToken')}`,
-          },
-        }
-      );
+      const response = await adminClient.get(`/admin/system-config/api/runs/${runId}/`);
       setRunData(response.data);
     } catch (error) {
       console.error('Failed to fetch run details:', error);
@@ -57,14 +49,7 @@ export const WorkflowExecutionDetails: React.FC = () => {
 
   const fetchExecutionLog = async () => {
     try {
-      const response = await axios.get(
-        `${API_BASE}/admin/system-config/api/runs/${runId}/execution-log/`,
-        {
-          headers: {
-            Authorization: `Token ${localStorage.getItem('authToken')}`,
-          },
-        }
-      );
+      const response = await adminClient.get(`/admin/system-config/api/runs/${runId}/execution-log/`);
       setExecutionLog(response.data.timeline || []);
     } catch (error) {
       console.error('Failed to fetch execution log:', error);

--- a/frontend/src/pages/Workflows/WorkflowMonitor.tsx
+++ b/frontend/src/pages/Workflows/WorkflowMonitor.tsx
@@ -6,14 +6,13 @@
  */
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import { adminClient } from '../../services/apiService';
 import { Activity, Clock, CheckCircle, XCircle, AlertCircle, ChevronRight, RefreshCw, Play, Filter } from 'lucide-react';
 import styled from 'styled-components';
 import { PageContainer } from '../../components/ui/PageContainer';
 import { Card } from '../../components/ui/Card';
 import { Button } from '../../components/ui/Button';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'https://dev.meatscentral.com';
 
 interface WorkflowRun {
   id: string;
@@ -26,9 +25,7 @@ interface WorkflowRun {
   modified_on: string;
 }
 
-interface WorkflowMonitorProps {
-  tenantId?: string;
-}
+
 
 /* === Styled Components === */
 
@@ -362,7 +359,7 @@ const Spinner = styled.div`
 
 /* === Main Component === */
 
-export const WorkflowMonitor: React.FC<WorkflowMonitorProps> = ({ tenantId }) => {
+export const WorkflowMonitor: React.FC = () => {
   const navigate = useNavigate();
   const [workflows, setWorkflows] = useState<WorkflowRun[]>([]);
   const [loading, setLoading] = useState(true);
@@ -385,15 +382,7 @@ export const WorkflowMonitor: React.FC<WorkflowMonitorProps> = ({ tenantId }) =>
         params.status = filter;
       }
 
-      const response = await axios.get(
-        `${API_BASE}/admin/system-config/api/runs/my-workflows/`,
-        {
-          params,
-          headers: {
-            Authorization: `Token ${localStorage.getItem('authToken')}`,
-          },
-        }
-      );
+      const response = await adminClient.get('/admin/system-config/api/runs/my-workflows/', { params });
       setWorkflows(response.data.results || []);
     } catch (error) {
       console.error('Failed to fetch workflows:', error);


### PR DESCRIPTION
Removes remaining raw axios usage from key UI surfaces so auth + tenant headers are consistently applied.

Changes:
- ChoiceListEditor uses apiClient and /system/* paths; replaces heroicons with lucide-react.
- ThemeContext uses apiClient for preferences/theme endpoints and fixes high-contrast vs css-theme typing.
- Workflow monitor/details use adminClient for /admin/system-config APIs.

Validation:
- eslint on touched files
- vite build