### PR TITLE
FlowEditor: step edges + thicker markers

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1687,6 +1687,7 @@ const staticEdgeTypes = {
   error: ErrorEdge,
   success: SuccessEdge,
   enhanced: EnhancedConnectionEdge,
+  step: EnhancedConnectionEdge, // Use enhanced edge UX (toolbar, hitbox) with step routing
   insert: InsertNodeEdge,
   default: CustomEdge, // Fallback to custom for untyped edges
 } as unknown as EdgeTypes;
@@ -6853,13 +6854,20 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         maxZoom={4}
         minZoom={0.1}
         defaultEdgeOptions={{
-          // Keep our enhanced edge component, but render it with thicker step-like styling.
-          type: 'enhanced',
-          style: { strokeWidth: 3, stroke: 'rgb(148, 163, 184)' },
-          markerEnd: { type: MarkerType.ArrowClosed, width: 24, height: 24, color: 'rgb(148, 163, 184)' },
+          // Step edges with larger markers + wider interaction area.
+          // NOTE: edgeTypes.step maps to EnhancedConnectionEdge to preserve toolbars/hitbox.
+          type: 'step',
+          style: { strokeWidth: 3, stroke: 'rgb(var(--color-text-secondary))' },
+          interactionWidth: 28,
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            width: 32,
+            height: 32,
+            color: 'rgb(var(--color-text-secondary))',
+          },
         }}
         connectionLineStyle={{
-          stroke: 'rgb(148, 163, 184)',
+          stroke: 'rgb(var(--color-text-secondary))',
           strokeWidth: 3,
           strokeDasharray: '5,5',
           animation: 'dash 0.5s linear infinite',

--- a/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
@@ -340,7 +340,7 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
       targetX,
       targetY,
       targetPosition,
-      borderRadius: 16,
+      borderRadius: 0,
     });
 
     const edgeColor = getEdgeColor(status);
@@ -466,7 +466,7 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
         {/* Invisible thick hitbox under the visible edge to stabilize hover/interaction */}
         <path
           d={edgePath}
-          style={{ stroke: 'transparent', strokeWidth: 30, strokeOpacity: 0 }}
+          style={{ stroke: 'transparent', strokeWidth: 44, strokeOpacity: 0 }}
           pointerEvents="stroke"
           onMouseEnter={setHoverOn}
           onMouseLeave={scheduleHoverOff}


### PR DESCRIPTION
Prompt 3.

- UnifiedFlowEditor: defaultEdgeOptions now use type 'step' with thicker stroke + larger ArrowClosed marker (theme tokens) and increased interactionWidth.
- edgeTypes.step mapped to EnhancedConnectionEdge so step edges retain toolbar + hitbox.
- EnhancedConnectionEdge: borderRadius=0 (true step routing) and larger invisible hitbox.

Tests:
- vitest FlowEditor container tests (34 passing).