### PR TITLE
Vanguard 1: viewport virtualization

### DIFF
--- a/docs/workforms/WORKFLOW_EDITOR_ENHANCEMENT_ROADMAP.md
+++ b/docs/workforms/WORKFLOW_EDITOR_ENHANCEMENT_ROADMAP.md
@@ -23,6 +23,20 @@ To reach an **Enterprise-Grade, AI-Assisted Multiplayer Engine**, remaining work
 - 150+ node workflows remain responsive while panning/zooming.
 - Error handling contract is defined and usable by the runtime.
 
+**Draft: Error Edge + Retry JSON contract**
+```json
+{
+  "type": "error",
+  "label": "On Error",
+  "errorType": "timeout",
+  "retry": {
+    "maxAttempts": 3,
+    "backoffMs": 2000,
+    "strategy": "exponential"
+  }
+}
+```
+
 ### 🧩 Vanguard 2: Advanced Orchestration (Power & Reusability)
 **Goal**: upgrade from linear flow builder → reusable, composable programming interface.
 

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -41,6 +41,7 @@ import { logger } from '../../utils/logger'; // Centralized logging
 import { isTypingInInput } from './utils/keyboardUtils'; // Phase 4
 import Joyride from 'react-joyride'; // Gap Analysis Phase 1.1
 import { useRenderPerformance } from '../../utils/performance'; // Phase 7.5
+import { useVirtualizedNodes } from './hooks/useVirtualizedNodes';
 import { 
   useOnboardingTour, 
   workflowEditorTourSteps, 
@@ -63,6 +64,7 @@ import {
   OnSelectionChangeParams,
   useReactFlow,
   MarkerType,
+  type Viewport,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import './UnifiedFlowEditor.responsive.css'; // Gap Analysis Phase 1.2
@@ -1990,6 +1992,16 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   
   // React Flow instance for viewport controls
   const { setCenter: reactFlowSetCenter, ...reactFlowInstance } = useReactFlow();
+
+  // Phase 7.5/Vanguard 1: track viewport for optional strict node/edge list virtualization
+  const [viewport, setViewport] = useState<Viewport>({ x: 0, y: 0, zoom: 1 });
+  const didInitViewportRef = useRef(false);
+  useEffect(() => {
+    if (didInitViewportRef.current) return;
+    if (!reactFlowInstance?.getViewport) return;
+    didInitViewportRef.current = true;
+    setViewport(reactFlowInstance.getViewport());
+  }, [reactFlowInstance]);
   
   // ============================================================================
   // CONFIG PANEL PORTAL - Enhanced with full styling (2026-02-24)
@@ -6372,6 +6384,38 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     });
   }, [addFormStepInsideContainer, handleNodeDelete, handleNodeEdit, handleNodeTitleChange, handleSaveWorkflow, lastNodeIdSet, nodes]);
 
+  // Vanguard 1: Optional strict render-list virtualization for very large workflows.
+  // React Flow already does viewport culling (onlyRenderVisibleElements); this additionally reduces
+  // the nodes/edges arrays passed into React Flow to shrink reconciliation work.
+  const virtualizedNodes = useVirtualizedNodes(nodesWithHandlers, viewport, {
+    threshold: 180,
+    bufferPx: 320,
+    debounceMs: 50,
+    enabled: true,
+  });
+
+  const renderedNodesForCanvas = useMemo(() => {
+    if (!virtualizedNodes.isVirtualized) return nodesWithHandlers;
+
+    const byId = new Map(nodesWithHandlers.map((n) => [n.id, n] as const));
+    const renderIdSet = new Set(virtualizedNodes.visibleNodes.map((n) => n.id));
+
+    const includeNodeAndAncestors = (nodeId: string) => {
+      let cur: string | undefined = nodeId;
+      while (cur) {
+        if (renderIdSet.has(cur)) break;
+        renderIdSet.add(cur);
+        const node = byId.get(cur);
+        cur = node?.parentId;
+      }
+    };
+
+    if (selectedNodeId) includeNodeAndAncestors(selectedNodeId);
+
+    // Preserve ordering + include parents before children (React Flow stability)
+    return nodesWithHandlers.filter((n) => renderIdSet.has(n.id));
+  }, [nodesWithHandlers, selectedNodeId, virtualizedNodes.isVirtualized, virtualizedNodes.visibleNodes]);
+
   // Render-time edge virtualization: when a form process group is collapsed, edges to hidden child nodes
   // are re-targeted to virtual handles on the container boundary so connectivity remains visible.
   const edgesForCanvas = useMemo(() => {
@@ -6434,6 +6478,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
     return derived;
   }, [edges, nodesWithHandlers]);
+
+  const renderedEdgesForCanvas = useMemo(() => {
+    if (!virtualizedNodes.isVirtualized) return edgesForCanvas;
+
+    const renderedIdSet = new Set(renderedNodesForCanvas.map((n) => n.id));
+    return edgesForCanvas.filter((e) => renderedIdSet.has(e.source) && renderedIdSet.has(e.target));
+  }, [edgesForCanvas, renderedNodesForCanvas, virtualizedNodes.isVirtualized]);
 
   return (
     <FormBuilderProvider onNodeDataUpdate={handleNodeDataUpdate}>
@@ -6897,11 +6948,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       {/* React Flow Canvas - Visual Mode */}
       {normalizedEditorMode === 'visual' && (
         <DebugAwareReactFlow
-        nodes={nodesWithHandlers}
-        edges={edgesForCanvas}
+        nodes={renderedNodesForCanvas}
+        edges={renderedEdgesForCanvas}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
+        onMoveEnd={(_, vp) => setViewport(vp)}
         onNodesDelete={onNodesDelete}
         nodesDraggable={true}
         nodeDragHandle=".custom-drag-handle"

--- a/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
@@ -11,13 +11,13 @@ import React from 'react';
 import { EdgeProps, getBezierPath, EdgeLabelRenderer, MarkerType } from '@xyflow/react';
 import styled from 'styled-components';
 
+import type { ErrorEdgeContract } from '../types/errorHandling';
+
 // ============================================================================
 // Types
 // ============================================================================
 
-interface ErrorEdgeData {
-  label?: string;
-  errorType?: string;
+interface ErrorEdgeData extends ErrorEdgeContract {
   animated?: boolean;
   errorCount?: number;
 }

--- a/frontend/src/components/FlowEditor/types/errorHandling.ts
+++ b/frontend/src/components/FlowEditor/types/errorHandling.ts
@@ -1,0 +1,19 @@
+export type RetryBackoffStrategy = 'fixed' | 'exponential';
+
+export interface RetryPolicy {
+  /** Total attempts including the initial try. */
+  maxAttempts: number;
+  /** Base delay before retry in milliseconds. */
+  backoffMs: number;
+  /** Backoff strategy; default is fixed. */
+  strategy?: RetryBackoffStrategy;
+}
+
+export interface ErrorEdgeContract {
+  /** Human label shown on the edge. */
+  label?: string;
+  /** Optional classifier for grouping errors (e.g. "http_5xx", "timeout"). */
+  errorType?: string;
+  /** Optional retry policy before routing to the error path. */
+  retry?: RetryPolicy;
+}


### PR DESCRIPTION
Vanguard 1: strict viewport virtualization + error edge/retry contract draft.

Changes:
- UnifiedFlowEditor: track viewport and reduce nodes/edges arrays passed to React Flow using useVirtualizedNodes (in addition to onlyRenderVisibleElements).
- ErrorEdge: import contract type cleanly.
- New types: FlowEditor/types/errorHandling.ts (ErrorEdgeContract + RetryPolicy).
- Roadmap: add draft JSON contract snippet for error edges/retry.

Notes:
- Selected node + ancestors are always included to avoid selection instability.

Test:
- Open a large workflow, pan/zoom; verify editor remains responsive and selection works.
