### PR TITLE
Admin Studio: use adminClient (auth/CSRF safe)

### DIFF
--- a/frontend/src/apps/admin-studio/components/SchemaEditor.tsx
+++ b/frontend/src/apps/admin-studio/components/SchemaEditor.tsx
@@ -20,7 +20,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import styled, { keyframes } from 'styled-components';
-import axios from 'axios';
+import { adminClient } from '@/services/apiService';
 import {
   useReactTable,
   getCoreRowModel,
@@ -1337,7 +1337,7 @@ const SchemaEditor: React.FC = () => {
                         document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
       
       // Save schema to API - backend expects schema_config, not fields
-      const response = await axios.patch(
+      const response = await adminClient.patch(
         `/admin/system-config/api/studio/versions/${blueprintId}/schema/`,
         { 
           schema_config: fields.map((f, index) => ({

--- a/frontend/src/apps/admin-studio/components/SchemaEditorSimple.tsx
+++ b/frontend/src/apps/admin-studio/components/SchemaEditorSimple.tsx
@@ -6,8 +6,8 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
 import FormPreview from './FormPreview';
+import { adminClient } from '@/services/apiService';
 
 interface FieldDefinition {
   id: string;
@@ -322,12 +322,10 @@ const SchemaEditor: React.FC<Props> = ({ blueprintId, csrfToken }) => {
   const fetchSchema = async () => {
     try {
       setLoading(true);
-      const response = await axios.get(
+      const response = await adminClient.get(
         `/admin/system-config/api/studio/versions/${blueprintId}/`,
         {
-          headers: {
-            'X-CSRFToken': csrfToken,
-          },
+          headers: csrfToken ? { 'X-CSRFToken': csrfToken } : undefined,
         }
       );
       
@@ -344,14 +342,16 @@ const SchemaEditor: React.FC<Props> = ({ blueprintId, csrfToken }) => {
   const handleSave = async () => {
     try {
       setSaving(true);
-      await axios.patch(
+      await adminClient.patch(
         `/admin/system-config/api/studio/versions/${blueprintId}/`,
         { schema_config: fields },
         {
-          headers: {
-            'X-CSRFToken': csrfToken,
-            'Content-Type': 'application/json',
-          },
+          headers: csrfToken
+            ? {
+                'X-CSRFToken': csrfToken,
+                'Content-Type': 'application/json',
+              }
+            : undefined,
         }
       );
       

--- a/frontend/src/apps/admin-studio/components/VersionHistory.tsx
+++ b/frontend/src/apps/admin-studio/components/VersionHistory.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import { Clock, GitBranch, Check, X, History, RotateCcw } from 'lucide-react';
-
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'https://dev.meatscentral.com';
+import { adminClient } from '@/services/apiService';
 
 interface Version {
   id: string;
@@ -40,13 +38,10 @@ export const VersionHistory: React.FC<VersionHistoryProps> = ({
   const fetchVersionHistory = async () => {
     setLoading(true);
     try {
-      const response = await axios.get(
-        `${API_BASE}/admin/system-config/api/studio/versions/history/`,
+      const response = await adminClient.get(
+        '/admin/system-config/api/studio/versions/history/',
         {
           params: { blueprint_id: blueprintId },
-          headers: {
-            Authorization: `Token ${localStorage.getItem('authToken')}`,
-          },
         }
       );
       setVersions(response.data.versions || []);
@@ -63,14 +58,9 @@ export const VersionHistory: React.FC<VersionHistoryProps> = ({
     }
 
     try {
-      const response = await axios.post(
-        `${API_BASE}/admin/system-config/api/studio/versions/${versionId}/rollback/`,
-        {},
-        {
-          headers: {
-            Authorization: `Token ${localStorage.getItem('authToken')}`,
-          },
-        }
+      const response = await adminClient.post(
+        `/admin/system-config/api/studio/versions/${versionId}/rollback/`,
+        {}
       );
 
       alert(response.data.message);
@@ -86,13 +76,10 @@ export const VersionHistory: React.FC<VersionHistoryProps> = ({
     if (!selectedForCompare) return;
 
     try {
-      const response = await axios.get(
-        `${API_BASE}/admin/system-config/api/studio/versions/${selectedForCompare}/compare/`,
+      const response = await adminClient.get(
+        `/admin/system-config/api/studio/versions/${selectedForCompare}/compare/`,
         {
           params: { with: versionBId },
-          headers: {
-            Authorization: `Token ${localStorage.getItem('authToken')}`,
-          },
         }
       );
       setComparisonData(response.data);

--- a/frontend/src/apps/admin-studio/pages/Dashboard.tsx
+++ b/frontend/src/apps/admin-studio/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
 import { Link } from 'react-router-dom';
+import { adminClient } from '@/services/apiService';
 
 interface Blueprint {
   id: string;
@@ -24,7 +24,7 @@ export const Dashboard: React.FC = () => {
       // Using the available-workflows endpoint which lists published blueprints
       // For studio admin, we might want a different endpoint that lists ALL blueprints (drafts included)
       // But for now let's try available-workflows or check if there is a 'blueprints' endpoint
-      const response = await axios.get('/admin/system-config/api/available-workflows/');
+      const response = await adminClient.get('/admin/system-config/api/available-workflows/');
       setBlueprints(response.data);
       setError(null);
     } catch (err) {

--- a/frontend/src/apps/admin-studio/pages/Editor.tsx
+++ b/frontend/src/apps/admin-studio/pages/Editor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
 import SchemaEditor from '../components/SchemaEditorSimple';
+import { adminClient } from '@/services/apiService';
 // Use UnifiedFlowEditor instead of WorkflowCanvas
 import { UnifiedFlowEditor } from '../../../components/FlowEditor';
 import { VersionHistory } from '../components/VersionHistory';
@@ -44,13 +44,15 @@ const Editor: React.FC<EditorProps> = () => {
   const fetchBlueprintStatus = async (id: string, token: string) => {
     try {
       setLoading(true);
-      const response = await axios.get(
+      const response = await adminClient.get(
         `/admin/system-config/api/studio/versions/${id}/`,
         {
-          headers: {
-            'X-CSRFToken': token,
-            'Content-Type': 'application/json',
-          },
+          headers: token
+            ? {
+                'X-CSRFToken': token,
+                'Content-Type': 'application/json',
+              }
+            : undefined,
         }
       );
       setIsPublished(response.data.is_published || false);
@@ -68,14 +70,16 @@ const Editor: React.FC<EditorProps> = () => {
     if (confirm('Publish this workflow? It will become available to all tenant users.')) {
       try {
         setPublishing(true);
-        await axios.post(
+        await adminClient.post(
           `/admin/system-config/api/studio/versions/${blueprintId}/publish/`,
           {},
           {
-            headers: {
-              'X-CSRFToken': csrfToken,
-              'Content-Type': 'application/json',
-            },
+            headers: csrfToken
+              ? {
+                  'X-CSRFToken': csrfToken,
+                  'Content-Type': 'application/json',
+                }
+              : undefined,
           }
         );
         setIsPublished(true);
@@ -95,14 +99,16 @@ const Editor: React.FC<EditorProps> = () => {
     if (confirm('Unpublish this workflow? It will be removed from the catalog.')) {
       try {
         setPublishing(true);
-        await axios.post(
+        await adminClient.post(
           `/admin/system-config/api/studio/versions/${blueprintId}/unpublish/`,
           {},
           {
-            headers: {
-              'X-CSRFToken': csrfToken,
-              'Content-Type': 'application/json',
-            },
+            headers: csrfToken
+              ? {
+                  'X-CSRFToken': csrfToken,
+                  'Content-Type': 'application/json',
+                }
+              : undefined,
           }
         );
         setIsPublished(false);


### PR DESCRIPTION
Admin Studio pages/components were using raw axios + manual token headers, which can break auth and tenant behavior in dev/prod.

Changes:
- Replace raw axios calls with adminClient for Studio endpoints.
- Remove manual Authorization: Token header usage.
- Keep optional X-CSRFToken header where already present.

Validation:
- eslint on touched files
- vite build