### PR TITLE
feat: add VectorMemory upsert endpoint

### DIFF
--- a/backend/tenant_apps/ai_assistant/serializers.py
+++ b/backend/tenant_apps/ai_assistant/serializers.py
@@ -15,6 +15,24 @@ class VectorMemorySearchRequestSerializer(serializers.Serializer):
         return value
 
 
+class VectorMemoryUpsertRequestSerializer(serializers.Serializer):
+    embedding = serializers.ListField(child=serializers.FloatField(), allow_empty=False)
+    source_type = serializers.CharField(required=False, default='context', max_length=64)
+    document_id = serializers.UUIDField(required=False, allow_null=True)
+    content = serializers.CharField(required=False, allow_blank=True, default='')
+    metadata = serializers.JSONField(required=False, default=dict)
+
+    def validate_embedding(self, value):
+        if len(value) != 1536:
+            raise serializers.ValidationError('embedding must be a 1536-length float array')
+        return value
+
+    def validate_metadata(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError('metadata must be an object')
+        return value
+
+
 class PendingReviewResolveRequestSerializer(serializers.Serializer):
     user_corrected_data = serializers.JSONField(required=False, allow_null=True)
 

--- a/backend/tenant_apps/ai_assistant/urls.py
+++ b/backend/tenant_apps/ai_assistant/urls.py
@@ -16,6 +16,7 @@ from .views import (
     SwarmInvokeAPIView,
     SwarmToolsOpenAPIView,
     VectorMemorySearchAPIView,
+    VectorMemoryUpsertAPIView,
 )
 
 # Create router for ViewSets
@@ -28,6 +29,7 @@ urlpatterns = [
     path("tools/openapi/", SwarmToolsOpenAPIView.as_view(), name="ai-tools-openapi"),
     path("swarm/invoke/", SwarmInvokeAPIView.as_view(), name="ai-swarm-invoke"),
     path("memory/search/", VectorMemorySearchAPIView.as_view(), name="ai-memory-search"),
+    path("memory/upsert/", VectorMemoryUpsertAPIView.as_view(), name="ai-memory-upsert"),
     path("review/pending/", PendingReviewAPIView.as_view(), name="ai-review-pending"),
     path("review/<uuid:feedback_id>/resolve/", PendingReviewResolveAPIView.as_view(), name="ai-review-resolve"),
     path("", include(router.urls)),

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -28,6 +28,7 @@ from .serializers import (
     PendingReviewResolveRequestSerializer,
     SwarmInvokeRequestSerializer,
     VectorMemorySearchRequestSerializer,
+    VectorMemoryUpsertRequestSerializer,
 )
 
 logger = logging.getLogger(__name__)
@@ -317,6 +318,64 @@ class VectorMemorySearchAPIView(APIView):
             )
 
         return Response({'results': results}, status=status.HTTP_200_OK)
+
+
+class VectorMemoryUpsertAPIView(APIView):
+    """Staff-only ingestion endpoint for VectorMemory.
+
+    Caller must supply a 1536-dim embedding (no OpenAI dependency here).
+    If document_id is provided, best-effort upsert keyed by (tenant, source_type, document_id).
+    """
+
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        serializer = VectorMemoryUpsertRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        tenant = getattr(request, 'tenant', None)
+        tenant_id = str(getattr(tenant, 'id', '') or '')
+        if not tenant_id:
+            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        embedding = serializer.validated_data['embedding']
+        source_type = serializer.validated_data['source_type']
+        document_id = serializer.validated_data.get('document_id')
+        content = serializer.validated_data.get('content', '')
+        metadata = serializer.validated_data.get('metadata', {})
+
+        if document_id:
+            obj, created = VectorMemory.objects.update_or_create(
+                tenant_id=tenant_id,
+                source_type=source_type,
+                document_id=document_id,
+                defaults={
+                    'content': content,
+                    'metadata': metadata,
+                    'embedding': embedding,
+                },
+            )
+        else:
+            obj = VectorMemory.objects.create(
+                tenant_id=tenant_id,
+                source_type=source_type,
+                document_id=None,
+                content=content,
+                metadata=metadata,
+                embedding=embedding,
+            )
+            created = True
+
+        return Response(
+            {
+                'id': str(obj.id),
+                'created': created,
+                'source_type': obj.source_type,
+                'document_id': str(obj.document_id) if obj.document_id else None,
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 class PendingReviewAPIView(APIView):


### PR DESCRIPTION
Adds staff-only POST /api/v1/ai-assistant/memory/upsert/ to ingest/update VectorMemory for the current tenant. Requires caller-supplied 1536-dim embedding (no OpenAI dependency).\n\nVerification:\n- python backend/manage.py check\n- python backend/manage.py makemigrations --check --dry-run\n- bash scripts/verify_golden_state.sh