### PR TITLE
Fix Configure Node Apply/Save

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
@@ -75,7 +75,7 @@ const DirtyIndicatorBanner = styled.div<{ $show: boolean }>`
 `;
 
 const ActionBar = styled.div<{ $show: boolean }>`
-  display: ${props => props.$show ? 'flex' : 'none'};
+  display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 12px;
@@ -83,6 +83,9 @@ const ActionBar = styled.div<{ $show: boolean }>`
   border-top: 1px solid rgb(var(--color-border));
   background: rgb(var(--color-surface));
   box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
+  position: sticky;
+  bottom: 0;
+  z-index: 10;
 `;
 
 const ConfirmationModal = styled.div<{ $show: boolean }>`
@@ -334,11 +337,11 @@ export const NodeConfigPanelWithShadow: React.FC<NodeConfigPanelWithShadowProps>
       </PanelContent>
 
       {/* Action Bar (Apply/Discard) */}
-      <ActionBar $show={isDirty}>
-        <SecondaryButton onClick={handleDiscard}>
+      <ActionBar $show={true}>
+        <SecondaryButton onClick={handleDiscard} disabled={!isDirty}>
           Discard Changes
         </SecondaryButton>
-        <PrimaryButton onClick={handleApply}>
+        <PrimaryButton onClick={handleApply} disabled={!isDirty}>
           Apply Changes
         </PrimaryButton>
       </ActionBar>

--- a/frontend/src/components/FlowEditor/ConfigPanel/StepManagerPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/StepManagerPanel.tsx
@@ -296,7 +296,11 @@ export const StepManagerPanel: React.FC<StepManagerPanelProps> = ({
       label: node.data?.label || node.data?.name || `${node.type || 'Node'} ${node.id.slice(0, 8)}`,
       stepNumber,
       hasErrors: false, // TODO: Add validation logic
-      isConfigured: !!(node.data?.entityType || node.data?.selectedFields?.length > 0),
+      isConfigured: Boolean(
+        node.data?.entityType ||
+          (Array.isArray(node.data?.fields) && node.data.fields.length > 0) ||
+          (Array.isArray(node.data?.selectedFields) && node.data.selectedFields.length > 0)
+      ),
     };
   }).sort((a, b) => {
     // Sort by step number (nulls at end)

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
@@ -72,7 +72,7 @@ const DirtyIndicatorBanner = styled.div<{ $show: boolean }>`
 `;
 
 const ActionBar = styled.div<{ $show: boolean }>`
-  display: ${props => props.$show ? 'flex' : 'none'};
+  display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 12px;
@@ -80,6 +80,9 @@ const ActionBar = styled.div<{ $show: boolean }>`
   border-top: 1px solid rgb(var(--color-border));
   background: rgb(var(--color-surface));
   box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
+  position: sticky;
+  bottom: 0;
+  z-index: 10;
 `;
 
 const ConfirmationModal = styled.div<{ $show: boolean }>`
@@ -233,11 +236,11 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
         </PanelContent>
 
         {/* Action Bar (Apply/Discard) */}
-        <ActionBar $show={isDirty}>
-          <SecondaryButton onClick={handleDiscard}>
+        <ActionBar $show={true}>
+          <SecondaryButton onClick={handleDiscard} disabled={!isDirty}>
             Discard Changes
           </SecondaryButton>
-          <PrimaryButton onClick={handleApply}>
+          <PrimaryButton onClick={handleApply} disabled={!isDirty}>
             Apply Changes
           </PrimaryButton>
         </ActionBar>


### PR DESCRIPTION
Fixes Configure Node panel save UX:

- Always show a sticky Apply/Discard bar (disabled until dirty) so field edits can always be committed.
- StepManagerPanel now treats both node.data.fields and node.data.selectedFields as configured (prevents false "not saved" state).

Test:
- Open WorkForms editor → select a formStep → add fields via entity-field-picker → Apply Changes.
- Verify step shows Configured in container step list.
