### PR TITLE
Harden OAuth initiation flow

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -53,6 +53,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 - 2026-03-23 — Cockpit UX: Inline create Sales Order subview (URL-driven) — PR: #3804
 - 2026-03-23 — Cockpit UX: Notes & Calls drawer (unified timeline + add note) — PR: #3805
 - 2026-03-23 — Admin Branding: reliably load tenant logo/colors after login + cache-bust on update — PR: #3807
+- 2026-03-23 — Hardened OAuth initiation flow (Removed direct API navigation to preserve JWT/Tenant context) — PR: #TBD
 
 - 2026-03-22T16:39:58Z — EMERGENCY ROLLBACK: Reverted Workform Container UI to stable Friday baseline due to UX degradation.
 

--- a/frontend/src/components/Integrations/EmailConnection.tsx
+++ b/frontend/src/components/Integrations/EmailConnection.tsx
@@ -8,6 +8,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { toast } from 'react-hot-toast';
 import { Mail, CheckCircle, AlertCircle, ExternalLink } from 'lucide-react';
+import { apiClient } from '../../services/apiService';
 
 interface EmailConnectionProps {
   provider: 'microsoft' | 'google';
@@ -55,15 +56,21 @@ export const EmailConnection: React.FC<EmailConnectionProps> = ({
     }
 
     setIsConnecting(true);
-    
+
     try {
-      const tenantId = localStorage.getItem('tenantId');
-      const tenantParam = tenantId ? `&tenant_id=${encodeURIComponent(tenantId)}` : '';
-      window.location.href = `/api/v1/integrations/oauth/authorize/?provider=${encodeURIComponent(provider)}&redirect=1${tenantParam}`;
+      const response = await apiClient.get('/integrations/oauth/authorize/', {
+        params: { provider },
+      });
+
+      if (!response.data?.auth_url) {
+        throw new Error('Authorization URL not received from server');
+      }
+
+      window.location.href = response.data.auth_url;
     } catch (error: any) {
       console.error('[EmailConnection] OAuth initiation failed:', error);
-      const message = error?.message ? String(error.message) : '';
-      toast.error(message ? `Failed to initiate connection: ${message}` : 'Failed to initiate connection');
+      toast.error(error.response?.data?.error || 'Failed to initiate connection. Please try again.');
+    } finally {
       setIsConnecting(false);
     }
   };

--- a/frontend/src/components/Widgets/EmailIntegrationWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIntegrationWidget.tsx
@@ -334,12 +334,23 @@ export const EmailIntegrationWidget: React.FC<EmailIntegrationWidgetProps> = ({ 
     onRefresh?.();
   };
 
-  const handleConnect = (provider: 'outlook' | 'gmail') => {
-    // Initiate OAuth flow
-    const baseUrl = window.location.origin;
-    const redirectUri = `${baseUrl}/auth/email/callback`;
-    const authUrl = `/api/v1/workflows/email-accounts/connect/${provider}/?redirect_uri=${encodeURIComponent(redirectUri)}`;
-    window.location.href = authUrl;
+  const handleConnect = async (provider: 'outlook' | 'gmail') => {
+    try {
+      // Use secure apiClient to get the Microsoft URL, preserving JWT and Tenant headers
+      const response = await apiClient.get('/integrations/oauth/authorize/', {
+        params: { provider },
+      });
+
+      if (response.data?.auth_url) {
+        // Safely redirect directly to Microsoft
+        window.location.href = response.data.auth_url;
+      } else {
+        throw new Error('Authorization URL not received from server');
+      }
+    } catch (err: any) {
+      console.error('Failed to initiate OAuth connection:', err);
+      alert(err.response?.data?.error || 'Failed to initiate connection. Please try again.');
+    }
   };
 
   const handleDisconnect = async (accountId: number) => {


### PR DESCRIPTION
Use apiClient to fetch /integrations/oauth/authorize/ before redirecting, preserving JWT + tenant headers.