### PR TITLE
Fix tenant logo upload (multipart)

### DIFF
--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -77,6 +77,18 @@ const adminClient = axios.create({
 apiClient.interceptors.request.use(
   async (config) => {
     try {
+      // IMPORTANT: When uploading files, ensure we do NOT force application/json.
+      // Axios will set the correct multipart boundary automatically.
+      if (typeof FormData !== 'undefined' && config.data instanceof FormData) {
+        // Support both AxiosHeaders and plain object.
+        try {
+          delete (config.headers as any)['Content-Type'];
+          delete (config.headers as any)['content-type'];
+        } catch {
+          // ignore
+        }
+      }
+
       // Check if token needs refresh before making request
       if (isUsingJwt() && needsRefresh() && !isRefreshing) {
         console.debug('[API] Token needs refresh, refreshing before request...');
@@ -117,6 +129,17 @@ apiClient.interceptors.request.use(
 adminClient.interceptors.request.use(
   async (config) => {
     try {
+      // IMPORTANT: When uploading files, ensure we do NOT force application/json.
+      // Axios will set the correct multipart boundary automatically.
+      if (typeof FormData !== 'undefined' && config.data instanceof FormData) {
+        try {
+          delete (config.headers as any)['Content-Type'];
+          delete (config.headers as any)['content-type'];
+        } catch {
+          // ignore
+        }
+      }
+
       // Check if token needs refresh before making request
       if (isUsingJwt() && needsRefresh() && !isRefreshing) {
         console.debug('[Admin API] Token needs refresh, refreshing before request...');


### PR DESCRIPTION
Fixes: Logo validation failed: 'The submitted data was not a file'\n\nRoot cause: apiClient globally forced Content-Type: application/json, which breaks FormData uploads (Django receives non-file).\n\nChanges:\n- In apiClient/adminClient request interceptors, delete Content-Type when config.data is FormData so Axios sets proper multipart boundary.\n\nTest:\n- cd frontend && npm run test -- --run