### PR TITLE
Vanguard 1: Panel migration batch 3

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DocumentConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DocumentConfigPanel.tsx
@@ -300,40 +300,7 @@ const Divider = styled.div`
   margin: 24px 0;
 `;
 
-
-
-const Button = styled.button<{ variant?: 'primary' | 'secondary' }>`
-  padding: 10px 20px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
-  border: none;
-
-  ${props => props.variant === 'primary' ? `
-    background: rgb(var(--color-primary));
-    color: white;
-
-    &:hover:not(:disabled) {
-      opacity: 0.9;
-      transform: translateY(-1px);
-    }
-
-    &:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-  ` : `
-    background: rgb(var(--color-surface));
-    color: rgb(var(--color-text-primary));
-    border: 1px solid rgb(var(--color-border));
-
-    &:hover {
-      background: rgb(var(--color-surface-hover));
-    }
-  `}
-`;
+// NOTE: Buttons are provided by shared StyledComponents.
 
 const WarningBox = styled.div`
   display: flex;
@@ -368,10 +335,21 @@ export const DocumentConfigPanel: React.FC<DocumentConfigPanelProps> = ({
 }) => {
   const { availableFields: ctxAvailableFields } = useFlowEditor();
 
+  const normalizeLogic = (logic: unknown): ConditionLogic => {
+    const value = typeof logic === 'string' ? logic.toLowerCase() : '';
+    return value === 'or' ? 'or' : 'and';
+  };
+
   const availableFields = (availableFieldsProp?.length
     ? availableFieldsProp
     : ctxAvailableFields.map((f) => ({ id: f.key, label: f.label, type: f.type }))
   );
+
+  const conditionAvailableFields = availableFields?.map((f) => ({
+    key: f.id,
+    label: f.label,
+    type: f.type,
+  }));
 
   const [formData, setFormData] = useState<DocumentData>({
     label: document.label || '',
@@ -383,11 +361,16 @@ export const DocumentConfigPanel: React.FC<DocumentConfigPanelProps> = ({
     uploadFolder: document.uploadFolder || 'uploads',
     enableOCR: document.enableOCR ?? false,
     required: document.required ?? true,
-    conditionalVisibility: document.conditionalVisibility || {
-      enabled: false,
-      conditions: [],
-      logic: 'AND' as ConditionLogic,
-    },
+    conditionalVisibility: document.conditionalVisibility
+      ? {
+          ...document.conditionalVisibility,
+          logic: normalizeLogic(document.conditionalVisibility.logic),
+        }
+      : {
+          enabled: false,
+          conditions: [],
+          logic: 'and',
+        },
   });
 
   const [visibilityMode, setVisibilityMode] = useState<'always' | 'conditional'>(
@@ -668,12 +651,8 @@ export const DocumentConfigPanel: React.FC<DocumentConfigPanelProps> = ({
             <div style={{ marginTop: '16px' }}>
               <ConditionBuilder
                 conditions={formData.conditionalVisibility!.conditions || []}
-                logic={formData.conditionalVisibility!.logic || 'and'}
-                availableFields={availableFields?.map((f) => ({
-                  key: f.id,
-                  label: f.label,
-                  type: f.type,
-                }))}
+                logic={normalizeLogic(formData.conditionalVisibility!.logic)}
+                availableFields={conditionAvailableFields}
                 onChange={handleConditionsChange}
               />
             </div>

--- a/frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPickerDiagnostic.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPickerDiagnostic.tsx
@@ -10,6 +10,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useEntityList, useEntityFields } from '../../../services/schemaService';
+import { Select, PrimaryButton, SecondaryButton } from './shared/StyledComponents';
 
 const DiagnosticContainer = styled.div`
   padding: 20px;
@@ -56,27 +57,6 @@ const LogLine = styled.div<{ $type?: 'info' | 'success' | 'error' | 'warning' }>
   border-radius: 4px;
 `;
 
-const Select = styled.select`
-  width: 100%;
-  padding: 8px;
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 4px;
-  margin: 10px 0;
-`;
-
-const Button = styled.button`
-  padding: 8px 16px;
-  background: rgb(var(--color-primary));
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  margin-right: 10px;
-
-  &:hover {
-    background: rgba(var(--color-primary), 0.8);
-  }
-`;
 
 export const EntityFieldPickerDiagnostic: React.FC = () => {
   const [selectedEntity, setSelectedEntity] = useState<string>('');
@@ -212,10 +192,12 @@ export const EntityFieldPickerDiagnostic: React.FC = () => {
         </Select>
 
         <div>
-          <Button onClick={clearLogs}>Clear Logs</Button>
-          <Button onClick={testDirectFetch} disabled={!selectedEntity}>
+          <SecondaryButton type="button" onClick={clearLogs}>
+            Clear Logs
+          </SecondaryButton>
+          <PrimaryButton type="button" onClick={testDirectFetch} disabled={!selectedEntity}>
             Test Direct API Fetch
-          </Button>
+          </PrimaryButton>
         </div>
       </Section>
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormReferenceConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormReferenceConfigPanel.tsx
@@ -16,9 +16,14 @@ import {
   PanelTitle,
   CloseButton,
   PanelContent,
+  PanelFooter,
   FormField,
   Label,
+  HelpText,
+  Checkbox,
+  Button,
   PrimaryButton,
+  SecondaryButton,
   EmptyState as SharedEmptyState,
   EmptyIcon as SharedEmptyIcon,
   EmptyText as SharedEmptyText,
@@ -125,55 +130,6 @@ const ActionButtons = styled.div`
   margin-top: 12px;
 `;
 
-const ActionButton = styled.button`
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  font-size: 13px;
-  font-weight: 500;
-  color: rgb(var(--color-text-secondary));
-  background: transparent;
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.2s;
-  
-  &:hover {
-    background: rgba(var(--color-primary), 0.05);
-    border-color: rgb(var(--color-primary));
-    color: rgb(var(--color-primary));
-  }
-`;
-
-
-
-
-
-
-
-const SelectButton = styled.button`
-  padding: 8px 16px;
-  background: rgb(var(--color-primary));
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
-  
-  &:hover {
-    opacity: 0.9;
-  }
-`;
-
-const Checkbox = styled.input`
-  width: 18px;
-  height: 18px;
-  cursor: pointer;
-`;
-
 const CheckboxLabel = styled.label`
   display: flex;
   align-items: center;
@@ -181,41 +137,6 @@ const CheckboxLabel = styled.label`
   font-size: 14px;
   color: rgb(var(--color-text-primary));
   cursor: pointer;
-`;
-
-const HelpText = styled.p`
-  margin: 8px 0 0 0;
-  font-size: 12px;
-  color: rgb(var(--color-text-secondary));
-  line-height: 1.4;
-`;
-
-const Footer = styled.div`
-  display: flex;
-  justify-content: space-between;
-  padding: 16px 24px;
-  border-top: 1px solid rgb(var(--color-border));
-`;
-
-const Button = styled.button<{ $variant?: 'primary' }>`
-  padding: 10px 20px;
-  border: none;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
-  
-  ${props => props.$variant === 'primary' ? `
-    background: rgb(var(--color-primary));
-    color: white;
-    &:hover { opacity: 0.9; }
-  ` : `
-    background: transparent;
-    color: rgb(var(--color-text-secondary));
-    border: 1px solid rgb(var(--color-border));
-    &:hover { background: rgb(var(--color-background)); }
-  `}
 `;
 
 // ============================================================================
@@ -307,19 +228,19 @@ export const FormReferenceConfigPanel: React.FC<FormReferenceConfigPanelProps> =
                     {localData.sectionCount} sections • {localData.fieldCount} fields
                   </div>
                   <ActionButtons>
-                    <ActionButton onClick={() => setShowFormSelector(true)}>
+                    <Button $variant="secondary" $size="sm" type="button" onClick={() => setShowFormSelector(true)}>
                       <ExternalLink size={14} />
                       Change Form
-                    </ActionButton>
+                    </Button>
                   </ActionButtons>
                 </FormCard>
               ) : (
                 <SharedEmptyState>
                   <SharedEmptyIcon>📋</SharedEmptyIcon>
                   <SharedEmptyText>No form selected</SharedEmptyText>
-                  <SelectButton onClick={() => setShowFormSelector(true)}>
+                  <PrimaryButton type="button" onClick={() => setShowFormSelector(true)}>
                     Select a Form
-                  </SelectButton>
+                  </PrimaryButton>
                 </SharedEmptyState>
               )}
             </FormField>
@@ -341,12 +262,14 @@ export const FormReferenceConfigPanel: React.FC<FormReferenceConfigPanelProps> =
             )}
           </PanelContent>
           
-          <Footer>
-            <Button onClick={onClose}>Cancel</Button>
-            <Button $variant="primary" onClick={handleSave}>
+          <PanelFooter>
+            <SecondaryButton type="button" onClick={onClose}>
+              Cancel
+            </SecondaryButton>
+            <PrimaryButton type="button" onClick={handleSave}>
               Save Configuration
-            </Button>
-          </Footer>
+            </PrimaryButton>
+          </PanelFooter>
         </Panel>
       </PanelOverlay>
       

--- a/frontend/src/components/FlowEditor/ConfigPanel/SubFlowLibraryDialog.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/SubFlowLibraryDialog.tsx
@@ -11,6 +11,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import { Search, X, Download, Upload, Trash2, Copy, FileText, Tag } from 'lucide-react';
+import { PanelFooter, PrimaryButton, SecondaryButton } from './shared/StyledComponents';
 import {
   getAllTemplates,
   searchTemplates,
@@ -263,37 +264,6 @@ const EmptyStateHint = styled.div`
   opacity: 0.7;
 `;
 
-const Footer = styled.div`
-  padding: 16px 24px;
-  border-top: 1px solid rgb(var(--color-border));
-  display: flex;
-  gap: 12px;
-  justify-content: flex-end;
-`;
-
-const Button = styled.button<{ $primary?: boolean }>`
-  padding: 10px 20px;
-  border: ${props => props.$primary ? 'none' : '1px solid rgb(var(--color-border))'};
-  border-radius: var(--radius-md);
-  background: ${props => props.$primary ? 'rgb(var(--color-primary))' : 'rgb(var(--color-background-secondary))'};
-  color: ${props => props.$primary ? 'white' : 'rgb(var(--color-text-primary))'};
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  
-  &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  }
-  
-  &:active {
-    transform: translateY(0);
-  }
-`;
 
 // ============================================================================
 // Component
@@ -463,15 +433,15 @@ export const SubFlowLibraryDialog: React.FC<SubFlowLibraryDialogProps> = ({
           )}
         </Content>
 
-        <Footer>
-          <Button onClick={handleImport}>
+        <PanelFooter>
+          <PrimaryButton type="button" onClick={handleImport}>
             <Upload size={16} />
             Import Template
-          </Button>
-          <Button onClick={onClose}>
+          </PrimaryButton>
+          <SecondaryButton type="button" onClick={onClose}>
             Close
-          </Button>
-        </Footer>
+          </SecondaryButton>
+        </PanelFooter>
       </Dialog>
     </Overlay>
   );


### PR DESCRIPTION
Migrates additional FlowEditor config panels to shared StyledComponents to reduce drift and simplify future changes.

Changes:
- DocumentConfigPanel: normalize ConditionLogic defaults and remove unused local Button
- FormReferenceConfigPanel: replace local Button/Footer/HelpText/Checkbox with shared StyledComponents
- SubFlowLibraryDialog: use shared PanelFooter + Primary/Secondary buttons
- EntityFieldPickerDiagnostic: use shared Select + buttons

Verification:
- frontend: npx vitest run --silent
