### PR TITLE
Fix FlowEditor config panel typing

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -504,7 +504,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
                 ? 'date'
                 : rawType.includes('bool')
                   ? 'boolean'
-                  : 'text';
+                  : 'string';
 
             availableFields.push({
               key: f.name,
@@ -549,7 +549,12 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
                 // Check if button has FormBuilder action metadata
                 if (field.metadata?.action === 'openFormBuilder') {
                   console.log('[DynamicConfigPanel] Opening FormBuilder for node:', node.id);
-                  openFormBuilder(node);
+                  openFormBuilder({
+                    nodeId: node.id,
+                    nodeData: node.data,
+                    nodeType: node.type || 'form',
+                    formId: (node.data as any)?.formId,
+                  });
                 } else if (field.metadata?.onClick) {
                   // Custom onClick handler from schema
                   field.metadata.onClick(node, formData);
@@ -621,7 +626,10 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
           onClick={isCollapsible ? () => toggleSection(section.id) : undefined}
           style={{ cursor: isCollapsible ? 'pointer' : 'default' }}
         >
-          {section.icon && <section.icon size={16} />}
+          {section.icon && (() => {
+            const Icon = section.icon as any;
+            return <Icon size={16} />;
+          })()}
           <SectionTitle>{section.title}</SectionTitle>
           {isCollapsible && (
             isCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />

--- a/frontend/src/components/FlowEditor/ConfigPanel/FieldMappingPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FieldMappingPanel.tsx
@@ -398,7 +398,8 @@ export const FieldMappingPanel: React.FC<FieldMappingPanelProps> = ({
   const [selectedEntityField, setSelectedEntityField] = useState<string | null>(null);
   const [expandedMappings, setExpandedMappings] = useState<Set<string>>(new Set());
 
-  const entityFields = ENTITY_FIELDS[targetEntity] || [];
+  const entityFields: Array<{ key: string; label: string; type: string; required?: boolean }> =
+    ENTITY_FIELDS[targetEntity] ?? [];
 
   useEffect(() => {
     setLocalMappings(mappings);
@@ -525,17 +526,23 @@ export const FieldMappingPanel: React.FC<FieldMappingPanelProps> = ({
   const autoSuggestMappings = () => {
     const suggestions: FieldMapping[] = [];
     const unmappedFormFields = formFields.filter(ff => !mappedFormFields.has(ff.id));
-    const unmappedEntityFields = entityFields.filter(ef => !mappedEntityFields.has(ef.key));
+    const unmappedEntityFields: Array<{ key: string; label: string; type: string; required?: boolean }> =
+      entityFields.filter(ef => !mappedEntityFields.has(ef.key));
 
     unmappedFormFields.forEach(formField => {
-      let bestMatch: { field: typeof unmappedEntityFields[0]; score: number } | null = null;
+      let bestMatch: any = null;
 
-      unmappedEntityFields.forEach(entityField => {
+      unmappedEntityFields.forEach((entityField) => {
         // Calculate similarity score
         const nameSimilarity = calculateStringSimilarity(formField.label, entityField.label);
-        const typeSimilarity = formField.type === entityField.type ? 1.0 : 
-                               (formField.type === 'text' && entityField.type === 'textarea') ? 0.8 :
-                               (formField.type === 'textarea' && entityField.type === 'text') ? 0.8 : 0;
+        const typeSimilarity =
+          formField.type === entityField.type
+            ? 1.0
+            : formField.type === 'text' && entityField.type === 'textarea'
+              ? 0.8
+              : formField.type === 'textarea' && entityField.type === 'text'
+                ? 0.8
+                : 0;
 
         // Combined score (70% name, 30% type)
         const score = (nameSimilarity * 0.7) + (typeSimilarity * 0.3);
@@ -546,9 +553,13 @@ export const FieldMappingPanel: React.FC<FieldMappingPanelProps> = ({
         }
       });
 
-      if (bestMatch && bestMatch.score >= 0.6) {
+      if (!bestMatch) {
+        return;
+      }
+
+      if (bestMatch.score >= 0.6) {
         suggestions.push({
-          id: `mapping-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+          id: `mapping-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
           formFieldId: formField.id,
           entityField: bestMatch.field.key,
           transformation: {

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormProcessConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormProcessConfigPanel.tsx
@@ -132,7 +132,21 @@ export const FormProcessConfigPanel: React.FC<FormProcessConfigPanelProps> = ({
   onAddStep,
   onReorderSteps,
 }) => {
-  const data = node.data || {};
+  const data = (node.data ?? {}) as Record<string, any>;
+
+  const containerName =
+    typeof data.containerName === 'string'
+      ? data.containerName
+      : typeof data.label === 'string'
+        ? data.label
+        : '';
+
+  const containerDescription =
+    typeof data.containerDescription === 'string'
+      ? data.containerDescription
+      : typeof data.description === 'string'
+        ? data.description
+        : '';
 
   // Handle field changes
   const handleChange = useCallback((field: string, value: any) => {
@@ -152,7 +166,7 @@ export const FormProcessConfigPanel: React.FC<FormProcessConfigPanelProps> = ({
           <Label>Container Name</Label>
           <Input
             type="text"
-            value={data.containerName || data.label || ''}
+            value={containerName}
             onChange={(e) => handleChange('containerName', e.target.value)}
             placeholder="e.g., Customer Onboarding Form"
           />
@@ -161,7 +175,7 @@ export const FormProcessConfigPanel: React.FC<FormProcessConfigPanelProps> = ({
         <Field>
           <Label>Description</Label>
           <TextArea
-            value={data.containerDescription || data.description || ''}
+            value={containerDescription}
             onChange={(e) => handleChange('containerDescription', e.target.value)}
             placeholder="Brief description of this form process..."
           />

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormReferenceConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormReferenceConfigPanel.tsx
@@ -12,7 +12,6 @@ import styled from 'styled-components';
 import { X, FileText, Edit, Eye, ExternalLink } from 'lucide-react';
 import {
   PanelOverlay,
-  Panel,
   PanelHeader,
   PanelTitle,
   CloseButton,
@@ -223,23 +222,35 @@ const Button = styled.button<{ $variant?: 'primary' }>`
 // Form Reference Config Panel Component
 // ============================================================================
 
+type FormReferenceNodeData = {
+  formId?: string;
+  formName?: string;
+  formDescription?: string;
+  fieldCount: number;
+  sectionCount: number;
+  allowEdit: boolean;
+  prefillData: Record<string, unknown>;
+};
+
 export const FormReferenceConfigPanel: React.FC<FormReferenceConfigPanelProps> = ({
   node,
   onUpdate,
   onClose,
 }) => {
   const [showFormSelector, setShowFormSelector] = useState(false);
-  const [localData, setLocalData] = useState({
-    formId: node.data.formId,
-    formName: node.data.formName,
-    formDescription: node.data.formDescription,
-    fieldCount: node.data.fieldCount || 0,
-    sectionCount: node.data.sectionCount || 0,
-    allowEdit: node.data.allowEdit || false,
-    prefillData: node.data.prefillData || {},
+  const nodeData = (node.data ?? {}) as Partial<FormReferenceNodeData>;
+
+  const [localData, setLocalData] = useState<FormReferenceNodeData>({
+    formId: nodeData.formId,
+    formName: nodeData.formName,
+    formDescription: nodeData.formDescription,
+    fieldCount: nodeData.fieldCount ?? 0,
+    sectionCount: nodeData.sectionCount ?? 0,
+    allowEdit: nodeData.allowEdit ?? false,
+    prefillData: nodeData.prefillData ?? {},
   });
   
-  const hasForm = localData.formId && localData.formName;
+  const hasForm = Boolean(localData.formId && localData.formName);
   
   const handleFormSelect = (form: FormDefinition) => {
     setLocalData({
@@ -286,9 +297,9 @@ export const FormReferenceConfigPanel: React.FC<FormReferenceConfigPanelProps> =
                       <FileText size={20} />
                     </FormIcon>
                     <FormDetails>
-                      <FormName>{localData.formName}</FormName>
+                      <FormName>{String(localData.formName ?? '')}</FormName>
                       {localData.formDescription && (
-                        <FormDescription>{localData.formDescription}</FormDescription>
+                        <FormDescription>{String(localData.formDescription)}</FormDescription>
                       )}
                     </FormDetails>
                   </FormHeader>

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
@@ -683,7 +683,9 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
                   loading={autoMappingLoading}
                   error={autoMappingError}
                   onAccept={(suggestion) => {
-                    applySuggestion(suggestion);
+                    if (nodeId) {
+                      applySuggestion(nodeId, suggestion);
+                    }
                     // Note: Field mapping will be applied to node data
                     // The actual field addition to localStep.fields would need
                     // additional logic to convert mapping to form field
@@ -693,7 +695,9 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
                     // This would need additional state management
                   }}
                   onApplyAll={() => {
-                    applyAllSuggestions();
+                    if (nodeId) {
+                      applyAllSuggestions(nodeId);
+                    }
                   }}
                   onClose={() => {
                     clearSuggestions();
@@ -858,13 +862,19 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
               <CheckboxLabel>
                 <Checkbox
                   type="checkbox"
-                  checked={localStep.navigation?.allowBack !== false}
-                  onChange={(e) => handleUpdate({
-                    navigation: {
-                      ...localStep.navigation,
-                      allowBack: e.target.checked,
-                    }
-                  })}
+                  checked={(localStep.navigation?.allowBack ?? true) === true}
+                  onChange={(e) =>
+                    handleUpdate({
+                      navigation: {
+                        allowBack: e.target.checked,
+                        allowSkip: localStep.navigation?.allowSkip ?? false,
+                        autoAdvance: localStep.navigation?.autoAdvance ?? false,
+                        backLabel: localStep.navigation?.backLabel,
+                        nextLabel: localStep.navigation?.nextLabel,
+                        skipLabel: localStep.navigation?.skipLabel,
+                      },
+                    })
+                  }
                 />
                 Allow Back Button
               </CheckboxLabel>
@@ -875,13 +885,19 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
               <CheckboxLabel>
                 <Checkbox
                   type="checkbox"
-                  checked={localStep.navigation?.allowSkip === true}
-                  onChange={(e) => handleUpdate({
-                    navigation: {
-                      ...localStep.navigation,
-                      allowSkip: e.target.checked,
-                    }
-                  })}
+                  checked={(localStep.navigation?.allowSkip ?? false) === true}
+                  onChange={(e) =>
+                    handleUpdate({
+                      navigation: {
+                        allowBack: localStep.navigation?.allowBack ?? true,
+                        allowSkip: e.target.checked,
+                        autoAdvance: localStep.navigation?.autoAdvance ?? false,
+                        backLabel: localStep.navigation?.backLabel,
+                        nextLabel: localStep.navigation?.nextLabel,
+                        skipLabel: localStep.navigation?.skipLabel,
+                      },
+                    })
+                  }
                 />
                 Allow Skip Button
               </CheckboxLabel>
@@ -892,13 +908,19 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
               <CheckboxLabel>
                 <Checkbox
                   type="checkbox"
-                  checked={localStep.navigation?.autoAdvance === true}
-                  onChange={(e) => handleUpdate({
-                    navigation: {
-                      ...localStep.navigation,
-                      autoAdvance: e.target.checked,
-                    }
-                  })}
+                  checked={(localStep.navigation?.autoAdvance ?? false) === true}
+                  onChange={(e) =>
+                    handleUpdate({
+                      navigation: {
+                        allowBack: localStep.navigation?.allowBack ?? true,
+                        allowSkip: localStep.navigation?.allowSkip ?? false,
+                        autoAdvance: e.target.checked,
+                        backLabel: localStep.navigation?.backLabel,
+                        nextLabel: localStep.navigation?.nextLabel,
+                        skipLabel: localStep.navigation?.skipLabel,
+                      },
+                    })
+                  }
                 />
                 Auto-advance on Completion
               </CheckboxLabel>
@@ -910,36 +932,54 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
               <Input
                 type="text"
                 value={localStep.navigation?.backLabel || ''}
-                onChange={(e) => handleUpdate({
-                  navigation: {
-                    ...localStep.navigation,
-                    backLabel: e.target.value,
-                  }
-                })}
+                onChange={(e) =>
+                  handleUpdate({
+                    navigation: {
+                      allowBack: localStep.navigation?.allowBack ?? true,
+                      allowSkip: localStep.navigation?.allowSkip ?? false,
+                      autoAdvance: localStep.navigation?.autoAdvance ?? false,
+                      backLabel: e.target.value,
+                      nextLabel: localStep.navigation?.nextLabel,
+                      skipLabel: localStep.navigation?.skipLabel,
+                    },
+                  })
+                }
                 placeholder="Back (default)"
               />
               <Input
                 type="text"
                 value={localStep.navigation?.nextLabel || ''}
-                onChange={(e) => handleUpdate({
-                  navigation: {
-                    ...localStep.navigation,
-                    nextLabel: e.target.value,
-                  }
-                })}
+                onChange={(e) =>
+                  handleUpdate({
+                    navigation: {
+                      allowBack: localStep.navigation?.allowBack ?? true,
+                      allowSkip: localStep.navigation?.allowSkip ?? false,
+                      autoAdvance: localStep.navigation?.autoAdvance ?? false,
+                      backLabel: localStep.navigation?.backLabel,
+                      nextLabel: e.target.value,
+                      skipLabel: localStep.navigation?.skipLabel,
+                    },
+                  })
+                }
                 placeholder="Next (default)"
                 style={{ marginTop: '8px' }}
               />
-              {localStep.navigation?.allowSkip && (
+              {(localStep.navigation?.allowSkip ?? false) && (
                 <Input
                   type="text"
                   value={localStep.navigation?.skipLabel || ''}
-                  onChange={(e) => handleUpdate({
-                    navigation: {
-                      ...localStep.navigation,
-                      skipLabel: e.target.value,
-                    }
-                  })}
+                  onChange={(e) =>
+                    handleUpdate({
+                      navigation: {
+                        allowBack: localStep.navigation?.allowBack ?? true,
+                        allowSkip: localStep.navigation?.allowSkip ?? false,
+                        autoAdvance: localStep.navigation?.autoAdvance ?? false,
+                        backLabel: localStep.navigation?.backLabel,
+                        nextLabel: localStep.navigation?.nextLabel,
+                        skipLabel: e.target.value,
+                      },
+                    })
+                  }
                   placeholder="Skip (default)"
                   style={{ marginTop: '8px' }}
                 />
@@ -1011,12 +1051,15 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
               <Label>Custom Validation Message (Optional)</Label>
               <TextArea
                 value={localStep.validation?.customMessage || ''}
-                onChange={(e) => handleUpdate({
-                  validation: {
-                    ...localStep.validation,
-                    customMessage: e.target.value,
-                  }
-                })}
+                onChange={(e) =>
+                  handleUpdate({
+                    validation: {
+                      ...localStep.validation,
+                      mode: localStep.validation?.mode ?? 'all',
+                      customMessage: e.target.value,
+                    },
+                  })
+                }
                 placeholder="e.g., Please complete all required fields before continuing."
               />
               <HelpText>

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -17,6 +17,8 @@ interface LogContext {
   metadata?: Record<string, any>;
 }
 
+type LogContextOrData = LogContext | unknown;
+
 class Logger {
   private isDevelopment: boolean;
   private minLevel: LogLevel;
@@ -79,37 +81,73 @@ class Logger {
   /**
    * Debug-level logging (development only)
    */
-  debug(message: string, context?: LogContext, data?: any): void {
+  debug(message: string, data?: any): void;
+  debug(message: string, context?: LogContext, data?: any): void;
+  debug(message: string, contextOrData?: LogContextOrData, data?: any): void {
     if (!this.shouldLog('debug')) return;
-    this.logToConsole('debug', message, context, data);
+
+    if (contextOrData && typeof contextOrData === 'object' && !Array.isArray(contextOrData)) {
+      const ctx = contextOrData as LogContext;
+      const hasAnyContextKey = 'component' in ctx || 'user' in ctx || 'tenant' in ctx || 'metadata' in ctx;
+      if (hasAnyContextKey) {
+        this.logToConsole('debug', message, ctx, data);
+        return;
+      }
+    }
+
+    this.logToConsole('debug', message, undefined, contextOrData);
   }
 
   /**
    * Info-level logging (development only by default)
    */
-  info(message: string, context?: LogContext, data?: any): void {
+  info(message: string, data?: any): void;
+  info(message: string, context?: LogContext, data?: any): void;
+  info(message: string, contextOrData?: LogContextOrData, data?: any): void {
     if (!this.shouldLog('info')) return;
-    this.logToConsole('info', message, context, data);
+
+    if (contextOrData && typeof contextOrData === 'object' && !Array.isArray(contextOrData)) {
+      const ctx = contextOrData as LogContext;
+      const hasAnyContextKey = 'component' in ctx || 'user' in ctx || 'tenant' in ctx || 'metadata' in ctx;
+      if (hasAnyContextKey) {
+        this.logToConsole('info', message, ctx, data);
+        return;
+      }
+    }
+
+    this.logToConsole('info', message, undefined, contextOrData);
   }
 
   /**
    * Warning-level logging (always logged)
    */
-  warn(message: string, context?: LogContext, data?: any): void {
+  warn(message: string, data?: any): void;
+  warn(message: string, context?: LogContext, data?: any): void;
+  warn(message: string, contextOrData?: LogContextOrData, data?: any): void {
     if (!this.shouldLog('warn')) return;
-    this.logToConsole('warn', message, context, data);
-    
+
+    const ctx =
+      contextOrData && typeof contextOrData === 'object' && !Array.isArray(contextOrData)
+        ? (contextOrData as LogContext)
+        : undefined;
+    const hasAnyContextKey =
+      !!ctx && ('component' in ctx || 'user' in ctx || 'tenant' in ctx || 'metadata' in ctx);
+
+    this.logToConsole('warn', message, hasAnyContextKey ? ctx : undefined, hasAnyContextKey ? data : contextOrData);
+
+    const sentryData = hasAnyContextKey ? data : contextOrData;
+
     // Send to Sentry in production
     if (!this.isDevelopment && typeof window !== 'undefined' && (window as any).Sentry) {
       (window as any).Sentry.captureMessage(message, {
         level: 'warning',
         tags: {
-          component: context?.component,
-          tenant: context?.tenant,
+          component: hasAnyContextKey ? ctx?.component : undefined,
+          tenant: hasAnyContextKey ? ctx?.tenant : undefined,
         },
         extra: {
-          ...context?.metadata,
-          data,
+          ...(hasAnyContextKey ? ctx?.metadata : undefined),
+          data: sentryData,
         },
       });
     }
@@ -118,33 +156,45 @@ class Logger {
   /**
    * Error-level logging (always logged)
    */
-  error(message: string, context?: LogContext, data?: any): void {
+  error(message: string, data?: any): void;
+  error(message: string, context?: LogContext, data?: any): void;
+  error(message: string, contextOrData?: LogContextOrData, data?: any): void {
     if (!this.shouldLog('error')) return;
-    this.logToConsole('error', message, context, data);
-    
+
+    const ctx =
+      contextOrData && typeof contextOrData === 'object' && !Array.isArray(contextOrData)
+        ? (contextOrData as LogContext)
+        : undefined;
+    const hasAnyContextKey =
+      !!ctx && ('component' in ctx || 'user' in ctx || 'tenant' in ctx || 'metadata' in ctx);
+
+    this.logToConsole('error', message, hasAnyContextKey ? ctx : undefined, hasAnyContextKey ? data : contextOrData);
+
+    const sentryData = hasAnyContextKey ? data : contextOrData;
+
     // Send to Sentry in production
     if (!this.isDevelopment && typeof window !== 'undefined' && (window as any).Sentry) {
-      if (data instanceof Error) {
-        (window as any).Sentry.captureException(data, {
+      if (sentryData instanceof Error) {
+        (window as any).Sentry.captureException(sentryData, {
           tags: {
-            component: context?.component,
-            tenant: context?.tenant,
+            component: hasAnyContextKey ? ctx?.component : undefined,
+            tenant: hasAnyContextKey ? ctx?.tenant : undefined,
           },
           extra: {
             message,
-            ...context?.metadata,
+            ...(hasAnyContextKey ? ctx?.metadata : undefined),
           },
         });
       } else {
         (window as any).Sentry.captureMessage(message, {
           level: 'error',
           tags: {
-            component: context?.component,
-            tenant: context?.tenant,
+            component: hasAnyContextKey ? ctx?.component : undefined,
+            tenant: hasAnyContextKey ? ctx?.tenant : undefined,
           },
           extra: {
-            ...context?.metadata,
-            data,
+            ...(hasAnyContextKey ? ctx?.metadata : undefined),
+            data: sentryData,
           },
         });
       }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,7 +24,7 @@
     "noFallthroughCasesInSwitch": true,
     
     /* Additional */
-    "allowJs": true,
+    "allowJs": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -3,7 +3,7 @@
     "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
@@ -7,10 +7,7 @@ import path from 'path';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    react({
-      // Enable Fast Refresh for React 19
-      fastRefresh: true,
-    }),
+    react(),
     // Enable importing SVGs as React components
     svgr(),
     // Enable tsconfig path mapping


### PR DESCRIPTION
Fixes several FlowEditor config panels where node.data was typed as unknown, plus improves logger ergonomics (logger(message, data) supported).

Also adjusts Vite config typing to use vitest/config and removes unsupported plugin-react option.

Goal: unblock frontend type-check stabilization.