### PR TITLE
Simplify Cockpit sidebar navigation

### DIFF
--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -30,17 +30,8 @@ export const navigation: NavigationItem[] = [
   {
     label: 'Cockpit',
     icon: '🎯',
+    path: '/cockpit',
     children: [
-      {
-        label: 'Dashboard',
-        icon: '📊',
-        path: '/cockpit',
-      },
-      {
-        label: 'Process Monitor',
-        icon: '🧭',
-        path: '/cockpit/process-monitor',
-      },
       {
         label: 'Calls',
         icon: '📞',


### PR DESCRIPTION
- Clicking Cockpit now navigates to /cockpit\n- Removed Dashboard and Process Monitor entries from sidebar navigation