### PR TITLE
Admin Workspace: enforce AdminGuard

### DIFF
--- a/frontend/src/pages/Admin/Activity/index.tsx
+++ b/frontend/src/pages/Admin/Activity/index.tsx
@@ -20,7 +20,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { apiClient } from '@/services/apiService';
-import { AdminPage, AdminSection, EmptyState, LoadingSkeleton } from '@/components/Admin';
+import { AdminGuard, AdminPage, AdminSection, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 
@@ -86,7 +86,7 @@ const getActionTone = (action: string): Tone => {
 };
 
 const ActivityPage: React.FC = () => {
-  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const { permissions } = useAdminPermissions();
   const canView = permissions.can_view_audit_logs;
 
   const [logs, setLogs] = useState<ActivityLog[]>([]);
@@ -232,42 +232,15 @@ const ActivityPage: React.FC = () => {
     return <FileText size={16} />;
   };
 
-  if (permissionsLoading) {
-    return (
-      <AdminPage
-        title="Activity & Audit Logs"
-        description="Complete audit trail of admin actions for your tenant."
-        icon="🕒"
-      >
-        <LoadingSkeleton type="list" rows={8} />
-      </AdminPage>
-    );
-  }
-
-  if (!canView) {
-    return (
-      <AdminPage
-        title="Activity & Audit Logs"
-        description="Complete audit trail of admin actions for your tenant."
-        icon="🕒"
-      >
-        <EmptyState
-          icon="🔒"
-          title="Access restricted"
-          message="Only tenant administrators can view audit logs."
-        />
-      </AdminPage>
-    );
-  }
-
   return (
     <AdminPage
       title="Activity & Audit Logs"
       description="Complete audit trail of admin actions for your tenant."
       icon="🕒"
       actions={
-        <>
-          <Button
+        canView ? (
+          <>
+            <Button
             variant={showFilters ? 'primary' : 'outline'}
             size="sm"
             onClick={() => setShowFilters((s) => !s)}
@@ -284,7 +257,8 @@ const ActivityPage: React.FC = () => {
             {exporting ? <Loader size={16} /> : <Download size={16} />}
             Export CSV
           </Button>
-        </>
+          </>
+        ) : undefined
       }
       headerExtras={
         showFilters ? (
@@ -366,7 +340,12 @@ const ActivityPage: React.FC = () => {
         ) : null
       }
     >
-      {error && (
+      <AdminGuard
+        feature="audit_logs"
+        allow={(p) => p.can_view_audit_logs}
+        loadingFallback={<LoadingSkeleton type="list" rows={8} />}
+      >
+        {error && (
         <ErrorBanner role="alert">
           <AlertCircle size={18} />
           {error}
@@ -446,6 +425,7 @@ const ActivityPage: React.FC = () => {
           </Timeline>
         )}
       </AdminSection>
+      </AdminGuard>
     </AdminPage>
   );
 };

--- a/frontend/src/pages/Admin/Configurations/index.tsx
+++ b/frontend/src/pages/Admin/Configurations/index.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { apiClient } from '@/services/apiService';
-import { AdminPage, AdminSection, ConfirmDialog, EmptyState, LoadingSkeleton } from '@/components/Admin';
+import { AdminGuard, AdminPage, AdminSection, ConfirmDialog, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
@@ -40,7 +40,7 @@ const CATEGORIES: Array<{ key: Category; label: string; icon: string }> = [
 
 const ConfigurationsPage: React.FC = () => {
   const toast = useToast();
-  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const { permissions } = useAdminPermissions();
   const canManage = permissions.can_manage_configurations;
 
   const [activeCategory, setActiveCategory] = useState<Category>('general');
@@ -168,15 +168,11 @@ const ConfigurationsPage: React.FC = () => {
         </CategoryTabs>
       }
     >
-      {permissionsLoading ? (
-        <LoadingSkeleton type="list" rows={6} />
-      ) : !canManage ? (
-        <EmptyState
-          icon="🔒"
-          title="Access restricted"
-          message="Only tenant administrators can manage configurations."
-        />
-      ) : (
+      <AdminGuard
+        feature="configurations"
+        allow={(p) => p.can_manage_configurations}
+        loadingFallback={<LoadingSkeleton type="list" rows={6} />}
+      >
         <>
           <AdminSection
             title={CATEGORIES.find((c) => c.key === activeCategory)?.label || 'Category'}
@@ -265,7 +261,7 @@ const ConfigurationsPage: React.FC = () => {
             confirmVariant="danger"
           />
         </>
-      )}
+      </AdminGuard>
     </AdminPage>
   );
 };

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -16,7 +16,7 @@ import {
   Unlock,
 } from 'lucide-react';
 import { adminClient } from '@/services/apiService';
-import { AdminPage, EmptyState, LoadingSkeleton } from '@/components/Admin';
+import { AdminGuard, AdminPage, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
@@ -52,7 +52,7 @@ interface SystemChoiceItem {
 
 const OptionListsPage: React.FC = () => {
   const toast = useToast();
-  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const { permissions } = useAdminPermissions();
   const canManage = permissions.can_manage_option_lists;
 
   const [lists, setLists] = useState<SystemChoiceList[]>([]);
@@ -158,15 +158,12 @@ const OptionListsPage: React.FC = () => {
         </SearchBar>
       }
     >
-      {permissionsLoading ? (
-        <LoadingSkeleton type="card" rows={2} />
-      ) : !canManage ? (
-        <EmptyState
-          icon="🔒"
-          title="Access restricted"
-          message="Only tenant administrators can manage option lists."
-        />
-      ) : loading ? (
+      <AdminGuard
+        feature="option_lists"
+        allow={(p) => p.can_manage_option_lists}
+        loadingFallback={<LoadingSkeleton type="card" rows={2} />}
+      >
+        {loading ? (
         <LoadingSkeleton type="card" rows={3} />
       ) : filteredLists.length === 0 ? (
         <EmptyState
@@ -174,8 +171,8 @@ const OptionListsPage: React.FC = () => {
           title={searchQuery ? 'No matches' : 'No option lists'}
           message={searchQuery ? 'No option lists match your search.' : 'No option lists were returned.'}
         />
-      ) : (
-        <ListsGrid>
+        ) : (
+          <ListsGrid>
           {filteredLists.map((list) => {
             const isExpanded = expandedList === list.slug;
             const items = listItems[list.slug] || [];
@@ -272,8 +269,9 @@ const OptionListsPage: React.FC = () => {
               </ListCard>
             );
           })}
-        </ListsGrid>
-      )}
+          </ListsGrid>
+        )}
+      </AdminGuard>
 
       {editingList && (
         <OptionListModal

--- a/frontend/src/pages/Admin/Profile/index.tsx
+++ b/frontend/src/pages/Admin/Profile/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Building2, Image as ImageIcon, X } from 'lucide-react';
 import { apiClient } from '@/services/apiService';
-import { AdminPage, AdminSection, EmptyState, LoadingSkeleton } from '@/components/Admin';
+import { AdminGuard, AdminPage, AdminSection, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
@@ -43,7 +43,7 @@ const DEFAULT_DARK = '#' + '3498DB';
 const AdminProfilePage: React.FC = () => {
   const toast = useToast();
   const queryClient = useQueryClient();
-  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const { permissions } = useAdminPermissions();
   const canManage = permissions.can_manage_profile;
 
   const [logoFile, setLogoFile] = useState<File | null>(null);
@@ -203,77 +203,37 @@ const AdminProfilePage: React.FC = () => {
     updateProfileMutation.mutate(formDataToSubmit);
   };
 
-  if (permissionsLoading) {
-    return (
-      <AdminPage
-        title="Organization Profile"
-        description="Manage your organization’s information and branding."
-        icon={<Building2 size={18} />}
-      >
-        <LoadingSkeleton type="card" rows={2} />
-      </AdminPage>
-    );
-  }
-
-  if (!canManage) {
-    return (
-      <AdminPage
-        title="Organization Profile"
-        description="Manage your organization’s information and branding."
-        icon={<Building2 size={18} />}
-      >
-        <EmptyState
-          icon="🔒"
-          title="Access restricted"
-          message="Only tenant administrators and owners can manage organization profile."
-        />
-      </AdminPage>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <AdminPage
-        title="Organization Profile"
-        description="Manage your organization’s information and branding."
-        icon={<Building2 size={18} />}
-      >
-        <LoadingSkeleton type="card" rows={2} />
-      </AdminPage>
-    );
-  }
-
-  if (!tenant) {
-    return (
-      <AdminPage
-        title="Organization Profile"
-        description="Manage your organization’s information and branding."
-        icon={<Building2 size={18} />}
-      >
-        <EmptyState icon="🏢" title="Not available" message="Unable to load tenant information." />
-      </AdminPage>
-    );
-  }
-
   return (
     <AdminPage
       title="Organization Profile"
       description="Update company information, logo, and tenant branding."
       icon={<Building2 size={18} />}
       actions={
-        <Button
-          variant="primary"
-          size="sm"
-          form="tenant-profile-form"
-          type="submit"
-          disabled={!isDirty || updateProfileMutation.isPending}
-          title={!isDirty ? 'No changes to save' : undefined}
-        >
-          {updateProfileMutation.isPending ? 'Saving…' : 'Save Changes'}
-        </Button>
+        tenant ? (
+          <Button
+            variant="primary"
+            size="sm"
+            form="tenant-profile-form"
+            type="submit"
+            disabled={!isDirty || updateProfileMutation.isPending}
+            title={!isDirty ? 'No changes to save' : undefined}
+          >
+            {updateProfileMutation.isPending ? 'Saving…' : 'Save Changes'}
+          </Button>
+        ) : undefined
       }
     >
-      <form id="tenant-profile-form" onSubmit={handleSubmit}>
+      <AdminGuard
+        feature="profile"
+        allow={(p) => p.can_manage_profile}
+        loadingFallback={<LoadingSkeleton type="card" rows={2} />}
+      >
+        {isLoading ? (
+          <LoadingSkeleton type="card" rows={2} />
+        ) : !tenant ? (
+          <EmptyState icon="🏢" title="Not available" message="Unable to load tenant information." />
+        ) : (
+          <form id="tenant-profile-form" onSubmit={handleSubmit}>
         <Stack>
           <AdminSection title="Basic Information" description="How your organization appears across the app.">
             <FormGrid>
@@ -447,7 +407,9 @@ const AdminProfilePage: React.FC = () => {
             </BrandingGrid>
           </AdminSection>
         </Stack>
-      </form>
+          </form>
+        )}
+      </AdminGuard>
     </AdminPage>
   );
 };

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -9,10 +9,12 @@ import { Search } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/services/apiService';
 import {
+  AdminGuard,
   AdminPage,
   AdminSection,
   AdminTable,
   ConfirmDialog,
+  LoadingSkeleton,
   RoleBadge,
   StatusBadge,
 } from '@/components/Admin';
@@ -50,7 +52,7 @@ const UsersPage: React.FC = () => {
   const toast = useToast();
   const queryClient = useQueryClient();
   const { user: currentUser } = useAuth();
-  const { permissions, isLoading: permissionsLoading } = useAdminPermissions();
+  const { permissions } = useAdminPermissions();
   const canAccess =
     permissions.can_manage_users || permissions.can_invite_users || permissions.can_change_roles;
 
@@ -287,17 +289,11 @@ const UsersPage: React.FC = () => {
         ) : null
       }
     >
-      {permissionsLoading ? (
-        <AdminSection>
-          <div>Loading…</div>
-        </AdminSection>
-      ) : !canAccess ? (
-        <AdminSection>
-          <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
-            Access restricted. Contact your tenant owner/admin for access.
-          </div>
-        </AdminSection>
-      ) : (
+      <AdminGuard
+        feature="manage_users"
+        allow={(p) => p.can_manage_users || p.can_invite_users || p.can_change_roles}
+        loadingFallback={<LoadingSkeleton type="table" rows={6} columns={4} />}
+      >
         <>
           <AdminSection title={`Active Users (${activeUsers.length})`}>
             <AdminTable
@@ -365,7 +361,7 @@ const UsersPage: React.FC = () => {
             </AdminSection>
           )}
         </>
-      )}
+      </AdminGuard>
 
       <Modal isOpen={showInviteModal} onClose={() => setShowInviteModal(false)} title="Invite User">
         <Form


### PR DESCRIPTION
Standardize permission gating across Admin Workspace pages:\n- Wrap Users/Profile/Configurations/Option Lists/Activity in AdminGuard\n- Remove duplicated manual permission loading/restricted branches\n\nVerification: frontend build (vite) passes.