### PR TITLE
Vanguard 1: Panel migration batch 2 (variable picker + form builder)

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx
@@ -348,7 +348,8 @@ export const VariablePickerWithUpstream: React.FC<VariablePickerWithUpstreamProp
     if (!isOpen) return;
     
     const handleClickOutside = (e: MouseEvent) => {
-      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+      const target = e.target;
+      if (pickerRef.current && target instanceof globalThis.Node && !pickerRef.current.contains(target)) {
         onClose();
       }
     };

--- a/frontend/src/components/FlowEditor/ConfigPanel/VisualFormBuilderPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VisualFormBuilderPanel.tsx
@@ -207,7 +207,7 @@ const RequiredBadge = styled.span`
   font-weight: 600;
 `;
 
-const FieldType = styled.span`
+const FieldTypePill = styled.span`
   font-size: 12px;
   color: rgb(var(--color-text-secondary));
 `;
@@ -403,7 +403,7 @@ const SortableFieldItem: React.FC<SortableFieldItemProps> = ({ field, onEdit, on
             {field.label || 'Untitled Field'}
             {field.required && <RequiredBadge>REQUIRED</RequiredBadge>}
           </FieldLabel>
-          <FieldType>{fieldTypeInfo?.label || field.type}</FieldType>
+          <FieldTypePill>{fieldTypeInfo?.label || field.type}</FieldTypePill>
         </FieldInfo>
         
         <FieldActions>

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/complexRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/complexRenderers.tsx
@@ -14,7 +14,7 @@ import styled from 'styled-components';
 import { ConfigField, FieldRenderProps } from '../types';
 import EntityFieldPicker, { SelectedField } from '../../ConfigPanel/EntityFieldPicker';
 import FieldMappingPanel from '../../ConfigPanel/FieldMappingPanel';
-import VariablePickerWithUpstream from '../../ConfigPanel/VariablePickerWithUpstream';
+import { VariablePicker, Variable as PickerVariable } from '../../components/VariablePicker';
 import ValidationRuleBuilder from '../../ConfigPanel/ValidationRuleBuilder';
 
 // ============================================================================
@@ -165,24 +165,41 @@ export function renderFieldMapping(props: FieldRenderProps): React.ReactElement 
 // ============================================================================
 
 /**
- * Renders the VariablePickerWithUpstream for selecting variables from upstream nodes
- * Used for expression fields, conditional logic, and anywhere variables are needed
+ * Renders a VariablePicker that can select from upstream variables.
+ * This renderer uses precomputed upstream variables injected by DynamicConfigPanel.
  */
 export function renderVariablePicker(props: FieldRenderProps): React.ReactElement {
   const { field, value, onChange, error, data } = props;
-  
+
   const selectedVariable = value as string | undefined;
-  
-  const handleVariableSelect = (variablePath: string) => {
-    onChange(variablePath);
+  const upstreamVariables = (data?._upstreamVariables as any[]) || [];
+
+  const variables: PickerVariable[] = upstreamVariables.map((v: any) => ({
+    id: `${String(v.nodeId)}.${String(v.fieldName)}`,
+    name: String(v.fieldName),
+    displayName: String(v.fieldLabel || v.fieldName),
+    type: String(v.fieldType || 'string'),
+    nodeId: String(v.nodeId),
+    nodeName: String(v.nodeName || v.nodeId),
+    nodeType: String(v.nodeType || 'unknown'),
+    path: String(v.template || `{{${String(v.nodeId)}.${String(v.fieldName)}}}`),
+    description: v.required ? 'Required' : undefined,
+  }));
+
+  const selectedVariables: PickerVariable[] = selectedVariable
+    ? variables.filter((v) => v.path === selectedVariable)
+    : [];
+
+  const handleVariableSelect = (variable: PickerVariable) => {
+    onChange(variable.path);
   };
-  
+
   return (
     <FieldContainer>
-      <VariablePickerWithUpstream
-        selectedVariable={selectedVariable}
+      <VariablePicker
+        variables={variables}
         onSelect={handleVariableSelect}
-        upstreamVariables={data?._upstreamVariables || []}
+        selectedVariables={selectedVariables}
         placeholder={field.placeholder || 'Select a variable...'}
       />
       {error && <ErrorMessage>{error}</ErrorMessage>}


### PR DESCRIPTION
Cleans up remaining config-panel migration blockers around variable selection + the visual form builder.\n\nChanges:\n- VariablePickerWithUpstream: fix click-outside handler to use DOM Node type guard (no @xyflow/react Node confusion)\n- VisualFormBuilderPanel: rename local FieldType styled component to FieldTypePill to avoid collision with imported FieldType type\n- DynamicConfigPanel complex renderer: renderVariablePicker now uses shared FlowEditor/components/VariablePicker fed by precomputed _upstreamVariables, eliminating mismatched props to VariablePickerWithUpstream\n\nVerification:\n- frontend: npx vitest run --silent\n