### PR TITLE
fix(workforms): config panel in fullscreen

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2119,7 +2119,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       height: 100vh;
       overflow-y: auto;
       background: #fff;
-      z-index: 1000;
+      /* Must sit above fullscreen canvas (EditorContainer uses z-index: 9990) */
+      z-index: 10050;
       box-shadow: -4px 0 12px rgba(0,0,0,0.1);
       display: none;
       pointer-events: none;
@@ -2158,7 +2159,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           height: 100vh;
           overflow-y: auto;
           background: #fff;
-          z-index: 1000;
+          /* Must sit above fullscreen canvas (EditorContainer uses z-index: 9990) */
+          z-index: 10050;
           box-shadow: -4px 0 12px rgba(0,0,0,0.1);
           display: flex;
           pointer-events: auto;

--- a/frontend/src/components/FlowEditor/__tests__/UnifiedFlowEditor.integration.test.tsx
+++ b/frontend/src/components/FlowEditor/__tests__/UnifiedFlowEditor.integration.test.tsx
@@ -165,6 +165,9 @@ describe('UnifiedFlowEditor - E2E Integration Tests', () => {
       const portal = document.getElementById('config-portal');
       expect(portal).toBeInTheDocument();
       expect(portal?.style.display).toBe('none');
+
+      // Regression: portal must render above fullscreen canvas (EditorContainer z-index: 9990)
+      expect(portal?.style.zIndex).toBe('10050');
     });
 
     it('should load existing form when formId provided', async () => {


### PR DESCRIPTION
Fixes config panel not appearing in fullscreen canvas mode by raising #config-portal z-index above the fullscreen EditorContainer. Adds a regression assertion in UnifiedFlowEditor integration tests.\n\nVerification:\n- bash scripts/verify_golden_state.sh\n- frontend: npm run test:ci