### PR TITLE
AI: show Outlook connection + gate email tools

### DIFF
--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -24,7 +24,7 @@ DEFAULT_OPENAI_TOOLS = [
         'type': 'function',
         'function': {
             'name': 'check_unread_emails',
-            'description': "Check the user's connected Microsoft Outlook inbox for unread emails and attachments.",
+            'description': 'Check the tenant\'s connected Microsoft Outlook inbox for unread emails and attachments.',
             'parameters': {'type': 'object', 'properties': {}},
         },
     }
@@ -62,6 +62,25 @@ class ToolExecutor:
             return json.dumps({'ok': False, 'tool': tool_name, 'error': str(e)}, default=str)
 
     def _check_unread_emails(self, arguments: Dict[str, Any], tenant: Any) -> Any:
+        from apps.integrations.models import ExternalAuthProvider
         from tenant_apps.integrations.services.email_ingestion import EmailIngestionService
+
+        tenant_id = getattr(tenant, 'id', None)
+        if not tenant_id:
+            raise ValueError('Tenant not resolved; cannot access email tools')
+
+        provider = (
+            ExternalAuthProvider.objects.filter(
+                tenant=tenant,
+                provider_type='microsoft',
+                is_active=True,
+            )
+            .select_related('tenant')
+            .first()
+        )
+        if not provider:
+            raise ValueError('Outlook not connected. Connect it in Settings → Email Integrations.')
+        if provider.is_token_expired():
+            raise ValueError('Outlook connection expired. Reconnect in Settings → Email Integrations.')
 
         return EmailIngestionService(tenant).fetch_unread_actionable_emails()

--- a/backend/tenant_apps/ai_assistant/swarm/router.py
+++ b/backend/tenant_apps/ai_assistant/swarm/router.py
@@ -28,12 +28,20 @@ logger = logging.getLogger(__name__)
 
 EventType = Literal["email", "user_chat", "webhook"]
 
-SWARM_SYSTEM_PROMPT = (
-    "You are the ProjectMeats Autonomous Swarm Orchestrator. "
-    "You are an expert in wholesale meat logistics, purchase orders, cold storage, and supplier management. "
-    "You have access to the user's connected email and ERP data via tools. "
-    "Be highly analytical, concise, and proactive."
-)
+def build_swarm_system_prompt(*, outlook_connected: bool, outlook_email: str | None, outlook_expired: bool) -> str:
+    base = (
+        "You are the ProjectMeats Autonomous Swarm Orchestrator. "
+        "You are an expert in wholesale meat logistics, purchase orders, cold storage, and supplier management. "
+        "Be highly analytical, concise, and proactive. "
+    )
+
+    if outlook_connected:
+        return base + f"Outlook: CONNECTED ({outlook_email or 'unknown'}). You may use email tools when relevant."
+
+    if outlook_expired:
+        return base + "Outlook: CONNECTED but EXPIRED. Do not claim you can read email; instruct user to reconnect."
+
+    return base + "Outlook: NOT CONNECTED. Do not claim you can read email; instruct user to connect Outlook."
 
 
 @dataclass(frozen=True)
@@ -118,7 +126,33 @@ class SwarmOrchestrator:
             organization=getattr(settings, 'OPENAI_ORG_ID', None) or None,
         )
 
-        messages: List[Dict[str, Any]] = [{'role': 'system', 'content': SWARM_SYSTEM_PROMPT}]
+        from apps.integrations.models import ExternalAuthProvider
+
+        provider = (
+            ExternalAuthProvider.objects.filter(
+                tenant=tenant,
+                provider_type='microsoft',
+                is_active=True,
+            )
+            .select_related('tenant')
+            .first()
+        )
+        outlook_email = getattr(provider, 'connected_email', None) if provider else None
+        outlook_expired = bool(provider.is_token_expired()) if provider else False
+        outlook_connected = bool(provider and not outlook_expired)
+
+        tools = DEFAULT_OPENAI_TOOLS if outlook_connected else []
+
+        messages: List[Dict[str, Any]] = [
+            {
+                'role': 'system',
+                'content': build_swarm_system_prompt(
+                    outlook_connected=outlook_connected,
+                    outlook_email=outlook_email,
+                    outlook_expired=outlook_expired,
+                ),
+            }
+        ]
         if history:
             messages.extend(history)
         messages.append({'role': 'user', 'content': user_message})
@@ -137,14 +171,17 @@ class SwarmOrchestrator:
             if rounds > max_rounds:
                 break
 
-            completion = client.chat.completions.create(
-                model=model_name,
-                messages=messages,
-                tools=DEFAULT_OPENAI_TOOLS,
-                tool_choice='auto',
-                temperature=temperature,
-                max_tokens=max_tokens,
-            )
+            create_kwargs: Dict[str, Any] = {
+                'model': model_name,
+                'messages': messages,
+                'temperature': temperature,
+                'max_tokens': max_tokens,
+            }
+            if tools:
+                create_kwargs['tools'] = tools
+                create_kwargs['tool_choice'] = 'auto'
+
+            completion = client.chat.completions.create(**create_kwargs)
 
             msg = completion.choices[0].message
             tool_calls = getattr(msg, 'tool_calls', None)

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 SWARM_SYSTEM_PROMPT = (
     "You are the ProjectMeats Autonomous Swarm Orchestrator. "
     "You are an expert in wholesale meat logistics, purchase orders, cold storage, and supplier management. "
-    "You have access to the user's connected email and ERP data via tools. "
+    "Use tools only when they are available for the tenant (e.g., Outlook connection). "
     "Be highly analytical, concise, and proactive."
 )
 
@@ -146,7 +146,14 @@ class ChatBotAPIViewSet(viewsets.ViewSet):
             # Generate AI response (live OpenAI)
             if not getattr(settings, 'OPENAI_API_KEY', None):
                 return Response(
-                    {'error': 'OpenAI not configured (missing OPENAI_API_KEY)'},
+                    {
+                        'error': 'OpenAI not configured (missing OPENAI_API_KEY)',
+                        'detail': (
+                            'Backend container is missing OPENAI_API_KEY. '
+                            'Verify the GitHub Environment secret OPENAI_API_KEY is set for this <env>-backend '
+                            'and that the deploy-backend job writes it into backend.env.'
+                        ),
+                    },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
@@ -173,11 +180,6 @@ class ChatBotAPIViewSet(viewsets.ViewSet):
             except Exception as e:
                 # Per requirements: return 400 with error detail for OpenAI API errors.
                 logger.warning('OpenAI swarm tool loop failed: %s', str(e), exc_info=True)
-                return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-            except Exception as e:
-                # Per requirements: return 400 with error detail for OpenAI API errors.
-                logger.warning('OpenAI chat completion failed: %s', str(e), exc_info=True)
                 return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
             metadata = {
@@ -236,12 +238,45 @@ class SwarmToolsOpenAPIView(APIView):
     Reliability mandate:
     - Always return a safe `tools` list shaped for OpenAI ChatCompletions
     - Avoid fragile runtime introspection that could 500
+
+    UX mandate:
+    - Do not advertise email tools unless the tenant is actually connected.
     """
 
-    permission_classes = [IsAdminUser]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        payload = {'tools': DEFAULT_OPENAI_TOOLS}
+        from apps.integrations.models import ExternalAuthProvider
+
+        outlook = {
+            'connected': False,
+            'expired': False,
+            'connected_email': None,
+            'connected_name': None,
+        }
+
+        try:
+            provider = (
+                ExternalAuthProvider.objects.filter(
+                    tenant=request.tenant,
+                    provider_type='microsoft',
+                    is_active=True,
+                )
+                .select_related('tenant')
+                .first()
+            )
+            if provider:
+                outlook['expired'] = bool(provider.is_token_expired())
+                outlook['connected_email'] = provider.connected_email
+                outlook['connected_name'] = provider.connected_name
+                outlook['connected'] = bool(not outlook['expired'])
+        except Exception:
+            logger.warning('tools/openapi: failed to load outlook connection status', exc_info=True)
+
+        payload = {
+            'tools': DEFAULT_OPENAI_TOOLS if outlook['connected'] else [],
+            'capabilities': {'outlook': outlook},
+        }
 
         try:
             # Keep legacy OpenAPI-ish document for backward compatibility.

--- a/frontend/src/components/AIAssistant/AIAgentWidget.tsx
+++ b/frontend/src/components/AIAssistant/AIAgentWidget.tsx
@@ -20,6 +20,13 @@ type ChatMessage = {
   createdAt: number;
 };
 
+type OutlookStatus = {
+  connected: boolean;
+  expired: boolean;
+  connectedEmail?: string;
+  connectedName?: string;
+};
+
 const calmPulse = keyframes`
   0%, 100% { transform: translateY(0); box-shadow: 0 10px 28px rgb(var(--color-text-primary) / 0.10); }
   50% { transform: translateY(-1px); box-shadow: 0 12px 34px rgb(var(--color-text-primary) / 0.14); }
@@ -147,6 +154,35 @@ const Body = styled.div`
   border-top: 1px solid rgb(var(--color-border));
 `;
 
+const IntegrationBanner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-surface));
+  font-size: 12px;
+  color: rgb(var(--color-text-secondary));
+`;
+
+const IntegrationDot = styled.span<{ $connected: boolean }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: ${(p) => (p.$connected ? 'rgb(34, 197, 94)' : 'rgb(239, 68, 68)')};
+`;
+
+const IntegrationLink = styled.a`
+  margin-left: auto;
+  color: rgb(var(--color-primary));
+  font-weight: 800;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 const Messages = styled.div`
   flex: 1;
   overflow: auto;
@@ -226,6 +262,7 @@ export const AIAgentWidget: React.FC = () => {
   const [detail, setDetail] = useState<ReviewRequiredDetail>({});
   const [draft, setDraft] = useState('');
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [outlookStatus, setOutlookStatus] = useState<OutlookStatus | null>(null);
 
   const defaultActionMessage = useMemo(
     () => 'I just processed a Purchase Order from Sysco, but the delivery date is unclear. Can you verify?',
@@ -300,6 +337,31 @@ export const AIAgentWidget: React.FC = () => {
 
   useEffect(() => {
     if (!expanded) return;
+
+    const loadOutlookStatus = async () => {
+      try {
+        const res = await businessApi.get<{ connections?: any[] }>('/integrations/oauth/status/');
+        const connections = Array.isArray(res.data?.connections) ? res.data.connections : [];
+        const outlook = connections.find((c) => c?.provider === 'microsoft');
+        if (!outlook) {
+          setOutlookStatus({ connected: false, expired: false });
+          return;
+        }
+
+        setOutlookStatus({
+          connected: !outlook.is_expired,
+          expired: Boolean(outlook.is_expired),
+          connectedEmail: outlook.connected_email,
+          connectedName: outlook.connected_name,
+        });
+      } catch {
+        // Don’t block chat UX on integration status.
+        setOutlookStatus(null);
+      }
+    };
+
+    void loadOutlookStatus();
+
     if (pendingReviewPollingDisabledRef.current) return;
 
     let isCancelled = false;
@@ -381,14 +443,22 @@ export const AIAgentWidget: React.FC = () => {
   const handleListTools = async () => {
     setState('thinking');
     try {
-      const res = await businessApi.get<{ paths?: Record<string, any> }>('/ai-assistant/tools/openapi/');
-      const paths = res.data?.paths ?? {};
-      const toolNames = Object.keys(paths)
-        .map((p) => paths[p]?.post?.operationId as string | undefined)
-        .filter((x): x is string => !!x)
-        .sort();
+      const res = await businessApi.get<any>('/ai-assistant/tools/openapi/');
 
-      const preview = toolNames.length ? toolNames.slice(0, 25).join(', ') : 'No tools registered.';
+      const tools = Array.isArray(res.data?.tools) ? res.data.tools : [];
+      const toolNamesFromTools = tools
+        .map((t: any) => t?.function?.name as string | undefined)
+        .filter((x: any): x is string => typeof x === 'string' && x.length > 0);
+
+      const openapi = res.data?.openapi ?? res.data;
+      const paths = openapi?.paths ?? {};
+      const toolNamesFromOpenApi = Object.keys(paths)
+        .map((p) => paths[p]?.post?.operationId as string | undefined)
+        .filter((x): x is string => !!x);
+
+      const toolNames = Array.from(new Set([...toolNamesFromTools, ...toolNamesFromOpenApi])).sort();
+
+      const preview = toolNames.length ? toolNames.slice(0, 25).join(', ') : 'No tools available.';
       const suffix = toolNames.length > 25 ? ` (+${toolNames.length - 25} more)` : '';
 
       setMessages((m) => [
@@ -402,7 +472,7 @@ export const AIAgentWidget: React.FC = () => {
         {
           id: newId(),
           role: 'assistant',
-          content: 'Tools list is unavailable (requires staff permissions).',
+          content: 'Tools list is unavailable right now. Please try again.',
           createdAt: Date.now(),
         },
       ]);
@@ -662,13 +732,19 @@ export const AIAgentWidget: React.FC = () => {
 
       setMessages((m) => [...m, { id: newId(), role: 'assistant', content: responseText, createdAt: Date.now() }]);
       setState('idle');
-    } catch (err) {
+    } catch (err: any) {
+      const serverError = err?.response?.data?.error || err?.response?.data?.detail;
+      const message =
+        typeof serverError === 'string' && serverError.length
+          ? serverError
+          : 'Sorry — I couldn\'t reach the AI service. Please try again.';
+
       setMessages((m) => [
         ...m,
         {
           id: newId(),
           role: 'assistant',
-          content: 'Sorry — I couldn\'t reach the AI service. Please try again.',
+          content: message,
           createdAt: Date.now(),
         },
       ]);
@@ -700,6 +776,23 @@ export const AIAgentWidget: React.FC = () => {
 
         {expanded ? (
           <Body>
+            <IntegrationBanner>
+              <IntegrationDot $connected={Boolean(outlookStatus?.connected)} />
+              <span>
+                Outlook:{' '}
+                {outlookStatus
+                  ? outlookStatus.connected
+                    ? `Connected${outlookStatus.connectedEmail ? ` (${outlookStatus.connectedEmail})` : ''}`
+                    : outlookStatus.expired
+                      ? 'Connected (Expired)'
+                      : 'Not connected'}
+                  : 'Status unavailable'}
+              </span>
+              <IntegrationLink href="/settings/email-integrations">
+                {outlookStatus?.connected ? 'Manage' : 'Connect'}
+              </IntegrationLink>
+            </IntegrationBanner>
+
             <Messages>
               {messages.map((m) => (
                 <Bubble key={m.id} $role={m.role}>


### PR DESCRIPTION
Fixes AI widget + Swarm tool truthfulness:\n\n- AI widget shows Outlook connection status (Connected / Expired / Not connected) with a quick link to Settings → Email Integrations\n- Tools registry only advertises email tools when Outlook is actually connected\n- ToolExecutor blocks email tool execution when not connected/expired (clear error)\n- Tools list parsing fixed (handles {tools, openapi}) and chat now surfaces server error details\n\nTests:\n- python -m compileall backend/tenant_apps/ai_assistant backend/tenant_apps/integrations backend/apps/integrations\n- cd frontend && npm run test -- --run src/components/FlowEditor/__tests__/nodeNormalization.test.tsx