### PR TITLE
fix(frontend): default export WorkForms editor

### DIFF
--- a/frontend/src/pages/WorkForms/Editor.tsx
+++ b/frontend/src/pages/WorkForms/Editor.tsx
@@ -396,3 +396,5 @@ export const WorkFormsEditor: React.FC = () => {
   );
 };
 
+export default WorkFormsEditor;
+


### PR DESCRIPTION
Fixes dev deploy failure: Vite build error "default is not exported by src/pages/WorkForms/Editor.tsx". Adds a default export while preserving the named export.