### PR TITLE
FlowEditor: fix edge thickness distortion (templates)

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -252,6 +252,12 @@ const EditorContainer = styled.div<{ $isFullscreen?: boolean }>`
     animation: dash 0.5s linear infinite;
     filter: drop-shadow(0 0 4px rgb(var(--color-primary) / 0.35));
   }
+
+  /* Keep edge stroke thickness stable across zoom/template loads */
+  .react-flow__edge-path,
+  .react-flow__edge path {
+    vector-effect: non-scaling-stroke;
+  }
   
   /* Phase 7.2: Enhanced snap feedback */
   .react-flow__node.dragging {
@@ -6103,6 +6109,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         };
       });
 
+      const stripStrokeWidth = (style: any) => {
+        if (!style) return style;
+        const { strokeWidth: _strokeWidth, vectorEffect: _vectorEffect, ...rest } = style;
+        return rest;
+      };
+
       // Normalize template edges so they render with consistent types/markers.
       // Templates often omit type and rely on handle IDs (true/false/error).
       const mappedEdges: Edge[] = template.edges.map((edge) => {
@@ -6120,6 +6132,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           ...edge,
           type: inferredType,
           interactionWidth: edge.interactionWidth ?? 28,
+          // Ensure templates can't accidentally persist huge stroke widths (common source of thickness distortion)
+          style: stripStrokeWidth(edge.style),
         };
 
         if (inferredType === 'conditional' && !(edge as any).data && (sourceHandle === 'true' || sourceHandle === 'false')) {
@@ -6138,9 +6152,9 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
         if (inferredType === 'step') {
           next.style = {
-            strokeWidth: 3,
+            ...(stripStrokeWidth(edge.style) || {}),
             stroke: 'rgb(var(--color-text-secondary))',
-            ...(edge.style || {}),
+            strokeWidth: 3,
           };
           next.markerEnd =
             edge.markerEnd ||

--- a/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
@@ -105,12 +105,15 @@ export const ConditionalEdge = React.memo<EdgeProps<ConditionalEdgeData>>(({
   const animated = data?.animated || false;
   const isTrue = data?.isTrue;
 
+  const { strokeWidth: _strokeWidth, vectorEffect: _vectorEffect, ...safeStyle } = (style || {}) as any;
+
   const edgeStyle: React.CSSProperties = {
+    ...safeStyle,
     stroke: 'rgb(245, 158, 11)', // Orange
     strokeWidth: 2.5,
     strokeDasharray: animated ? '8,4' : undefined,
+    vectorEffect: 'non-scaling-stroke',
     transition: 'all 0.3s ease',
-    ...style,
   };
 
   // Custom diamond marker for conditional edges

--- a/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
@@ -109,12 +109,15 @@ export const ErrorEdge = React.memo<EdgeProps<ErrorEdgeData>>(({
   const animated = data?.animated ?? true;
   const errorCount = data?.errorCount;
 
+  const { strokeWidth: _strokeWidth, vectorEffect: _vectorEffect, ...safeStyle } = (style || {}) as any;
+
   const edgeStyle: React.CSSProperties = {
+    ...safeStyle,
     stroke: 'rgb(239, 68, 68)', // Tailwind red-500
     strokeWidth: 2.5,
     strokeDasharray: '5,5',
+    vectorEffect: 'non-scaling-stroke',
     transition: 'all 0.3s ease',
-    ...style,
   };
 
   // Custom warning marker for error edges

--- a/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
@@ -108,11 +108,14 @@ export const SuccessEdge = React.memo<EdgeProps<SuccessEdgeData>>(({
   const animated = data?.animated || false;
   const successCount = data?.successCount;
 
+  const { strokeWidth: _strokeWidth, vectorEffect: _vectorEffect, ...safeStyle } = (style || {}) as any;
+
   const edgeStyle: React.CSSProperties = {
+    ...safeStyle,
     stroke: 'rgb(34, 197, 94)', // Green
     strokeWidth: 3,
+    vectorEffect: 'non-scaling-stroke',
     transition: 'all 0.3s ease',
-    ...style,
   };
 
   // Custom checkmark marker for success edges


### PR DESCRIPTION
Fix\n- Prevent template-loaded edges from persisting huge strokeWidth values (sanitized on template apply)\n- Ensure edge strokes do not scale with zoom by applying non-scaling-stroke globally and in Conditional/Error/Success edge types\n\nWhy\n- Some templates include edge.style.strokeWidth artifacts, causing distorted/thick connection lines when loaded\n- Default/custom edge paths were inconsistent about vector-effect, so zoom could visually distort thickness\n\nValidation\n- npm --prefix frontend run build