### PR TITLE
feat: add swarm route preview in widget

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -36,6 +36,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 - Self-healing data pipeline (Auto-Tune Flywheel): nightly `process_rlhf_flywheel` aggregates `AIFeedbackLog` into JSONL instruction sets for future fine-tuning of local enrichment models.
 - Vector Memory, Tool Registry, RLHF Pipeline, and AIAgentWidget successfully scaffolded via CLI agent.
 - Added staff-only tool discovery endpoint: `GET /api/v1/ai-assistant/tools/openapi/` (PR #3689).
+- Added staff-only swarm router preview endpoint: `POST /api/v1/ai-assistant/swarm/invoke/` (PR #3693).
 
 ## Phase 9.5: Preemptive Hardening & Advanced UX (Workforms Editor)
 
@@ -46,6 +47,10 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
   - WorkForms InProgress/History now use `businessApi` (no legacy `apiClient`).
   - WorkForms /monitoring now reuses Cockpit ProcessMonitor (single source of truth).
   - Normalized invalid rgba/rgb color strings in WorkForms pages.
+
+- 2026-03-20 — Phase 8.0: staff-only swarm router preview endpoint (PR: #3693)
+  - PR: https://github.com/Meats-Central/ProjectMeats/pull/3693
+  - Adds `POST /api/v1/ai-assistant/swarm/invoke/` to run SwarmOrchestrator routing (no tool execution, no side effects).
 
 - 2026-03-19 — Phase 9.5: Book + Pages paradigm shift — Commit: fca3d658 (PR: #3631)
   - PR: https://github.com/Meats-Central/ProjectMeats/pull/3631

--- a/frontend/src/components/AIAssistant/AIAgentWidget.tsx
+++ b/frontend/src/components/AIAssistant/AIAgentWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
-import { AlertTriangle, BrainCircuit, CheckCircle2, Send, Wrench, X } from 'lucide-react';
+import { AlertTriangle, BrainCircuit, CheckCircle2, GitBranch, Send, Wrench, X } from 'lucide-react';
 
 import { businessApi } from '../../services/businessApi';
 
@@ -336,6 +336,72 @@ export const AIAgentWidget: React.FC = () => {
     }
   };
 
+  const handleRoutePreview = async () => {
+    const text = draft.trim();
+    const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user')?.content ?? '';
+    const message = text || lastUserMessage;
+
+    if (!message) {
+      setMessages((m) => [
+        ...m,
+        {
+          id: newId(),
+          role: 'assistant',
+          content: 'Add a message first (or send one) to preview routing.',
+          createdAt: Date.now(),
+        },
+      ]);
+      return;
+    }
+
+    setState('thinking');
+    try {
+      const res = await businessApi.post<{
+        tenant_id: string;
+        event_type: string;
+        intent: string;
+        urgency: string;
+        agent_chain: string[];
+        notes?: string;
+      }>('/ai-assistant/swarm/invoke/', {
+        event_type: 'user_chat',
+        payload: {
+          message,
+          session_id: sessionId ?? undefined,
+          ui_source: 'AIAgentWidget',
+        },
+        correlation_id: sessionId ?? undefined,
+      });
+
+      const chain = Array.isArray(res.data?.agent_chain) ? res.data.agent_chain.join(' → ') : '—';
+      const intent = res.data?.intent ?? '—';
+      const urgency = res.data?.urgency ?? '—';
+      const notes = res.data?.notes ? `\nNotes: ${res.data.notes}` : '';
+
+      setMessages((m) => [
+        ...m,
+        {
+          id: newId(),
+          role: 'assistant',
+          content: `Router decision: intent=${intent}, urgency=${urgency}\nAgent chain: ${chain}${notes}`,
+          createdAt: Date.now(),
+        },
+      ]);
+      setState('idle');
+    } catch {
+      setMessages((m) => [
+        ...m,
+        {
+          id: newId(),
+          role: 'assistant',
+          content: 'Routing preview is unavailable (requires staff permissions).',
+          createdAt: Date.now(),
+        },
+      ]);
+      setState('idle');
+    }
+  };
+
   const handleSend = async () => {
     const text = draft.trim();
     if (!text) return;
@@ -425,6 +491,16 @@ export const AIAgentWidget: React.FC = () => {
                 }}
               >
                 <Wrench size={16} />
+              </IconBtn>
+
+              <IconBtn
+                type="button"
+                title="Route preview"
+                onClick={() => {
+                  handleRoutePreview();
+                }}
+              >
+                <GitBranch size={16} />
               </IconBtn>
 
               <IconBtn type="button" title="Close" onClick={() => setExpanded(false)}>


### PR DESCRIPTION
Adds a Route preview button in AIAgentWidget that calls staff-only POST /api/v1/ai-assistant/swarm/invoke/ and prints router decision. Handles 403 gracefully.\n\nVerification: npm --prefix frontend run test:ci