### PR TITLE
Refactor Form container to formBook (subflows)

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx
@@ -29,8 +29,8 @@ import {
 // ============================================================================
 
 interface FormSelectionPanelProps {
-  /** Node type: 'formStep' or 'formProcessGroup' */
-  nodeType: 'formStep' | 'formProcessGroup';
+  /** Node type: 'formStep' or container */
+  nodeType: 'formStep' | 'formProcessGroup' | 'formBook';
   
   /** Currently selected form ID (if editing existing node) */
   selectedFormId?: string;

--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
@@ -290,7 +290,8 @@ export const NodeConfigPanelWithShadow: React.FC<NodeConfigPanelWithShadowProps>
 
       {/* Inner Panel Content */}
       <PanelContent>
-        {node?.type === 'formProcessGroup' ||
+        {node?.type === 'formBook' ||
+        node?.type === 'formProcessGroup' ||
         node?.type === 'formMultiStepContainer' ||
         node?.type === 'formProcess' ? (
           /* Form Process (canonical group) - Structured config panel */

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
@@ -82,6 +82,7 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
 
   // Context-aware tab visibility
   const isContainerNode =
+    node?.type === 'formBook' ||
     node?.type === 'formProcessGroup' ||
     node?.type === 'formMultiStepContainer' ||
     node?.type === 'formProcess';

--- a/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
@@ -549,7 +549,7 @@ export const FormProcessModal: React.FC<ContainerModalProps> = ({
       case 1:
         return (
           <FormSelectionPanel
-            nodeType="formProcessGroup"
+            nodeType="formBook"
             selectedFormId={state.selectedWorkflowId || undefined}
             onSelectionChange={handleContainerSelection}
             onProceed={handleProceedFromStep1}

--- a/frontend/src/components/FlowEditor/NodeContextMenu.tsx
+++ b/frontend/src/components/FlowEditor/NodeContextMenu.tsx
@@ -290,23 +290,26 @@ export const NodeContextMenu: React.FC<ContextMenuProps> = ({ node, x, y, onClos
    */
   const handleAddStep = useCallback(() => {
     if (!node) return;
-    
-    const childNodes = getNodes().filter(n => n.parentId === node.id);
+
+    const childNodes = getNodes().filter((n) => n.parentId === node.id);
     const newStepId = `step-${Date.now()}`;
-    
+
+    // Book + Pages: add a new Form Step (Page) constrained to the container
     const newStep: Node = {
       id: newStepId,
-      type: 'formStepSingle',
-      position: { x: 20, y: 60 + childNodes.length * 120 },
-      data: {
-        label: `Step ${childNodes.length + 1}`,
-        formFields: [],
-      },
+      type: 'form',
       parentId: node.id,
       extent: 'parent' as const,
+      expandParent: true,
+      position: { x: 30 + childNodes.length * 350, y: 90 },
+      data: {
+        label: `Step ${childNodes.length + 1}`,
+        status: 'draft',
+        fields: [],
+      },
       draggable: true,
     };
-    
+
     setNodes((nodes) => [...nodes, newStep]);
     onClose();
   }, [node, getNodes, setNodes, onClose]);
@@ -372,7 +375,7 @@ export const NodeContextMenu: React.FC<ContextMenuProps> = ({ node, x, y, onClos
    */
   const handleSaveAsSubFlowTemplate = useCallback(async () => {
     if (!node) return;
-    if (node.type !== 'formProcessGroup') return;
+    if (node.type !== 'formProcessGroup' && node.type !== 'formBook') return;
 
     try {
       const allNodes = getNodes();
@@ -582,8 +585,9 @@ export const NodeContextMenu: React.FC<ContextMenuProps> = ({ node, x, y, onClos
   
   if (!node) return null;
   
-  const isContainer = node.type === 'formProcessGroup' || 
-                     node.type === 'formProcess' || 
+  const isContainer = node.type === 'formBook' ||
+                     node.type === 'formProcessGroup' ||
+                     node.type === 'formProcess' ||
                      node.type === 'formMultiStepContainer';
   
   const isChildNode = !!node.parentId;

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -254,7 +254,8 @@ const EditorContainer = styled.div<{ $isFullscreen?: boolean }>`
   /* Animate container expand/collapse */
   .react-flow__node[data-type="formMultiStepContainer"],
   .react-flow__node[data-type="formProcess"],
-  .react-flow__node[data-type="formProcessGroup"] {
+  .react-flow__node[data-type="formProcessGroup"],
+  .react-flow__node[data-type="formBook"] {
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
                 width 0.3s ease,
                 height 0.3s ease,
@@ -1643,8 +1644,9 @@ const ToggleSwitch = styled.button<{ $active: boolean }>`
 // we cast here to keep editor typing stable while runtime behavior remains unchanged.
 const staticNodeTypes = {
   // Form nodes (Phase E - 2026-02-19)
-  form: FormNode,  // NEW: Primary form node name
+  form: FormNode,  // Form Step (Page)
   formStepSingle: FormStepSingleNode,  // Backward compatibility
+  formBook: FormProcessGroupNode,  // NEW: Singular Form container (Book)
   formProcess: FormProcessGroupNode,  // Upgraded: legacy type now uses the group node component
   formProcessGroup: FormProcessGroupNode,
   // Backward compatibility aliases
@@ -3285,18 +3287,18 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         selected: true,
       };
 
-      // Upgrade legacy container types to the canonical group container
+      // Canonical container type: singular Form (Book)
       if (isNewContainer) {
         newNode.style = {
           width: 600,
-          height: 400,
+          height: 450,
         };
         newNode.data = {
           ...newNode.data,
           isExpanded: true,
           isGroup: true,
         };
-        (newNode as any).type = 'formProcessGroup';
+        (newNode as any).type = 'formBook';
       }
 
       const spawnDefaultFormPage = (parentId: string) => {
@@ -3974,8 +3976,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       const edgesToAdd: Edge[] = [];
       let counterDelta = 1;
 
-      // Phase 10: Auto-spawn a default Form page inside a new formProcessGroup
-      if (isContainerNode && newNode.type === 'formProcessGroup') {
+      // Auto-spawn a default Form Step (Page) inside a new Form (Book)
+      if (isContainerNode && (newNode.type === 'formBook' || newNode.type === 'formProcessGroup')) {
         const pageId = `node-${nodeIdCounter + 1}`;
         const pageNode: Node = {
           id: pageId,
@@ -4039,7 +4041,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
       updatedEdges = [...updatedEdges, ...edgesToAdd];
 
-      if (isContainerNode && newNode.type === 'formProcessGroup') {
+      if (isContainerNode && (newNode.type === 'formBook' || newNode.type === 'formProcessGroup')) {
         applyAutoLayoutImmediate(updatedNodes, updatedEdges);
       } else {
         setNodes(updatedNodes);
@@ -5479,11 +5481,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       case 'formProcess': {
         // Phase 7 Stabilization: these node types are deprecated.
         // Migrate in-memory to the canonical Form Process Group node.
-        logger.debug('✏️ [EDIT BUTTON] Migrating legacy container to formProcessGroup');
+        logger.debug('✏️ [EDIT BUTTON] Migrating legacy container to formBook');
 
         const migratedNode = {
           ...node,
-          type: 'formProcessGroup',
+          type: 'formBook',
           data: {
             ...(node.data || {}),
             // Ensure group semantics are enabled
@@ -7571,12 +7573,14 @@ function getReactFlowNodeType(nodeTypeId: string): string {
 
   // Preserve specific types for all other nodes so their specific schemas load
   if (nodeTypeId === 'formMultiStepContainer') return 'formMultiStepContainer';
+  if (nodeTypeId === 'formBook') return 'formBook';
   return nodeTypeId;
 }
 
 /** Returns true for all Form Process container node type IDs (current + legacy). */
 function isFormProcessContainerType(nodeType: string | undefined | null): boolean {
   return (
+    nodeType === 'formBook' ||
     nodeType === 'formProcessGroup' ||
     nodeType === 'formProcess' ||
     nodeType === 'formMultiStepContainer'
@@ -7615,7 +7619,7 @@ function getDefaultNodeData(nodeTypeId: string): Record<string, any> {
   }
 
   // Special handling for containers
-  if (resolvedType === 'formMultiStepContainer' || resolvedType === 'formProcessGroup') {
+  if (resolvedType === 'formMultiStepContainer' || resolvedType === 'formProcessGroup' || resolvedType === 'formBook') {
     defaults.fields = [];
     defaults.containerName = 'New Container';
     defaults.isExpanded = true;

--- a/frontend/src/components/FlowEditor/__tests__/containerStyling.test.ts
+++ b/frontend/src/components/FlowEditor/__tests__/containerStyling.test.ts
@@ -74,6 +74,7 @@ describe('Container Styling Utilities', () => {
 
   describe('getContainerIcon', () => {
     it('should return correct icon for known container types', () => {
+      expect(getContainerIcon('formBook')).toBe('Book');
       expect(getContainerIcon('formProcessGroup')).toBe('Layers');
       expect(getContainerIcon('subWorkflow')).toBe('GitBranch');
       expect(getContainerIcon('parallelPath')).toBe('GitMerge');

--- a/frontend/src/components/FlowEditor/__tests__/useContainerDragAndDrop.test.tsx
+++ b/frontend/src/components/FlowEditor/__tests__/useContainerDragAndDrop.test.tsx
@@ -31,7 +31,7 @@ describe('useContainerDragAndDrop', () => {
     mockGetNodes.mockReturnValue([
       {
         id: 'container-1',
-        type: 'formProcessGroup',
+        type: 'formBook',
         position: { x: 100, y: 100 },
         width: 300,
         height: 400,
@@ -51,7 +51,7 @@ describe('useContainerDragAndDrop', () => {
       if (id === 'container-1') {
         return {
           id: 'container-1',
-          type: 'formProcessGroup',
+          type: 'formBook',
           position: { x: 100, y: 100 },
           width: 300,
           height: 400,
@@ -86,7 +86,7 @@ describe('useContainerDragAndDrop', () => {
     it('should identify container nodes', () => {
       const { result } = renderHook(() => useContainerDragAndDrop());
 
-      const containerNode = { id: '1', type: 'formProcessGroup', position: { x: 0, y: 0 }, data: {} };
+      const containerNode = { id: '1', type: 'formBook', position: { x: 0, y: 0 }, data: {} };
       const regularNode = { id: '2', type: 'formInputField', position: { x: 0, y: 0 }, data: {} };
 
       expect(result.current.isContainer(containerNode as any)).toBe(true);
@@ -129,7 +129,7 @@ describe('useContainerDragAndDrop', () => {
 
       const containerNode = {
         id: 'container-1',
-        type: 'formProcessGroup',
+        type: 'formBook',
         position: { x: 100, y: 100 },
         data: {},
       };

--- a/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
+++ b/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
@@ -78,6 +78,7 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
   const isContainerNode = useCallback((node: Node | null) => {
     if (!node) return false;
     return (
+      node.type === 'formBook' ||
       node.type === 'formProcessGroup' ||
       node.type === 'formProcess' ||
       node.type === 'formMultiStepContainer'

--- a/frontend/src/components/FlowEditor/components/EnhancedContextMenu.tsx
+++ b/frontend/src/components/FlowEditor/components/EnhancedContextMenu.tsx
@@ -211,7 +211,7 @@ export const EnhancedContextMenu: React.FC<EnhancedContextMenuProps> = React.mem
    */
   const canConvertToSubflow = useMemo(() => {
     // Only certain node types can become subflows
-    const convertibleTypes = ['formProcessGroup', 'formReference'];
+    const convertibleTypes = ['formBook', 'formProcessGroup', 'formReference'];
     return convertibleTypes.includes(node.type || '');
   }, [node.type]);
 

--- a/frontend/src/components/FlowEditor/components/VariablePicker.tsx
+++ b/frontend/src/components/FlowEditor/components/VariablePicker.tsx
@@ -204,6 +204,8 @@ const getNodeIcon = (nodeType: string) => {
     case 'formStepSingle':
       return FileText;
     case 'formProcess':
+    case 'formBook':
+    case 'formBook':
     case 'formProcessGroup':
       return Layers;
     case 'createRecord':

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -53,8 +53,8 @@ import { Package, FileText, CheckSquare, Settings, Mail, Navigation, Database, Z
  */
 export const formSchema: NodeConfigSchema = {
   nodeType: 'form',
-  displayName: 'Form',
-  description: 'Single-page form for data collection',
+  displayName: 'Form Step',
+  description: 'Single form step (page) for data collection',
   icon: FileText,
   version: '2.0.0',  // Updated for Phase E rename
   tags: ['form', 'data-collection', 'user-input'],
@@ -596,8 +596,8 @@ export const formProcessSchema: NodeConfigSchema = {
  */
 export const formProcessGroupSchema: NodeConfigSchema = {
   nodeType: 'formProcessGroup',
-  displayName: 'Form Process Group',
-  description: 'Labeled container with auto-layout for multi-step forms',
+  displayName: 'Form Process (Legacy)',
+  description: '[DEPRECATED] Legacy container type. Use Form (Book).',
   icon: Package,
   version: '1.0.0',
   tags: ['form', 'container', 'group', 'multi-step', 'layout'],
@@ -683,6 +683,22 @@ export const formProcessGroupSchema: NodeConfigSchema = {
       ]
     }
   ]
+};
+
+// ============================================================================
+// Singular Form (Book) Container Schema
+// ============================================================================
+
+/**
+ * Schema for the singular Form container (Book & Pages).
+ *
+ * This is the canonical container type going forward.
+ */
+export const formBookSchema: NodeConfigSchema = {
+  ...formProcessGroupSchema,
+  nodeType: 'formBook',
+  displayName: 'Form',
+  description: 'Multi-step form container (Book) that groups Form Steps (Pages)',
 };
 
 // ============================================================================
@@ -926,8 +942,9 @@ export const outlookEmailSchema: NodeConfigSchema = {
  */
 const buildAllSchemas = (): NodeConfigSchema[] => [
   // === CORE SCHEMAS (Phase 1-3) ===
-  formSchema,  // NEW: Primary form schema (Phase E - 2026-02-19)
+  formSchema,  // NEW: Primary form step schema (Phase E - 2026-02-19)
   formProcessSchema,
+  formBookSchema,
   formProcessGroupSchema,
   createRecordSchema,
   outlookEmailSchema,

--- a/frontend/src/components/FlowEditor/hooks/useContainerDragAndDrop.ts
+++ b/frontend/src/components/FlowEditor/hooks/useContainerDragAndDrop.ts
@@ -49,7 +49,7 @@ export interface ContainerDropResult {
  * @returns Drag state and handler functions
  */
 export function useContainerDragAndDrop(
-  containerNodeTypes: string[] = ['formProcessGroup'],
+  containerNodeTypes: string[] = ['formBook', 'formProcessGroup'],
   snapThreshold: number = 30,
   gridSize: number = 20
 ) {

--- a/frontend/src/components/FlowEditor/hooks/useFormDataMapping.ts
+++ b/frontend/src/components/FlowEditor/hooks/useFormDataMapping.ts
@@ -92,7 +92,7 @@ export const useFormDataMapping = (): UseFormDataMappingReturn => {
     const data = node.data;
 
     // Extract fields from different form node types
-    if (node.type === 'formProcessGroup' || node.type === 'formReference') {
+    if (node.type === 'formBook' || node.type === 'formProcessGroup' || node.type === 'formReference') {
       // Get child nodes with form fields
       const childNodes = getNodes().filter(n => n.parentId === node.id);
       childNodes.forEach((child, stepIndex) => {
@@ -201,7 +201,7 @@ export const useFormDataMapping = (): UseFormDataMappingReturn => {
 
       incomingEdges.forEach((edge) => {
         const sourceNode = nodes.find((n) => n.id === edge.source);
-        if (sourceNode && ['formProcessGroup', 'formReference', 'formStepSingle'].includes(sourceNode.type || '')) {
+        if (sourceNode && ['formBook', 'formProcessGroup', 'formReference', 'formStepSingle'].includes(sourceNode.type || '')) {
           const fields = generateFormOutputs(sourceNode);
           upstreamFields.push(...fields);
         }

--- a/frontend/src/components/FlowEditor/nodeTypes.ts
+++ b/frontend/src/components/FlowEditor/nodeTypes.ts
@@ -103,14 +103,14 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
   
   // === FORM ELEMENTS ===
   
-  // Form node (renamed from formStepSingle in Phase E - 2026-02-19)
+  // Form step node (page) (renamed from formStepSingle in Phase E - 2026-02-19)
   form: {
     id: 'form',
-    name: 'Form',
+    name: 'Form Step',
     category: 'form',
-    icon: '📋',
+    icon: '📄',
     color: '#3b82f6', // blue
-    description: 'Single-page form for data collection - works standalone or in Form Process containers',
+    description: 'Single form step (page). Use inside a Form (Book) container or standalone.',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
@@ -146,17 +146,31 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
     hidden: true, // Hide from node palette
   },
   
-  // Advanced Form Process with React Flow grouping
-  formProcessGroup: {
-    id: 'formProcessGroup',
-    name: 'Form Process',
+  // NEW: Singular Form container using React Flow sub-flows (Book & Pages)
+  formBook: {
+    id: 'formBook',
+    name: 'Form',
     category: 'form',
-    icon: '📂',
-    color: '#a78bfa', // lighter purple - group variant
-    description: 'Advanced form container with labeled header, automatic step sequencing, and React Flow grouping',
+    icon: '📚',
+    color: '#a78bfa',
+    description: 'Multi-step form container (Book) that groups Form Steps (Pages) using React Flow sub-flows',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
+  },
+
+  // Legacy container type (kept for backward compatibility)
+  formProcessGroup: {
+    id: 'formProcessGroup',
+    name: 'Form Process (Legacy)',
+    category: 'form',
+    icon: '📂',
+    color: '#a78bfa', // lighter purple - group variant
+    description: '[DEPRECATED] Use "Form" (formBook). Existing workflows will continue to work.',
+    maxInputs: 1,
+    maxOutputs: 1,
+    requiresConfig: true,
+    hidden: true,
   },
   
   // DEPRECATED: Phase 2 - Backward compatibility aliases (2026-02-14)

--- a/frontend/src/components/FlowEditor/utils/containerStyling.ts
+++ b/frontend/src/components/FlowEditor/utils/containerStyling.ts
@@ -109,9 +109,10 @@ export function calculateContainerSize(
  * @returns Icon component name (for lucide-react)
  */
 export function getContainerIcon(
-  containerType: string = 'formProcessGroup'
+  containerType: string = 'formBook'
 ): string {
   const iconMap: Record<string, string> = {
+    formBook: 'Book',
     formProcessGroup: 'Layers',
     formMultiStepContainer: 'List',
     subWorkflow: 'GitBranch',

--- a/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
@@ -25,13 +25,12 @@ export function normalizeNodeData(node: Node): Node {
   }
 
   // --------------------------------------------------------------------------
-  // Phase 7 Stabilization: canonicalize legacy Form Process container types
+  // Phase 7 Stabilization: canonicalize legacy Form container types
   // --------------------------------------------------------------------------
-  // We standardize on the React Flow group implementation (formProcessGroup).
-  // Legacy types should continue to load, but are migrated in-memory so the UI
-  // and config routing are consistent.
-  if (node.type === 'formMultiStepContainer' || node.type === 'formProcess') {
-    const canonicalType = 'formProcessGroup';
+  // We standardize on the React Flow group implementation and present it as a
+  // singular "Form" container (formBook). Legacy types continue to load.
+  if (node.type === 'formMultiStepContainer' || node.type === 'formProcess' || node.type === 'formProcessGroup') {
+    const canonicalType = 'formBook';
     const canonicalDef = NODE_TYPE_REGISTRY[canonicalType];
 
     return {
@@ -46,6 +45,15 @@ export function normalizeNodeData(node: Node): Node {
         maxOutputs: (node.data as any)?.maxOutputs ?? canonicalDef?.maxOutputs ?? 1,
       },
     };
+  }
+
+  // Ensure strict parent bounds for any node that lives inside a container
+  if (node.parentId) {
+    node = {
+      ...node,
+      extent: node.extent || 'parent',
+      expandParent: node.expandParent ?? true,
+    } as Node;
   }
 
   // Get node type definition

--- a/frontend/src/components/FlowEditor/utils/outputSchemaInference.ts
+++ b/frontend/src/components/FlowEditor/utils/outputSchemaInference.ts
@@ -106,6 +106,7 @@ export function inferOutputSchema(node: Node): NodeOutputSchema | null {
   switch (node.type) {
     case 'form':
     case 'formStep':
+    case 'formBook':
     case 'formProcessGroup':
       return inferOutputSchemaFromFormNode(node);
     

--- a/frontend/src/components/FlowEditor/utils/validationEngine.ts
+++ b/frontend/src/components/FlowEditor/utils/validationEngine.ts
@@ -146,7 +146,7 @@ export function validateNodeConfig(node: Node): ValidationIssue[] {
   
   // Basic validation without schema dependency
   // Type-specific validations
-  if (node.type === 'form' || node.type === 'formProcessGroup') {
+  if (node.type === 'form' || node.type === 'formProcessGroup' || node.type === 'formBook') {
     const fields = node.data.fields || [];
     if (fields.length === 0) {
       issues.push({

--- a/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
+++ b/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
@@ -14,6 +14,7 @@
 import { Node, Edge } from '@xyflow/react';
 import { logger } from '@/utils/logger';
 
+import { sortNodesTopologically } from './nodeSorting';
 import { apiClient } from '../../../services/apiService';
 
 // ============================================================================
@@ -108,7 +109,7 @@ export const extractFormReferences = (nodes: Node[]): string[] => {
 
     // Form containers
     if (
-      (node.type === 'formMultiStepContainer' || node.type === 'formProcessGroup') &&
+      (node.type === 'formMultiStepContainer' || node.type === 'formProcessGroup' || node.type === 'formBook') &&
       nodeData.tenantFormId
     ) {
       formIds.add(nodeData.tenantFormId);
@@ -129,12 +130,16 @@ export const prepareWorkflowForSave = (
   viewport?: { x: number; y: number; zoom: number }
 ): SaveWorkflowPayload['workflow_definition'] => {
   // Make deep copies to avoid mutating original state
-  const nodesCopy = JSON.parse(JSON.stringify(nodes));
-  const edgesCopy = JSON.parse(JSON.stringify(edges));
+  const nodesCopy = JSON.parse(JSON.stringify(nodes)) as Node[];
+  const edgesCopy = JSON.parse(JSON.stringify(edges)) as Edge[];
+
+  // Ensure parents appear before children for React Flow subflows.
+  // This also prevents "disappearing" nodes when reloading persisted workflows.
+  const sortedNodes = sortNodesTopologically(nodesCopy);
   
   // Ensure all nodes have proper parentId metadata (React Flow v11+)
   // (This is already set by React Flow, but we verify it's serialized)
-  for (const node of nodesCopy) {
+  for (const node of sortedNodes) {
     if (node.parentId) {
       // Ensure extent is serialized
       if (!node.extent) {
@@ -149,7 +154,7 @@ export const prepareWorkflowForSave = (
   }
   
   return {
-    nodes: nodesCopy,
+    nodes: sortedNodes,
     edges: edgesCopy,
     viewport: viewport || { x: 0, y: 0, zoom: 1 },
   };


### PR DESCRIPTION
Implements Prompt 1 foundation by introducing a canonical `formBook` container type (Book & Pages) and migrating legacy container types in-memory on load.\n\nKey changes:\n- Adds `formBook` to node registry + config schemas\n- Ensures any child nodes have `extent: 'parent'` + `expandParent` for strict bounds\n- Wires `formBook` through editor checks, persistence (topological sort on save), validation, menus, drag/drop\n- Updates FlowEditor unit tests for container utilities\n\nNotes:\n- Legacy types `formProcessGroup`/`formProcess`/`formMultiStepContainer` still load and are migrated to `formBook` at runtime.