### PR TITLE
Fix email ingestion monitor API paths

### DIFF
--- a/frontend/src/components/Integrations/IngestionMonitor.tsx
+++ b/frontend/src/components/Integrations/IngestionMonitor.tsx
@@ -73,7 +73,7 @@ export const IngestionMonitor: React.FC = () => {
     setLoading(true);
     try {
       const response = await businessApi.get<EmailLogsResponse>(
-        `/tenants/${tenantId}/integrations/email/logs/?limit=10`
+        `/integrations/email/logs/?limit=10`
       );
       setEmails(response.data.emails);
     } catch (error) {
@@ -93,7 +93,7 @@ export const IngestionMonitor: React.FC = () => {
 
     setSyncing(true);
     try {
-      await businessApi.post(`/tenants/${tenantId}/integrations/email/sync/`);
+      await businessApi.post(`/integrations/email/sync/`);
       message.success('Email sync started. This may take a few moments...');
       
       // Refresh logs after 3 seconds

--- a/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
@@ -253,7 +253,7 @@ export const EmailIngestionMonitorWidget: React.FC<EmailIngestionMonitorWidgetPr
     setLoading(true);
     try {
       const response = await businessApi.get<EmailLogsResponse>(
-        `/tenants/${tenantId}/integrations/email/logs/?limit=5`
+        `/integrations/email/logs/?limit=5`
       );
       setEmails(response.data.emails);
     } catch (error) {
@@ -272,7 +272,7 @@ export const EmailIngestionMonitorWidget: React.FC<EmailIngestionMonitorWidgetPr
 
     setSyncing(true);
     try {
-      await businessApi.post(`/tenants/${tenantId}/integrations/email/sync/`);
+      await businessApi.post(`/integrations/email/sync/`);
       
       // Refresh logs after 2 seconds
       setTimeout(() => {


### PR DESCRIPTION
Fixes 404s in the Email Ingestion Monitor.\n\n- Update monitor + cockpit widget to use backend routes:\n  - GET /integrations/email/logs/\n  - POST /integrations/email/sync/\n- Tenant context remains via X-Tenant-ID header (apiClient interceptor)\n\nValidation:\n- npm --prefix frontend run build