### PR TITLE
feat: resolve HITL review items

### DIFF
--- a/backend/tenant_apps/ai_assistant/serializers.py
+++ b/backend/tenant_apps/ai_assistant/serializers.py
@@ -15,6 +15,17 @@ class VectorMemorySearchRequestSerializer(serializers.Serializer):
         return value
 
 
+class PendingReviewResolveRequestSerializer(serializers.Serializer):
+    user_corrected_data = serializers.JSONField(required=False, allow_null=True)
+
+    def validate_user_corrected_data(self, value):
+        if value is None:
+            return value
+        if not isinstance(value, dict):
+            raise serializers.ValidationError('user_corrected_data must be an object')
+        return value
+
+
 class ChatSessionListSerializer(serializers.ModelSerializer):
     """Serializer for chat session list view."""
 

--- a/backend/tenant_apps/ai_assistant/urls.py
+++ b/backend/tenant_apps/ai_assistant/urls.py
@@ -12,6 +12,7 @@ from .views import (
     ChatMessageViewSet,
     ChatSessionViewSet,
     PendingReviewAPIView,
+    PendingReviewResolveAPIView,
     SwarmInvokeAPIView,
     SwarmToolsOpenAPIView,
     VectorMemorySearchAPIView,
@@ -28,5 +29,6 @@ urlpatterns = [
     path("swarm/invoke/", SwarmInvokeAPIView.as_view(), name="ai-swarm-invoke"),
     path("memory/search/", VectorMemorySearchAPIView.as_view(), name="ai-memory-search"),
     path("review/pending/", PendingReviewAPIView.as_view(), name="ai-review-pending"),
+    path("review/<uuid:feedback_id>/resolve/", PendingReviewResolveAPIView.as_view(), name="ai-review-resolve"),
     path("", include(router.urls)),
 ]

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -25,6 +25,7 @@ from .serializers import (
     ChatSessionDetailSerializer,
     ChatSessionListSerializer,
     PendingReviewItemSerializer,
+    PendingReviewResolveRequestSerializer,
     SwarmInvokeRequestSerializer,
     VectorMemorySearchRequestSerializer,
 )
@@ -356,3 +357,53 @@ class PendingReviewAPIView(APIView):
 
         payload = PendingReviewItemSerializer(items, many=True).data
         return Response({'results': payload}, status=status.HTTP_200_OK)
+
+
+class PendingReviewResolveAPIView(APIView):
+    """Staff-only endpoint to resolve a HITL item.
+
+    Marks AIFeedbackLog.resolved_by and optionally stores user_corrected_data.
+    """
+
+    permission_classes = [IsAdminUser]
+
+    def post(self, request, feedback_id):
+        serializer = PendingReviewResolveRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        tenant = getattr(request, 'tenant', None)
+        tenant_id = str(getattr(tenant, 'id', '') or '')
+        if not tenant_id:
+            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            row = AIFeedbackLog.objects.get(id=feedback_id, tenant_id=tenant_id)
+        except AIFeedbackLog.DoesNotExist:
+            return Response({'error': 'Not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        if row.resolved_by_id:
+            return Response(
+                {
+                    'id': str(row.id),
+                    'resolved_by': str(row.resolved_by_id),
+                    'precision_delta': float(row.precision_delta or 0.0),
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        corrected = serializer.validated_data.get('user_corrected_data')
+        if corrected is not None:
+            row.user_corrected_data = corrected
+
+        row.resolved_by = request.user
+        row.save(update_fields=['user_corrected_data', 'resolved_by', 'precision_delta', 'modified_on'])
+
+        return Response(
+            {
+                'id': str(row.id),
+                'resolved_by': str(request.user.id),
+                'precision_delta': float(row.precision_delta or 0.0),
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/frontend/src/components/AIAssistant/AIAgentWidget.tsx
+++ b/frontend/src/components/AIAssistant/AIAgentWidget.tsx
@@ -296,6 +296,7 @@ export const AIAgentWidget: React.FC = () => {
 
   const seenPendingReviewIdsRef = useRef<Set<string>>(new Set());
   const pendingReviewPollingDisabledRef = useRef(false);
+  const latestPendingReviewRef = useRef<{ id: string; document_type: string } | null>(null);
 
   useEffect(() => {
     if (!expanded) return;
@@ -322,6 +323,11 @@ export const AIAgentWidget: React.FC = () => {
         newItems.forEach((i) => seenPendingReviewIdsRef.current.add(i.id));
 
         if (newItems.length) {
+          latestPendingReviewRef.current = {
+            id: newItems[0].id,
+            document_type: newItems[0].document_type,
+          };
+
           setState('action_required');
           setDetail({
             document_type: newItems[0].document_type,
@@ -397,6 +403,44 @@ export const AIAgentWidget: React.FC = () => {
           id: newId(),
           role: 'assistant',
           content: 'Tools list is unavailable (requires staff permissions).',
+          createdAt: Date.now(),
+        },
+      ]);
+      setState('idle');
+    }
+  };
+
+  const handleResolveLatest = async () => {
+    const latest = latestPendingReviewRef.current;
+    if (!latest) {
+      setMessages((m) => [
+        ...m,
+        { id: newId(), role: 'assistant', content: 'No pending review item found to resolve yet.', createdAt: Date.now() },
+      ]);
+      return;
+    }
+
+    setState('thinking');
+    try {
+      await businessApi.post(`/ai-assistant/review/${latest.id}/resolve/`, {});
+      setMessages((m) => [
+        ...m,
+        {
+          id: newId(),
+          role: 'assistant',
+          content: `Resolved: ${latest.document_type} (${latest.id.slice(0, 8)}…)`,
+          createdAt: Date.now(),
+        },
+      ]);
+      latestPendingReviewRef.current = null;
+      setState('idle');
+    } catch {
+      setMessages((m) => [
+        ...m,
+        {
+          id: newId(),
+          role: 'assistant',
+          content: 'Resolve action is unavailable (requires staff permissions).',
           createdAt: Date.now(),
         },
       ]);


### PR DESCRIPTION
Adds staff-only POST /api/v1/ai-assistant/review/<feedback_id>/resolve/ to mark AIFeedbackLog resolved_by and optionally store user_corrected_data.\n\nAlso adds a minimal 'Resolve latest' action in AIAgentWidget (staff-only; 403 handled gracefully).\n\nVerification:\n- python backend/manage.py check\n- python backend/manage.py makemigrations --check --dry-run\n- npm --prefix frontend run test:ci\n- bash scripts/verify_golden_state.sh