### PR TITLE
Prefill create flows from cockpit actions

### DIFF
--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -673,17 +673,43 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
    */
   const handleQuickAction = useCallback((action: SearchEntity) => {
     const actionType = action.metadata?.action as string | undefined;
-    const entityId = action.metadata?.entityId;
+    const entityId = (action.metadata?.entityId as string | number | undefined) ?? action.id;
 
     if (!actionType) {
       console.warn('[SmartSearch] Quick action missing actionType', action);
       return;
     }
 
+    const activeContext = navigation.path[navigation.path.length - 1];
+    const prefillBase = {
+      source: 'cockpit',
+      query,
+      contextEntity: activeContext
+        ? {
+            id: activeContext.id,
+            type: activeContext.type,
+            label: activeContext.label,
+          }
+        : undefined,
+    };
+
     switch (actionType) {
-      case 'create_po':
-        navigate(`/purchase-orders?action=create&supplier_id=${entityId}`);
+      case 'create_po': {
+        const supplierId = entityId ? String(entityId) : '';
+        const params = new URLSearchParams({ action: 'create' });
+        if (supplierId) params.set('supplier_id', supplierId);
+        if (query) params.set('cockpit_q', query);
+
+        navigate(`/purchase-orders?${params.toString()}`, {
+          state: {
+            prefill: {
+              ...prefillBase,
+              supplierId,
+            },
+          },
+        });
         break;
+      }
       case 'view_purchase_history':
       case 'view_history':
         navigate(`/purchase-orders?supplier_id=${entityId}`);
@@ -691,16 +717,29 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
       case 'send_email':
         window.dispatchEvent(new CustomEvent('pm:open-tool', { detail: { toolId: 'tool:email' } }));
         break;
-      case 'create_so':
-        navigate(`/sales-orders?action=create&customer_id=${entityId}`);
+      case 'create_so': {
+        const customerId = entityId ? String(entityId) : '';
+        const params = new URLSearchParams({ action: 'create' });
+        if (customerId) params.set('customer_id', customerId);
+        if (query) params.set('cockpit_q', query);
+
+        navigate(`/sales-orders?${params.toString()}`, {
+          state: {
+            prefill: {
+              ...prefillBase,
+              customerId,
+            },
+          },
+        });
         break;
+      }
       case 'view_sales_history':
         navigate(`/sales-orders?customer_id=${entityId}`);
         break;
       default:
         console.warn('Unhandled quick action:', actionType, 'for entity', entityId);
     }
-  }, [navigate]);
+  }, [navigate, navigation.path, query]);
 
   /**
    * Toggle favorite

--- a/frontend/src/components/Shared/CreateOrderModal.tsx
+++ b/frontend/src/components/Shared/CreateOrderModal.tsx
@@ -33,6 +33,15 @@ interface CreateOrderModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: () => void;
+  /** Optional prefill values (e.g., from Cockpit suggested actions) */
+  initialValues?: Partial<{
+    customer: string;
+    supplier: string;
+    product: string;
+    total_amount: string;
+    order_date: string;
+    notes: string;
+  }>;
 }
 
 interface Customer {
@@ -229,6 +238,7 @@ export const CreateOrderModal: React.FC<CreateOrderModalProps> = ({
   isOpen,
   onClose,
   onSuccess,
+  initialValues,
 }) => {
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
@@ -247,23 +257,31 @@ export const CreateOrderModal: React.FC<CreateOrderModalProps> = ({
     notes: '',
   });
 
+  const buildDefaultFormData = () => ({
+    customer: '',
+    supplier: '',
+    product: '',
+    total_amount: '',
+    order_date: new Date().toISOString().split('T')[0],
+    notes: '',
+  });
+
   // Load dropdown data when modal opens
   useEffect(() => {
-    if (isOpen) {
-      loadDropdownData();
-      // Reset form
-      setFormData({
-        customer: '',
-        supplier: '',
-        product: '',
-        total_amount: '',
-        order_date: new Date().toISOString().split('T')[0],
-        notes: '',
-      });
-      setError(null);
-      setFilteredProducts([]);
-    }
-  }, [isOpen]);
+    if (!isOpen) return;
+
+    loadDropdownData();
+
+    const defaults = buildDefaultFormData();
+    setFormData({
+      ...defaults,
+      ...(initialValues ?? {}),
+      order_date: initialValues?.order_date ?? defaults.order_date,
+    });
+
+    setError(null);
+    setFilteredProducts([]);
+  }, [isOpen, initialValues]);
 
   // Reactive filtering: Update products when customer or supplier changes
   useEffect(() => {

--- a/frontend/src/pages/PurchaseOrders.tsx
+++ b/frontend/src/pages/PurchaseOrders.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { apiService, PurchaseOrder, Supplier } from '../services/apiService';
 import { LocationSelector } from '../components/Shared';
@@ -352,6 +352,18 @@ const SubmitButton = styled.button`
 
 const PurchaseOrders: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+
+  type CockpitPrefill = {
+    source?: string;
+    query?: string;
+    supplierId?: string;
+    contextEntity?: { id?: string; type?: string; label?: string };
+  };
+
+  const cockpitPrefill = (location.state as any)?.prefill as CockpitPrefill | undefined;
+  const [pendingCreatePrefill, setPendingCreatePrefill] = useState<CockpitPrefill | null>(null);
+
   const [purchaseOrders, setPurchaseOrders] = useState<PurchaseOrder[]>([]);
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
   const [loading, setLoading] = useState(true);
@@ -370,14 +382,62 @@ const PurchaseOrders: React.FC = () => {
     delivery_location: null as string | null, // Phase 4: Location integration
   });
 
-  // Auto-open form if ?action=create in URL
+  // Auto-open form if ?action=create in URL (e.g., from Cockpit suggested actions)
   useEffect(() => {
-    if (searchParams.get('action') === 'create') {
-      setShowForm(true);
-      searchParams.delete('action');
-      setSearchParams(searchParams);
+    if (searchParams.get('action') !== 'create') return;
+
+    const supplierId =
+      searchParams.get('supplier_id') ??
+      cockpitPrefill?.supplierId ??
+      undefined;
+
+    const cockpitQuery =
+      searchParams.get('cockpit_q') ??
+      cockpitPrefill?.query ??
+      undefined;
+
+    setPendingCreatePrefill({
+      source: 'cockpit',
+      supplierId: supplierId || undefined,
+      query: cockpitQuery || undefined,
+      contextEntity: cockpitPrefill?.contextEntity,
+    });
+
+    setEditingPurchaseOrder(null);
+    setShowForm(true);
+
+    // Clear params so refresh doesn't keep reopening.
+    ['action', 'supplier_id', 'cockpit_q'].forEach((key) => searchParams.delete(key));
+    setSearchParams(searchParams);
+  }, [searchParams, setSearchParams, cockpitPrefill]);
+
+  // Apply prefill once we have loaded suppliers + existing orders (for next suggested order_number)
+  useEffect(() => {
+    if (!pendingCreatePrefill || !showForm) return;
+
+    const supplierId = pendingCreatePrefill.supplierId ?? '';
+    const noteParts: string[] = [];
+
+    if (pendingCreatePrefill.query) {
+      noteParts.push(`Cockpit search: "${pendingCreatePrefill.query}"`);
     }
-  }, [searchParams, setSearchParams]);
+
+    if (pendingCreatePrefill.contextEntity?.label) {
+      noteParts.push(`Context: ${pendingCreatePrefill.contextEntity.label}`);
+    }
+
+    const suggestedNotes = noteParts.join('\n');
+
+    setFormData((prev) => ({
+      ...prev,
+      order_number: prev.order_number || getNextOrderNumber(),
+      supplier: supplierId || prev.supplier,
+      order_date: prev.order_date || new Date().toISOString().split('T')[0],
+      notes: prev.notes || suggestedNotes,
+    }));
+
+    setPendingCreatePrefill(null);
+  }, [pendingCreatePrefill, showForm, suppliers.length, purchaseOrders.length]);
 
   useEffect(() => {
     loadData();

--- a/frontend/src/pages/SalesOrders/SalesOrders.tsx
+++ b/frontend/src/pages/SalesOrders/SalesOrders.tsx
@@ -12,8 +12,8 @@
  * 
  * Pattern: Follows Claims.tsx architecture for consistency
  */
-import React, { useState, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useState, useEffect, useMemo } from 'react';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { ActivityFeed, CreateOrderModal } from '../../components/Shared';
 import { apiClient } from '../../services/apiService';
@@ -418,6 +418,18 @@ const DetailAmount = styled.div`
 
 export const SalesOrdersPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+
+  type CockpitPrefill = {
+    source?: string;
+    query?: string;
+    customerId?: string;
+    contextEntity?: { id?: string; type?: string; label?: string };
+  };
+
+  const cockpitPrefill = (location.state as any)?.prefill as CockpitPrefill | undefined;
+  const [createPrefill, setCreatePrefill] = useState<CockpitPrefill | null>(null);
+
   const [orders, setOrders] = useState<SalesOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -426,14 +438,45 @@ export const SalesOrdersPage: React.FC = () => {
   const [selectedOrder, setSelectedOrder] = useState<SalesOrder | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // Auto-open modal if ?action=create in URL
+  const modalInitialValues = useMemo(() => {
+    if (!createPrefill) return undefined;
+
+    const noteParts: string[] = [];
+    if (createPrefill.query) noteParts.push(`Cockpit search: \"${createPrefill.query}\"`);
+    if (createPrefill.contextEntity?.label) noteParts.push(`Context: ${createPrefill.contextEntity.label}`);
+
+    return {
+      customer: createPrefill.customerId ?? '',
+      notes: noteParts.join('\n'),
+    };
+  }, [createPrefill]);
+
+  // Auto-open modal if ?action=create in URL (e.g., from Cockpit suggested actions)
   useEffect(() => {
-    if (searchParams.get('action') === 'create') {
-      setIsModalOpen(true);
-      searchParams.delete('action');
-      setSearchParams(searchParams);
-    }
-  }, [searchParams, setSearchParams]);
+    if (searchParams.get('action') !== 'create') return;
+
+    const customerId =
+      searchParams.get('customer_id') ??
+      cockpitPrefill?.customerId ??
+      undefined;
+
+    const cockpitQuery =
+      searchParams.get('cockpit_q') ??
+      cockpitPrefill?.query ??
+      undefined;
+
+    setCreatePrefill({
+      source: 'cockpit',
+      customerId: customerId || undefined,
+      query: cockpitQuery || undefined,
+      contextEntity: cockpitPrefill?.contextEntity,
+    });
+
+    setIsModalOpen(true);
+
+    ['action', 'customer_id', 'cockpit_q'].forEach((key) => searchParams.delete(key));
+    setSearchParams(searchParams);
+  }, [searchParams, setSearchParams, cockpitPrefill]);
 
   useEffect(() => {
     fetchOrders();
@@ -497,7 +540,7 @@ export const SalesOrdersPage: React.FC = () => {
       <PageHeader>
         <PageTitle>Sales Orders</PageTitle>
         <HeaderActions>
-          <PrimaryButton onClick={() => setIsModalOpen(true)}>
+          <PrimaryButton onClick={() => { setCreatePrefill(null); setIsModalOpen(true); }}>
             + New Sales Order
           </PrimaryButton>
         </HeaderActions>
@@ -676,6 +719,7 @@ export const SalesOrdersPage: React.FC = () => {
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onSuccess={fetchOrders}
+        initialValues={modalInitialValues}
       />
     </PageContainer>
   );


### PR DESCRIPTION
When Cockpit SmartSearch suggested actions are clicked, open create flow with best-effort prefill:\n\n- Create PO: opens /purchase-orders?action=create with supplier preselected + context notes\n- Create SO: opens modal with customer preselected + context notes\n\nTests: cd frontend && npm run test -- --run