### PR TITLE
Products: add MasterProduct API (tenant)

### DIFF
--- a/backend/tenant_apps/products/urls.py
+++ b/backend/tenant_apps/products/urls.py
@@ -7,17 +7,24 @@ Uses shared-schema multi-tenancy with tenant filtering in viewset.
 import logging
 from django.urls import path
 from rest_framework.routers import DefaultRouter
-from .views import ProductViewSet
+from .views import ProductViewSet, MasterProductViewSet
 
 logger = logging.getLogger(__name__)
 
 router = DefaultRouter()
 
-# Register ProductViewSet
+# Register legacy product alias (system catalog)
 try:
     router.register(r'products', ProductViewSet, basename='product')
     logger.info("✅ ProductViewSet registered at /api/v1/products/")
 except Exception as e:
     logger.error(f"❌ Failed to register ProductViewSet: {e}")
+
+# Register tenant master products (canonical for supplier availability)
+try:
+    router.register(r'master-products', MasterProductViewSet, basename='master-product')
+    logger.info("✅ MasterProductViewSet registered at /api/v1/master-products/")
+except Exception as e:
+    logger.error(f"❌ Failed to register MasterProductViewSet: {e}")
 
 urlpatterns = router.urls

--- a/backend/tenant_apps/products/views.py
+++ b/backend/tenant_apps/products/views.py
@@ -19,9 +19,30 @@ from rest_framework import permissions, viewsets
 
 from apps.system.views.product_viewset import SystemProductViewSet
 
-from .serializers import LegacySystemProductSerializer
+from .models import MasterProduct
+from .serializers import LegacySystemProductSerializer, ProductSerializer
 
 logger = logging.getLogger(__name__)
+
+
+class MasterProductViewSet(viewsets.ModelViewSet):
+    """CRUD API for tenant-scoped MasterProduct.
+
+    This is the canonical API for the tenant's product definitions used by supplier
+    availability (SupplierAvailableItem) and plant associations.
+
+    Kept separate from /api/v1/products/, which is a deprecated, read-only alias to
+    /api/v1/system/products/ (three-tier catalog).
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = ProductSerializer
+
+    def get_queryset(self):
+        return MasterProduct.objects.filter(tenant=self.request.tenant).order_by('display_name')
+
+    def perform_create(self, serializer):
+        serializer.save(tenant=self.request.tenant)
 
 
 class ProductViewSet(SystemProductViewSet):


### PR DESCRIPTION
Fix\n- Add canonical tenant MasterProduct CRUD API at /api/v1/master-products/\n- Keep /api/v1/products/ as backward-compatible read-only alias to /api/v1/system/products/\n\nNotes\n- Backend test runs in this workspace are currently blocked by missing pgvector extension in the local postgres:15 docker-compose DB (ai_assistant vector migrations require it).\n\nValidation\n- python -m compileall backend/tenant_apps/products/views.py backend/tenant_apps/products/urls.py