### PR TITLE
Hotfix: reduce false OpenAI missing-key errors

### DIFF
--- a/backend/apps/core/utils/health.py
+++ b/backend/apps/core/utils/health.py
@@ -65,9 +65,11 @@ def check_openai() -> dict:
             'note': str
         }
     """
-    api_key = getattr(settings, 'OPENAI_API_KEY', None)
-    model = getattr(settings, 'OPENAI_MODEL', 'not-configured')
-    
+    import os
+
+    api_key = getattr(settings, 'OPENAI_API_KEY', None) or os.environ.get('OPENAI_API_KEY')
+    model = getattr(settings, 'OPENAI_MODEL', None) or os.environ.get('OPENAI_MODEL') or 'not-configured'
+
     return {
         'configured': api_key is not None,
         'api_key_set': bool(api_key),

--- a/backend/tenant_apps/ai_assistant/swarm/router.py
+++ b/backend/tenant_apps/ai_assistant/swarm/router.py
@@ -113,7 +113,10 @@ class SwarmOrchestrator:
         Returns:
             {"response": <final text>, "messages": <final history>}
         """
-        if not getattr(settings, 'OPENAI_API_KEY', None):
+        import os
+
+        openai_api_key = getattr(settings, 'OPENAI_API_KEY', None) or os.environ.get('OPENAI_API_KEY')
+        if not openai_api_key:
             raise ValueError('OpenAI not configured (missing OPENAI_API_KEY)')
 
         try:
@@ -122,8 +125,8 @@ class SwarmOrchestrator:
             raise RuntimeError('OpenAI client not available on server') from e
 
         client = OpenAI(
-            api_key=settings.OPENAI_API_KEY,
-            organization=getattr(settings, 'OPENAI_ORG_ID', None) or None,
+            api_key=openai_api_key,
+            organization=(getattr(settings, 'OPENAI_ORG_ID', None) or os.environ.get('OPENAI_ORG_ID') or None),
         )
 
         from apps.integrations.models import ExternalAuthProvider

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -144,14 +144,19 @@ class ChatBotAPIViewSet(viewsets.ViewSet):
             )
 
             # Generate AI response (live OpenAI)
-            if not getattr(settings, 'OPENAI_API_KEY', None):
+            # Use both Django settings and environment variables to avoid false negatives
+            # if env is loaded after settings import in some deployment setups.
+            import os
+
+            openai_api_key = getattr(settings, 'OPENAI_API_KEY', None) or os.environ.get('OPENAI_API_KEY')
+            if not openai_api_key:
                 return Response(
                     {
                         'error': 'OpenAI not configured (missing OPENAI_API_KEY)',
                         'detail': (
                             'Backend container is missing OPENAI_API_KEY. '
-                            'Verify the GitHub Environment secret OPENAI_API_KEY is set for this <env>-backend '
-                            'and that the deploy-backend job writes it into backend.env.'
+                            'Verify the GitHub Environment secret OPENAI_API_KEY is set for the active backend environment '
+                            'and that the deploy-backend job writes it into backend.env / passes it to docker run.'
                         ),
                     },
                     status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
Reduces false negatives where backend returns 'OpenAI not configured (missing OPENAI_API_KEY)' despite environment secrets being present, by falling back to process environment variables for OPENAI_* values.

Changes:
- AI chat endpoint: check settings.OPENAI_API_KEY OR environment variable
- Swarm router tool loop: same fallback + ORG id fallback
- Core health check: same fallback

Verification:
- python -m compileall backend
