### PR TITLE
Use parentId for FlowEditor containers

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1925,9 +1925,9 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         // Unparent all children of deleted containers
         setNodes((nds) =>
           nds.map((n) => {
-            if (removedContainerIds.includes(n.parentNode || '')) {
+            if (removedContainerIds.includes(n.parentId || '')) {
               // Calculate absolute position before unparenting
-              const parent = nds.find(p => p.id === n.parentNode);
+              const parent = nds.find(p => p.id === n.parentId);
               const absolutePosition = parent
                 ? {
                     x: n.position.x + parent.position.x,
@@ -1939,7 +1939,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
               return {
                 ...n,
                 position: absolutePosition,
-                parentNode: undefined,
+                parentId: undefined,
                 extent: undefined,
               };
             }
@@ -4206,7 +4206,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             } else if (currentParentId) {
               // Node is being removed from container
               updatedNode.position = absolutePosition;
-              delete updatedNode.parentNode;
+              delete (updatedNode as any).parentId;
               delete updatedNode.extent;
               logger.debug(`[Container] Node ${node.id} removed from container`);
             }
@@ -4524,7 +4524,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       try {
         // Log container information for debugging (Phase E)
         const containerNodes = nodes.filter(n => n.type === 'formMultiStepContainer');
-        const nodesInContainers = nodes.filter(n => n.parentNode); // Phase E: Using React Flow parentNode
+        const nodesInContainers = nodes.filter(n => n.parentId);
         
         logger.debug('[Save] Workflow saved with container state:');
         logger.debug(`  - ${containerNodes.length} container(s)`);

--- a/frontend/src/components/FlowEditor/hooks/useContainerManagement.ts
+++ b/frontend/src/components/FlowEditor/hooks/useContainerManagement.ts
@@ -201,7 +201,7 @@ export function useContainerManagement(): ContainerManagementResult {
               y: node.position.y - containerNode.position.y,
             },
             // Set parent reference
-            parentNode: containerId,
+            parentId: containerId,
             extent: 'parent' as const,
           };
         }
@@ -247,7 +247,7 @@ export function useContainerManagement(): ContainerManagementResult {
 
             return {
               ...node,
-              parentNode: containerNodeId,
+              parentId: containerNodeId,
               extent: 'parent' as const,
               position: {
                 x: node.position.x - containerNode.position.x,
@@ -288,13 +288,13 @@ export function useContainerManagement(): ContainerManagementResult {
           }
 
           // Update child nodes (make absolute again)
-          if (nodeIds.includes(node.id) && node.parentNode === containerNodeId) {
+          if (nodeIds.includes(node.id) && node.parentId === containerNodeId) {
             const containerNode = nodes.find((n) => n.id === containerNodeId);
             if (!containerNode) return node;
 
             return {
               ...node,
-              parentNode: undefined,
+              parentId: undefined,
               extent: undefined,
               position: {
                 x: node.position.x + containerNode.position.x,
@@ -325,10 +325,10 @@ export function useContainerManagement(): ContainerManagementResult {
         return nodes
           .filter((node) => node.id !== containerNodeId)
           .map((node) => {
-            if (node.parentNode === containerNodeId) {
+            if (node.parentId === containerNodeId) {
               return {
                 ...node,
-                parentNode: undefined,
+                parentId: undefined,
                 extent: undefined,
                 position: {
                   x: node.position.x + containerNode.position.x,
@@ -354,7 +354,7 @@ export function useContainerManagement(): ContainerManagementResult {
           return nodes;
         }
 
-        const children = nodes.filter((n) => n.parentNode === containerNodeId);
+        const children = nodes.filter((n) => n.parentId === containerNodeId);
         if (children.length === 0) {
           return nodes;
         }

--- a/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
@@ -410,9 +410,7 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
       const anyNode = node as any;
       return (
         anyNode.parentId === id ||
-        anyNode.parentNode === id ||
-        (node.data as any)?.parentId === id ||
-        (node.data as any)?.parentNode === id
+        (node.data as any)?.parentId === id
       );
     });
     logger.debug('[FormProcessGroup] Children found:', children.length, 'IDs:', children.map((c) => c.id));
@@ -514,7 +512,7 @@ export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props
         }
 
         // Hide/show children
-        if ((node as any).parentId === id || (node as any).parentNode === id) {
+        if ((node as any).parentId === id) {
           return {
             ...node,
             hidden: !nextExpanded,

--- a/frontend/src/components/FlowEditor/utils/subflowManager.ts
+++ b/frontend/src/components/FlowEditor/utils/subflowManager.ts
@@ -116,7 +116,7 @@ export function exportSubFlow(
   category?: string
 ): SubFlowTemplate {
   // Find all child nodes (nodes with parentId = containerNode.id)
-  const childNodes = allNodes.filter(node => node.parentNode === containerNode.id);
+  const childNodes = allNodes.filter(node => node.parentId === containerNode.id);
   
   // Find all edges connecting children (source and target both are children)
   const childNodeIds = new Set(childNodes.map(n => n.id));
@@ -216,7 +216,7 @@ export function importSubFlow(
       type: childTemplate.type!,
       data: childTemplate.data,
       position: childTemplate.position!,
-      parentNode: containerNewId, // Set parent to new container
+      parentId: containerNewId,
       extent: childTemplate.extent || 'parent',
       expandParent: childTemplate.expandParent,
       width: childTemplate.width,


### PR DESCRIPTION
Standardize FlowEditor container parenting on @xyflow/react's parentId (replacing legacy parentNode) across:
- UnifiedFlowEditor container unparenting + drag-in/out
- useContainerManagement
- FormProcessGroupNode child detection
- subflow import/export

This should reduce TS churn and avoid runtime mismatches.