### PR TITLE
Admin Workspace: permission guards + UX hardening

### DIFF
--- a/frontend/src/components/Admin/AdminGuard.tsx
+++ b/frontend/src/components/Admin/AdminGuard.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { useAdminPermissions, getAdminUpgradeMessage } from '@/hooks/useAdminPermissions';
+import type { AdminPermissions } from '@/hooks/useAdminPermissions';
+
+import { EmptyState } from './EmptyState';
+import { LoadingSkeleton } from './LoadingSkeleton';
+
+export type AdminFeature =
+  | 'manage_users'
+  | 'billing'
+  | 'configurations'
+  | 'audit_logs'
+  | 'option_lists'
+  | 'profile'
+  | 'customizations'
+  | 'workspace';
+
+interface AdminGuardProps {
+  feature: AdminFeature;
+  allow: (permissions: AdminPermissions) => boolean;
+  loadingFallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const AdminGuard: React.FC<AdminGuardProps> = ({
+  feature,
+  allow,
+  loadingFallback,
+  children,
+}) => {
+  const { permissions, isLoading } = useAdminPermissions();
+
+  if (isLoading) {
+    return <>{loadingFallback ?? <LoadingSkeleton type="card" rows={2} />}</>;
+  }
+
+  if (!allow(permissions)) {
+    return (
+      <EmptyState
+        icon="🔒"
+        title="Access restricted"
+        message={getAdminUpgradeMessage(feature, permissions.role)}
+      />
+    );
+  }
+
+  return <>{children}</>;
+};

--- a/frontend/src/components/Admin/index.ts
+++ b/frontend/src/components/Admin/index.ts
@@ -16,6 +16,9 @@ export { LoadingSkeleton } from './LoadingSkeleton';
 export { RoleBadge } from './RoleBadge';
 export { StatusBadge } from './StatusBadge';
 
+export { AdminGuard } from './AdminGuard';
+export type { AdminFeature } from './AdminGuard';
+
 // Phase 3: Tiered Choice Engine & Virtual Schema UI
 export { default as SystemChoiceManager } from './SystemChoiceManager';
 export { default as TenantChoiceOverride } from './TenantChoiceOverride';

--- a/frontend/src/hooks/useAdminPermissions.ts
+++ b/frontend/src/hooks/useAdminPermissions.ts
@@ -104,7 +104,15 @@ export function isAdminOrOwner(permissions: AdminPermissions | undefined): boole
  * Helper function to get upgrade message for restricted features.
  */
 export function getAdminUpgradeMessage(
-  feature: 'manage_users' | 'billing' | 'configurations' | 'audit_logs',
+  feature:
+    | 'manage_users'
+    | 'billing'
+    | 'configurations'
+    | 'audit_logs'
+    | 'option_lists'
+    | 'profile'
+    | 'customizations'
+    | 'workspace',
   currentRole: string
 ): string {
   const messages: Record<string, string> = {
@@ -112,6 +120,10 @@ export function getAdminUpgradeMessage(
     billing: 'Only tenant owners can manage billing and subscriptions',
     configurations: 'Only tenant administrators can manage configurations',
     audit_logs: 'Only tenant administrators can view audit logs',
+    option_lists: 'Only tenant administrators can manage option lists',
+    profile: 'Only tenant administrators and owners can manage organization profile',
+    customizations: 'Only tenant administrators can manage customizations',
+    workspace: 'Only tenant administrators and owners can access the Admin Workspace',
   };
 
   if (currentRole === 'user') {

--- a/frontend/src/pages/Admin/Activity/index.tsx
+++ b/frontend/src/pages/Admin/Activity/index.tsx
@@ -22,6 +22,7 @@ import {
 import { apiClient } from '@/services/apiService';
 import { AdminPage, AdminSection, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
+import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 
 interface ActivityLog {
   id: number;
@@ -85,6 +86,9 @@ const getActionTone = (action: string): Tone => {
 };
 
 const ActivityPage: React.FC = () => {
+  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const canView = permissions.can_view_audit_logs;
+
   const [logs, setLogs] = useState<ActivityLog[]>([]);
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState(false);
@@ -195,8 +199,9 @@ const ActivityPage: React.FC = () => {
   };
 
   useEffect(() => {
+    if (!canView) return;
     loadLogs(1, false);
-  }, []);
+  }, [canView]);
 
   const formatDateTime = (isoString: string) => {
     const date = new Date(isoString);
@@ -226,6 +231,34 @@ const ActivityPage: React.FC = () => {
     if (action.includes('update') || action.includes('change') || action.includes('role')) return <Info size={16} />;
     return <FileText size={16} />;
   };
+
+  if (permissionsLoading) {
+    return (
+      <AdminPage
+        title="Activity & Audit Logs"
+        description="Complete audit trail of admin actions for your tenant."
+        icon="🕒"
+      >
+        <LoadingSkeleton type="list" rows={8} />
+      </AdminPage>
+    );
+  }
+
+  if (!canView) {
+    return (
+      <AdminPage
+        title="Activity & Audit Logs"
+        description="Complete audit trail of admin actions for your tenant."
+        icon="🕒"
+      >
+        <EmptyState
+          icon="🔒"
+          title="Access restricted"
+          message="Only tenant administrators can view audit logs."
+        />
+      </AdminPage>
+    );
+  }
 
   return (
     <AdminPage

--- a/frontend/src/pages/Admin/Billing/index.tsx
+++ b/frontend/src/pages/Admin/Billing/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CreditCard } from 'lucide-react';
-import { AdminPage, EmptyState } from '@/components/Admin';
+import { AdminGuard, AdminPage, EmptyState } from '@/components/Admin';
 
 const BillingPage: React.FC = () => {
   return (
@@ -9,11 +9,13 @@ const BillingPage: React.FC = () => {
       description="Subscription, invoices, and payment methods."
       icon={<CreditCard size={18} />}
     >
-      <EmptyState
-        icon="💳"
-        title="Billing coming soon"
-        message="This area will allow tenant owners to manage subscriptions, payment methods, and invoices."
-      />
+      <AdminGuard feature="billing" allow={(p) => p.can_manage_billing}>
+        <EmptyState
+          icon="💳"
+          title="Billing coming soon"
+          message="This area will allow tenant owners to manage subscriptions, payment methods, and invoices."
+        />
+      </AdminGuard>
     </AdminPage>
   );
 };

--- a/frontend/src/pages/Admin/Configurations/index.tsx
+++ b/frontend/src/pages/Admin/Configurations/index.tsx
@@ -6,9 +6,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { apiClient } from '@/services/apiService';
-import { AdminPage, AdminSection, EmptyState, LoadingSkeleton } from '@/components/Admin';
+import { AdminPage, AdminSection, ConfirmDialog, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
+import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 
 interface Configuration {
   id: string;
@@ -39,16 +40,20 @@ const CATEGORIES: Array<{ key: Category; label: string; icon: string }> = [
 
 const ConfigurationsPage: React.FC = () => {
   const toast = useToast();
+  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const canManage = permissions.can_manage_configurations;
 
   const [activeCategory, setActiveCategory] = useState<Category>('general');
   const [configurations, setConfigurations] = useState<Configuration[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [changes, setChanges] = useState<Record<string, string>>({});
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
 
   useEffect(() => {
+    if (!canManage) return;
     loadConfigurations();
-  }, []);
+  }, [canManage]);
 
   const loadConfigurations = async () => {
     try {
@@ -105,11 +110,11 @@ const ConfigurationsPage: React.FC = () => {
     }
   };
 
-  const handleReset = async () => {
-    if (!window.confirm(`Reset all configurations in "${activeCategory}" category to defaults?`)) {
-      return;
-    }
+  const handleReset = () => {
+    setShowResetConfirm(true);
+  };
 
+  const confirmReset = async () => {
     try {
       setSaving(true);
       await apiClient.post('/configurations/reset_category/', {
@@ -124,6 +129,7 @@ const ConfigurationsPage: React.FC = () => {
       toast.error('Failed to reset configurations');
     } finally {
       setSaving(false);
+      setShowResetConfirm(false);
     }
   };
 
@@ -133,7 +139,7 @@ const ConfigurationsPage: React.FC = () => {
       description="Manage tenant-specific settings organized by category."
       icon="🔧"
       actions={
-        hasChanges ? (
+        canManage && hasChanges ? (
           <>
             <Button variant="outline" size="sm" onClick={() => setChanges({})} disabled={saving}>
               Cancel
@@ -162,82 +168,104 @@ const ConfigurationsPage: React.FC = () => {
         </CategoryTabs>
       }
     >
-      <AdminSection
-        title={CATEGORIES.find((c) => c.key === activeCategory)?.label || 'Category'}
-        description={
-          hasChanges
-            ? `You have ${Object.keys(changes).length} unsaved change(s).`
-            : 'Edit values and save when ready.'
-        }
-        actions={
-          <Button variant="outline" size="sm" onClick={handleReset} disabled={saving}>
-            Reset Category
-          </Button>
-        }
-      >
-        {loading ? (
-          <LoadingSkeleton type="list" rows={6} />
-        ) : filteredConfigs.length === 0 ? (
-          <EmptyState
-            icon="📋"
-            title="No configurations"
-            message="No configurations exist in this category."
+      {permissionsLoading ? (
+        <LoadingSkeleton type="list" rows={6} />
+      ) : !canManage ? (
+        <EmptyState
+          icon="🔒"
+          title="Access restricted"
+          message="Only tenant administrators can manage configurations."
+        />
+      ) : (
+        <>
+          <AdminSection
+            title={CATEGORIES.find((c) => c.key === activeCategory)?.label || 'Category'}
+            description={
+              hasChanges
+                ? `You have ${Object.keys(changes).length} unsaved change(s).`
+                : 'Edit values and save when ready.'
+            }
+            actions={
+              <Button variant="outline" size="sm" onClick={handleReset} disabled={saving}>
+                Reset Category
+              </Button>
+            }
+          >
+            {loading ? (
+              <LoadingSkeleton type="list" rows={6} />
+            ) : filteredConfigs.length === 0 ? (
+              <EmptyState
+                icon="📋"
+                title="No configurations"
+                message="No configurations exist in this category."
+              />
+            ) : (
+              <ConfigGrid>
+                {filteredConfigs.map((config) => (
+                  <ConfigField key={config.id}>
+                    <FieldHeader>
+                      <FieldLabel>
+                        {config.display_name}
+                        {config.is_required && <Required title="Required">*</Required>}
+                      </FieldLabel>
+                      {config.is_system && <SystemBadge>System</SystemBadge>}
+                    </FieldHeader>
+
+                    {config.description && <FieldDescription>{config.description}</FieldDescription>}
+
+                    {config.data_type === 'boolean' ? (
+                      <CheckboxRow>
+                        <CheckboxInput
+                          type="checkbox"
+                          checked={
+                            changes[config.id] !== undefined
+                              ? changes[config.id] === 'true'
+                              : Boolean(config.typed_value)
+                          }
+                          onChange={(e) =>
+                            handleValueChange(config.id, e.target.checked ? 'true' : 'false')
+                          }
+                          aria-label={config.display_name}
+                        />
+                        <CheckboxLabel>{changes[config.id] !== undefined ? 'Modified' : 'Enabled'}</CheckboxLabel>
+                      </CheckboxRow>
+                    ) : config.data_type === 'json' ? (
+                      <TextArea
+                        value={changes[config.id] !== undefined ? changes[config.id] : config.value}
+                        onChange={(e) => handleValueChange(config.id, e.target.value)}
+                        rows={4}
+                      />
+                    ) : (
+                      <TextInput
+                        type={config.data_type === 'integer' || config.data_type === 'float' ? 'number' : 'text'}
+                        step={config.data_type === 'float' ? '0.01' : undefined}
+                        value={changes[config.id] !== undefined ? changes[config.id] : config.value}
+                        onChange={(e) => handleValueChange(config.id, e.target.value)}
+                      />
+                    )}
+
+                    {config.updated_by_name && (
+                      <FieldMeta>
+                        Updated by {config.updated_by_name} • {new Date(config.updated_at).toLocaleString()}
+                      </FieldMeta>
+                    )}
+                  </ConfigField>
+                ))}
+              </ConfigGrid>
+            )}
+          </AdminSection>
+
+          <ConfirmDialog
+            isOpen={showResetConfirm}
+            onClose={() => setShowResetConfirm(false)}
+            onConfirm={confirmReset}
+            title="Reset Category"
+            message={`Reset all configurations in "${CATEGORIES.find((c) => c.key === activeCategory)?.label || activeCategory}" to defaults?`}
+            confirmText="Reset"
+            confirmVariant="danger"
           />
-        ) : (
-          <ConfigGrid>
-            {filteredConfigs.map((config) => (
-              <ConfigField key={config.id}>
-                <FieldHeader>
-                  <FieldLabel>
-                    {config.display_name}
-                    {config.is_required && <Required title="Required">*</Required>}
-                  </FieldLabel>
-                  {config.is_system && <SystemBadge>System</SystemBadge>}
-                </FieldHeader>
-
-                {config.description && <FieldDescription>{config.description}</FieldDescription>}
-
-                {config.data_type === 'boolean' ? (
-                  <CheckboxRow>
-                    <CheckboxInput
-                      type="checkbox"
-                      checked={
-                        changes[config.id] !== undefined
-                          ? changes[config.id] === 'true'
-                          : Boolean(config.typed_value)
-                      }
-                      onChange={(e) =>
-                        handleValueChange(config.id, e.target.checked ? 'true' : 'false')
-                      }
-                      aria-label={config.display_name}
-                    />
-                    <CheckboxLabel>{changes[config.id] !== undefined ? 'Modified' : 'Enabled'}</CheckboxLabel>
-                  </CheckboxRow>
-                ) : config.data_type === 'json' ? (
-                  <TextArea
-                    value={changes[config.id] !== undefined ? changes[config.id] : config.value}
-                    onChange={(e) => handleValueChange(config.id, e.target.value)}
-                    rows={4}
-                  />
-                ) : (
-                  <TextInput
-                    type={config.data_type === 'integer' || config.data_type === 'float' ? 'number' : 'text'}
-                    step={config.data_type === 'float' ? '0.01' : undefined}
-                    value={changes[config.id] !== undefined ? changes[config.id] : config.value}
-                    onChange={(e) => handleValueChange(config.id, e.target.value)}
-                  />
-                )}
-
-                {config.updated_by_name && (
-                  <FieldMeta>
-                    Updated by {config.updated_by_name} • {new Date(config.updated_at).toLocaleString()}
-                  </FieldMeta>
-                )}
-              </ConfigField>
-            ))}
-          </ConfigGrid>
-        )}
-      </AdminSection>
+        </>
+      )}
     </AdminPage>
   );
 };

--- a/frontend/src/pages/Admin/Customizations/index.tsx
+++ b/frontend/src/pages/Admin/Customizations/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Palette } from 'lucide-react';
-import { AdminPage, EmptyState } from '@/components/Admin';
+import { AdminGuard, AdminPage, EmptyState } from '@/components/Admin';
 
 const CustomizationsPage: React.FC = () => {
   return (
@@ -9,11 +9,13 @@ const CustomizationsPage: React.FC = () => {
       description="Tenant-specific UI preferences and extensibility."
       icon={<Palette size={18} />}
     >
-      <EmptyState
-        icon="🎨"
-        title="Customizations coming soon"
-        message="This area will provide tenant-level UI customization, custom fields, and template tooling."
-      />
+      <AdminGuard feature="customizations" allow={(p) => p.can_manage_customizations}>
+        <EmptyState
+          icon="🎨"
+          title="Customizations coming soon"
+          message="This area will provide tenant-level UI customization, custom fields, and template tooling."
+        />
+      </AdminGuard>
     </AdminPage>
   );
 };

--- a/frontend/src/pages/Admin/Home/index.tsx
+++ b/frontend/src/pages/Admin/Home/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/Button';
 import { AdminPage } from '@/components/Admin/AdminPage';
+import { AdminGuard, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 
 interface WorkspaceCard {
@@ -62,6 +63,7 @@ const CARDS: WorkspaceCard[] = [
 
 const AdminWorkspaceHome: React.FC = () => {
   const { permissions, isLoading } = useAdminPermissions();
+  const canAccess = ['admin', 'owner', 'superuser'].includes(permissions.role);
 
   const roleLabel = permissions.role === 'superuser'
     ? 'Superuser'
@@ -102,7 +104,12 @@ const AdminWorkspaceHome: React.FC = () => {
         </MetaBar>
       }
     >
-      <Grid>
+      <AdminGuard
+        feature="workspace"
+        allow={() => canAccess}
+        loadingFallback={<LoadingSkeleton type="card" rows={2} />}
+      >
+        <Grid>
         {CARDS.map((card) => (
           <CardLink
             key={card.path}
@@ -117,7 +124,8 @@ const AdminWorkspaceHome: React.FC = () => {
             <CardDescription>{card.description}</CardDescription>
           </CardLink>
         ))}
-      </Grid>
+        </Grid>
+      </AdminGuard>
     </AdminPage>
   );
 };

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -19,6 +19,7 @@ import { adminClient } from '@/services/apiService';
 import { AdminPage, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
+import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 import { OptionListModal } from './OptionListModal';
 
 interface SystemChoiceList {
@@ -51,6 +52,8 @@ interface SystemChoiceItem {
 
 const OptionListsPage: React.FC = () => {
   const toast = useToast();
+  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const canManage = permissions.can_manage_option_lists;
 
   const [lists, setLists] = useState<SystemChoiceList[]>([]);
   const [expandedList, setExpandedList] = useState<string | null>(null);
@@ -61,8 +64,9 @@ const OptionListsPage: React.FC = () => {
   const [editingList, setEditingList] = useState<SystemChoiceList | null>(null);
 
   useEffect(() => {
+    if (!canManage) return;
     loadChoiceLists();
-  }, []);
+  }, [canManage]);
 
   const loadChoiceLists = async () => {
     setLoading(true);
@@ -154,7 +158,15 @@ const OptionListsPage: React.FC = () => {
         </SearchBar>
       }
     >
-      {loading ? (
+      {permissionsLoading ? (
+        <LoadingSkeleton type="card" rows={2} />
+      ) : !canManage ? (
+        <EmptyState
+          icon="🔒"
+          title="Access restricted"
+          message="Only tenant administrators can manage option lists."
+        />
+      ) : loading ? (
         <LoadingSkeleton type="card" rows={3} />
       ) : filteredLists.length === 0 ? (
         <EmptyState
@@ -242,7 +254,15 @@ const OptionListsPage: React.FC = () => {
                               </ItemDetails>
                             </ItemLeft>
 
-
+                            <ItemBadges>
+                              {item.is_system_defined ? (
+                                <Badge $tone="system">System</Badge>
+                              ) : (
+                                <Badge $tone="tenant">Tenant</Badge>
+                              )}
+                              {item.is_default && <Badge $tone="default">Default</Badge>}
+                              {!item.is_active && <Badge $tone="inactive">Inactive</Badge>}
+                            </ItemBadges>
                           </ItemRow>
                         ))}
                       </ItemsList>
@@ -549,5 +569,47 @@ const ItemValue = styled.div`
   white-space: nowrap;
 `;
 
+const ItemBadges = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+`;
+
+const Badge = styled.span<{ $tone: 'system' | 'tenant' | 'default' | 'inactive' }>`
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  font-weight: 650;
+
+  ${(props) =>
+    props.$tone === 'system' &&
+    `
+      background: rgba(var(--color-info), 0.12);
+      color: rgb(var(--color-info));
+    `}
+
+  ${(props) =>
+    props.$tone === 'tenant' &&
+    `
+      background: rgba(var(--color-success), 0.12);
+      color: rgb(var(--color-success));
+    `}
+
+  ${(props) =>
+    props.$tone === 'default' &&
+    `
+      background: rgba(var(--color-primary), 0.12);
+      color: rgb(var(--color-primary));
+    `}
+
+  ${(props) =>
+    props.$tone === 'inactive' &&
+    `
+      background: rgba(var(--color-danger), 0.12);
+      color: rgb(var(--color-danger));
+    `}
+`;
 
 export default OptionListsPage;

--- a/frontend/src/pages/Admin/Profile/index.tsx
+++ b/frontend/src/pages/Admin/Profile/index.tsx
@@ -6,6 +6,7 @@ import { apiClient } from '@/services/apiService';
 import { AdminPage, AdminSection, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
+import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 
 interface Tenant {
   id: string;
@@ -42,12 +43,15 @@ const DEFAULT_DARK = '#' + '3498DB';
 const AdminProfilePage: React.FC = () => {
   const toast = useToast();
   const queryClient = useQueryClient();
+  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const canManage = permissions.can_manage_profile;
 
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [logoPreview, setLogoPreview] = useState<string | null>(null);
 
   const { data: tenant, isLoading } = useQuery<Tenant>({
     queryKey: ['tenant'],
+    enabled: canManage,
     queryFn: async () => {
       const response = await apiClient.get('/tenants/current/');
       return response.data;
@@ -198,6 +202,34 @@ const AdminProfilePage: React.FC = () => {
 
     updateProfileMutation.mutate(formDataToSubmit);
   };
+
+  if (permissionsLoading) {
+    return (
+      <AdminPage
+        title="Organization Profile"
+        description="Manage your organization’s information and branding."
+        icon={<Building2 size={18} />}
+      >
+        <LoadingSkeleton type="card" rows={2} />
+      </AdminPage>
+    );
+  }
+
+  if (!canManage) {
+    return (
+      <AdminPage
+        title="Organization Profile"
+        description="Manage your organization’s information and branding."
+        icon={<Building2 size={18} />}
+      >
+        <EmptyState
+          icon="🔒"
+          title="Access restricted"
+          message="Only tenant administrators and owners can manage organization profile."
+        />
+      </AdminPage>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -5,6 +5,7 @@
  */
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
+import { Search } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/services/apiService';
 import {
@@ -18,6 +19,7 @@ import {
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
+import { useAuth } from '@/contexts/AuthContext';
 import Modal from '@/components/Modal/Modal';
 
 interface TenantUser {
@@ -47,8 +49,12 @@ interface Invitation {
 const UsersPage: React.FC = () => {
   const toast = useToast();
   const queryClient = useQueryClient();
+  const { user: currentUser } = useAuth();
   const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const canAccess =
+    permissions.can_manage_users || permissions.can_invite_users || permissions.can_change_roles;
 
+  const [searchQuery, setSearchQuery] = useState('');
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeactivateConfirm, setShowDeactivateConfirm] = useState(false);
@@ -59,6 +65,7 @@ const UsersPage: React.FC = () => {
 
   const { data: users = [], isLoading: usersLoading } = useQuery<TenantUser[]>({
     queryKey: ['tenant-users'],
+    enabled: canAccess,
     queryFn: async () => {
       const response = await apiClient.get('/tenant-users/');
       const data = response.data.results || response.data;
@@ -68,6 +75,7 @@ const UsersPage: React.FC = () => {
 
   const { data: invitations = [] } = useQuery<Invitation[]>({
     queryKey: ['tenant-invitations'],
+    enabled: canAccess,
     queryFn: async () => {
       const response = await apiClient.get('/invitations/?status=pending');
       const data = response.data.results || response.data;
@@ -75,7 +83,29 @@ const UsersPage: React.FC = () => {
     },
   });
 
-  const activeUsers = useMemo(() => users.filter((u) => u.is_active), [users]);
+  const normalizedQuery = useMemo(() => searchQuery.trim().toLowerCase(), [searchQuery]);
+
+  const matchesUser = (row: TenantUser) => {
+    if (!normalizedQuery) return true;
+    const name = `${row.user.first_name || ''} ${row.user.last_name || ''}`.trim().toLowerCase();
+    return (
+      row.user.username.toLowerCase().includes(normalizedQuery) ||
+      row.user.email.toLowerCase().includes(normalizedQuery) ||
+      name.includes(normalizedQuery)
+    );
+  };
+
+  const matchesInvitation = (row: Invitation) => {
+    if (!normalizedQuery) return true;
+    return row.email.toLowerCase().includes(normalizedQuery) || (row.role || '').toLowerCase().includes(normalizedQuery);
+  };
+
+  const activeUsers = useMemo(() => users.filter((u) => u.is_active).filter(matchesUser), [users, normalizedQuery]);
+  const inactiveUsers = useMemo(() => users.filter((u) => !u.is_active).filter(matchesUser), [users, normalizedQuery]);
+  const pendingInvitations = useMemo(
+    () => invitations.filter((inv) => inv.status === 'pending' || !inv.status).filter(matchesInvitation),
+    [invitations, normalizedQuery]
+  );
 
   const inviteMutation = useMutation({
     mutationFn: async (data: { email: string; role: string }) => apiClient.post('/invitations/', data),
@@ -115,6 +145,17 @@ const UsersPage: React.FC = () => {
     },
   });
 
+  const reactivateMutation = useMutation({
+    mutationFn: async (id: number) => apiClient.patch(`/tenant-users/${id}/`, { is_active: true }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tenant-users'] });
+      toast.success('User reactivated');
+    },
+    onError: (error: any) => {
+      toast.error(error.response?.data?.detail || 'Failed to reactivate');
+    },
+  });
+
   const revokeMutation = useMutation({
     mutationFn: async (id: number) => apiClient.post(`/invitations/${id}/revoke/`),
     onSuccess: () => {
@@ -123,6 +164,17 @@ const UsersPage: React.FC = () => {
     },
     onError: (error: any) => {
       toast.error(error.response?.data?.detail || 'Failed to revoke invitation');
+    },
+  });
+
+  const resendMutation = useMutation({
+    mutationFn: async (id: number) => apiClient.post(`/invitations/${id}/resend/`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tenant-invitations'] });
+      toast.success('Invitation resent');
+    },
+    onError: (error: any) => {
+      toast.error(error.response?.data?.detail || 'Failed to resend invitation');
     },
   });
 
@@ -183,14 +235,27 @@ const UsersPage: React.FC = () => {
         label: 'Deactivate',
         icon: '🚫',
         onClick: (user: TenantUser) => {
+          if (currentUser?.id && user.user.id === currentUser.id) {
+            toast.error('You cannot deactivate yourself');
+            return;
+          }
           setSelectedUser(user);
           setShowDeactivateConfirm(true);
         },
         variant: 'danger' as const,
-        hidden: (row: TenantUser) => !permissions.can_manage_users || !row.is_active,
+        hidden: (row: TenantUser) =>
+          !permissions.can_manage_users ||
+          !row.is_active ||
+          (currentUser?.id ? row.user.id === currentUser.id : false),
+      },
+      {
+        label: 'Reactivate',
+        icon: '✅',
+        onClick: (user: TenantUser) => reactivateMutation.mutate(user.id),
+        hidden: (row: TenantUser) => !permissions.can_manage_users || row.is_active,
       },
     ],
-    [permissions.can_change_roles, permissions.can_manage_users]
+    [permissions.can_change_roles, permissions.can_manage_users, currentUser?.id, toast]
   );
 
   return (
@@ -207,10 +272,30 @@ const UsersPage: React.FC = () => {
           )}
         </>
       }
+      headerExtras={
+        canAccess ? (
+          <SearchRow>
+            <SearchIcon aria-hidden="true" />
+            <SearchInput
+              type="text"
+              value={searchQuery}
+              placeholder="Search users and invitations…"
+              onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label="Search users and invitations"
+            />
+          </SearchRow>
+        ) : null
+      }
     >
       {permissionsLoading ? (
         <AdminSection>
           <div>Loading…</div>
+        </AdminSection>
+      ) : !canAccess ? (
+        <AdminSection>
+          <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
+            Access restricted. Contact your tenant owner/admin for access.
+          </div>
         </AdminSection>
       ) : (
         <>
@@ -228,28 +313,52 @@ const UsersPage: React.FC = () => {
             />
           </AdminSection>
 
-          {invitations.length > 0 && (
-            <AdminSection title={`Pending Invitations (${invitations.length})`}>
+          {inactiveUsers.length > 0 && (
+            <AdminSection title={`Inactive Users (${inactiveUsers.length})`}>
+              <AdminTable
+                columns={columns as any}
+                data={inactiveUsers}
+                actions={actions as any}
+                loading={usersLoading}
+                emptyState={{
+                  icon: '👥',
+                  title: 'No inactive users',
+                  message: 'Deactivated users will appear here.',
+                }}
+              />
+            </AdminSection>
+          )}
+
+          {pendingInvitations.length > 0 && (
+            <AdminSection title={`Pending Invitations (${pendingInvitations.length})`}>
               <InvitationList role="list">
-                {invitations.map((inv) => (
+                {pendingInvitations.map((inv) => (
                   <InvitationRow key={inv.id} role="listitem">
                     <div>
                       <div style={{ fontWeight: 600 }}>{inv.email}</div>
                       <MetaRow>
                         <RoleBadge role={inv.role as any} />
-                        <MetaText>
-                          Expires {new Date(inv.expires_at).toLocaleDateString()}
-                        </MetaText>
+                        <MetaText>Expires {new Date(inv.expires_at).toLocaleDateString()}</MetaText>
                       </MetaRow>
                     </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => revokeMutation.mutate(inv.id)}
-                      disabled={revokeMutation.isPending}
-                    >
-                      Revoke
-                    </Button>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => resendMutation.mutate(inv.id)}
+                        disabled={resendMutation.isPending}
+                      >
+                        Resend
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => revokeMutation.mutate(inv.id)}
+                        disabled={revokeMutation.isPending}
+                      >
+                        Revoke
+                      </Button>
+                    </div>
                   </InvitationRow>
                 ))}
               </InvitationList>
@@ -282,7 +391,9 @@ const UsersPage: React.FC = () => {
               <option value="readonly">Read Only</option>
               <option value="user">User</option>
               <option value="manager">Manager</option>
-              {permissions.role === 'owner' && <option value="admin">Admin</option>}
+              {(permissions.role === 'owner' || permissions.role === 'superuser') && (
+                <option value="admin">Admin</option>
+              )}
             </Select>
           </FormGroup>
           <ButtonGroup>
@@ -311,7 +422,9 @@ const UsersPage: React.FC = () => {
               <option value="readonly">Read Only</option>
               <option value="user">User</option>
               <option value="manager">Manager</option>
-              {permissions.role === 'owner' && <option value="admin">Admin</option>}
+              {(permissions.role === 'owner' || permissions.role === 'superuser') && (
+                <option value="admin">Admin</option>
+              )}
             </Select>
           </FormGroup>
           <ButtonGroup>
@@ -328,7 +441,15 @@ const UsersPage: React.FC = () => {
       <ConfirmDialog
         isOpen={showDeactivateConfirm}
         onClose={() => setShowDeactivateConfirm(false)}
-        onConfirm={() => selectedUser && deactivateMutation.mutate(selectedUser.id)}
+        onConfirm={() => {
+          if (!selectedUser) return;
+          if (currentUser?.id && selectedUser.user.id === currentUser.id) {
+            toast.error('You cannot deactivate yourself');
+            setShowDeactivateConfirm(false);
+            return;
+          }
+          deactivateMutation.mutate(selectedUser.id);
+        }}
         title="Deactivate User"
         message={`Deactivate ${selectedUser?.user.username}? They will lose access.`}
         confirmText="Deactivate"
@@ -365,6 +486,36 @@ const MetaRow = styled.div`
 const MetaText = styled.span`
   font-size: 12px;
   color: rgb(var(--color-text-secondary));
+`;
+
+const SearchRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgb(var(--color-border));
+  border-radius: var(--radius-lg);
+  background: rgb(var(--color-surface));
+  min-width: 320px;
+`;
+
+const SearchIcon = styled(Search)`
+  width: 18px;
+  height: 18px;
+  color: rgb(var(--color-text-secondary));
+`;
+
+const SearchInput = styled.input`
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: rgb(var(--color-text-primary));
+  font-size: 14px;
+
+  &::placeholder {
+    color: rgb(var(--color-text-secondary));
+  }
 `;
 
 const Form = styled.form`


### PR DESCRIPTION
What\n- Makes every Admin Workspace subpage more resilient and industry-grade (permission-aware, simplified, and fully functional).\n\nHighlights\n- Added AdminGuard for consistent access restriction UX\n- Users & Invitations: search, inactive users section, resend/revoke invitations, prevent self-deactivate\n- Configurations: reset uses ConfirmDialog (no browser confirm)\n- Option Lists: clearer item rows with System/Tenant/Default/Inactive badges\n- Billing/Customizations placeholders are permission-guarded\n\nValidation\n- npm --prefix frontend run lint (warnings only)\n- npm --prefix frontend run build