### PR TITLE
fix(ui): Hard rollback Form Process node to Friday baseline

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -47,6 +47,8 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
+- 2026-03-22T16:39:58Z — EMERGENCY ROLLBACK: Reverted Workform Container UI to stable Friday baseline due to UX degradation.
+
 - 2026-03-20 — Deployed LoopNode, ErrorEdge, Viewport Virtualization, and Backend Try/Catch Graph Routing — PR: #3745
 
 - 2026-03-21 — Admin Workspace: restore API contracts (permissions/current tenant/activity logs/pagination) — PR: #3746
@@ -171,6 +173,9 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 ### PR Log (append-only)
 
 > Fill in as PRs are opened/merged.
+
+- 2026-03-22T17:41:54Z — Hotfix: Corrected Ops workflows to use environment-scoped `SSH_HOST/SSH_USER` (single source of truth) and verified seeding uses `seed_system_products`, resolving pipeline crashes.
+- 2026-03-22T17:56:08Z — Hotfix: Unblocked dev deploy by removing `run_before` edges from `tenants.0011_bootstrap_rls_session_vars` (prevents `InconsistentMigrationHistory` with historical RLS migrations) and hardened Ops SSH auth (prefer `SSH_PASSWORD`, support optional `SSH_KEY`, retain legacy fallbacks).
 
 - 2026-03-13 — Phase 7 Stabilization + Cockpit Navigation — Commit: 6144c189 (PR: #3447)
   - PR: https://github.com/Meats-Central/ProjectMeats/pull/3447
@@ -868,3 +873,8 @@ Deliverables:
 
 
 - 2026-03-20 — MSAL common authority restoration (B2B/B2C support) & prompt enforcement — PR: #TBD.
+
+
+## PR Log (append-only) — Workforms UI Hardening (merge-safe)
+
+- 2026-03-22T19:05:59Z — UI Hardening: Restored standard default container for 'formProcess' nodes, disabling 'formProcessGroup' purple canonicalization/styling overrides.

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -33,7 +33,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { debounce } from 'lodash';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { adminClient } from '../../services/apiService';
 import toast, { Toaster } from 'react-hot-toast'; // Phase 8.1
 import * as Sentry from '@sentry/react'; // Error tracking
@@ -41,7 +41,6 @@ import { logger } from '../../utils/logger'; // Centralized logging
 import { isTypingInInput } from './utils/keyboardUtils'; // Phase 4
 import Joyride from 'react-joyride'; // Gap Analysis Phase 1.1
 import { useRenderPerformance } from '../../utils/performance'; // Phase 7.5
-import { useVirtualizedNodes } from './hooks/useVirtualizedNodes';
 import { 
   useOnboardingTour, 
   workflowEditorTourSteps, 
@@ -64,7 +63,6 @@ import {
   OnSelectionChangeParams,
   useReactFlow,
   MarkerType,
-  type Viewport,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import './UnifiedFlowEditor.responsive.css'; // Gap Analysis Phase 1.2
@@ -109,11 +107,9 @@ import {
 
 import {
   FormNode,
-  FormProcessNode,
-  FormStepNode,
   FormStepSingleNode,
   FormReferenceNode,
-  SmartWorkFormNode,
+  FormProcessGroupNode,
   TriggerNode,
   ConditionIfNode,
   ActionNode,
@@ -121,8 +117,8 @@ import {
   DocumentNode,
   UtilityNode,
   TerminalNode,
-  LoopNode,
 } from './nodes';
+import FormProcessNode from './nodes/FormProcessNode';
 import { CustomEdge, ConditionalEdge, ErrorEdge, SuccessEdge, InsertNodeEdge, EnhancedConnectionEdge } from './edges';
 import { FormBuilder } from '../form-builder';
 import { useFormBuilder } from './hooks/useFormBuilder';
@@ -180,28 +176,21 @@ export type EditorMode = 'wizard' | 'visual' | 'expert'; // 'expert' is deprecat
 interface UnifiedFlowEditorProps {
   initialNodes?: Node[];
   initialEdges?: Edge[];
-  /** Optional initial viewport (e.g., loaded workflow_definition.viewport) */
-  initialViewport?: { x: number; y: number; zoom: number };
-
-  /**
-   * Legacy callback (deprecated): saving is now handled internally via tenant-workforms persistence.
-   */
   onSave?: (nodes: Node[], edges: Edge[]) => void;
-
   onChange?: (nodes: Node[], edges: Edge[]) => void; // Track changes for auto-save
-
-  /**
-   * Optional initial workflow metadata (used when embedding the editor in a route-driven page).
-   */
-  initialWorkflowId?: string;
-  initialWorkflowName?: string;
-  initialWorkflowDescription?: string;
-  initialWorkflowStatus?: 'draft' | 'active' | 'archived';
-  onWorkflowSaved?: (workflow: { id: string; name: string }) => void;
-
   readOnly?: boolean;
   editorMode?: EditorMode;
   allowedNodeCategories?: string[]; // Phase 4.2: Filter nodes by permission
+
+  /**
+   * Punch-In mode: read-only monitoring view focused on the active node.
+   * Uses FlowEditor debug tracing (no mutations to saved workflow graph).
+   */
+  punchIn?: {
+    activeNodeId: string | null;
+    executedNodeIds?: string[];
+    centerOnActiveNode?: boolean;
+  };
 }
 
 interface HistoryState {
@@ -223,8 +212,7 @@ const ENABLE_FULL_DYNAMIC_MODE = true;
 
 const EditorContainer = styled.div<{ $isFullscreen?: boolean }>`
   width: 100%;
-  /* Better default sizing on page load */
-  height: ${props => props.$isFullscreen ? '100vh' : 'clamp(640px, calc(100vh - 220px), 980px)'};
+  height: ${props => props.$isFullscreen ? '100vh' : '600px'};
   background: rgb(var(--color-background));
   border: ${props => props.$isFullscreen ? 'none' : '1px solid rgb(var(--color-border))'};
   border-radius: ${props => props.$isFullscreen ? '0' : 'var(--radius-lg)'};
@@ -235,6 +223,15 @@ const EditorContainer = styled.div<{ $isFullscreen?: boolean }>`
   right: ${props => props.$isFullscreen ? '0' : 'auto'};
   bottom: ${props => props.$isFullscreen ? '0' : 'auto'};
   z-index: ${props => props.$isFullscreen ? '9990' : 'auto'};
+
+  /* Punch-In / debug highlighting (wrapper-level react-flow nodes) */
+  .react-flow__node.pm-active-node,
+  .react-flow__node.rf-active-node {
+    box-shadow:
+      0 0 0 3px rgb(var(--color-primary) / 0.35),
+      0 10px 24px rgba(0, 0, 0, 0.12);
+    border-radius: 12px;
+  }
   
   /* Phase 7.2: Smart Snapping - Connection Line Animation */
   @keyframes dash {
@@ -245,12 +242,11 @@ const EditorContainer = styled.div<{ $isFullscreen?: boolean }>`
   
   /* Phase 7.2: Smart Snapping - Visual Connection Indicators */
   .react-flow__connection-path {
-    stroke: rgb(var(--color-primary)) !important;
-    stroke-width: 2 !important;
-    vector-effect: non-scaling-stroke;
+    stroke: #667eea !important;
+    stroke-width: 3 !important;
     stroke-dasharray: 5, 5;
     animation: dash 0.5s linear infinite;
-    filter: drop-shadow(0 0 4px rgb(var(--color-primary) / 0.35));
+    filter: drop-shadow(0 0 4px rgba(102, 126, 234, 0.4));
   }
   
   /* Phase 7.2: Enhanced snap feedback */
@@ -278,8 +274,7 @@ const EditorContainer = styled.div<{ $isFullscreen?: boolean }>`
   /* Animate container expand/collapse */
   .react-flow__node[data-type="formMultiStepContainer"],
   .react-flow__node[data-type="formProcess"],
-  .react-flow__node[data-type="formProcessGroup"],
-  .react-flow__node[data-type="formBook"] {
+  .react-flow__node[data-type="formProcessGroup"] {
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
                 width 0.3s ease,
                 height 0.3s ease,
@@ -1668,16 +1663,13 @@ const ToggleSwitch = styled.button<{ $active: boolean }>`
 // we cast here to keep editor typing stable while runtime behavior remains unchanged.
 const staticNodeTypes = {
   // Form nodes (Phase E - 2026-02-19)
-  form: FormStepNode,  // Form Step (Page)
+  form: FormNode,  // NEW: Primary form node name
   formStepSingle: FormStepSingleNode,  // Backward compatibility
-  formBook: FormNode,  // Form container (Book)
-  // Restore legacy purple FormProcess container renderer (kept stable for business users)
-  formProcess: FormProcessNode,
-  formProcessGroup: FormProcessNode,
-  smartWorkForm: SmartWorkFormNode,
+  formProcess: FormProcessGroupNode,  // Upgraded: legacy type now uses the group node component
+  formProcessGroup: FormProcessGroupNode,
   // Backward compatibility aliases
   formStep: FormStepSingleNode,  // Deprecated
-  formMultiStepContainer: FormProcessNode,  // Legacy container alias (render as purple process container)
+  formMultiStepContainer: FormProcessGroupNode,  // Upgraded: legacy type now uses the group node component
   // Other nodes
   formReference: FormReferenceNode,
   trigger: TriggerNode,
@@ -1701,11 +1693,15 @@ Object.keys(NODE_TYPE_REGISTRY).forEach((typeId) => {
   else if (typeId.startsWith('wait') || typeId.startsWith('timer') || typeId.startsWith('pending')) dynamicNodeTypes[typeId] = WaitStateNode;
   else if (typeId.startsWith('document')) dynamicNodeTypes[typeId] = DocumentNode;
   else if (typeId.startsWith('terminal') || typeId.startsWith('end')) dynamicNodeTypes[typeId] = TerminalNode;
-  else if (typeId.startsWith('loop')) dynamicNodeTypes[typeId] = LoopNode;
   else if (typeId.startsWith('form')) dynamicNodeTypes[typeId] = FormStepSingleNode;
   else dynamicNodeTypes[typeId] = UtilityNode;
 });
 
+// Hotfix/rollback safety: render all Form Process container variants using the stable container node
+// (avoids the purple group container regressions while keeping legacy type IDs compatible).
+dynamicNodeTypes.formProcess = FormProcessNode;
+dynamicNodeTypes.formProcessGroup = FormProcessNode;
+dynamicNodeTypes.formMultiStepContainer = FormProcessNode;
 
 // Static edge types (no useMemo needed - these are constant)
 const staticEdgeTypes = {
@@ -1714,7 +1710,6 @@ const staticEdgeTypes = {
   error: ErrorEdge,
   success: SuccessEdge,
   enhanced: EnhancedConnectionEdge,
-  step: EnhancedConnectionEdge, // Use enhanced edge UX (toolbar, hitbox) with step routing
   insert: InsertNodeEdge,
   default: CustomEdge, // Fallback to custom for untyped edges
 } as unknown as EdgeTypes;
@@ -1733,7 +1728,20 @@ const DebugAwareReactFlow: React.FC<React.ComponentProps<typeof ReactFlow>> = (p
     return nodes.map((n) => {
       const isActive = activeId === n.id;
       const isExecuted = executed.has(n.id);
-      if (isActive || isExecuted) return n;
+
+      if (isActive) {
+        return {
+          ...n,
+          className: [n.className, 'pm-active-node', 'rf-active-node'].filter(Boolean).join(' '),
+        };
+      }
+
+      if (isExecuted) {
+        return {
+          ...n,
+          className: [n.className, 'rf-executed-node'].filter(Boolean).join(' '),
+        };
+      }
 
       return {
         ...n,
@@ -1796,6 +1804,44 @@ const DebugAwareReactFlow: React.FC<React.ComponentProps<typeof ReactFlow>> = (p
       edges={decoratedEdges}
     />
   );
+};
+
+const PunchInController: React.FC<{ punchIn: UnifiedFlowEditorProps['punchIn'] | undefined }> = ({ punchIn }) => {
+  const { startDebugSession, setDebugActiveNodeId, markNodesExecuted } = useFlowEditor();
+  const reactFlow = useReactFlow();
+
+  useEffect(() => {
+    if (!punchIn) return;
+
+    startDebugSession(punchIn.activeNodeId);
+    setDebugActiveNodeId(punchIn.activeNodeId);
+    markNodesExecuted(punchIn.executedNodeIds || []);
+  }, [
+    punchIn?.activeNodeId,
+    JSON.stringify(punchIn?.executedNodeIds || []),
+    startDebugSession,
+    setDebugActiveNodeId,
+    markNodesExecuted,
+  ]);
+
+  useEffect(() => {
+    if (!punchIn?.centerOnActiveNode) return;
+    if (!punchIn.activeNodeId) return;
+
+    const id = window.setTimeout(() => {
+      const node = reactFlow.getNode?.(punchIn.activeNodeId || '');
+      if (!node) return;
+
+      const x = (node.positionAbsolute?.x ?? node.position.x) + (node.width ?? 0) / 2;
+      const y = (node.positionAbsolute?.y ?? node.position.y) + (node.height ?? 0) / 2;
+
+      reactFlow.setCenter(x, y, { zoom: 1, duration: 350 });
+    }, 50);
+
+    return () => window.clearTimeout(id);
+  }, [punchIn?.centerOnActiveNode, punchIn?.activeNodeId, reactFlow]);
+
+  return null;
 };
 
 // ============================================================================
@@ -1870,17 +1916,12 @@ class ConfigPanelErrorBoundary extends React.Component<
 const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   initialNodes = [],
   initialEdges = [],
-  initialViewport,
   onSave,
   onChange, // Track changes for auto-save
-  initialWorkflowId,
-  initialWorkflowName,
-  initialWorkflowDescription,
-  initialWorkflowStatus,
-  onWorkflowSaved,
   readOnly = false,
   editorMode = 'visual',
   allowedNodeCategories, // Phase 4.2: Permission-based filtering
+  punchIn,
 }) => {
   // Normalize nodes to ensure all have required properties (maxInputs, maxOutputs)
   const normalizedInitialNodes = useMemo(() => normalizeNodes(initialNodes), [initialNodes]);
@@ -1889,8 +1930,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [nodeIdCounter, setNodeIdCounter] = useState(normalizedInitialNodes.length + 1);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-
-  const queryClient = useQueryClient();
   
   // Keep ref to current nodes for stable callbacks
   const nodesRef = useRef<Node[]>(nodes);
@@ -1995,16 +2034,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   
   // React Flow instance for viewport controls
   const { setCenter: reactFlowSetCenter, ...reactFlowInstance } = useReactFlow();
-
-  // Phase 7.5/Vanguard 1: track viewport for optional strict node/edge list virtualization
-  const [viewport, setViewport] = useState<Viewport>({ x: 0, y: 0, zoom: 1 });
-  const didInitViewportRef = useRef(false);
-  useEffect(() => {
-    if (didInitViewportRef.current) return;
-    if (!reactFlowInstance?.getViewport) return;
-    didInitViewportRef.current = true;
-    setViewport(reactFlowInstance.getViewport());
-  }, [reactFlowInstance]);
   
   // ============================================================================
   // CONFIG PANEL PORTAL - Enhanced with full styling (2026-02-24)
@@ -2431,6 +2460,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     const handleKeyDown = (e: KeyboardEvent) => {
       if (isTypingInInput(e)) return;
       
+      // Ctrl/Cmd + S: Save
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        handleSave();
+      }
+      
       // Ctrl/Cmd + Z: Undo
       if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
         e.preventDefault();
@@ -2694,27 +2729,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Workflow Persistence State (Phase 7)
   // ============================================================================
   
-  const [currentWorkflowId, setCurrentWorkflowId] = useState<string | undefined>(initialWorkflowId);
-  const [currentWorkflowName, setCurrentWorkflowName] = useState<string>(
-    initialWorkflowName || 'Untitled Workflow'
-  );
-  const [currentWorkflowDescription, setCurrentWorkflowDescription] = useState<string>(
-    initialWorkflowDescription || ''
-  ); // Phase 8.2
-  const [currentWorkflowStatus, setCurrentWorkflowStatus] = useState<'draft' | 'active' | 'archived'>(
-    initialWorkflowStatus || 'draft'
-  ); // Phase 8.2
+  const [currentWorkflowId, setCurrentWorkflowId] = useState<string | undefined>(undefined);
+  const [currentWorkflowName, setCurrentWorkflowName] = useState<string>('Untitled Workflow');
+  const [currentWorkflowDescription, setCurrentWorkflowDescription] = useState<string>(''); // Phase 8.2
+  const [currentWorkflowStatus, setCurrentWorkflowStatus] = useState<'draft' | 'active' | 'archived'>('draft'); // Phase 8.2
   const [workflowList, setWorkflowList] = useState<WorkflowListItem[]>([]);
   const [isLoadMenuOpen, setIsLoadMenuOpen] = useState(false);
-
-  // Keep workflow metadata in sync when the parent route/page swaps the loaded workflow.
-  useEffect(() => {
-    if (initialWorkflowId !== undefined) setCurrentWorkflowId(initialWorkflowId);
-    if (initialWorkflowName !== undefined) setCurrentWorkflowName(initialWorkflowName || 'Untitled Workflow');
-    if (initialWorkflowDescription !== undefined) setCurrentWorkflowDescription(initialWorkflowDescription || '');
-    if (initialWorkflowStatus !== undefined)
-      setCurrentWorkflowStatus(initialWorkflowStatus || 'draft');
-  }, [initialWorkflowId, initialWorkflowName, initialWorkflowDescription, initialWorkflowStatus]);
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isWorkflowModalOpen, setIsWorkflowModalOpen] = useState(false); // Phase 8.2
@@ -3194,34 +3214,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         return;
       }
       
-      const sourceHandle = params.sourceHandle;
-      const nextType =
-        sourceHandle === 'error'
-          ? 'error'
-          : sourceHandle === 'true' || sourceHandle === 'false'
-            ? 'conditional'
-            : 'step';
-
-      const nextData =
-        sourceHandle === 'error'
-          ? { label: 'Error', animated: true }
-          : sourceHandle === 'true'
-            ? { label: 'True', isTrue: true }
-            : sourceHandle === 'false'
-              ? { label: 'False', isTrue: false }
-              : undefined;
-
-      setEdges((eds) =>
-        addEdge(
-          {
-            ...params,
-            type: nextType,
-            data: nextData,
-            interactionWidth: 28,
-          } as any,
-          eds
-        )
-      );
+      setEdges((eds) => addEdge(params, eds));
     },
     [nodes, edges, setEdges, isValidConnectionType, getNodeMaxConnections]
   );
@@ -3354,7 +3347,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       const reactFlowType = getReactFlowNodeType(nodeTypeId);
 
       // Ensure default dimensions upfront (prevents React Flow dimension errors)
-      const defaultDimensions = isNewContainer ? { width: 600, height: 450 } : undefined;
+      const defaultDimensions = isNewContainer ? { width: 600, height: 400 } : undefined;
 
       const newNode: Node = {
         id: newNodeId,
@@ -3369,11 +3362,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         selected: true,
       };
 
-      // Canonical container type: Form Process (group container)
+      // Upgrade legacy container types to the canonical group container
       if (isNewContainer) {
         newNode.style = {
           width: 600,
-          height: 450,
+          height: 400,
         };
         newNode.data = {
           ...newNode.data,
@@ -3392,8 +3385,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           parentId,
           extent: 'parent',
           expandParent: true,
-          // Keep the first step safely inside default container bounds
-          position: { x: 50, y: 80 },
+          position: { x: 30, y: 90 },
           data: {
             label: NODE_TYPE_REGISTRY.form?.name || 'Form',
             status: 'draft',
@@ -3861,7 +3853,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       // Fix #2: Ensure default dimensions upfront (prevents React Flow dimension errors)
       const isContainerNode = isFormProcessContainerType(type);
       const defaultDimensions = isContainerNode
-        ? { width: 600, height: 450 } // Larger for containers (fits first step inside bounds)
+        ? { width: 600, height: 400 } // Larger for containers
         : undefined; // Let React Flow calculate for regular nodes
 
       const newNode: Node = {
@@ -4059,8 +4051,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       const edgesToAdd: Edge[] = [];
       let counterDelta = 1;
 
-      // Auto-spawn a default Form Step (Page) inside a new Form (Book)
-      if (isContainerNode && (newNode.type === 'formBook' || newNode.type === 'formProcessGroup')) {
+      // Phase 10: Auto-spawn a default Form page inside a new formProcessGroup
+      if (isContainerNode && newNode.type === 'formProcessGroup') {
         const pageId = `node-${nodeIdCounter + 1}`;
         const pageNode: Node = {
           id: pageId,
@@ -4124,7 +4116,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
       updatedEdges = [...updatedEdges, ...edgesToAdd];
 
-      if (isContainerNode && (newNode.type === 'formBook' || newNode.type === 'formProcessGroup')) {
+      if (isContainerNode && newNode.type === 'formProcessGroup') {
         applyAutoLayoutImmediate(updatedNodes, updatedEdges);
       } else {
         setNodes(updatedNodes);
@@ -4592,10 +4584,53 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   }, [nodes, setNodes]);
 
   // ============================================================================
-  // Save Handler (Legacy compatibility)
+  // Save Handler
   // ============================================================================
-  // NOTE: The editor persists workflows via `handleSaveWorkflow` (tenant-workforms).
-  // `handleSaveRef` remains as a stable indirection for keyboard/UI triggers.
+  
+  const handleSaveImpl = useCallback(() => {
+    logger.debug('[FlowEditor] Quick save triggered');
+    
+    // SAFETY: Validate state before save
+    if (!nodes || !edges) {
+      logger.error('[FlowEditor] Cannot save: nodes or edges undefined');
+      toast.error('Cannot save workflow: Invalid state');
+      return;
+    }
+    
+    toast.success('Workflow saved');
+    
+    if (onSave) {
+      try {
+        // Log container information for debugging (Phase E)
+        const containerNodes = nodes.filter(n => n.type === 'formMultiStepContainer');
+        const nodesInContainers = nodes.filter(n => n.parentId);
+        
+        logger.debug('[Save] Workflow saved with container state:');
+        logger.debug(`  - ${containerNodes.length} container(s)`);
+        logger.debug(`  - ${nodesInContainers.length} node(s) in containers`);
+        
+        if (containerNodes.length > 0) {
+          containerNodes.forEach(container => {
+            const childNodes = nodes.filter(n => n.parentId === container.id); // Phase E: Using parentNode
+            logger.debug(`  - Container ${container.id}: ${childNodes.length} nodes`);
+          });
+        }
+        
+        onSave(nodes, edges);
+        logger.debug('Flow saved successfully!');
+        setHasUnsavedChanges(false);
+      } catch (error) {
+        logger.error('[FlowEditor] Save failed:', error);
+        toast.error('Failed to save workflow');
+      }
+    }
+  }, [nodes, edges, onSave]);
+  
+  // Populate forward ref (CRITICAL: Must be after useCallback definition)
+  handleSaveRef.current = handleSaveImpl;
+  
+  // Alias for keyboard shortcut (now points to the forward ref wrapper)
+  const handleQuickSave = handleSave;
 
   // ============================================================================
   // Phase 7: Workflow Persistence Handlers
@@ -4609,23 +4644,22 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     const errors: string[] = [];
     
     // Find all container nodes
-    const containerNodes = nodes.filter((n) =>
-      ['formBook', 'formProcessGroup', 'formProcess', 'formMultiStepContainer'].includes(n.type || '')
+    const containerNodes = nodes.filter(
+      n => n.type === 'formMultiStepContainer'
     );
     
     for (const container of containerNodes) {
       // Get child nodes
       const childNodes = nodes.filter(n => n.parentId === container.id);
       
-      // Check for form/page steps in the container.
-      const formSteps = childNodes.filter((n) =>
-        ['form', 'formStepSingle', 'formStep', 'formReference'].includes(n.type || '')
+      // Check for at least one form step
+      const formSteps = childNodes.filter(
+        n => n.type === 'formStep' || n.type === 'formReference'
       );
-
-      const minSteps = container.type === 'formBook' ? 3 : 1;
-      if (formSteps.length < minSteps) {
+      
+      if (formSteps.length === 0) {
         errors.push(
-          `Container "${container.data.label || container.id}" must have at least ${minSteps} step(s)`
+          `Container "${container.data.label || container.id}" must have at least one form step`
         );
       }
       
@@ -4690,12 +4724,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       if (!currentWorkflowId) {
         setCurrentWorkflowId(savedWorkflow.id);
       }
-
-      onWorkflowSaved?.({ id: savedWorkflow.id, name: savedWorkflow.name });
-
-      // Refresh any UI surfaces that list available forms/workforms.
-      queryClient.invalidateQueries({ queryKey: ['tenant-forms'] });
-      queryClient.invalidateQueries({ queryKey: ['tenant-workforms'] });
       
       setHasUnsavedChanges(false);
       logger.debug('✅ Workflow saved:', savedWorkflow.name);
@@ -4716,12 +4744,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     } finally {
       setIsSaving(false);
     }
-  }, [nodes, edges, currentWorkflowId, currentWorkflowName, isSaving, reactFlowInstance, validateContainers, currentWorkflowDescription, currentWorkflowStatus, onWorkflowSaved, queryClient]);
-
-  // Populate forward ref now that the real save handler exists.
-  handleSaveRef.current = () => {
-    void handleSaveWorkflow();
-  };
+  }, [nodes, edges, currentWorkflowId, currentWorkflowName, isSaving, reactFlowInstance, validateContainers, currentWorkflowDescription, currentWorkflowStatus]);
   
   /**
    * Auto-layout: Apply dagre layout to all nodes
@@ -5145,46 +5168,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Viewport Controls
   // ============================================================================
   
-  const fitView = useCallback(
-    (opts?: { padding?: number; duration?: number; maxZoom?: number }) => {
-      if (reactFlowInstance?.fitView) {
-        reactFlowInstance.fitView({
-          padding: opts?.padding ?? 0.28,
-          duration: opts?.duration ?? 300,
-          maxZoom: opts?.maxZoom ?? 1.1,
-        } as any);
-      }
-    },
-    [reactFlowInstance]
-  );
-
-  const didApplyInitialViewportRef = useRef(false);
-
-  // On first load: restore saved viewport (if provided) else fit-to-content.
-  useEffect(() => {
-    if (didApplyInitialViewportRef.current) return;
-    if (!reactFlowInstance) return;
-
-    const hasGraph = nodes.length > 0 || edges.length > 0;
-    if (!hasGraph) return;
-
-    didApplyInitialViewportRef.current = true;
-
-    requestAnimationFrame(() => {
-      if (initialViewport && reactFlowInstance?.setViewport) {
-        reactFlowInstance.setViewport(initialViewport);
-        return;
-      }
-
-      fitView({ padding: 0.32, duration: 350, maxZoom: 1.05 });
-
-      // Nudge the fitted view so the default left palette doesn't occlude the first nodes.
-      if (isPaletteVisible && reactFlowInstance?.getViewport && reactFlowInstance?.setViewport) {
-        const vp = reactFlowInstance.getViewport();
-        reactFlowInstance.setViewport({ ...vp, x: vp.x + 140 });
-      }
-    });
-  }, [edges.length, fitView, initialViewport, isPaletteVisible, nodes.length, reactFlowInstance]);
+  const fitView = useCallback(() => {
+    if (reactFlowInstance?.fitView) {
+      reactFlowInstance.fitView({ padding: 0.2, duration: 300 });
+    }
+  }, [reactFlowInstance]);
   
   const zoomIn = useCallback(() => {
     if (reactFlowInstance?.zoomIn) {
@@ -5568,11 +5556,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       case 'formProcess': {
         // Phase 7 Stabilization: these node types are deprecated.
         // Migrate in-memory to the canonical Form Process Group node.
-        logger.debug('✏️ [EDIT BUTTON] Migrating legacy container to formBook');
+        logger.debug('✏️ [EDIT BUTTON] Migrating legacy container to formProcessGroup');
 
         const migratedNode = {
           ...node,
-          type: 'formBook',
+          type: 'formProcessGroup',
           data: {
             ...(node.data || {}),
             // Ensure group semantics are enabled
@@ -6069,150 +6057,68 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Template Selection Handler (Phase 2.5 Integration)
   // ============================================================================
   
-  const handleTemplateSelect = useCallback(
-    (template: FlowTemplate) => {
-      logger.debug('[Template] Selected:', template.name);
-
-      const normalizeTemplateNodeType = (typeId: string) => {
-        // Consolidate legacy form types to the canonical ones (additive/back-compat)
-        if (typeId === 'formStep' || typeId === 'formStepSingle') return 'form';
-        if (typeId === 'formProcess' || typeId === 'formMultiStepContainer') return 'formProcessGroup';
-        return typeId;
+  const handleTemplateSelect = useCallback((template: FlowTemplate) => {
+    logger.debug('[Template] Selected:', template.name);
+    
+    // Map template nodes to proper React Flow node types with full metadata
+    const mappedNodes = template.nodes.map(node => {
+      // Get node definition from registry for metadata (color, icon, etc.)
+      const nodeDef = getNodeTypeDefinition(node.type);
+      
+      // Ensure node has proper type mapping
+      const reactFlowType = getReactFlowNodeType(node.type);
+      
+      // Merge default data + template data + registry metadata
+      const defaultData = getDefaultNodeData(node.type);
+      
+      return {
+        ...node,
+        type: reactFlowType, // Override with React Flow node type
+        data: {
+          ...defaultData,      // Default node data (fields, actions, etc.)
+          ...node.data,        // Template-specific data
+          label: node.data.label || nodeDef?.name || node.type, // Ensure label exists
+          // Add registry metadata for proper styling
+          color: nodeDef?.color,
+          icon: nodeDef?.icon,
+          category: nodeDef?.category,
+          description: nodeDef?.description,
+        }
       };
-
-      const mappedNodes = template.nodes.map((node) => {
-        const normalizedTypeId = normalizeTemplateNodeType(node.type);
-
-        // Prefer metadata from normalized type, but fall back to the raw one
-        const nodeDef = getNodeTypeDefinition(normalizedTypeId) || getNodeTypeDefinition(node.type);
-        const reactFlowType = getReactFlowNodeType(normalizedTypeId);
-        const defaultData = getDefaultNodeData(normalizedTypeId);
-
-        return {
-          ...node,
-          type: reactFlowType,
-          data: {
-            ...defaultData,
-            ...node.data,
-            label: (node.data as any)?.label || nodeDef?.name || normalizedTypeId,
-            color: nodeDef?.color,
-            icon: nodeDef?.icon,
-            category: nodeDef?.category,
-            description: nodeDef?.description,
-          },
-        };
-      });
-
-      // Normalize template edges so they render with consistent types/markers.
-      // Templates often omit type and rely on handle IDs (true/false/error).
-      const mappedEdges: Edge[] = template.edges.map((edge) => {
-        const sourceHandle = (edge as any).sourceHandle as string | undefined;
-
-        const inferredType =
-          edge.type ||
-          (sourceHandle === 'error'
-            ? 'error'
-            : sourceHandle === 'true' || sourceHandle === 'false'
-              ? 'conditional'
-              : 'step');
-
-        const next: Edge = {
-          ...edge,
-          type: inferredType,
-          interactionWidth: edge.interactionWidth ?? 28,
-        };
-
-        if (inferredType === 'conditional' && !(edge as any).data && (sourceHandle === 'true' || sourceHandle === 'false')) {
-          (next as any).data = {
-            label: edge.label || (sourceHandle === 'true' ? 'True' : 'False'),
-            isTrue: sourceHandle === 'true',
-          };
-        }
-
-        if (inferredType === 'error' && !(edge as any).data) {
-          (next as any).data = {
-            label: edge.label || 'Error',
-            animated: true,
-          };
-        }
-
-        if (inferredType === 'step') {
-          next.style = {
-            strokeWidth: 3,
-            stroke: 'rgb(var(--color-text-secondary))',
-            ...(edge.style || {}),
-          };
-          next.markerEnd =
-            edge.markerEnd ||
-            ({
-              type: MarkerType.ArrowClosed,
-              width: 24,
-              height: 24,
-              color: 'rgb(var(--color-text-secondary))',
-            } as any);
-        }
-
-        return next;
-      });
-
-      // Hardening: ensure container children are inside bounds on template load.
-      let layoutedNodes = mappedNodes as Node[];
-      let layoutedEdges = mappedEdges;
-
-      const containerIds = layoutedNodes
-        .filter((n) => isFormProcessContainerType(n.type))
-        .map((n) => n.id);
-
-      for (const containerId of containerIds) {
-        const layoutResult = calculateContainerLayout(containerId, layoutedNodes, layoutedEdges);
-
-        layoutedNodes = layoutResult.nodes.map((n) => {
-          if (n.id !== containerId) return n;
-          return {
-            ...n,
-            style: {
-              ...(n.style || {}),
-              width: Math.max(layoutResult.containerWidth, (n.style as any)?.width || 400),
-              height: Math.max(layoutResult.containerHeight, (n.style as any)?.height || 300),
-            },
-          };
-        });
-
-        layoutedEdges = autoConnectSequentialSteps(containerId, layoutedNodes, layoutedEdges).edges;
+    });
+    
+    // Load template nodes and edges into canvas
+    setNodes(mappedNodes);
+    setEdges(template.edges);
+    
+    // Reset history with template as initial state
+    const newHistory: HistoryState[] = [{
+      nodes: mappedNodes,
+      edges: template.edges
+    }];
+    setHistory(newHistory);
+    setHistoryIndex(0);
+    
+    // Update node ID counter based on loaded nodes
+    const maxId = Math.max(
+      0,
+      ...template.nodes.map(n => {
+        const match = n.id.match(/node-(\d+)/);
+        return match ? parseInt(match[1], 10) : 0;
+      })
+    );
+    setNodeIdCounter(maxId + 1);
+    
+    // Close modal
+    setIsTemplateModalOpen(false);
+    
+    // Fit view to show full template
+    setTimeout(() => {
+      if (reactFlowInstance?.fitView) {
+        reactFlowInstance.fitView({ padding: 0.2, duration: 400 });
       }
-
-      // Load into canvas
-      setNodes(layoutedNodes);
-      setEdges(layoutedEdges);
-
-      // Reset history with template as initial state
-      setHistory([
-        {
-          nodes: layoutedNodes,
-          edges: layoutedEdges,
-        },
-      ]);
-      setHistoryIndex(0);
-
-      const maxId = Math.max(
-        0,
-        ...layoutedNodes.map((n) => {
-          const match = n.id.match(/node-(\d+)/);
-          return match ? parseInt(match[1], 10) : 0;
-        })
-      );
-      setNodeIdCounter(maxId + 1);
-
-      setIsTemplateModalOpen(false);
-
-      setTimeout(() => {
-        if (reactFlowInstance?.fitView) {
-          reactFlowInstance.fitView({ padding: 0.2, duration: 400 });
-        }
-      }, 100);
-    },
-    [setNodes, setEdges, reactFlowInstance]
-  );
+    }, 100);
+  }, [setNodes, setEdges, reactFlowInstance]);
 
   const handleStartBlank = useCallback(() => {
     logger.debug('[Template] Starting blank canvas');
@@ -6293,192 +6199,39 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       .map(id => NODE_TYPE_REGISTRY[id])
       .filter(Boolean);
   }, [recentNodes]);
-
-  const lastNodeIdSet = useMemo(() => {
-    const nodeById = new Map(nodes.map((n) => [n.id, n] as const));
-    const outgoingWithinScope = new Set<string>();
-
-    edges.forEach((e) => {
-      const sourceNode = nodeById.get(e.source);
-      const targetNode = nodeById.get(e.target);
-      if (!sourceNode || !targetNode) return;
-
-      const sourceScope = sourceNode.parentId ?? '__root__';
-      const targetScope = targetNode.parentId ?? '__root__';
-
-      if (sourceScope !== targetScope) return;
-      outgoingWithinScope.add(sourceNode.id);
-    });
-
-    const sinks = new Set<string>();
-    nodes.forEach((n) => {
-      if (n.hidden) return;
-      if (!outgoingWithinScope.has(n.id)) sinks.add(n.id);
-    });
-
-    return sinks;
-  }, [edges, nodes]);
-
-  // React Flow Sub-flows reference: https://reactflow.dev/examples/nodes/sub-flows
-  // We treat Form containers as true parent nodes (parentId + extent:'parent') and insert pages within that scope.
-  const addFormStepInsideContainer = useCallback(
-    (containerId: string, afterNodeId?: string) => {
-      setNodes((prev) => {
-        const nodeById = new Map(prev.map((n) => [n.id, n] as const));
-        const container = nodeById.get(containerId);
-        if (!container) return prev;
-
-        const isPageNodeType = (type?: string) =>
-          type === 'form' || type === 'formStepSingle' || type === 'formStep' || type === 'formReference';
-
-        const pageNodes = prev.filter((n) => n.parentId === containerId && isPageNodeType(n.type));
-        const pageIdSet = new Set(pageNodes.map((n) => n.id));
-
-        const existingOrder = Array.isArray((container.data as any)?.pageOrder)
-          ? (((container.data as any).pageOrder as string[]) || [])
-          : [];
-
-        const normalizedExisting = existingOrder.filter((pid) => pageIdSet.has(pid));
-        const missing = pageNodes
-          .filter((n) => !normalizedExisting.includes(n.id))
-          .sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0) || (a.position?.y || 0) - (b.position?.y || 0))
-          .map((n) => n.id);
-
-        const baseOrder = [...normalizedExisting, ...missing];
-        const insertIndex = afterNodeId && baseOrder.includes(afterNodeId) ? baseOrder.indexOf(afterNodeId) + 1 : baseOrder.length;
-
-        const enforceStrictPages = container.type === 'formProcessGroup' || container.type === 'formProcess' || container.type === 'formMultiStepContainer';
-
-        const newPageId = `page-${uuidv4()}`;
-        const nextOrder = [...baseOrder.slice(0, insertIndex), newPageId, ...baseOrder.slice(insertIndex)];
-
-        const newPageNumber = insertIndex + 1;
-        const newPage: Node = {
-          id: newPageId,
-          type: 'form',
-          position: {
-            x: 50 + insertIndex * 350,
-            y: 80,
-          },
-          style: enforceStrictPages ? { width: 320, height: 320, overflow: 'hidden' } : undefined,
-          data: {
-            stepTitle: `Page ${newPageNumber}`,
-            label: `Page ${newPageNumber}`,
-            fields: [],
-            order: insertIndex,
-          },
-          parentId: containerId,
-          extent: 'parent',
-          expandParent: true,
-          draggable: enforceStrictPages ? false : true,
-        };
-
-        const nextNodes = prev.map((n) => {
-          if (n.id === containerId) {
-            return {
-              ...n,
-              data: {
-                ...(n.data || {}),
-                pageOrder: nextOrder,
-                isExpanded: true,
-              },
-            };
-          }
-
-          if (n.parentId !== containerId) return n;
-
-          const isPageNodeType = (type?: string) =>
-            type === 'form' || type === 'formStepSingle' || type === 'formStep' || type === 'formReference';
-          if (!isPageNodeType(n.type)) return n;
-
-          const idx = nextOrder.indexOf(n.id);
-          if (idx === -1) return n;
-
-          return {
-            ...n,
-            position: {
-              x: 50 + idx * 350,
-              y: 80,
-            },
-            draggable: enforceStrictPages ? false : n.draggable,
-            style: enforceStrictPages
-              ? {
-                  ...(n.style || {}),
-                  width: 320,
-                  height: 320,
-                  overflow: 'hidden',
-                }
-              : n.style,
-            data: {
-              ...(n.data || {}),
-              order: idx,
-            },
-          };
-        });
-
-        return [...nextNodes, newPage];
-      });
-    },
-    [setNodes]
-  );
   
   // Batch 3: Inject edit/delete handlers into node data
   // Batch 4: Also inject title change handler
   const nodesWithHandlers = useMemo(() => {
-    const nodeById = new Map(nodes.map((n) => [n.id, n] as const));
-    const isFormContainerType = (type?: string) => type === 'formBook' || type === 'formProcessGroup';
-
     return nodes.map((node) => {
       const data = node.data ?? {};
 
       const onEdit =
-        typeof (data as any).onEdit === 'function'
-          ? (data as any).onEdit
+        typeof data.onEdit === 'function'
+          ? data.onEdit
           : () => handleNodeEdit(node.id);
-
       const onDelete =
-        typeof (data as any).onDelete === 'function'
-          ? (data as any).onDelete
+        typeof data.onDelete === 'function'
+          ? data.onDelete
           : () => handleNodeDelete(node.id);
-
       const onSave =
-        typeof (data as any).onSave === 'function'
-          ? (data as any).onSave
+        typeof data.onSave === 'function'
+          ? data.onSave
           : () => handleSaveWorkflow();
-
       const onTitleChange =
-        typeof (data as any).onTitleChange === 'function'
-          ? (data as any).onTitleChange
+        typeof data.onTitleChange === 'function'
+          ? data.onTitleChange
           : (newTitle: string) => handleNodeTitleChange(node.id, newTitle);
 
       const onInsertAfter =
-        typeof (data as any).onInsertAfter === 'function'
-          ? (data as any).onInsertAfter
+        typeof data.onInsertAfter === 'function'
+          ? data.onInsertAfter
           : () => {
               window.dispatchEvent(
                 new CustomEvent('pm:openNodePalette', {
                   detail: { anchorNodeId: node.id },
                 })
               );
-            };
-
-      const parent = node.parentId ? nodeById.get(node.parentId) : undefined;
-      const parentIsFormContainer = parent && isFormContainerType(parent.type);
-      const nodeIsFormContainer = isFormContainerType(node.type);
-
-      const onAddStepInsideForm =
-        typeof (data as any).onAddStepInsideForm === 'function'
-          ? (data as any).onAddStepInsideForm
-          : () => {
-              if (nodeIsFormContainer) {
-                addFormStepInsideContainer(node.id);
-                return;
-              }
-              if (parentIsFormContainer && node.parentId) {
-                addFormStepInsideContainer(node.parentId, node.id);
-                return;
-              }
-              onInsertAfter();
             };
 
       return {
@@ -6490,44 +6243,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           onSave,
           onTitleChange,
           onInsertAfter,
-          onAddStepInsideForm,
-          isLastInWorkflow: lastNodeIdSet.has(node.id),
         },
       };
     });
-  }, [addFormStepInsideContainer, handleNodeDelete, handleNodeEdit, handleNodeTitleChange, handleSaveWorkflow, lastNodeIdSet, nodes]);
-
-  // Vanguard 1: Optional strict render-list virtualization for very large workflows.
-  // React Flow already does viewport culling (onlyRenderVisibleElements); this additionally reduces
-  // the nodes/edges arrays passed into React Flow to shrink reconciliation work.
-  const virtualizedNodes = useVirtualizedNodes(nodesWithHandlers, viewport, {
-    threshold: 180,
-    bufferPx: 320,
-    debounceMs: 50,
-    enabled: true,
-  });
-
-  const renderedNodesForCanvas = useMemo(() => {
-    if (!virtualizedNodes.isVirtualized) return nodesWithHandlers;
-
-    const byId = new Map(nodesWithHandlers.map((n) => [n.id, n] as const));
-    const renderIdSet = new Set(virtualizedNodes.visibleNodes.map((n) => n.id));
-
-    const includeNodeAndAncestors = (nodeId: string) => {
-      let cur: string | undefined = nodeId;
-      while (cur) {
-        if (renderIdSet.has(cur)) break;
-        renderIdSet.add(cur);
-        const node = byId.get(cur);
-        cur = node?.parentId;
-      }
-    };
-
-    if (selectedNodeId) includeNodeAndAncestors(selectedNodeId);
-
-    // Preserve ordering + include parents before children (React Flow stability)
-    return nodesWithHandlers.filter((n) => renderIdSet.has(n.id));
-  }, [nodesWithHandlers, selectedNodeId, virtualizedNodes.isVirtualized, virtualizedNodes.visibleNodes]);
+  }, [nodes, handleNodeEdit, handleNodeDelete, handleNodeTitleChange, handleSaveWorkflow]);
 
   // Render-time edge virtualization: when a form process group is collapsed, edges to hidden child nodes
   // are re-targeted to virtual handles on the container boundary so connectivity remains visible.
@@ -6592,13 +6311,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     return derived;
   }, [edges, nodesWithHandlers]);
 
-  const renderedEdgesForCanvas = useMemo(() => {
-    if (!virtualizedNodes.isVirtualized) return edgesForCanvas;
-
-    const renderedIdSet = new Set(renderedNodesForCanvas.map((n) => n.id));
-    return edgesForCanvas.filter((e) => renderedIdSet.has(e.source) && renderedIdSet.has(e.target));
-  }, [edgesForCanvas, renderedNodesForCanvas, virtualizedNodes.isVirtualized]);
-
   return (
     <FormBuilderProvider onNodeDataUpdate={handleNodeDataUpdate}>
     <FlowEditorProvider
@@ -6607,6 +6319,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       currentNodeId={selectedFormStep?.id || null}
     >
       <EditorContainer $isFullscreen={isFullscreen}>
+        <PunchInController punchIn={punchIn} />
       {/* Deprecation Banner (Phase 6.1) */}
       {hasDeprecatedNodes && !bannerDismissed && (
         <DeprecationBanner>
@@ -7061,12 +6774,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       {/* React Flow Canvas - Visual Mode */}
       {normalizedEditorMode === 'visual' && (
         <DebugAwareReactFlow
-        nodes={renderedNodesForCanvas}
-        edges={renderedEdgesForCanvas}
+        nodes={nodesWithHandlers}
+        edges={edgesForCanvas}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
-        onMoveEnd={(_, vp) => setViewport(vp)}
         onNodesDelete={onNodesDelete}
         nodesDraggable={true}
         nodeDragHandle=".custom-drag-handle"
@@ -7099,25 +6811,19 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         maxZoom={4}
         minZoom={0.1}
         defaultEdgeOptions={{
-          // Step edges with larger markers + wider interaction area.
-          // NOTE: edgeTypes.step maps to EnhancedConnectionEdge to preserve toolbars/hitbox.
-          type: 'step',
-          style: { strokeWidth: 3, stroke: 'rgb(var(--color-text-secondary))' },
-          interactionWidth: 28,
-          markerEnd: {
-            type: MarkerType.ArrowClosed,
-            width: 24,
-            height: 24,
-            color: 'rgb(var(--color-text-secondary))',
-          },
+          // Keep our enhanced edge component, but render it with thicker step-like styling.
+          type: 'enhanced',
+          style: { strokeWidth: 3, stroke: 'rgb(148, 163, 184)' },
+          markerEnd: { type: MarkerType.ArrowClosed, width: 24, height: 24, color: 'rgb(148, 163, 184)' },
         }}
         connectionLineStyle={{
-          stroke: 'rgb(var(--color-text-secondary))',
+          stroke: 'rgb(148, 163, 184)',
           strokeWidth: 3,
           strokeDasharray: '5,5',
           animation: 'dash 0.5s linear infinite',
         }}
         connectionLineType="step"
+        fitView
         snapToGrid={snapToGrid}
         snapGrid={[gridSize, gridSize]}
         connectionRadius={20}
@@ -7941,16 +7647,34 @@ function getReactFlowNodeType(nodeTypeId: string): string {
   // Force all triggers to use the rich Unified Trigger node & schema
   if (nodeTypeId.startsWith('trigger')) return 'trigger';
 
+  // Rollback: render all legacy Form Process container variants as plain `default` nodes.
+  if (
+    nodeTypeId === 'formMultiStepContainer' ||
+    nodeTypeId === 'formProcess' ||
+    nodeTypeId === 'formProcessGroup' ||
+    nodeTypeId === 'formBook'
+  ) {
+    return 'default';
+  }
+
   // Preserve specific types for all other nodes so their specific schemas load
   if (nodeTypeId === 'formMultiStepContainer') return 'formMultiStepContainer';
-  if (nodeTypeId === 'formBook') return 'formBook';
   return nodeTypeId;
 }
 
 /** Returns true for all Form Process container node type IDs (current + legacy). */
 function isFormProcessContainerType(nodeType: string | undefined | null): boolean {
+  // Rollback: treat legacy Form Process containers as plain nodes (no group semantics).
+  if (
+    nodeType === 'formProcessGroup' ||
+    nodeType === 'formProcess' ||
+    nodeType === 'formMultiStepContainer' ||
+    nodeType === 'formBook'
+  ) {
+    return false;
+  }
+
   return (
-    nodeType === 'formBook' ||
     nodeType === 'formProcessGroup' ||
     nodeType === 'formProcess' ||
     nodeType === 'formMultiStepContainer'
@@ -7989,7 +7713,7 @@ function getDefaultNodeData(nodeTypeId: string): Record<string, any> {
   }
 
   // Special handling for containers
-  if (resolvedType === 'formMultiStepContainer' || resolvedType === 'formProcessGroup' || resolvedType === 'formBook') {
+  if (resolvedType === 'formMultiStepContainer' || resolvedType === 'formProcessGroup') {
     defaults.fields = [];
     defaults.containerName = 'New Container';
     defaults.isExpanded = true;

--- a/frontend/src/components/FlowEditor/nodeTypes.ts
+++ b/frontend/src/components/FlowEditor/nodeTypes.ts
@@ -103,14 +103,14 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
   
   // === FORM ELEMENTS ===
   
-  // Form step node (page) (renamed from formStepSingle in Phase E - 2026-02-19)
+  // Form node (renamed from formStepSingle in Phase E - 2026-02-19)
   form: {
     id: 'form',
     name: 'Form',
     category: 'form',
-    icon: '📄',
+    icon: '📋',
     color: '#3b82f6', // blue
-    description: 'Single form step. Use inside a Form Process or standalone.',
+    description: 'Single-page form for data collection - works standalone or in Form Process containers',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
@@ -146,44 +146,14 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
     hidden: true, // Hide from node palette
   },
   
-  // NEW: Singular Form container using React Flow sub-flows (Book & Pages)
-  // Temporarily hidden while we revert to the purple FormProcess container UX.
-  formBook: {
-    id: 'formBook',
-    name: 'Form (Book - Hidden)',
-    category: 'form',
-    icon: '📚',
-    color: '#a78bfa',
-    description: '[HIDDEN] Book-style form container. Use Form Process instead.',
-    maxInputs: 1,
-    maxOutputs: 1,
-    requiresConfig: true,
-    hidden: true,
-  },
-
-  // Phase 7+: Smart WorkForm (single-node wizard)
-  // Kept for backward compatibility, but hidden from the palette for now.
-  smartWorkForm: {
-    id: 'smartWorkForm',
-    name: 'Smart WorkForm (Hidden)',
-    category: 'form',
-    icon: '🧠',
-    color: '#a78bfa',
-    description: '[HIDDEN] Kept for backward compatibility. Use Form Process instead.',
-    maxInputs: 1,
-    maxOutputs: 1,
-    requiresConfig: true,
-    hidden: true,
-  },
-
-  // Purple multi-step container (restored as primary)
+  // Advanced Form Process with React Flow grouping
   formProcessGroup: {
     id: 'formProcessGroup',
     name: 'Form Process',
     category: 'form',
-    icon: '📦',
-    color: '#8b5cf6',
-    description: 'Multi-step container that keeps child form steps constrained and arranged horizontally.',
+    icon: '📂',
+    color: '#a78bfa', // lighter purple - group variant
+    description: 'Advanced form container with labeled header, automatic step sequencing, and React Flow grouping',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
@@ -218,45 +188,40 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
   },
   
   // OTHER FORM ELEMENTS
-  // Consolidation: keep the palette focused on just Form + Form Process.
-  // These node types remain supported for backward compatibility.
   formReference: {
     id: 'formReference',
-    name: 'Form Reference (Hidden)',
+    name: 'Form Reference',
     category: 'form',
     icon: '📄',
     color: '#3b82f6',
-    description: '[HIDDEN] Backward compatible. Use Form steps inside a Form Process instead.',
+    description: 'Reference a reusable form from the library',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
-    hidden: true,
   },
   
   formSignature: {
     id: 'formSignature',
-    name: 'Signature Field (Hidden)',
+    name: 'Signature Field',
     category: 'form',
     icon: '✍️',
     color: '#3b82f6',
-    description: '[HIDDEN] Backward compatible.',
+    description: 'Electronic signature capture',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
-    hidden: true,
   },
   
   formFileUpload: {
     id: 'formFileUpload',
-    name: 'File Upload (Hidden)',
+    name: 'File Upload',
     category: 'form',
     icon: '📎',
     color: '#3b82f6',
-    description: '[HIDDEN] Backward compatible.',
+    description: 'Document/file upload field',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
-    hidden: true,
   },
   
   // REMOVED: formMultiStepContainer moved above as deprecated alias

--- a/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessGroupNode.tsx
@@ -1,15 +1,1062 @@
 /**
- * Legacy FormProcessGroupNode
- *
- * Kept for backward compatibility.
- * Restored to the purple multi-step container renderer (FormProcessNode).
+ * Form Process Group Node Component
+ * 
+ * Implements React Flow's labeled group + parent-child pattern for multi-step forms.
+ * This is the IDEAL container implementation using React Flow's native grouping.
+ * 
+ * Architecture:
+ * - Uses type: 'formProcessGroup' (registered in nodeTypes)
+ * - Children have parentId pointing to this group's ID
+ * - Children have extent: 'parent' for containment
+ * - Group has isGroup: true for React Flow grouping behavior
+ * - Resizable container with labeled header
+ * - Vertical auto-layout for children
+ * - Schema-driven configuration via DynamicConfigPanel
+ * 
+ * References:
+ * - https://reactflow.dev/examples/nodes/draggable-subflow
+ * - https://reactflow.dev/examples/layout/sub-flows
+ * 
+ * Created: 2026-02-19 - Phase E.3
+ * 
+ * @module FormProcessGroupNode
  */
 
-import { FormProcessNode, type ContainerNodeData } from './FormProcessNode';
+import React, { useCallback, useMemo, useEffect, useState } from 'react';
+import { logger } from '@/utils/logger';
 
-export type FormProcessGroupData = ContainerNodeData;
+import styled from 'styled-components';
+import { Handle, Position, NodeProps, Node, Edge, useReactFlow, useNodes, useEdges } from '@xyflow/react';
+import type { BaseNodeData } from './BaseNode';
+import { ChevronDown, ChevronRight, Plus, Settings, Save, Check } from 'lucide-react';
+import { calculateChildXPosition } from './FormProcessChildWrapper';
+import { saveFormProcessGroup } from '../../../services/tenantFormService';
+import toast from 'react-hot-toast';
 
-// Deprecated alias
-export const FormProcessGroupNode = FormProcessNode;
+// ============================================================================
+// TypeScript Interfaces
+// ============================================================================
 
-export default FormProcessNode;
+/**
+ * Data structure for Form Process Group Node
+ * Extends BaseNodeData with group-specific properties
+ */
+export interface FormProcessGroupData extends BaseNodeData {
+  /** Display name of the form process */
+  containerName?: string;
+  /** Description of the form process */
+  containerDescription?: string;
+  /** Whether the group is visually expanded to show children */
+  isExpanded?: boolean;
+  /** Show progress indicator in runtime */
+  showProgressIndicator?: boolean;
+  /** Allow users to navigate back to previous steps */
+  allowBackNavigation?: boolean;
+  /** Allow users to skip optional steps */
+  allowSkipSteps?: boolean;
+  /** Reference to tenant form */
+  tenantFormId?: string;
+  /** Reference to tenant workform */
+  tenantWorkFormId?: string;
+  /** Group flag for React Flow */
+  isGroup?: boolean;
+  /** Drop target indicator (Phase 3) */
+  isDropTarget?: boolean;
+  /** Sequential execution order enabled (Phase 3) */
+  sequentialExecution?: boolean;
+  /** Stable horizontal ordering for page nodes (computed, additive-only) */
+  pageOrder?: string[];
+  /** Edit handler from UnifiedFlowEditor */
+  onEdit?: () => void;
+  /** Delete handler from UnifiedFlowEditor */
+  onDelete?: () => void;
+}
+
+export interface FormProcessGroupNodeProps extends NodeProps<FormProcessGroupData> {}
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+/**
+ * Global keyframes animation for spinner
+ */
+const spinAnimation = `
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+`;
+
+/**
+ * Container wrapper with group styling
+ * Adapts size based on expanded/collapsed state
+ * Phase 3: Added drop zone indicator
+ */
+const GroupContainer = styled.div<{ isExpanded: boolean; isDropTarget?: boolean }>`
+  ${spinAnimation}
+
+  /* Removed min-width/min-height - sizing is now controlled directly via React Flow style prop */
+  width: 100%;
+  height: 100%;
+
+  background: ${(props) =>
+    props.isDropTarget
+      ? 'rgba(var(--color-primary), 0.15)'
+      : props.isExpanded
+        ? 'rgba(var(--color-primary), 0.03)'
+        : 'rgb(var(--color-background-secondary))'};
+
+  border-width: 2px;
+  border-style: ${(props) => (props.isExpanded ? 'dashed' : 'solid')};
+  border-color: ${(props) =>
+    props.isDropTarget ? 'rgba(var(--color-primary), 0.8)' : 'rgba(var(--color-primary), 0.5)'};
+  border-radius: 12px;
+  overflow: ${(props) => (props.isExpanded ? 'visible' : 'hidden')};
+  position: relative;
+
+  box-shadow: ${(props) => {
+    if (!props.isExpanded) return 'none';
+    return props.isDropTarget
+      ? '0 8px 24px rgba(var(--color-primary), 0.3), 0 0 0 6px rgba(var(--color-primary), 0.2)'
+      : '0 4px 12px rgba(0, 0, 0, 0.1), 0 0 0 4px rgba(var(--color-primary), 0.1)';
+  }};
+
+  &:hover {
+    box-shadow: ${(props) => {
+      if (!props.isExpanded) return 'none';
+      return '0 6px 16px rgba(0, 0, 0, 0.15), 0 0 0 4px rgba(var(--color-primary), 0.2)';
+    }};
+  }
+
+  /* ONLY transition colors/shadows, NEVER dimensions */
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+
+  /* Group label indicator */
+  ${(props) =>
+    props.isExpanded &&
+    `
+    &::after {
+      content: '${props.isDropTarget ? 'DROP HERE TO ADD' : 'FORM PROCESS GROUP'}';
+      position: absolute;
+      top: 12px;
+      right: 16px;
+      font-size: 10px;
+      font-weight: 600;
+      color: rgba(var(--color-primary), 0.4);
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      pointer-events: none;
+      user-select: none;
+    }
+  `}
+`;
+
+/**
+ * Labeled header with step count and controls
+ */
+const GroupHeader = styled.div<{ isExpanded: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  background: ${props => props.isExpanded 
+    ? 'rgba(139, 92, 246, 0.08)' 
+    : 'rgba(139, 92, 246, 0.12)'};
+  border-bottom: 1px solid rgba(139, 92, 246, 0.2);
+  cursor: pointer;
+  user-select: none;
+  
+  &:hover {
+    background: rgba(139, 92, 246, 0.15);
+  }
+  
+  transition: background 0.2s ease;
+`;
+
+const ExpandIcon = styled.div<{ isExpanded: boolean }>`
+  display: flex;
+  align-items: center;
+  color: rgba(139, 92, 246, 0.7);
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+`;
+
+const GroupTitle = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const GroupName = styled.div`
+  font-weight: 600;
+  font-size: 15px;
+  color: rgb(var(--color-text-primary));
+`;
+
+const GroupMeta = styled.div`
+  font-size: 12px;
+  color: rgb(var(--color-text-secondary));
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const StepCount = styled.span<{ hasSteps: boolean }>`
+  font-weight: 500;
+  color: ${props => props.hasSteps 
+    ? 'rgba(139, 92, 246, 0.9)' 
+    : 'rgb(var(--color-text-tertiary))'};
+`;
+
+const HeaderActions = styled.div`
+  display: flex;
+  gap: 6px;
+  align-items: center;
+`;
+
+const IconButton = styled.button<{ variant?: 'primary' | 'default'; isSaving?: boolean }>`
+  padding: 6px;
+  background: ${props => {
+    if (props.variant === 'primary') return 'rgba(139, 92, 246, 0.15)';
+    return 'transparent';
+  }};
+  border: none;
+  border-radius: var(--radius-sm);
+  color: ${props => 
+    props.variant === 'primary' 
+      ? 'rgba(139, 92, 246, 0.9)' 
+      : 'rgb(var(--color-text-secondary))'
+  };
+  cursor: ${props => props.isSaving ? 'wait' : 'pointer'};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  transition: all 0.15s ease;
+  font-size: 12px;
+  font-weight: 500;
+  opacity: ${props => props.isSaving ? 0.6 : 1};
+  
+  &:hover {
+    background: rgba(139, 92, 246, 0.15);
+    color: rgba(139, 92, 246, 0.9);
+  }
+  
+  &:active {
+    transform: ${props => props.isSaving ? 'none' : 'scale(0.95)'};
+  }
+  
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const GroupBody = styled.div<{ isExpanded: boolean }>`
+  /* Switch to horizontal track layout for "Book and Pages" paradigm */
+  display: ${(props) => (props.isExpanded ? 'flex' : 'none')};
+  flex-direction: row;
+  align-items: flex-start;
+  padding: 20px;
+  gap: 40px;
+  height: 100%;
+  position: relative;
+`;
+
+/**
+ * Empty state message
+ */
+const EmptyState = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: rgb(var(--color-text-tertiary));
+  font-size: 14px;
+  pointer-events: none;
+  user-select: none;
+  
+  svg {
+    margin-bottom: 8px;
+    opacity: 0.3;
+  }
+`;
+
+/**
+ * Collapsed preview of steps
+ */
+const CollapsedStepList = styled.div`
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+`;
+
+const StepPreview = styled.div`
+  font-size: 13px;
+  color: rgb(var(--color-text-secondary));
+  padding: 6px 8px;
+  background: rgba(139, 92, 246, 0.05);
+  border-radius: var(--radius-sm);
+  border-left: 2px solid rgba(139, 92, 246, 0.3);
+`;
+
+/**
+ * Sequential execution indicator (Phase 3)
+ */
+const SequentialIndicator = styled.div<{ enabled: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: ${props => props.enabled 
+    ? 'rgba(34, 197, 94, 0.1)' 
+    : 'rgba(148, 163, 184, 0.1)'};
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-weight: 600;
+  color: ${props => props.enabled 
+    ? 'rgb(34, 197, 94)' 
+    : 'rgb(148, 163, 184)'};
+  
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+`;
+
+/**
+ * Drop zone overlay (Phase 3)
+ */
+const DropZoneOverlay = styled.div<{ show: boolean }>`
+  position: absolute;
+  inset: 0;
+  display: ${props => props.show ? 'flex' : 'none'};
+  align-items: center;
+  justify-content: center;
+  background: rgba(139, 92, 246, 0.1);
+  border: 3px dashed rgba(139, 92, 246, 0.5);
+  border-radius: 12px;
+  pointer-events: none;
+  z-index: 10;
+  animation: pulse 2s ease-in-out infinite;
+  
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; }
+  }
+`;
+
+const DropZoneText = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+  color: rgba(139, 92, 246, 0.9);
+  text-align: center;
+  padding: 20px;
+  background: rgb(var(--color-surface));
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+`;
+
+const VirtualHandle = styled(Handle)<{ $side: 'in' | 'out' }>`
+  width: 10px;
+  height: 10px;
+  border-radius: 4px;
+  border: 2px solid rgb(var(--color-surface));
+  background: ${(p) => (p.$side === 'in' ? 'rgb(var(--color-primary))' : 'rgb(var(--color-success))')};
+  z-index: 30;
+`;
+
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Form Process Group Node
+ * 
+ * Labeled group container following React Flow's parent-child pattern.
+ * Children are positioned with parentId and extent: 'parent'.
+ * 
+ * @param props - Node props from React Flow
+ */
+export const FormProcessGroupNode = React.memo<FormProcessGroupNodeProps>((props) => {
+  const { id, data } = props;
+  const { setNodes, setEdges, updateNodeInternals } = useReactFlow();
+  const allNodes = useNodes();
+  const allEdges = useEdges();
+  
+  // Local state for save operations
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSaved, setLastSaved] = useState<Date | null>(null);
+  
+  // Debug logging
+  logger.debug('[FormProcessGroup] Rendered with ID:', id, 'Data:', data);
+  
+  // ============================================================================
+  // Derived State
+  // ============================================================================
+  
+  /**
+   * Find all child nodes with parentId matching this group's ID
+   */
+  const childNodes = useMemo(() => {
+    const children = allNodes.filter((node) => {
+      const anyNode = node as any;
+      return (
+        anyNode.parentId === id ||
+        (node.data as any)?.parentId === id
+      );
+    });
+    logger.debug('[FormProcessGroup] Children found:', children.length, 'IDs:', children.map((c) => c.id));
+    return children;
+  }, [allNodes, id]);
+  
+  const isPageNodeType = (type?: string) =>
+    type === 'form' || type === 'formStepSingle' || type === 'formStep' || type === 'formReference';
+
+  const pageNodes = useMemo(() => childNodes.filter((n) => isPageNodeType(n.type)), [childNodes]);
+  const pageCount = pageNodes.length;
+
+  const stepCount = childNodes.length;
+  const containerName = data.containerName || 'Untitled Form Process';
+  const containerDescription = data.containerDescription;
+  const isExpanded = data.isExpanded ?? false;
+
+  // Keep React Flow internals in sync when toggling expanded/collapsed state.
+  useEffect(() => {
+    requestAnimationFrame(() => updateNodeInternals(id));
+  }, [id, isExpanded, updateNodeInternals]);
+  const isDropTarget = data.isDropTarget ?? false; // Phase 3: Drop zone indicator
+  const sequentialExecution = data.sequentialExecution ?? true; // Phase 3: Sequential by default
+
+  // Stable effect keys (avoid eslint-disable + reduce accidental effect churn)
+  const pageNodesIdsKey = useMemo(() => pageNodes.map((n) => n.id).sort().join('|'), [pageNodes]);
+
+  const pageNodesPositionsKey = useMemo(
+    () =>
+      pageNodes
+        .map((n) => `${n.id}:${n.position?.x ?? 0},${n.position?.y ?? 0}`)
+        .sort()
+        .join('|'),
+    [pageNodes]
+  );
+
+  const pageOrderKey = useMemo(() => JSON.stringify(data.pageOrder ?? []), [data.pageOrder]);
+
+  const collapsedVirtualHandles = useMemo(() => {
+    if (isExpanded) return { incoming: [] as string[], outgoing: [] as string[] };
+
+    const childIdSet = new Set(childNodes.map((n) => n.id));
+
+    const incomingIds = new Set<string>();
+    const outgoingIds = new Set<string>();
+
+    allEdges.forEach((e) => {
+      const sourceIsChild = childIdSet.has(e.source);
+      const targetIsChild = childIdSet.has(e.target);
+
+      // Only care about edges crossing the container boundary.
+      if (sourceIsChild && !targetIsChild) outgoingIds.add(e.source);
+      if (targetIsChild && !sourceIsChild) incomingIds.add(e.target);
+    });
+
+    const orderedChildren = [...childNodes].sort(
+      (a, b) => (a.position?.y || 0) - (b.position?.y || 0) || (a.position?.x || 0) - (b.position?.x || 0)
+    );
+
+    return {
+      incoming: orderedChildren.filter((c) => incomingIds.has(c.id)).map((c) => c.id),
+      outgoing: orderedChildren.filter((c) => outgoingIds.has(c.id)).map((c) => c.id),
+    };
+  }, [allEdges, childNodes, isExpanded]);
+  
+  logger.debug(`[FormProcessGroup] ${id} rendered with ${stepCount} steps (expanded: ${isExpanded})`);
+
+  
+  // ============================================================================
+  // Event Handlers
+  // ============================================================================
+  
+  /**
+   * Toggle expand/collapse state
+   * When collapsed, children are hidden but not removed
+   */
+  const handleToggleExpand = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    const nextExpanded = !isExpanded;
+
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === id) {
+          // Default expanded size; a separate effect will auto-fit to children.
+          const expandedWidth = Math.max(600, stepCount * 350 + 100);
+          return {
+            ...node,
+            style: {
+              ...(node.style || {}),
+              width: nextExpanded ? expandedWidth : 320,
+              // Explicit bounds prevent ResizeObserver "glitch" during expand/collapse
+              height: nextExpanded ? 450 : 80,
+            },
+            data: {
+              ...node.data,
+              isExpanded: nextExpanded,
+            },
+          };
+        }
+
+        // Hide/show children
+        if ((node as any).parentId === id) {
+          return {
+            ...node,
+            hidden: !nextExpanded,
+          };
+        }
+
+        return node;
+      })
+    );
+
+    requestAnimationFrame(() => {
+      if (typeof updateNodeInternals === 'function') {
+        updateNodeInternals(id);
+      }
+    });
+  }, [id, isExpanded, setNodes, stepCount, updateNodeInternals]);
+  
+  /**
+   * Save FormProcessGroup as TenantForm to backend
+   * Persists form definition and increments version
+   */
+  const handleSave = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    
+    if (isSaving) return;
+    
+    // Validate: Must have at least one form/page step
+    if (pageNodes.length === 0) {
+      toast.error('Cannot save: Form must have at least one step');
+      return;
+    }
+    
+    setIsSaving(true);
+    
+    try {
+      // Find the current node object
+      const currentNode = allNodes.find((n) => n.id === id);
+      if (!currentNode) {
+        logger.error('[FormProcessGroup] Save failed: container node missing', { id });
+        toast.error('Save failed: container not found');
+        return;
+      }
+      
+      logger.debug('[FormProcessGroup] Saving to backend:', id);
+      
+      const result = await saveFormProcessGroup(currentNode, allNodes, allEdges);
+      
+      logger.debug('[FormProcessGroup] Saved successfully:', result);
+      
+      // Update node data with tenantFormId and version
+      setNodes((nodes) =>
+        nodes.map((node) => {
+          if (node.id === id) {
+            return {
+              ...node,
+              data: {
+                ...node.data,
+                tenantFormId: result.tenantFormId,
+                version: result.version,
+              },
+            };
+          }
+          return node;
+        })
+      );
+      
+      setLastSaved(new Date());
+
+      if (typeof data.onSave === 'function') {
+        data.onSave();
+      }
+
+      toast.success(
+        result.created 
+          ? `Form saved successfully (v${result.version})` 
+          : `Form updated to v${result.version}`,
+        { duration: 3000 }
+      );
+      
+    } catch (error: any) {
+      logger.error('[FormProcessGroup] Save failed:', error);
+      toast.error(`Save failed: ${error.message}`);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [id, isSaving, pageNodes.length, allNodes, allEdges, setNodes, data]);
+  
+  /**
+   * Auto-layout pages (form nodes) horizontally.
+   * Non-form child nodes remain free-positioned inside the container.
+   */
+  useEffect(() => {
+    if (!isExpanded || pageNodes.length === 0) return;
+
+    const existingOrder = Array.isArray(data.pageOrder) ? data.pageOrder : undefined;
+    const pageIdSet = new Set(pageNodes.map((n) => n.id));
+
+    const normalizedExisting = existingOrder ? existingOrder.filter((pid) => pageIdSet.has(pid)) : [];
+    const missing = pageNodes
+      .filter((n) => !normalizedExisting.includes(n.id))
+      .sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0) || (a.position?.y || 0) - (b.position?.y || 0))
+      .map((n) => n.id);
+
+    const nextOrder = [...normalizedExisting, ...missing];
+
+    const PAGE_START_X = 30;
+    const PAGE_ROW_Y = 90;
+    const PAGE_SPACING_X = 360;
+
+    const desiredPositions = new Map(
+      nextOrder.map((pid, index) => [pid, { x: PAGE_START_X + index * PAGE_SPACING_X, y: PAGE_ROW_Y }])
+    );
+
+    const needsOrderUpdate = !existingOrder || JSON.stringify(existingOrder) !== JSON.stringify(nextOrder);
+    const needsPositionUpdate = pageNodes.some((n) => {
+      const desired = desiredPositions.get(n.id);
+      if (!desired) return false;
+      return n.position?.x !== desired.x || n.position?.y !== desired.y;
+    });
+
+    if (!needsOrderUpdate && !needsPositionUpdate) return;
+
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === id) {
+          const expandedWidth = Math.max(600, 140 + pageCount * 360);
+          return {
+            ...node,
+            style: {
+              ...(node.style || {}),
+              width: expandedWidth,
+            },
+            data: needsOrderUpdate
+              ? {
+                  ...node.data,
+                  pageOrder: nextOrder,
+                }
+              : node.data,
+          };
+        }
+
+        const desired = desiredPositions.get(node.id);
+        if (desired && node.parentId === id) {
+          return {
+            ...node,
+            position: desired,
+          };
+        }
+
+        return node;
+      })
+    );
+
+    requestAnimationFrame(() => updateNodeInternals(id));
+  }, [
+    id,
+    isExpanded,
+    pageCount,
+    pageNodes.length,
+    pageNodesIdsKey,
+    pageOrderKey,
+    setNodes,
+    updateNodeInternals,
+  ]);
+  
+  /**
+   * Auto-connect pages in sequential order.
+   * Only connects page nodes (form / legacy form types) and never deletes manual edges.
+   */
+  useEffect(() => {
+    if (!sequentialExecution || pageNodes.length < 2) return;
+
+    const existingOrder = Array.isArray(data.pageOrder) ? data.pageOrder : undefined;
+    const pageIdSet = new Set(pageNodes.map((n) => n.id));
+
+    const normalizedExisting = existingOrder ? existingOrder.filter((pid) => pageIdSet.has(pid)) : [];
+    const missing = pageNodes
+      .filter((n) => !normalizedExisting.includes(n.id))
+      .sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0) || (a.position?.y || 0) - (b.position?.y || 0))
+      .map((n) => n.id);
+
+    const orderedPageIds = [...normalizedExisting, ...missing];
+
+    setEdges((prevEdges) => {
+      const isThisAutoEdge = (edge: Edge) =>
+        edge.data?.auto === true && edge.data?.containerId === id && edge.data?.kind === 'pageSequence';
+
+      const prevAutoEdges = prevEdges.filter(isThisAutoEdge);
+      const preservedEdges = prevEdges.filter((e) => !isThisAutoEdge(e));
+
+      const nextAutoEdges: Edge[] = [];
+      for (let i = 0; i < orderedPageIds.length - 1; i++) {
+        const sourceId = orderedPageIds[i];
+        const targetId = orderedPageIds[i + 1];
+
+        // Don’t auto-generate an edge if a manual edge already exists.
+        const manualExists = preservedEdges.some(
+          (e) => e.source === sourceId && e.target === targetId && e.data?.auto !== true
+        );
+        if (manualExists) continue;
+
+        nextAutoEdges.push({
+          id: `auto-page-${id}-${sourceId}-${targetId}`,
+          source: sourceId,
+          target: targetId,
+          type: 'smoothstep',
+          animated: true,
+          data: {
+            auto: true,
+            containerId: id,
+            kind: 'pageSequence',
+          },
+          style: {
+            stroke: 'rgba(139, 92, 246, 0.6)',
+            strokeWidth: 2,
+          },
+        });
+      }
+
+      const prevIds = new Set(prevAutoEdges.map((e) => e.id));
+      const nextIds = new Set(nextAutoEdges.map((e) => e.id));
+      const same = prevIds.size === nextIds.size && [...nextIds].every((x) => prevIds.has(x));
+
+      if (same) return prevEdges;
+
+      logger.debug(`[FormProcessGroup] Auto-connect: updating ${nextAutoEdges.length} page edges`);
+      return [...preservedEdges, ...nextAutoEdges];
+    });
+  }, [
+    id,
+    sequentialExecution,
+    pageNodes.length,
+    pageNodesPositionsKey,
+    pageOrderKey,
+    setEdges,
+  ]);
+  
+  /**
+   * Add new page to this group.
+   * Creates a `form` node as a child; page nodes are laid out horizontally.
+   */
+  const handleAddStep = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+
+      const newPageIndex = pageCount;
+      const newPageId = `page-${Date.now()}`;
+
+      const newPage: Node = {
+        id: newPageId,
+        type: 'form',
+        position: {
+          x: calculateChildXPosition(newPageIndex),
+          y: 90,
+        },
+        data: {
+          stepTitle: `Page ${newPageIndex + 1}`,
+          label: `Page ${newPageIndex + 1}`,
+          fields: [],
+        },
+        parentId: id,
+        extent: 'parent' as const,
+        expandParent: true,
+        draggable: true,
+      };
+
+      setNodes((nodes) => [...nodes, newPage]);
+    },
+    [id, pageCount, setNodes]
+  );
+  
+  /**
+   * Open configuration panel
+   * Should trigger NodeConfigPanelWithShadow with formProcess schema
+   */
+  const handleConfigure = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    // Call the onEdit handler passed from UnifiedFlowEditor
+    if (typeof data.onEdit === 'function') {
+      data.onEdit();
+    }
+  }, [data]);
+  
+  // ============================================================================
+  // Auto-resize container to fit children (especially vertical)
+  // ============================================================================
+
+  const childBoundsKey = useMemo(
+    () =>
+      JSON.stringify(
+        childNodes
+          .map((n) => ({
+            id: n.id,
+            x: n.position?.x ?? 0,
+            y: n.position?.y ?? 0,
+            w: (n as any).measured?.width ?? n.width ?? 220,
+            h: (n as any).measured?.height ?? n.height ?? 140,
+          }))
+          .sort((a, b) => a.id.localeCompare(b.id))
+      ),
+    [childNodes]
+  );
+
+  useEffect(() => {
+    if (!isExpanded) return;
+
+    const HEADER_HEIGHT = 56;
+    const PADDING_X = 60;
+    const PADDING_Y = 120;
+
+    const pageWidthBaseline = Math.max(600, 140 + pageCount * 360);
+
+    const childBoxes = childNodes.map((n) => {
+      const measured = (n as any).measured;
+      const w = measured?.width ?? n.width ?? 220;
+      const h = measured?.height ?? n.height ?? 140;
+      const x = n.position?.x ?? 0;
+      const y = n.position?.y ?? 0;
+      return { x, y, w, h };
+    });
+
+    const maxRight = childBoxes.length ? Math.max(...childBoxes.map((b) => b.x + b.w)) : 0;
+    const maxBottom = childBoxes.length ? Math.max(...childBoxes.map((b) => b.y + b.h)) : 0;
+
+    const desiredWidth = Math.max(pageWidthBaseline, maxRight + PADDING_X);
+    const desiredHeight = Math.max(240, HEADER_HEIGHT + maxBottom + PADDING_Y);
+
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id !== id) return node;
+
+        const currentW = Number((node.style as any)?.width ?? node.width ?? 0);
+        const currentH = Number((node.style as any)?.height ?? node.height ?? 0);
+
+        const nextW = Math.round(desiredWidth);
+        const nextH = Math.round(desiredHeight);
+
+        if (currentW === nextW && currentH === nextH) return node;
+
+        return {
+          ...node,
+          style: {
+            ...(node.style || {}),
+            width: nextW,
+            height: nextH,
+          },
+        };
+      })
+    );
+
+    requestAnimationFrame(() => updateNodeInternals(id));
+  }, [childBoundsKey, id, isExpanded, pageCount, setNodes, updateNodeInternals]);
+
+  // ============================================================================
+  // Render
+  // ============================================================================
+
+  return (
+    <GroupContainer 
+      isExpanded={isExpanded} 
+      isDropTarget={isDropTarget}
+      data-node-id={id}
+      data-node-type="formProcessGroup"
+    >
+      {/* Always-available handles so the container can connect to other nodes */}
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="group:in"
+        aria-label="Incoming connection"
+        style={{ top: 42, zIndex: 40, background: 'rgb(var(--color-primary))' }}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="group:out"
+        aria-label="Outgoing connection"
+        style={{ top: 42, zIndex: 40, background: 'rgb(var(--color-success))' }}
+      />
+
+      {/* Virtual handles when collapsed: edges to hidden children are proxied to these handles */}
+      {!isExpanded && (
+        <>
+          {collapsedVirtualHandles.incoming.map((childId, idx) => (
+            <VirtualHandle
+              key={`vh-in-${childId}`}
+              id={`vh:in:${childId}`}
+              type="target"
+              position={Position.Left}
+              $side="in"
+              style={{ top: 58 + idx * 18 }}
+            />
+          ))}
+          {collapsedVirtualHandles.outgoing.map((childId, idx) => (
+            <VirtualHandle
+              key={`vh-out-${childId}`}
+              id={`vh:out:${childId}`}
+              type="source"
+              position={Position.Right}
+              $side="out"
+              style={{ top: 58 + idx * 18 }}
+            />
+          ))}
+        </>
+      )}
+
+      {/* Phase 3: Drop zone overlay */}
+      <DropZoneOverlay show={isDropTarget && isExpanded}>
+        <DropZoneText>
+          📦 Drop any node here<br/>
+          <small style={{ fontSize: '12px', opacity: 0.7 }}>
+            Forms, Actions, Logic, Wait states...
+          </small>
+        </DropZoneText>
+      </DropZoneOverlay>
+      
+      <GroupHeader isExpanded={isExpanded} onClick={handleToggleExpand}>
+        <ExpandIcon isExpanded={isExpanded}>
+          {isExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+        </ExpandIcon>
+        
+        <GroupTitle>
+          <GroupName>{containerName}</GroupName>
+          <GroupMeta>
+            <StepCount hasSteps={stepCount > 0}>
+              {stepCount} {stepCount === 1 ? 'step' : 'steps'}
+            </StepCount>
+            {containerDescription && (
+              <span>• {containerDescription.slice(0, 40)}{containerDescription.length > 40 ? '...' : ''}</span>
+            )}
+            {/* Phase 3: Sequential execution indicator */}
+            <SequentialIndicator enabled={sequentialExecution}>
+              ▶ Sequential
+            </SequentialIndicator>
+          </GroupMeta>
+        </GroupTitle>
+        
+        <HeaderActions onClick={(e) => e.stopPropagation()}>
+          <IconButton 
+            onClick={handleSave} 
+            title={data.tenantFormId ? `Save (v${data.version || 1})` : 'Save to database'}
+            variant="primary"
+            isSaving={isSaving}
+            disabled={isSaving || childNodes.length === 0}
+          >
+            {isSaving ? (
+              <>
+                <div style={{ 
+                  width: '14px', 
+                  height: '14px', 
+                  border: '2px solid rgba(139, 92, 246, 0.3)',
+                  borderTopColor: 'rgba(139, 92, 246, 0.9)',
+                  borderRadius: '50%',
+                  animation: 'spin 0.6s linear infinite'
+                }} />
+                <span>Saving...</span>
+              </>
+            ) : lastSaved ? (
+              <>
+                <Check size={14} />
+                <span>Saved</span>
+              </>
+            ) : (
+              <>
+                <Save size={14} />
+                <span>Save</span>
+              </>
+            )}
+          </IconButton>
+          <IconButton onClick={handleAddStep} title="Add step">
+            <Plus size={16} />
+          </IconButton>
+          <IconButton onClick={handleConfigure} title="Configure">
+            <Settings size={16} />
+          </IconButton>
+        </HeaderActions>
+      </GroupHeader>
+      
+      {isExpanded ? (
+        <GroupBody isExpanded={isExpanded}>
+          {stepCount === 0 && (
+            <EmptyState>
+              <Plus size={48} />
+              <div>Drop form steps here or click + to add</div>
+            </EmptyState>
+          )}
+          {/* Children render here automatically via React Flow's parent-child system */}
+        </GroupBody>
+      ) : (
+        <>
+          {stepCount > 0 && (
+            <CollapsedStepList>
+              {childNodes
+                .sort((a, b) => a.position.x - b.position.x) // Sort by X position for flow order
+                .slice(0, 5)
+                .map((child, index) => (
+                  <StepPreview key={child.id}>
+                    <span style={{ 
+                      display: 'inline-block',
+                      width: '20px',
+                      height: '20px',
+                      borderRadius: '50%',
+                      background: 'rgba(139, 92, 246, 0.2)',
+                      color: 'rgb(139, 92, 246)',
+                      fontSize: '11px',
+                      fontWeight: 600,
+                      lineHeight: '20px',
+                      textAlign: 'center',
+                      marginRight: '8px',
+                    }}>
+                      {index + 1}
+                    </span>
+                    {(child.data as any).label || 'Untitled'}
+                  </StepPreview>
+                ))}
+              {stepCount > 5 && (
+                <StepPreview>+ {stepCount - 5} more steps</StepPreview>
+              )}
+              {/* Version indicator */}
+              {data.tenantFormId && data.version && (
+                <div style={{
+                  marginTop: '8px',
+                  padding: '4px 8px',
+                  fontSize: '11px',
+                  color: 'rgba(139, 92, 246, 0.7)',
+                  textAlign: 'center',
+                  borderTop: '1px solid rgba(139, 92, 246, 0.1)',
+                }}>
+                  Saved: v{data.version} • ID: {data.tenantFormId.slice(0, 8)}...
+                  {lastSaved && (
+                    <span style={{ marginLeft: '4px', opacity: 0.6 }}>
+                      ({new Date(lastSaved).toLocaleTimeString()})
+                    </span>
+                  )}
+                </div>
+              )}
+            </CollapsedStepList>
+          )}
+        </>
+      )}
+    </GroupContainer>
+  );
+});
+
+// Export type for use in nodeTypes registry
+export default FormProcessGroupNode;

--- a/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
@@ -24,13 +24,54 @@ export function normalizeNodeData(node: Node): Node {
     return node;
   }
 
+  // Rollback: Force all legacy Form Process container variants to render as plain
+  // `react-flow__node-default` (no group semantics / purple container overrides).
+  if (
+    node.type === 'formMultiStepContainer' ||
+    node.type === 'formProcess' ||
+    node.type === 'formProcessGroup' ||
+    node.type === 'formBook'
+  ) {
+    const { parentId, extent, expandParent, ...rest } = node as any;
+
+    return {
+      ...rest,
+      type: 'default',
+      data: {
+        ...(node.data || {}),
+        label: (node.data as any)?.label ?? (node.data as any)?.containerName ?? 'Form Process',
+      },
+    } as Node;
+  }
+
   // --------------------------------------------------------------------------
-  // Phase 7 Stabilization: canonicalize legacy Form container types
+  // Canonicalize legacy Form types (additive/back-compat)
   // --------------------------------------------------------------------------
-  // We standardize on the React Flow group implementation and present it as a
-  // singular "Form" container (formBook). Legacy types continue to load.
-  if (node.type === 'formMultiStepContainer' || node.type === 'formProcess' || node.type === 'formProcessGroup') {
-    const canonicalType = 'formBook';
+  // Canonical nodes:
+  // - Form step: `form`
+  // - Form container: `formProcessGroup` ("Form Process")
+  if (node.type === 'formStep' || node.type === 'formStepSingle') {
+    const canonicalType = 'form';
+    const canonicalDef = NODE_TYPE_REGISTRY[canonicalType];
+
+    return {
+      ...node,
+      type: canonicalType,
+      data: {
+        ...(node.data || {}),
+        maxInputs: (node.data as any)?.maxInputs ?? canonicalDef?.maxInputs ?? 1,
+        maxOutputs: (node.data as any)?.maxOutputs ?? canonicalDef?.maxOutputs ?? 1,
+      },
+    };
+  }
+
+  if (
+    node.type === 'formMultiStepContainer' ||
+    node.type === 'formProcess' ||
+    node.type === 'formProcessGroup' ||
+    node.type === 'formBook'
+  ) {
+    const canonicalType = 'formProcessGroup';
     const canonicalDef = NODE_TYPE_REGISTRY[canonicalType];
 
     return {
@@ -40,7 +81,6 @@ export function normalizeNodeData(node: Node): Node {
         ...(node.data || {}),
         // Ensure group semantics are enabled
         isGroup: true,
-        // Ensure required sizing metadata exists for downstream logic
         maxInputs: (node.data as any)?.maxInputs ?? canonicalDef?.maxInputs ?? 1,
         maxOutputs: (node.data as any)?.maxOutputs ?? canonicalDef?.maxOutputs ?? 1,
       },


### PR DESCRIPTION
Time-travel rollback for Workform Editor Form Process node.

- Hard restore FlowEditor core files to Friday 03/20 baseline (nodeTypes + nodeNormalization + ContainerNode/FormProcessNode).
- Delete FormProcessGroupNode.tsx to eliminate unwanted structural wrapping.
- Normalize legacy container types back to plain formProcess.
- UnifiedFlowEditor now renders formProcess as a simple node (no group/book behavior).

Validation:
- npm run build (frontend) passes.
- npm run type-check currently fails on upstream/development baseline; ran for traceability.
