### PR TITLE
feat: add pending review endpoint

### DIFF
--- a/backend/tenant_apps/ai_assistant/serializers.py
+++ b/backend/tenant_apps/ai_assistant/serializers.py
@@ -132,3 +132,13 @@ class SwarmInvokeResponseSerializer(serializers.Serializer):
     urgency = serializers.CharField()
     agent_chain = serializers.ListField(child=serializers.CharField())
     notes = serializers.CharField(required=False, allow_blank=True)
+
+
+class PendingReviewItemSerializer(serializers.Serializer):
+    id = serializers.UUIDField()
+    document_id = serializers.UUIDField()
+    document_type = serializers.CharField()
+    confidence_score = serializers.FloatField()
+    precision_delta = serializers.FloatField()
+    created_on = serializers.DateTimeField()
+    original_extracted_data = serializers.JSONField()

--- a/backend/tenant_apps/ai_assistant/urls.py
+++ b/backend/tenant_apps/ai_assistant/urls.py
@@ -11,6 +11,7 @@ from .views import (
     ChatBotAPIViewSet,
     ChatMessageViewSet,
     ChatSessionViewSet,
+    PendingReviewAPIView,
     SwarmInvokeAPIView,
     SwarmToolsOpenAPIView,
     VectorMemorySearchAPIView,
@@ -26,5 +27,6 @@ urlpatterns = [
     path("tools/openapi/", SwarmToolsOpenAPIView.as_view(), name="ai-tools-openapi"),
     path("swarm/invoke/", SwarmInvokeAPIView.as_view(), name="ai-swarm-invoke"),
     path("memory/search/", VectorMemorySearchAPIView.as_view(), name="ai-memory-search"),
+    path("review/pending/", PendingReviewAPIView.as_view(), name="ai-review-pending"),
     path("", include(router.urls)),
 ]

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -15,7 +15,7 @@ from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .models import AIConfiguration, ChatMessage, ChatSession, MessageTypeChoices, VectorMemory
+from .models import AIFeedbackLog, AIConfiguration, ChatMessage, ChatSession, MessageTypeChoices, VectorMemory
 from .serializers import (
     AIConfigurationSerializer,
     ChatBotRequestSerializer,
@@ -24,6 +24,7 @@ from .serializers import (
     ChatMessageSerializer,
     ChatSessionDetailSerializer,
     ChatSessionListSerializer,
+    PendingReviewItemSerializer,
     SwarmInvokeRequestSerializer,
     VectorMemorySearchRequestSerializer,
 )
@@ -315,3 +316,43 @@ class VectorMemorySearchAPIView(APIView):
             )
 
         return Response({'results': results}, status=status.HTTP_200_OK)
+
+
+class PendingReviewAPIView(APIView):
+    """Staff-only queue of HITL items requiring human review.
+
+    Backed by AIFeedbackLog (unresolved rows with low confidence).
+    """
+
+    permission_classes = [IsAdminUser]
+
+    def get(self, request):
+        tenant = getattr(request, 'tenant', None)
+        tenant_id = str(getattr(tenant, 'id', '') or '')
+        if not tenant_id:
+            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        qs = (
+            AIFeedbackLog.objects.filter(
+                tenant_id=tenant_id,
+                resolved_by__isnull=True,
+                confidence_score__lt=0.85,
+            )
+            .order_by('-created_on')
+        )
+
+        items = [
+            {
+                'id': row.id,
+                'document_id': row.document_id,
+                'document_type': row.document_type,
+                'confidence_score': float(row.confidence_score or 0.0),
+                'precision_delta': float(row.precision_delta or 0.0),
+                'created_on': row.created_on,
+                'original_extracted_data': row.original_extracted_data or {},
+            }
+            for row in qs[:25]
+        ]
+
+        payload = PendingReviewItemSerializer(items, many=True).data
+        return Response({'results': payload}, status=status.HTTP_200_OK)


### PR DESCRIPTION
Adds staff-only GET /api/v1/ai-assistant/review/pending/ backed by AIFeedbackLog (unresolved, confidence_score < 0.85) so the widget can poll a concrete HITL queue.\n\nVerification: python backend/manage.py check