### PR TITLE
feat: validate swarm invoke payload

### DIFF
--- a/backend/tenant_apps/ai_assistant/serializers.py
+++ b/backend/tenant_apps/ai_assistant/serializers.py
@@ -110,3 +110,25 @@ class VectorMemorySearchResultSerializer(serializers.Serializer):
     distance = serializers.FloatField()
     content_preview = serializers.CharField()
     metadata = serializers.JSONField()
+
+
+class SwarmInvokeRequestSerializer(serializers.Serializer):
+    event_type = serializers.ChoiceField(choices=['email', 'user_chat', 'webhook'])
+    payload = serializers.JSONField()
+    correlation_id = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+
+    def validate_payload(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError('payload must be an object')
+        return value
+
+
+class SwarmInvokeResponseSerializer(serializers.Serializer):
+    tenant_id = serializers.UUIDField()
+    correlation_id = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+
+    event_type = serializers.CharField()
+    intent = serializers.CharField()
+    urgency = serializers.CharField()
+    agent_chain = serializers.ListField(child=serializers.CharField())
+    notes = serializers.CharField(required=False, allow_blank=True)

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -24,6 +24,7 @@ from .serializers import (
     ChatMessageSerializer,
     ChatSessionDetailSerializer,
     ChatSessionListSerializer,
+    SwarmInvokeRequestSerializer,
     VectorMemorySearchRequestSerializer,
 )
 
@@ -240,19 +241,18 @@ class SwarmInvokeAPIView(APIView):
     permission_classes = [IsAdminUser]
 
     def post(self, request):
-        event_type = (request.data or {}).get('event_type')
-        payload = (request.data or {}).get('payload')
-        correlation_id = (request.data or {}).get('correlation_id')
-
-        if event_type not in {'email', 'user_chat', 'webhook'}:
-            return Response({'error': 'Unsupported event_type'}, status=status.HTTP_400_BAD_REQUEST)
-        if not isinstance(payload, dict):
-            return Response({'error': 'payload must be an object'}, status=status.HTTP_400_BAD_REQUEST)
+        serializer = SwarmInvokeRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         tenant = getattr(request, 'tenant', None)
         tenant_id = str(getattr(tenant, 'id', '') or '')
         if not tenant_id:
             return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        event_type = serializer.validated_data['event_type']
+        payload = serializer.validated_data['payload']
+        correlation_id = serializer.validated_data.get('correlation_id')
 
         from .swarm.router import SwarmOrchestrator
 
@@ -262,6 +262,7 @@ class SwarmInvokeAPIView(APIView):
         return Response(
             {
                 'tenant_id': tenant_id,
+                'correlation_id': correlation_id,
                 'event_type': decision.event_type,
                 'intent': decision.intent,
                 'urgency': decision.urgency,


### PR DESCRIPTION
Hardens staff-only POST /api/v1/ai-assistant/swarm/invoke/ by using DRF serializers for request validation and consistent response contract (includes correlation_id).\n\nVerification: python backend/manage.py check