### PR TITLE
Revert Form container to purple FormProcess

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1663,12 +1663,13 @@ const staticNodeTypes = {
   form: FormStepNode,  // Form Step (Page)
   formStepSingle: FormStepSingleNode,  // Backward compatibility
   formBook: FormNode,  // Form container (Book)
-  formProcess: FormNode,  // Legacy container types render as canonical container
-  formProcessGroup: FormNode,
+  // Restore legacy purple FormProcess container renderer (kept stable for business users)
+  formProcess: FormProcessNode,
+  formProcessGroup: FormProcessNode,
   smartWorkForm: SmartWorkFormNode,
   // Backward compatibility aliases
   formStep: FormStepSingleNode,  // Deprecated
-  formMultiStepContainer: FormNode,  // Legacy container alias
+  formMultiStepContainer: FormProcessNode,  // Legacy container alias (render as purple process container)
   // Other nodes
   formReference: FormReferenceNode,
   trigger: TriggerNode,
@@ -6181,6 +6182,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         const baseOrder = [...normalizedExisting, ...missing];
         const insertIndex = afterNodeId && baseOrder.includes(afterNodeId) ? baseOrder.indexOf(afterNodeId) + 1 : baseOrder.length;
 
+        const enforceStrictPages = container.type === 'formProcessGroup' || container.type === 'formProcess' || container.type === 'formMultiStepContainer';
+
         const newPageId = `page-${uuidv4()}`;
         const nextOrder = [...baseOrder.slice(0, insertIndex), newPageId, ...baseOrder.slice(insertIndex)];
 
@@ -6189,28 +6192,61 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           id: newPageId,
           type: 'form',
           position: {
-            x: 30 + insertIndex * 360,
-            y: 90,
+            x: 50 + insertIndex * 350,
+            y: 80,
           },
+          style: enforceStrictPages ? { width: 320, height: 320, overflow: 'hidden' } : undefined,
           data: {
             stepTitle: `Page ${newPageNumber}`,
             label: `Page ${newPageNumber}`,
             fields: [],
+            order: insertIndex,
           },
           parentId: containerId,
           extent: 'parent',
           expandParent: true,
-          draggable: true,
+          draggable: enforceStrictPages ? false : true,
         };
 
         const nextNodes = prev.map((n) => {
-          if (n.id !== containerId) return n;
+          if (n.id === containerId) {
+            return {
+              ...n,
+              data: {
+                ...(n.data || {}),
+                pageOrder: nextOrder,
+                isExpanded: true,
+              },
+            };
+          }
+
+          if (n.parentId !== containerId) return n;
+
+          const isPageNodeType = (type?: string) =>
+            type === 'form' || type === 'formStepSingle' || type === 'formStep' || type === 'formReference';
+          if (!isPageNodeType(n.type)) return n;
+
+          const idx = nextOrder.indexOf(n.id);
+          if (idx === -1) return n;
+
           return {
             ...n,
+            position: {
+              x: 50 + idx * 350,
+              y: 80,
+            },
+            draggable: enforceStrictPages ? false : n.draggable,
+            style: enforceStrictPages
+              ? {
+                  ...(n.style || {}),
+                  width: 320,
+                  height: 320,
+                  overflow: 'hidden',
+                }
+              : n.style,
             data: {
               ...(n.data || {}),
-              pageOrder: nextOrder,
-              isExpanded: true,
+              order: idx,
             },
           };
         });

--- a/frontend/src/components/FlowEditor/nodeTypes.ts
+++ b/frontend/src/components/FlowEditor/nodeTypes.ts
@@ -147,43 +147,46 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
   },
   
   // NEW: Singular Form container using React Flow sub-flows (Book & Pages)
+  // Temporarily hidden while we revert to the purple FormProcess container UX.
   formBook: {
     id: 'formBook',
-    name: 'Form',
+    name: 'Form (Book - Hidden)',
     category: 'form',
     icon: '📚',
     color: '#a78bfa',
-    description: 'Multi-step form container (Book) that groups Form Steps (Pages) using React Flow sub-flows',
-    maxInputs: 1,
-    maxOutputs: 1,
-    requiresConfig: true,
-  },
-
-  // Phase 7+: Smart WorkForm (single-node wizard)
-  smartWorkForm: {
-    id: 'smartWorkForm',
-    name: 'Smart WorkForm',
-    category: 'form',
-    icon: '🧠',
-    color: '#a78bfa',
-    description: 'Single-node vertical wizard with field library + cascades + live preview',
-    maxInputs: 1,
-    maxOutputs: 1,
-    requiresConfig: true,
-  },
-
-  // Legacy container type (kept for backward compatibility)
-  formProcessGroup: {
-    id: 'formProcessGroup',
-    name: 'Form Process (Legacy)',
-    category: 'form',
-    icon: '📂',
-    color: '#a78bfa', // lighter purple - group variant
-    description: '[DEPRECATED] Use "Form" (formBook). Existing workflows will continue to work.',
+    description: '[HIDDEN] Book-style form container. Use Form Process instead.',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
     hidden: true,
+  },
+
+  // Phase 7+: Smart WorkForm (single-node wizard)
+  // Kept for backward compatibility, but hidden from the palette for now.
+  smartWorkForm: {
+    id: 'smartWorkForm',
+    name: 'Smart WorkForm (Hidden)',
+    category: 'form',
+    icon: '🧠',
+    color: '#a78bfa',
+    description: '[HIDDEN] Kept for backward compatibility. Use Form Process instead.',
+    maxInputs: 1,
+    maxOutputs: 1,
+    requiresConfig: true,
+    hidden: true,
+  },
+
+  // Purple multi-step container (restored as primary)
+  formProcessGroup: {
+    id: 'formProcessGroup',
+    name: 'Form Process',
+    category: 'form',
+    icon: '📦',
+    color: '#8b5cf6',
+    description: 'Multi-step container that keeps child form steps constrained and arranged horizontally.',
+    maxInputs: 1,
+    maxOutputs: 1,
+    requiresConfig: true,
   },
   
   // DEPRECATED: Phase 2 - Backward compatibility aliases (2026-02-14)

--- a/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
@@ -1,14 +1,15 @@
 /**
  * Legacy FormProcessGroupNode
  *
- * Kept for backward compatibility. The canonical Form container is `FormNode`.
+ * Kept for backward compatibility.
+ * Restored to the purple multi-step container renderer (FormProcessNode).
  */
 
-import { FormNode, type FormNodeData } from './FormNode';
+import { FormProcessNode, type ContainerNodeData } from './FormProcessNode';
 
-export type FormProcessGroupData = FormNodeData;
+export type FormProcessGroupData = ContainerNodeData;
 
 // Deprecated alias
-export const FormProcessGroupNode = FormNode;
+export const FormProcessGroupNode = FormProcessNode;
 
-export default FormNode;
+export default FormProcessNode;

--- a/frontend/src/components/FlowEditor/utils/containerLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/containerLayout.ts
@@ -22,18 +22,22 @@ export const LAYOUT_CONSTANTS = {
   START_X: 50,           // Starting x position for first form step
   STEP_SPACING: 350,     // Horizontal spacing between form steps
   STEP_Y: 80,            // Y position for form step row
-  
+
+  // Fixed dimensions for Form Step nodes (keeps steps inside parent bounds)
+  STEP_W: 320,
+  STEP_H: 320,
+
   // Vertical layout for action nodes
   ACTION_OFFSET_Y: 180,  // Vertical offset below form step
   ACTION_SPACING_Y: 120, // Spacing between stacked actions
-  
+
   // Container padding
   CONTAINER_PADDING_X: 20,
   CONTAINER_PADDING_Y: 20,
-  
+
   // Node dimensions (for calculating container size)
-  DEFAULT_NODE_WIDTH: 200,
-  DEFAULT_NODE_HEIGHT: 100,
+  DEFAULT_NODE_WIDTH: 320,
+  DEFAULT_NODE_HEIGHT: 320,
 } as const;
 
 // ============================================================================
@@ -69,7 +73,13 @@ export function calculateContainerLayout(
   allEdges: Edge[]
 ): LayoutResult {
   logger.debug(`[Layout] Calculating layout for container ${containerId}`);
-  
+
+  const containerNode = allNodes.find((n) => n.id === containerId);
+  const enforceStrictPages =
+    containerNode?.type === 'formProcessGroup' ||
+    containerNode?.type === 'formProcess' ||
+    containerNode?.type === 'formMultiStepContainer';
+
   // Filter child nodes (using parentId - React Flow v11+)
   const childNodes = allNodes.filter(node => node.parentId === containerId);
   
@@ -100,15 +110,24 @@ export function calculateContainerLayout(
   // Update form steps with horizontal layout
   const updatedFormSteps = formSteps.map((step, index) => {
     const newPosition: NodePosition = {
-      x: LAYOUT_CONSTANTS.START_X + (index * LAYOUT_CONSTANTS.STEP_SPACING),
+      x: LAYOUT_CONSTANTS.START_X + index * LAYOUT_CONSTANTS.STEP_SPACING,
       y: LAYOUT_CONSTANTS.STEP_Y,
     };
-    
+
     logger.debug(`[Layout] Form step \${step.id} positioned at (\${newPosition.x}, \${newPosition.y})`);
-    
+
     return {
       ...step,
       position: newPosition,
+      draggable: enforceStrictPages ? false : step.draggable,
+      style: enforceStrictPages
+        ? {
+            ...(step.style || {}),
+            width: LAYOUT_CONSTANTS.STEP_W,
+            height: LAYOUT_CONSTANTS.STEP_H,
+            overflow: 'hidden',
+          }
+        : step.style,
       data: {
         ...step.data,
         order: index, // Store order for future reordering


### PR DESCRIPTION
Reverts the Form container UX to the purple multi-step FormProcess container while preserving the key behavior: child step nodes stay constrained inside the parent and do not wiggle when the parent moves.\n\nChanges:\n- UnifiedFlowEditor: render formProcessGroup/formProcess/formMultiStepContainer via FormProcessNode\n- containerLayout: strict horizontal layout + fixed step dimensions for FormProcess containers\n- nodeTypes: show Form Process, hide Form (Book) + Smart WorkForm from palette (kept for backward compatibility)\n\nTests:\n- frontend: npm run test -- --run