### PR TITLE
Fix Container Version form process groups

### DIFF
--- a/backend/apps/system/models/tenant_workform.py
+++ b/backend/apps/system/models/tenant_workform.py
@@ -303,91 +303,136 @@ class TenantWorkForm(models.Model):
         self.save(update_fields=['clone_count'])
     
     def get_container_nodes(self):
-        """
-        Get all container nodes in this workflow.
-        
+        """Get all form container nodes in this workflow.
+
+        Supports both canonical and legacy container types.
+
         Returns:
             list: List of container node objects
         """
         nodes = self.workflow_definition.get('nodes', [])
-        return [node for node in nodes if node.get('type') == 'formMultiStepContainer']
-    
+        if not isinstance(nodes, list):
+            return []
+
+        container_types = {
+            'formBook',
+            'formProcessGroup',
+            'formProcess',
+            'formMultiStepContainer',
+            'smartWorkForm',
+        }
+
+        return [
+            node
+            for node in nodes
+            if isinstance(node, dict) and node.get('type') in container_types
+        ]
+
     def get_nodes_in_container(self, container_id):
-        """
-        Get all nodes that belong to a specific container.
-        
+        """Get all nodes that belong to a specific container.
+
+        Backward compatible with both grouping paradigms:
+        - React Flow sub-flows: node.parentId / node.parentNode
+        - Legacy container mapping: node.data.containerNodeId
+
         Args:
             container_id (str): ID of the container node
-            
+
         Returns:
-            list: List of node objects that have containerNodeId == container_id
+            list: List of node objects inside the container
         """
         nodes = self.workflow_definition.get('nodes', [])
-        return [
-            node for node in nodes 
-            if node.get('data', {}).get('containerNodeId') == container_id
-        ]
-    
+        if not isinstance(nodes, list):
+            return []
+
+        children = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            if node.get('id') == container_id:
+                continue
+
+            node_data = node.get('data') or {}
+            if not isinstance(node_data, dict):
+                node_data = {}
+
+            parent_id = node.get('parentId') or node.get('parentNode') or node_data.get('containerNodeId')
+            if parent_id == container_id:
+                children.append(node)
+
+        return children
+
     def get_container_summary(self, container_id):
-        """
-        Get summary of nodes within a container.
-        
-        Args:
-            container_id (str): ID of the container node
-            
-        Returns:
-            dict: {
-                "container_name": str,
-                "total_nodes": int,
-                "node_types": {"formStep": 2, "actionEmail": 1, ...},
-                "form_references": [uuid1, uuid2, ...]
-            }
-        """
+        """Get summary of nodes within a container."""
         container_nodes = self.get_nodes_in_container(container_id)
-        container_node = next(
-            (n for n in self.workflow_definition.get('nodes', []) if n.get('id') == container_id),
-            None
+
+        nodes = self.workflow_definition.get('nodes', [])
+        container_node = None
+        if isinstance(nodes, list):
+            container_node = next(
+                (n for n in nodes if isinstance(n, dict) and n.get('id') == container_id),
+                None,
+            )
+
+        container_data = (container_node or {}).get('data') or {}
+        if not isinstance(container_data, dict):
+            container_data = {}
+
+        container_name = (
+            container_data.get('containerName')
+            or container_data.get('label')
+            or container_data.get('name')
+            or 'Unnamed Container'
         )
-        
-        # Count node types
-        node_types = {}
+
+        node_types: dict[str, int] = {}
         form_refs = set()
         for node in container_nodes:
             node_type = node.get('type', 'unknown')
             node_types[node_type] = node_types.get(node_type, 0) + 1
-            
-            # Extract form references
-            node_data = node.get('data', {})
-            if node_type in ['formStep', 'formReference'] and node_data.get('tenantFormId'):
+
+            node_data = node.get('data') or {}
+            if isinstance(node_data, dict) and node_data.get('tenantFormId'):
                 form_refs.add(node_data['tenantFormId'])
-        
+
         return {
-            "container_name": container_node.get('data', {}).get('label', 'Unnamed Container') if container_node else 'Unknown',
-            "total_nodes": len(container_nodes),
-            "node_types": node_types,
-            "form_references": list(form_refs)
+            'container_name': container_name,
+            'total_nodes': len(container_nodes),
+            'node_types': node_types,
+            'form_references': list(form_refs),
         }
-    
+
     def update_node_container(self, node_id, container_id=None):
-        """
-        Update a node's containerNodeId field.
-        
-        Args:
-            node_id (str): ID of the node to update
-            container_id (str|None): ID of container to assign (None to remove from container)
-            
+        """Update a node's container relationship (legacy + sub-flow).
+
+        This keeps older APIs working while supporting the newer parentId grouping.
+
         Returns:
             bool: True if node was found and updated, False otherwise
         """
         nodes = self.workflow_definition.get('nodes', [])
-        
+        if not isinstance(nodes, list):
+            return False
+
         for node in nodes:
-            if node.get('id') == node_id:
-                if container_id:
-                    node.setdefault('data', {})['containerNodeId'] = container_id
-                else:
-                    # Remove containerNodeId
-                    node.get('data', {}).pop('containerNodeId', None)
-                return True
-        
+            if not isinstance(node, dict):
+                continue
+            if node.get('id') != node_id:
+                continue
+
+            node_data = node.get('data')
+            if not isinstance(node_data, dict):
+                node_data = {}
+                node['data'] = node_data
+
+            if container_id:
+                node_data['containerNodeId'] = container_id
+                node['parentId'] = container_id
+            else:
+                node_data.pop('containerNodeId', None)
+                node.pop('parentId', None)
+                node.pop('parentNode', None)
+
+            return True
+
         return False

--- a/backend/apps/system/services/container_versioning.py
+++ b/backend/apps/system/services/container_versioning.py
@@ -109,8 +109,14 @@ def has_container_changed(container_node: dict, existing_form: TenantForm) -> tu
     current_def = existing_form.form_definition
     container_data = container_node.get('data', {})
     
+    label_candidate = (
+        container_data.get('containerName')
+        or container_data.get('label')
+        or container_data.get('name')
+    )
+
     diff = {
-        'label_changed': container_data.get('label') != current_def.get('container_label'),
+        'label_changed': label_candidate != current_def.get('container_label'),
         'step_count_changed': False,
         'fields_changed': False
     }
@@ -151,12 +157,24 @@ def snapshot_container(
     container_data = container_node.get('data', {})
     
     # 1. Build form definition
+    container_label = (
+        container_data.get('containerName')
+        or container_data.get('label')
+        or container_data.get('name')
+        or 'Multi-Step Container'
+    )
+    container_description = (
+        container_data.get('containerDescription')
+        or container_data.get('description')
+        or ''
+    )
+
     definition = {
         'container_id': container_node['id'],
-        'container_label': container_data.get('label', 'Multi-Step Container'),
+        'container_label': container_label,
         'steps': [serialize_step(step) for step in child_steps],
         'layout': container_data.get('layout', {}),
-        'description': container_data.get('description', '')
+        'description': container_description,
     }
     
     definition_hash = hash_definition(definition)
@@ -178,7 +196,7 @@ def snapshot_container(
     
     new_form = TenantForm.objects.create(
         tenant=tenant,
-        name=f"Container: {container_data.get('label', 'Multi-Step Form')}",
+        name=f"Container: {container_label}",
         description=definition.get('description', ''),
         type=FormTypeChoices.MULTI_STEP,
         form_definition=definition,

--- a/backend/apps/system/tasks.py
+++ b/backend/apps/system/tasks.py
@@ -153,9 +153,17 @@ def pin_workflow_versions(workflow_id):
     nodes = workflow.workflow_definition.get('nodes', [])
     pinned_forms = []
     
+    container_types = {
+        'formBook',
+        'formProcessGroup',
+        'formProcess',
+        'formMultiStepContainer',
+        'smartWorkForm',
+    }
+
     for node in nodes:
-        if node.get('type') == 'formMultiStepContainer':
-            tenant_form_id = node.get('data', {}).get('tenantFormId')
+        if node.get('type') in container_types:
+            tenant_form_id = (node.get('data') or {}).get('tenantFormId')
             
             if tenant_form_id:
                 try:

--- a/backend/apps/system/tests/test_workform_container_methods.py
+++ b/backend/apps/system/tests/test_workform_container_methods.py
@@ -1,0 +1,89 @@
+"""Regression tests for WorkForm container methods.
+
+These APIs back the "Container Version" / container browsing endpoints.
+They must work for both legacy containerNodeId wiring and modern React Flow
+sub-flow grouping (parentId/parentNode).
+"""
+
+from django.test import TestCase
+
+from apps.tenants.models import Tenant
+from apps.system.models import TenantWorkForm
+
+
+class TenantWorkFormContainerMethodsTests(TestCase):
+    def setUp(self):
+        self.tenant = Tenant.objects.create(name='Test Tenant', slug='test-tenant')
+
+    def test_get_container_nodes_includes_form_process_group(self):
+        workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='WF',
+            workflow_definition={
+                'nodes': [
+                    {'id': 'c1', 'type': 'formProcessGroup', 'data': {'containerName': 'Group'}},
+                    {'id': 's1', 'type': 'form', 'parentId': 'c1', 'data': {'label': 'Step 1'}},
+                ],
+                'edges': [],
+            },
+        )
+
+        containers = workform.get_container_nodes()
+        self.assertEqual(len(containers), 1)
+        self.assertEqual(containers[0]['id'], 'c1')
+        self.assertEqual(containers[0]['type'], 'formProcessGroup')
+
+    def test_get_nodes_in_container_supports_parent_id(self):
+        workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='WF',
+            workflow_definition={
+                'nodes': [
+                    {'id': 'c1', 'type': 'formProcessGroup', 'data': {'containerName': 'Group'}},
+                    {'id': 's1', 'type': 'form', 'parentId': 'c1', 'data': {'label': 'Step 1'}},
+                    {'id': 's2', 'type': 'action', 'parentId': 'c1', 'data': {'label': 'Action'}},
+                    {'id': 'outside', 'type': 'form', 'data': {'label': 'Outside'}},
+                ],
+                'edges': [],
+            },
+        )
+
+        children = workform.get_nodes_in_container('c1')
+        child_ids = {n['id'] for n in children}
+        self.assertEqual(child_ids, {'s1', 's2'})
+
+    def test_get_nodes_in_container_supports_legacy_container_node_id(self):
+        workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='WF',
+            workflow_definition={
+                'nodes': [
+                    {'id': 'c1', 'type': 'formMultiStepContainer', 'data': {'label': 'Legacy Container'}},
+                    {'id': 's1', 'type': 'formStep', 'data': {'containerNodeId': 'c1', 'tenantFormId': None}},
+                    {'id': 'outside', 'type': 'formStep', 'data': {}},
+                ],
+                'edges': [],
+            },
+        )
+
+        children = workform.get_nodes_in_container('c1')
+        self.assertEqual([n['id'] for n in children], ['s1'])
+
+    def test_get_container_summary_prefers_container_name(self):
+        workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='WF',
+            workflow_definition={
+                'nodes': [
+                    {'id': 'c1', 'type': 'formProcessGroup', 'data': {'containerName': 'Onboarding'}},
+                    {'id': 's1', 'type': 'form', 'parentId': 'c1', 'data': {'label': 'Step 1', 'tenantFormId': '00000000-0000-0000-0000-000000000001'}},
+                ],
+                'edges': [],
+            },
+        )
+
+        summary = workform.get_container_summary('c1')
+        self.assertEqual(summary['container_name'], 'Onboarding')
+        self.assertEqual(summary['total_nodes'], 1)
+        self.assertEqual(summary['node_types']['form'], 1)
+        self.assertEqual(summary['form_references'], ['00000000-0000-0000-0000-000000000001'])

--- a/backend/apps/system/workform_serializers.py
+++ b/backend/apps/system/workform_serializers.py
@@ -232,7 +232,7 @@ class TenantWorkFormSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {
                         'workflow_definition': [
-                            f'Form "{(container_node.get("data") or {}).get("label", container_node.get("id"))}" must have at least 3 steps.'
+                            f'Form "{(container_node.get("data") or {}).get("containerName") or (container_node.get("data") or {}).get("label", container_node.get("id"))}" must have at least 3 steps.'
                         ]
                     }
                 )


### PR DESCRIPTION
Fixes the purple Form Process Group (formProcessGroup) not working in Container Version APIs by:
- Recognizing canonical + legacy container node types
- Resolving child membership via parentId/parentNode and legacy data.containerNodeId
- Improving snapshot naming to use containerName/containerDescription
- Pinning versions for all container types

Also adds regression tests for TenantWorkForm container methods.