### PR TITLE
Restore MSAL common authority + enforce select_account prompt

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -862,3 +862,5 @@ Deliverables:
 - PR: TBD (refactor/workforms): Phase 9.7 hardening & state sync
 
 
+
+- 2026-03-20 — MSAL common authority restoration (B2B/B2C support) & prompt enforcement — PR: #TBD.

--- a/backend/apps/integrations/microsoft/utils.py
+++ b/backend/apps/integrations/microsoft/utils.py
@@ -83,16 +83,20 @@ def get_microsoft_auth_url(
     redirect_uri = get_microsoft_redirect_uri(request)
     
     # Build authorization URL
-    tenant_id = getattr(settings, 'MICROSOFT_TENANT_ID', 'common')
+    tenant_id = getattr(settings, 'MICROSOFT_TENANT_ID', None)
+    if not tenant_id:
+        tenant_id = 'common'
+
     authority = f"https://login.microsoftonline.com/{tenant_id}"
     authorize_endpoint = f"{authority}/oauth2/v2.0/authorize"
-    
+
     params = {
         "client_id": client_id,
         "response_type": "code",
         "redirect_uri": redirect_uri,
         "response_mode": "query",
         "scope": " ".join(scopes),
+        "prompt": "select_account",
     }
     
     if state:


### PR DESCRIPTION
### Objectives
1) Restore MSAL common authority default for B2B/B2C support in Phase 5 Microsoft OAuth util.
2) Enforce prompt=select_account for a clean interactive flow.
3) Append master plan log entry.

### Changes
- backend/apps/integrations/microsoft/utils.py
  - get_microsoft_auth_url now defaults MICROSOFT_TENANT_ID to common when unset
  - adds prompt=select_account
- .github/MASTER_PLAN.md
  - 2026-03-20 — MSAL common authority restoration (B2B/B2C support) & prompt enforcement — PR: #TBD.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
