### PR TITLE
fix(workforms): FormProcess auto-realign + edge fill fix + circular add button

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -10,6 +10,7 @@
 - Vanguard: Main Inquiry Flow Template – Complete (Meatscentral-Inquiry-Flow-Template is now the default blueprint for new workforms).
 - Vanguard: Cockpit-Detail-View-Template – Complete.
 - Vanguard: Cockpit Customer Detail View – Complete & Whiteboard-Accurate.
+- Vanguard: Workform Editor UX Polish – Auto-realign + Line fix + Circular Add Button.
 - Completed Batch 2: disabled manual node dragging/connecting, defaulted edges to inline insertion type, added "+" edge event listener to open the node palette with context, and enforced strict top-to-bottom auto-layout centering.
 - Hotfix: restored dev-site load by fixing nodeConfigSchemas TDZ initialization ordering (PR #3557).
 - Ops hardening: env secret audit aligned to manifests/env.manifest.json v5.1 + email_integration model/schema cleanup (PR #3558).

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -109,6 +109,7 @@ import {
   FormNode,
   FormProcessNode,
   FormProcessContainerNode,
+  FormProcessAddButtonNode,
   FormStepNode,
   FormStepSingleNode,
   FormReferenceNode,
@@ -129,7 +130,7 @@ import { DryRunDebugger } from './components/DryRunDebugger';
 import { validateWorkflow, type ValidationResult } from './utils/validationEngine';
 import { NODE_TYPE_REGISTRY, NodeCategory, CATEGORY_LABELS, CATEGORY_ORDER, getNodeTypeDefinition } from './nodeTypes';
 import { schemaRegistry } from './config/schemaRegistry';
-import { calculateContainerLayout, autoConnectSequentialSteps } from './utils/containerLayout'; // Phase 3-4
+import { calculateContainerLayout, autoConnectSequentialSteps, LAYOUT_CONSTANTS } from './utils/containerLayout'; // Phase 3-4
 import { NodeContextMenu, useContextMenu } from './NodeContextMenu'; // Phase E.3
 import { EnhancedContextMenu, useEnhancedContextMenu } from './components/EnhancedContextMenu'; // Phase 2: UI/UX
 import { saveWorkflow, loadWorkflow, listWorkflows, deleteWorkflow, type WorkflowListItem } from './utils/workflowPersistence'; // Phase 7, 8.3
@@ -1671,6 +1672,9 @@ const staticNodeTypes = {
   // Form Process: non-purple container renderer with toolbar (Add Step + Edit)
   formProcessContainer: FormProcessContainerNode,
 
+  // Render-time "+" button node for Form Process containers
+  formProcessAddButton: FormProcessAddButtonNode,
+
   smartWorkForm: SmartWorkFormNode,
 
   // Backward compatibility aliases
@@ -1934,6 +1938,65 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       });
       nextEdges = connectionResult.edges;
     }
+
+    setNodes(sortNodesTopologically(nextNodes));
+    setEdges(nextEdges);
+  }, [edges, nodes, setEdges, setNodes]);
+
+  // Dynamic FormProcess alignment: when steps are added/removed, re-stack all internal pages vertically.
+  // This is intentionally NOT persisted as a migration; it only updates node positions and container sizing.
+  const containerChildSignatureRef = useRef<Map<string, string>>(new Map());
+  useEffect(() => {
+    if (!didInitialFormProcessLayoutRef.current) return;
+
+    const isPageNodeType = (type?: string) =>
+      type === 'form' || type === 'formReference' || type === 'formStepSingle' || type === 'formStep';
+
+    const containerNodes = nodes.filter((n) =>
+      isFormProcessContainerType(((n.data as any)?.nodeType as string | undefined) || n.type)
+    );
+    if (containerNodes.length === 0) return;
+
+    let nextNodes = nodes;
+    let nextEdges = edges;
+    let didChange = false;
+
+    for (const container of containerNodes) {
+      const pages = nextNodes.filter((n) => n.parentId === container.id && isPageNodeType(n.type));
+      const signature = pages
+        .map((p) => String(p.id))
+        .sort()
+        .join('|');
+
+      const prevSig = containerChildSignatureRef.current.get(container.id);
+      if (prevSig === undefined) {
+        containerChildSignatureRef.current.set(container.id, signature);
+        continue;
+      }
+
+      if (prevSig === signature) continue;
+
+      const layoutResult = calculateContainerLayout(container.id, nextNodes, nextEdges);
+      const connectionResult = autoConnectSequentialSteps(container.id, layoutResult.nodes, nextEdges);
+
+      nextNodes = layoutResult.nodes.map((n) => {
+        if (n.id !== container.id) return n;
+        return {
+          ...n,
+          style: {
+            ...(n.style || {}),
+            width: Math.max(layoutResult.containerWidth, (n.style as any)?.width || 600),
+            height: Math.max(layoutResult.containerHeight, (n.style as any)?.height || 400),
+          },
+        };
+      });
+
+      nextEdges = connectionResult.edges;
+      containerChildSignatureRef.current.set(container.id, signature);
+      didChange = true;
+    }
+
+    if (!didChange) return;
 
     setNodes(sortNodesTopologically(nextNodes));
     setEdges(nextEdges);
@@ -4124,8 +4187,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           parentId: newNode.id,
           extent: 'parent',
           expandParent: true,
-          position: { x: 50 + index * 350, y: 80 },
+          position: {
+            x: LAYOUT_CONSTANTS.START_X,
+            y: LAYOUT_CONSTANTS.STEP_Y + index * LAYOUT_CONSTANTS.STEP_SPACING,
+          },
           draggable: false,
+          style: { width: LAYOUT_CONSTANTS.STEP_W, height: LAYOUT_CONSTANTS.STEP_H, overflow: 'hidden' },
           data: {
             label: `Page ${index + 1}`,
             status: 'draft',
@@ -4258,7 +4325,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
    */
   const onNodeDragStop = useCallback((event: React.MouseEvent, node: Node) => {
     // Phase 5: If node is inside a container and it's a form step, check for significant movement
-    if (node.parentId && (node.type === 'formStep' || node.type === 'formReference')) {
+    if (node.parentId && (node.type === 'form' || node.type === 'formStep' || node.type === 'formStepSingle' || node.type === 'formReference')) {
       // Check if position changed significantly (more than 30px horizontally)
       const dragStart = dragStartPositionRef.current;
       const SIGNIFICANT_MOVEMENT_THRESHOLD = 30; // pixels
@@ -6346,10 +6413,15 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         const newPage: Node = {
           id: newPageId,
           type: 'form',
-          position: {
-            x: 50 + insertIndex * 350,
-            y: 80,
-          },
+          position: enforceStrictPages
+            ? {
+                x: LAYOUT_CONSTANTS.START_X,
+                y: LAYOUT_CONSTANTS.STEP_Y + insertIndex * LAYOUT_CONSTANTS.STEP_SPACING,
+              }
+            : {
+                x: LAYOUT_CONSTANTS.START_X + insertIndex * LAYOUT_CONSTANTS.STEP_SPACING,
+                y: LAYOUT_CONSTANTS.STEP_Y,
+              },
           style: enforceStrictPages ? { width: 320, height: 320, overflow: 'hidden' } : undefined,
           data: {
             stepTitle: `Page ${newPageNumber}`,
@@ -6386,10 +6458,15 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
           return {
             ...n,
-            position: {
-              x: 50 + idx * 350,
-              y: 80,
-            },
+            position: enforceStrictPages
+              ? {
+                  x: LAYOUT_CONSTANTS.START_X,
+                  y: LAYOUT_CONSTANTS.STEP_Y + idx * LAYOUT_CONSTANTS.STEP_SPACING,
+                }
+              : {
+                  x: LAYOUT_CONSTANTS.START_X + idx * LAYOUT_CONSTANTS.STEP_SPACING,
+                  y: LAYOUT_CONSTANTS.STEP_Y,
+                },
             draggable: enforceStrictPages ? false : n.draggable,
             style: enforceStrictPages
               ? {
@@ -6551,6 +6628,51 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
     return derived;
   }, [edges, nodesWithHandlers]);
+
+  // Render-time "+" button beneath the last form step inside each expanded FormProcess container.
+  // This node is virtual (not persisted) and triggers creation of the next Form step.
+  const nodesForCanvas = useMemo(() => {
+    const isPageNodeType = (type?: string) =>
+      type === 'form' || type === 'formStepSingle' || type === 'formStep' || type === 'formReference';
+
+    const virtualNodes: Node[] = [];
+
+    nodesWithHandlers.forEach((n) => {
+      const containerType = ((n.data as any)?.nodeType as string | undefined) || n.type;
+      if (!isFormProcessContainerType(containerType)) return;
+      if ((n.data as any)?.isExpanded === false) return;
+
+      const pages = nodesWithHandlers
+        .filter((c) => c.parentId === n.id && isPageNodeType(c.type) && !c.hidden)
+        .sort((a, b) => (a.position?.y || 0) - (b.position?.y || 0));
+
+      const last = pages[pages.length - 1];
+      const anchorY = last ? last.position.y + LAYOUT_CONSTANTS.STEP_H : LAYOUT_CONSTANTS.STEP_Y;
+
+      const x = LAYOUT_CONSTANTS.START_X + (LAYOUT_CONSTANTS.STEP_W / 2 - LAYOUT_CONSTANTS.ADD_BUTTON_D / 2);
+      const y = anchorY + LAYOUT_CONSTANTS.ADD_BUTTON_MARGIN_Y;
+
+      virtualNodes.push({
+        id: `__virtual:add:${n.id}`,
+        type: 'formProcessAddButton',
+        parentId: n.id,
+        extent: 'parent',
+        position: { x, y },
+        draggable: false,
+        selectable: false,
+        connectable: false,
+        focusable: false,
+        deletable: false,
+        style: { width: LAYOUT_CONSTANTS.ADD_BUTTON_D, height: LAYOUT_CONSTANTS.ADD_BUTTON_D },
+        data: {
+          containerId: n.id,
+          onAddStepInsideForm: (n.data as any)?.onAddStepInsideForm,
+        },
+      });
+    });
+
+    return virtualNodes.length ? [...nodesWithHandlers, ...virtualNodes] : nodesWithHandlers;
+  }, [nodesWithHandlers]);
 
   return (
     <FormBuilderProvider onNodeDataUpdate={handleNodeDataUpdate}>
@@ -7014,7 +7136,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       {/* React Flow Canvas - Visual Mode */}
       {normalizedEditorMode === 'visual' && (
         <DebugAwareReactFlow
-        nodes={nodesWithHandlers}
+        nodes={nodesForCanvas}
         edges={edgesForCanvas}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
@@ -7054,7 +7176,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           // Step edges with larger markers + wider interaction area.
           // NOTE: edgeTypes.step maps to EnhancedConnectionEdge to preserve toolbars/hitbox.
           type: 'step',
-          style: { strokeWidth: 3, stroke: 'rgb(var(--color-text-secondary))' },
+          style: { fill: 'none', strokeWidth: 3, stroke: 'rgb(var(--color-text-secondary))' },
           interactionWidth: 28,
           markerEnd: {
             type: MarkerType.ArrowClosed,
@@ -7064,6 +7186,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           },
         }}
         connectionLineStyle={{
+          fill: 'none',
           stroke: 'rgb(var(--color-text-secondary))',
           strokeWidth: 3,
           strokeDasharray: '5,5',

--- a/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
@@ -148,6 +148,7 @@ export const ConditionalEdge = React.memo<EdgeProps<ConditionalEdgeData>>(({
         id={id}
         className="react-flow__edge-path"
         d={edgePath}
+        fill="none"
         style={edgeStyle}
         markerEnd={`url(#diamond-${id})`}
       />

--- a/frontend/src/components/FlowEditor/edges/CustomEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/CustomEdge.tsx
@@ -177,6 +177,7 @@ export const CustomEdge = React.memo<EdgeProps<CustomEdgeData>>(({
       <path
         d={edgePath}
         className="react-flow__edge-path"
+        fill="none"
         style={{ stroke: 'transparent', strokeWidth: 30, strokeOpacity: 0 }}
         pointerEvents="stroke"
       />
@@ -186,6 +187,7 @@ export const CustomEdge = React.memo<EdgeProps<CustomEdgeData>>(({
         id={id}
         className="react-flow__edge-path"
         d={edgePath}
+        fill="none"
         style={edgeStyle}
         markerEnd={markerEnd}
       />

--- a/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
@@ -466,6 +466,7 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
         {/* Invisible thick hitbox under the visible edge to stabilize hover/interaction */}
         <path
           d={edgePath}
+          fill="none"
           style={{ stroke: 'transparent', strokeWidth: 44, strokeOpacity: 0 }}
           pointerEvents="stroke"
           onMouseEnter={setHoverOn}
@@ -478,6 +479,7 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
           path={edgePath}
           markerEnd={markerEnd}
           style={{
+            fill: 'none',
             stroke: edgeColor,
             strokeWidth,
             transition: 'all 0.2s ease',

--- a/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
@@ -161,6 +161,7 @@ export const ErrorEdge = React.memo<EdgeProps<ErrorEdgeData>>(({
         id={id}
         className="react-flow__edge-path"
         d={edgePath}
+        fill="none"
         style={edgeStyle}
         markerEnd={`url(#warning-${id})`}
       />

--- a/frontend/src/components/FlowEditor/edges/InsertNodeEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/InsertNodeEdge.tsx
@@ -75,13 +75,14 @@ export default function InsertNodeEdge({
       <path
         d={edgePath}
         className="react-flow__edge-path"
+        fill="none"
         style={{ stroke: 'transparent', strokeWidth: 30, strokeOpacity: 0 }}
         pointerEvents="stroke"
       />
 
       <path
         id={id}
-        style={{ ...style, strokeWidth: 2, stroke: 'rgb(var(--color-border))' }}
+        style={{ ...style, fill: 'none', strokeWidth: 2, stroke: 'rgb(var(--color-border))' }}
         className="react-flow__edge-path"
         d={edgePath}
         markerEnd={markerEnd}

--- a/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
@@ -153,6 +153,7 @@ export const SuccessEdge = React.memo<EdgeProps<SuccessEdgeData>>(({
         id={id}
         className="react-flow__edge-path"
         d={edgePath}
+        fill="none"
         style={edgeStyle}
         markerEnd={`url(#checkmark-${id})`}
       />

--- a/frontend/src/components/FlowEditor/nodes/FormProcessAddButtonNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessAddButtonNode.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import styled from 'styled-components';
+import type { NodeProps } from '@xyflow/react';
+import { Plus } from 'lucide-react';
+
+export type FormProcessAddButtonData = {
+  containerId: string;
+  onAddStepInsideForm?: () => void;
+};
+
+const Wrap = styled.div`
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: all;
+`;
+
+const CircleButton = styled.button`
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  border: 2px solid rgb(var(--color-surface));
+  background: rgb(var(--color-primary));
+  color: white;
+  box-shadow:
+    0 12px 24px rgba(var(--color-primary), 0.25),
+    0 2px 8px rgba(0, 0, 0, 0.10);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.12s ease, opacity 0.12s ease;
+
+  &:hover {
+    transform: translateY(-1px) scale(1.03);
+    opacity: 0.96;
+  }
+
+  &:active {
+    transform: translateY(0) scale(0.98);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(var(--color-primary), 0.35);
+    outline-offset: 4px;
+  }
+`;
+
+export const FormProcessAddButtonNode = React.memo<NodeProps<FormProcessAddButtonData>>(({ data }) => {
+  return (
+    <Wrap className="nodrag nopan">
+      <CircleButton
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          data?.onAddStepInsideForm?.();
+        }}
+        aria-label="Add next step"
+        title="Add next step"
+      >
+        <Plus size={22} />
+      </CircleButton>
+    </Wrap>
+  );
+});
+
+export default FormProcessAddButtonNode;

--- a/frontend/src/components/FlowEditor/nodes/index.ts
+++ b/frontend/src/components/FlowEditor/nodes/index.ts
@@ -31,6 +31,8 @@ export { FormProcessNode } from './FormProcessNode';
 export type { ContainerNodeData } from './FormProcessNode';
 
 export { FormProcessContainerNode } from './FormProcessContainerNode';
+export { FormProcessAddButtonNode } from './FormProcessAddButtonNode';
+export type { FormProcessAddButtonData } from './FormProcessAddButtonNode';
 
 export { TriggerNode } from './TriggerNode';
 export type { TriggerNodeData } from './TriggerNode';

--- a/frontend/src/components/FlowEditor/utils/containerLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/containerLayout.ts
@@ -18,24 +18,28 @@ import { logger } from '@/utils/logger';
 // ============================================================================
 
 export const LAYOUT_CONSTANTS = {
-  // Horizontal layout for form steps
-  START_X: 50,           // Starting x position for first form step
-  STEP_SPACING: 350,     // Horizontal spacing between form steps
-  STEP_Y: 80,            // Y position for form step row
+  // Step layout (FormProcess: vertical stack; others may still use horizontal)
+  START_X: 50,
+  STEP_SPACING: 350,
+  STEP_Y: 80,
 
   // Fixed dimensions for Form Step nodes (keeps steps inside parent bounds)
   STEP_W: 320,
   STEP_H: 320,
 
   // Vertical layout for action nodes
-  ACTION_OFFSET_Y: 180,  // Vertical offset below form step
-  ACTION_SPACING_Y: 120, // Spacing between stacked actions
+  ACTION_OFFSET_Y: 180,
+  ACTION_SPACING_Y: 120,
 
   // Container padding
   CONTAINER_PADDING_X: 20,
   CONTAINER_PADDING_Y: 20,
 
-  // Node dimensions (for calculating container size)
+  // Virtual "+" add button (render-time, not persisted)
+  ADD_BUTTON_D: 56,
+  ADD_BUTTON_MARGIN_Y: 24,
+
+  // Fallback node dimensions (for calculating container size)
   DEFAULT_NODE_WIDTH: 320,
   DEFAULT_NODE_HEIGHT: 320,
 } as const;
@@ -106,15 +110,27 @@ export function calculateContainerLayout(
   
   logger.debug(`[Layout] Found \${formSteps.length} form steps, \${otherNodes.length} non-form child nodes`);
   
-  // Sort form steps by current x-position to preserve rough order
-  formSteps.sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0));
-  
-  // Update form steps with horizontal layout
+  const layoutDirection: 'vertical' | 'horizontal' = enforceStrictPages ? 'vertical' : 'horizontal';
+
+  // Preserve rough order based on the axis that matters for the container
+  formSteps.sort((a, b) => {
+    const ax = layoutDirection === 'vertical' ? (a.position?.y || 0) : (a.position?.x || 0);
+    const bx = layoutDirection === 'vertical' ? (b.position?.y || 0) : (b.position?.x || 0);
+    return ax - bx;
+  });
+
+  // Update form steps with container layout
   const updatedFormSteps = formSteps.map((step, index) => {
-    const newPosition: NodePosition = {
-      x: LAYOUT_CONSTANTS.START_X + index * LAYOUT_CONSTANTS.STEP_SPACING,
-      y: LAYOUT_CONSTANTS.STEP_Y,
-    };
+    const newPosition: NodePosition =
+      layoutDirection === 'vertical'
+        ? {
+            x: LAYOUT_CONSTANTS.START_X,
+            y: LAYOUT_CONSTANTS.STEP_Y + index * LAYOUT_CONSTANTS.STEP_SPACING,
+          }
+        : {
+            x: LAYOUT_CONSTANTS.START_X + index * LAYOUT_CONSTANTS.STEP_SPACING,
+            y: LAYOUT_CONSTANTS.STEP_Y,
+          };
 
     logger.debug(`[Layout] Form step \${step.id} positioned at (\${newPosition.x}, \${newPosition.y})`);
 
@@ -132,7 +148,7 @@ export function calculateContainerLayout(
         : step.style,
       data: {
         ...step.data,
-        order: index, // Store order for future reordering
+        order: index,
       },
     };
   });
@@ -140,18 +156,26 @@ export function calculateContainerLayout(
   // Book+Pages: only reposition form steps; leave other child nodes unchanged
   const updatedChildNodes = [...updatedFormSteps, ...otherNodes];
   
-  // Calculate required container dimensions
+  const getNodeSize = (n: Node) => {
+    const styleAny = (n.style || {}) as any;
+    const width = styleAny.width ?? (n as any).width ?? LAYOUT_CONSTANTS.DEFAULT_NODE_WIDTH;
+    const height = styleAny.height ?? (n as any).height ?? LAYOUT_CONSTANTS.DEFAULT_NODE_HEIGHT;
+    return { width: Number(width) || LAYOUT_CONSTANTS.DEFAULT_NODE_WIDTH, height: Number(height) || LAYOUT_CONSTANTS.DEFAULT_NODE_HEIGHT };
+  };
+
+  // Calculate required container dimensions (respect explicit style widths/heights when present)
   const maxX = Math.max(
-    ...updatedChildNodes.map(n => n.position.x + LAYOUT_CONSTANTS.DEFAULT_NODE_WIDTH),
+    ...updatedChildNodes.map((n) => n.position.x + getNodeSize(n).width),
     400 // Minimum width
   );
   const maxY = Math.max(
-    ...updatedChildNodes.map(n => n.position.y + LAYOUT_CONSTANTS.DEFAULT_NODE_HEIGHT),
+    ...updatedChildNodes.map((n) => n.position.y + getNodeSize(n).height),
     300 // Minimum height
   );
-  
+
   const containerWidth = maxX + LAYOUT_CONSTANTS.CONTAINER_PADDING_X;
-  const containerHeight = maxY + LAYOUT_CONSTANTS.CONTAINER_PADDING_Y;
+  const extraBottom = enforceStrictPages ? LAYOUT_CONSTANTS.ADD_BUTTON_D + LAYOUT_CONSTANTS.ADD_BUTTON_MARGIN_Y : 0;
+  const containerHeight = maxY + LAYOUT_CONSTANTS.CONTAINER_PADDING_Y + extraBottom;
   
   logger.debug(`[Layout] Calculated container dimensions: \${containerWidth}x\${containerHeight}`);
   
@@ -203,16 +227,30 @@ export function autoConnectSequentialSteps(
 ): ConnectionResult {
   logger.debug(`[AutoConnect] Creating sequential connections for container ${containerId}`);
   
+  const containerNode = allNodes.find((n) => n.id === containerId);
+  const containerType = ((containerNode?.data as any)?.nodeType as string | undefined) || containerNode?.type;
+  const enforceStrictPages = !!containerType &&
+    (containerType === 'formProcessGroup' ||
+      containerType === 'formProcess' ||
+      containerType === 'formMultiStepContainer' ||
+      containerType === 'formBook');
+
   // Filter child nodes (using parentId - React Flow v11+)
-  const childNodes = allNodes.filter(node => node.parentId === containerId);
-  
-  // Get only form steps and sort by x-position (left-to-right)
+  const childNodes = allNodes.filter((node) => node.parentId === containerId);
+
+  // Get only form steps and sort by the container axis
   const isPageNodeType = (type?: string) =>
     type === 'form' || type === 'formReference' || type === 'formStepSingle' || type === 'formStep';
 
+  const layoutDirection: 'vertical' | 'horizontal' = enforceStrictPages ? 'vertical' : 'horizontal';
+
   const formSteps = childNodes
     .filter((node) => isPageNodeType(node.type))
-    .sort((a, b) => (a.position?.x || 0) - (b.position?.x || 0));
+    .sort((a, b) =>
+      layoutDirection === 'vertical'
+        ? (a.position?.y || 0) - (b.position?.y || 0)
+        : (a.position?.x || 0) - (b.position?.x || 0)
+    );
   
   logger.debug(`[AutoConnect] Found ${formSteps.length} form steps to connect`);
   


### PR DESCRIPTION
Implements requested Workform Editor UX polish:

1) FormProcess container auto-realignment
- Form steps inside FormProcess containers now auto-stack vertically and re-layout when steps are added/removed.
- Container sizing updated accordingly.

2) Connection line styling fix
- Explicit fill=none on all edge paths + connectionLineStyle to eliminate black fill glitch.

3) Circular + add button
- Adds a virtual (render-time, non-persisted) circular + button node beneath the last step in each expanded FormProcess container.
- Clicking creates a new Form step in that container.

Docs:
- MASTER_PLAN.md updated with Vanguard entry.

Verification:
- scripts/verify_golden_state.sh ✅
- frontend: npm run test:ci ✅ (Vitest: 60 passed | 1 skipped)