### PR TITLE
feat: add swarm invoke endpoint

### DIFF
--- a/backend/tenant_apps/ai_assistant/urls.py
+++ b/backend/tenant_apps/ai_assistant/urls.py
@@ -7,7 +7,13 @@ and AI-powered business intelligence.
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from .views import ChatBotAPIViewSet, ChatMessageViewSet, ChatSessionViewSet, SwarmToolsOpenAPIView
+from .views import (
+    ChatBotAPIViewSet,
+    ChatMessageViewSet,
+    ChatSessionViewSet,
+    SwarmInvokeAPIView,
+    SwarmToolsOpenAPIView,
+)
 
 # Create router for ViewSets
 router = DefaultRouter()
@@ -17,5 +23,6 @@ router.register(r"ai-chat", ChatBotAPIViewSet, basename="ai-chatbot")
 
 urlpatterns = [
     path("tools/openapi/", SwarmToolsOpenAPIView.as_view(), name="ai-tools-openapi"),
+    path("swarm/invoke/", SwarmInvokeAPIView.as_view(), name="ai-swarm-invoke"),
     path("", include(router.urls)),
 ]

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -226,3 +226,45 @@ class SwarmToolsOpenAPIView(APIView):
         from .swarm.tools.registry import registry
 
         return Response(registry.to_openapi(), status=status.HTTP_200_OK)
+
+
+class SwarmInvokeAPIView(APIView):
+    """Staff-only entrypoint for PM-AS routing.
+
+    This is a safe endpoint: it only runs the semantic router and returns the
+    chosen agent chain + rationale. It does NOT execute tools or mutate data.
+    """
+
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        event_type = (request.data or {}).get('event_type')
+        payload = (request.data or {}).get('payload')
+        correlation_id = (request.data or {}).get('correlation_id')
+
+        if event_type not in {'email', 'user_chat', 'webhook'}:
+            return Response({'error': 'Unsupported event_type'}, status=status.HTTP_400_BAD_REQUEST)
+        if not isinstance(payload, dict):
+            return Response({'error': 'payload must be an object'}, status=status.HTTP_400_BAD_REQUEST)
+
+        tenant = getattr(request, 'tenant', None)
+        tenant_id = str(getattr(tenant, 'id', '') or '')
+        if not tenant_id:
+            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        from .swarm.router import SwarmOrchestrator
+
+        orch = SwarmOrchestrator(tenant_id=tenant_id)
+        decision = orch.route(event_type=event_type, payload=payload, correlation_id=correlation_id)
+
+        return Response(
+            {
+                'tenant_id': tenant_id,
+                'event_type': decision.event_type,
+                'intent': decision.intent,
+                'urgency': decision.urgency,
+                'agent_chain': decision.agent_chain,
+                'notes': decision.notes,
+            },
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
Adds staff-only POST /api/v1/ai-assistant/swarm/invoke/ to run SwarmOrchestrator routing (no side effects). Verified with python manage.py check.