### PR TITLE
FlowEditor: keep first Form step inside Form Process

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
@@ -221,32 +221,46 @@ export const NodeConfigPanelWithShadow: React.FC<NodeConfigPanelWithShadowProps>
   
   const handleAddStep = useCallback(() => {
     if (!node) return;
-    
-    // Create a new formStep node inside the container
+
+    const isStrictContainer =
+      node.type === 'formProcessGroup' || node.type === 'formProcess' || node.type === 'formMultiStepContainer';
+
+    const existingSteps = nodes.filter(
+      (n) => n.parentId === node.id && (n.type === 'form' || n.type === 'formStep' || n.type === 'formStepSingle')
+    );
+    const index = existingSteps.length;
+
+    // Create a new canonical Form (page) node inside the container
     const newStep: Node = {
-      id: `step-${Date.now()}`,
-      type: 'formStep',
-      position: { x: 50, y: 50 + (nodes.filter(n => n.parentId === node.id).length * 100) },
-      data: {
-        name: `Step ${nodes.filter(n => n.parentId === node.id).length + 1}`,
-        entityType: '',
-        fields: [],
-      },
+      id: `page-${Date.now()}`,
+      type: 'form',
       parentId: node.id,
+      extent: 'parent',
+      expandParent: true,
+      // Keep the first step safely inside the container bounds
+      position: { x: 50 + index * 350, y: 80 },
+      style: isStrictContainer ? { width: 320, height: 320, overflow: 'hidden' } : undefined,
+      draggable: isStrictContainer ? false : true,
+      data: {
+        stepTitle: `Page ${index + 1}`,
+        label: `Page ${index + 1}`,
+        fields: [],
+        order: index,
+      },
     };
-    
+
     setNodes((nds) => [...nds, newStep]);
   }, [node, nodes, setNodes]);
   
   const handleReorderSteps = useCallback((nodeIds: string[]) => {
-    // Reposition nodes based on new order
+    // Reposition nodes based on new order (left-to-right inside the container)
     setNodes((nds) =>
       nds.map((n) => {
         const index = nodeIds.indexOf(n.id);
         if (index !== -1) {
           return {
             ...n,
-            position: { x: 50, y: 50 + index * 100 },
+            position: { x: 50 + index * 350, y: 80 },
           };
         }
         return n;

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -4196,7 +4196,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
    */
   const onNodeDragStop = useCallback((event: React.MouseEvent, node: Node) => {
     // Phase 5: If node is inside a container and it's a form step, check for significant movement
-    if (node.parentId && (node.type === 'formStep' || node.type === 'formReference')) {
+    if (
+      node.parentId &&
+      (node.type === 'form' || node.type === 'formStep' || node.type === 'formStepSingle' || node.type === 'formReference')
+    ) {
       // Check if position changed significantly (more than 30px horizontally)
       const dragStart = dragStartPositionRef.current;
       const SIGNIFICANT_MOVEMENT_THRESHOLD = 30; // pixels

--- a/frontend/src/components/FlowEditor/utils/containerLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/containerLayout.ts
@@ -278,5 +278,10 @@ export function autoConnectSequentialSteps(
  * (Only form steps trigger auto-connection of sequential edges)
  */
 export function shouldTriggerConnection(nodeType: string): boolean {
-  return nodeType === 'formStep' || nodeType === 'formReference';
+  return (
+    nodeType === 'form' ||
+    nodeType === 'formStep' ||
+    nodeType === 'formStepSingle' ||
+    nodeType === 'formReference'
+  );
 }


### PR DESCRIPTION
Fix\n- Adding/reordering steps inside a Form Process now uses canonical Form nodes with extent parent and an in-bounds position\n- Layout and connection triggers now recognize canonical Form node type\n\nValidation\n- npm --prefix frontend run build