### PR TITLE
Fix Admin Workspace data wiring

### DIFF
--- a/frontend/src/pages/Admin/OptionLists/OptionListModal.test.tsx
+++ b/frontend/src/pages/Admin/OptionLists/OptionListModal.test.tsx
@@ -21,7 +21,7 @@ vi.mock('../../../hooks/useToast', () => ({
 
 // Mock the API service
 vi.mock('../../../services/apiService', () => ({
-  adminClient: {
+  apiClient: {
     get: vi.fn(),
     post: vi.fn(),
     patch: vi.fn(),
@@ -68,7 +68,7 @@ describe('OptionListModal', () => {
         },
       ];
 
-      vi.mocked(apiService.adminClient.get).mockResolvedValue({
+      vi.mocked(apiService.apiClient.get).mockResolvedValue({
         data: mockItems,
         status: 200,
         statusText: 'OK',
@@ -91,7 +91,7 @@ describe('OptionListModal', () => {
       // Simulate API returning an object instead of array (the bug scenario)
       const badResponse = { message: 'Some error', items: [] };
 
-      vi.mocked(apiService.adminClient.get).mockResolvedValue({
+      vi.mocked(apiService.apiClient.get).mockResolvedValue({
         data: badResponse as any, // Not an array!
         status: 200,
         statusText: 'OK',
@@ -110,7 +110,7 @@ describe('OptionListModal', () => {
     });
 
     it('handles null response gracefully', async () => {
-      vi.mocked(apiService.adminClient.get).mockResolvedValue({
+      vi.mocked(apiService.apiClient.get).mockResolvedValue({
         data: null as any,
         status: 200,
         statusText: 'OK',
@@ -129,7 +129,7 @@ describe('OptionListModal', () => {
     });
 
     it('handles undefined response gracefully', async () => {
-      vi.mocked(apiService.adminClient.get).mockResolvedValue({
+      vi.mocked(apiService.apiClient.get).mockResolvedValue({
         data: undefined as any,
         status: 200,
         statusText: 'OK',
@@ -148,7 +148,7 @@ describe('OptionListModal', () => {
     });
 
     it('handles error response gracefully', async () => {
-      vi.mocked(apiService.adminClient.get).mockRejectedValue(new Error('Network error'));
+      vi.mocked(apiService.apiClient.get).mockRejectedValue(new Error('Network error'));
 
       render(<OptionListModal {...mockProps} />);
 
@@ -163,7 +163,7 @@ describe('OptionListModal', () => {
 
   describe('system-locked list', () => {
     it('does not show add button for non-extensible list', async () => {
-      vi.mocked(apiService.adminClient.get).mockResolvedValue({
+      vi.mocked(apiService.apiClient.get).mockResolvedValue({
         data: [],
         status: 200,
         statusText: 'OK',

--- a/frontend/src/pages/Admin/OptionLists/OptionListModal.tsx
+++ b/frontend/src/pages/Admin/OptionLists/OptionListModal.tsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { X, Plus, Save, Trash2, ChevronUp, ChevronDown, Lock, Globe, Building } from 'lucide-react';
 import Modal from '@/components/Modal/Modal';
-import { adminClient } from '@/services/apiService';
+import { apiClient } from '@/services/apiService';
 import { useToast } from '@/hooks/useToast';
 
 // ============================================================================
@@ -360,7 +360,7 @@ export const OptionListModal: React.FC<OptionListModalProps> = ({
   const loadItems = async () => {
     setLoading(true);
     try {
-      const response = await adminClient.get(`/system/choice-lists/${listSlug}/items/`);
+      const response = await apiClient.get(`/system/choice-lists/${listSlug}/items/`);
       // Ensure response.data is always an array
       const itemsData = Array.isArray(response.data) ? response.data : [];
       setItems(itemsData);
@@ -439,7 +439,7 @@ export const OptionListModal: React.FC<OptionListModalProps> = ({
 
     // Otherwise, delete from backend
     try {
-      await adminClient.delete(`/system/choice-items/${id}/`);
+      await apiClient.delete(`/system/choice-items/${id}/`);
       setItems(items.filter(item => item.id !== id));
       setHasChanges(true);
     } catch (error) {
@@ -505,10 +505,10 @@ export const OptionListModal: React.FC<OptionListModalProps> = ({
         };
 
         if (item.id.startsWith('temp-')) {
-          return adminClient.post(`/system/choice-lists/${listSlug}/items/`, itemData);
+          return apiClient.post(`/system/choice-lists/${listSlug}/items/`, itemData);
         }
 
-        return adminClient.patch(`/system/choice-items/${item.id}/`, itemData);
+        return apiClient.patch(`/system/choice-items/${item.id}/`, itemData);
       });
 
       await Promise.all(promises);

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -15,7 +15,7 @@ import {
   Search,
   Unlock,
 } from 'lucide-react';
-import { adminClient } from '@/services/apiService';
+import { apiClient } from '@/services/apiService';
 import { AdminGuard, AdminPage, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
@@ -71,7 +71,7 @@ const OptionListsPage: React.FC = () => {
   const loadChoiceLists = async () => {
     setLoading(true);
     try {
-      const response = await adminClient.get('/system/choice-lists/');
+      const response = await apiClient.get('/system/choice-lists/');
       const raw = response.data as any;
       const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
       setLists(data);
@@ -87,7 +87,7 @@ const OptionListsPage: React.FC = () => {
   const loadListItems = async (slug: string) => {
     setLoadingItems(slug);
     try {
-      const response = await adminClient.get(`/system/choice-lists/${slug}/items/`);
+      const response = await apiClient.get(`/system/choice-lists/${slug}/items/`);
       const itemsData = Array.isArray(response.data) ? response.data : [];
       setListItems((prev) => ({ ...prev, [slug]: itemsData }));
     } catch (error) {

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -26,7 +26,9 @@ import Modal from '@/components/Modal/Modal';
 
 interface TenantUser {
   id: number;
-  user: {
+  // Backend may return a user ID (numeric) plus flat identity fields.
+  // Some older payloads may return a nested user object.
+  user: number | {
     id: number;
     username: string;
     email: string;
@@ -35,6 +37,10 @@ interface TenantUser {
   };
   role: 'owner' | 'admin' | 'manager' | 'user' | 'readonly';
   is_active: boolean;
+  username?: string;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
   created_at: string;
   updated_at: string;
 }
@@ -95,14 +101,35 @@ const UsersPage: React.FC = () => {
 
   const normalizedQuery = useMemo(() => searchQuery.trim().toLowerCase(), [searchQuery]);
 
+  const getUserId = (row: TenantUser): number | undefined =>
+    typeof row.user === 'number' ? row.user : row.user?.id;
+
+  const getUsername = (row: TenantUser): string =>
+    row.username ?? (typeof row.user === 'object' && row.user ? row.user.username : '');
+
+  const getEmail = (row: TenantUser): string =>
+    row.email ?? (typeof row.user === 'object' && row.user ? row.user.email : '');
+
+  const getFirstName = (row: TenantUser): string =>
+    row.first_name ?? (typeof row.user === 'object' && row.user ? row.user.first_name : '');
+
+  const getLastName = (row: TenantUser): string =>
+    row.last_name ?? (typeof row.user === 'object' && row.user ? row.user.last_name : '');
+
+  const getDisplayName = (row: TenantUser): string => {
+    const first = getFirstName(row);
+    const last = getLastName(row);
+    const full = `${first} ${last}`.trim();
+    return full || getUsername(row) || getEmail(row) || `User ${getUserId(row) ?? ''}`.trim();
+  };
+
   const matchesUser = (row: TenantUser) => {
     if (!normalizedQuery) return true;
-    const name = `${row.user.first_name || ''} ${row.user.last_name || ''}`.trim().toLowerCase();
-    return (
-      row.user.username.toLowerCase().includes(normalizedQuery) ||
-      row.user.email.toLowerCase().includes(normalizedQuery) ||
-      name.includes(normalizedQuery)
-    );
+    const name = getDisplayName(row).toLowerCase();
+    const username = getUsername(row).toLowerCase();
+    const email = getEmail(row).toLowerCase();
+
+    return username.includes(normalizedQuery) || email.includes(normalizedQuery) || name.includes(normalizedQuery);
   };
 
   const matchesInvitation = (row: Invitation) => {
@@ -191,19 +218,13 @@ const UsersPage: React.FC = () => {
   const columns = useMemo(
     () => [
       {
-        key: 'user.username',
+        key: 'username',
         label: 'User',
         sortable: true,
         render: (_: any, row: TenantUser) => (
           <div>
-            <div style={{ fontWeight: 600 }}>
-              {row.user.first_name && row.user.last_name
-                ? `${row.user.first_name} ${row.user.last_name}`
-                : row.user.username}
-            </div>
-            <div style={{ fontSize: '12px', color: 'rgb(var(--color-text-secondary))' }}>
-              {row.user.email}
-            </div>
+            <div style={{ fontWeight: 600 }}>{getDisplayName(row)}</div>
+            <div style={{ fontSize: '12px', color: 'rgb(var(--color-text-secondary))' }}>{getEmail(row)}</div>
           </div>
         ),
       },
@@ -245,7 +266,8 @@ const UsersPage: React.FC = () => {
         label: 'Deactivate',
         icon: '🚫',
         onClick: (user: TenantUser) => {
-          if (currentUser?.id && user.user.id === currentUser.id) {
+          const targetUserId = getUserId(user);
+          if (currentUser?.id && targetUserId && targetUserId === currentUser.id) {
             toast.error('You cannot deactivate yourself');
             return;
           }
@@ -253,10 +275,14 @@ const UsersPage: React.FC = () => {
           setShowDeactivateConfirm(true);
         },
         variant: 'danger' as const,
-        hidden: (row: TenantUser) =>
-          !permissions.can_manage_users ||
-          !row.is_active ||
-          (currentUser?.id ? row.user.id === currentUser.id : false),
+        hidden: (row: TenantUser) => {
+          const targetUserId = getUserId(row);
+          return (
+            !permissions.can_manage_users ||
+            !row.is_active ||
+            (currentUser?.id && targetUserId ? targetUserId === currentUser.id : false)
+          );
+        },
       },
       {
         label: 'Reactivate',
@@ -491,7 +517,8 @@ const UsersPage: React.FC = () => {
         onClose={() => setShowDeactivateConfirm(false)}
         onConfirm={() => {
           if (!selectedUser) return;
-          if (currentUser?.id && selectedUser.user.id === currentUser.id) {
+          const targetUserId = getUserId(selectedUser);
+          if (currentUser?.id && targetUserId && targetUserId === currentUser.id) {
             toast.error('You cannot deactivate yourself');
             setShowDeactivateConfirm(false);
             return;
@@ -499,7 +526,7 @@ const UsersPage: React.FC = () => {
           deactivateMutation.mutate(selectedUser.id);
         }}
         title="Deactivate User"
-        message={`Deactivate ${selectedUser?.user.username}? They will lose access.`}
+        message={`Deactivate ${selectedUser ? getDisplayName(selectedUser) : 'this user'}? They will lose access.`}
         confirmText="Deactivate"
         confirmVariant="danger"
       />


### PR DESCRIPTION
Fixes Admin Workspace subpages showing no data / wrong identity mapping.

Changes:
- Option Lists: use apiClient so calls hit /api/v1/system/choice-lists and /items
- Users: render identity from TenantUser flat fields (username/email/first_name/last_name), while remaining compatible with legacy nested user payloads
- OptionListModal tests updated to mock apiClient

Verification:
- frontend: vitest run (single worker) passed (60 files, 1149 tests, 24 skipped)
- frontend: type-check currently fails due to pre-existing FlowEditor typing issues (not introduced by this PR)