### PR TITLE
Fix Admin Workspace access + endpoints

### DIFF
--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { useTheme } from '../../contexts/ThemeContext';
 import { Theme } from '../../config/theme';
 import { navigation, adminWorkspaceNavigation } from '../../config/navigation';
+import { useAdminPermissions, isAdminOrOwner } from '../../hooks/useAdminPermissions';
 import NavigationMenu from '../Navigation/NavigationMenu';
 
 interface SidebarProps {
@@ -49,6 +50,8 @@ const LockIcon: React.FC = () => (
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle, onHoverChange }) => {
   const { theme, themeName, tenantBranding } = useTheme();
   const location = useLocation();
+  const { permissions, isLoading: isPermissionsLoading } = useAdminPermissions();
+  const showAdminWorkspace = !isPermissionsLoading && isAdminOrOwner(permissions);
   const [isHovered, setIsHovered] = useState(false);
   const [keepOpen, setKeepOpen] = useState(() => {
     // Load keep open preference from localStorage
@@ -146,9 +149,11 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle, onHoverChange }) =>
       </NavigationSection>
 
       {/* Admin Workspace Section - Bottom Navigation */}
-      <AdminWorkspaceSection $isDarkMode={isDarkMode}>
-        <NavigationMenu items={adminWorkspaceNavigation} isExpanded={isExpanded} />
-      </AdminWorkspaceSection>
+      {showAdminWorkspace ? (
+        <AdminWorkspaceSection $isDarkMode={isDarkMode}>
+          <NavigationMenu items={adminWorkspaceNavigation} isExpanded={isExpanded} />
+        </AdminWorkspaceSection>
+      ) : null}
 
       <SidebarFooter $isExpanded={isExpanded} $isDarkMode={isDarkMode}>
         {isExpanded && (

--- a/frontend/src/hooks/useAdminPermissions.ts
+++ b/frontend/src/hooks/useAdminPermissions.ts
@@ -27,18 +27,22 @@ export interface AdminPermissions {
   can_manage_customizations: boolean;
   can_view_audit_logs: boolean;
   can_manage_option_lists: boolean;
-  role: 'user' | 'manager' | 'admin' | 'owner' | 'superuser';
+  role: 'user' | 'readonly' | 'manager' | 'admin' | 'owner' | 'superuser';
 }
 
 /**
  * Hook to fetch and manage admin permissions for the current user.
  */
 export function useAdminPermissions() {
+  const tenantId = typeof window !== 'undefined' ? localStorage.getItem('tenantId') : null;
+
   const query = useQuery<AdminPermissions>({
-    queryKey: ['admin', 'permissions'],
+    queryKey: ['admin', 'permissions', tenantId ?? 'none'],
     queryFn: async () => {
       try {
-        const response = await apiClient.get('/tenants/tenants/admin_permissions/');
+        // NOTE: TenantViewSet is registered at /api/v1/tenants/
+        // so the admin permissions action is /api/v1/tenants/admin_permissions/
+        const response = await apiClient.get('/tenants/admin_permissions/');
         return response.data;
       } catch (error: any) {
         // If 401, let the axios interceptor handle it

--- a/frontend/src/pages/Admin/Activity/index.tsx
+++ b/frontend/src/pages/Admin/Activity/index.tsx
@@ -133,7 +133,7 @@ const ActivityPage: React.FC = () => {
       setError('');
 
       const params = buildParams(filters, pageNum);
-      const response = await apiClient.get('/tenants/activity-logs/', { params });
+      const response = await apiClient.get('/activity-logs/', { params });
       const results = Array.isArray((response.data as any)?.results) ? (response.data as any).results : [];
 
       if (appendMode) {
@@ -182,7 +182,7 @@ const ActivityPage: React.FC = () => {
       if (appliedFilters.start_date) params.created_at__gte = appliedFilters.start_date;
       if (appliedFilters.end_date) params.created_at__lte = appliedFilters.end_date;
 
-      const response = await apiClient.get('/tenants/activity-logs/export/', {
+      const response = await apiClient.get('/activity-logs/export/', {
         params,
         responseType: 'blob',
       });

--- a/frontend/src/pages/Admin/Configurations/index.tsx
+++ b/frontend/src/pages/Admin/Configurations/index.tsx
@@ -62,7 +62,7 @@ const ConfigurationsPage: React.FC = () => {
     try {
       setLoading(true);
       setLoadError(null);
-      const response = await apiClient.get('/tenants/configurations/');
+      const response = await apiClient.get('/configurations/');
       const raw = response.data as any;
       const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
       setConfigurations(data);
@@ -159,7 +159,7 @@ const ConfigurationsPage: React.FC = () => {
       setSaving(true);
       const configurationsToUpdate = Object.entries(changes).map(([id, value]) => ({ id, value }));
 
-      await apiClient.post('/tenants/configurations/bulk_update/', {
+      await apiClient.post('/configurations/bulk_update/', {
         configurations: configurationsToUpdate,
       });
 
@@ -181,7 +181,7 @@ const ConfigurationsPage: React.FC = () => {
   const confirmReset = async () => {
     try {
       setSaving(true);
-      await apiClient.post('/tenants/configurations/reset_category/', {
+      await apiClient.post('/configurations/reset_category/', {
         category: activeCategory,
       });
 

--- a/frontend/src/pages/Admin/Profile/index.tsx
+++ b/frontend/src/pages/Admin/Profile/index.tsx
@@ -127,7 +127,7 @@ const AdminProfilePage: React.FC = () => {
     queryKey: ['tenant'],
     enabled: canManage,
     queryFn: async () => {
-      const response = await apiClient.get('/tenants/tenants/current/');
+      const response = await apiClient.get('/tenants/current/');
       return response.data;
     },
   });
@@ -167,7 +167,7 @@ const AdminProfilePage: React.FC = () => {
       // IMPORTANT: Do NOT set Content-Type for FormData.
       // Axios will attach the correct multipart boundary, and apiClient interceptor
       // removes the default application/json header for FormData payloads.
-      const response = await apiClient.patch(`/tenants/tenants/${tenant?.id}/`, data, {
+      const response = await apiClient.patch(`/tenants/${tenant?.id}/`, data, {
         headers: {
           Accept: 'application/json',
         },

--- a/frontend/src/pages/Admin/README.md
+++ b/frontend/src/pages/Admin/README.md
@@ -220,16 +220,16 @@ Breakpoints:
 All endpoints require authentication and tenant filtering.
 
 ### Users & Invitations
-- `GET /api/v1/tenants/tenant-users/` - List tenant users
-- `PATCH /api/v1/tenants/tenant-users/:id/` - Update tenant user (role, is_active)
-- `GET /api/v1/tenants/invitations/?status=pending` - List invitations
-- `POST /api/v1/tenants/invitations/` - Create invitation
-- `POST /api/v1/tenants/invitations/:id/resend/` - Resend invitation
-- `POST /api/v1/tenants/invitations/:id/revoke/` - Revoke invitation
+- `GET /api/v1/tenant-users/` - List tenant users
+- `PATCH /api/v1/tenant-users/:id/` - Update tenant user (role, is_active)
+- `GET /api/v1/invitations/?status=pending` - List invitations
+- `POST /api/v1/invitations/` - Create invitation
+- `POST /api/v1/invitations/:id/resend/` - Resend invitation
+- `POST /api/v1/invitations/:id/revoke/` - Revoke invitation
 
 ### Profile
-- `GET /api/v1/tenants/tenants/current/` - Get current tenant details
-- `PATCH /api/v1/tenants/tenants/:id/` - Update tenant (includes branding/logo)
+- `GET /api/v1/tenants/current/` - Get current tenant details
+- `PATCH /api/v1/tenants/:id/` - Update tenant (includes branding/logo)
 
 ### Option Lists
 - `GET /api/v1/system/choice-lists/` - List all choice lists
@@ -240,13 +240,13 @@ All endpoints require authentication and tenant filtering.
 - `PATCH /api/v1/system/tenant-overrides/:id/` - Update tenant override
 
 ### Configurations
-- `GET /api/v1/tenants/configurations/` - List tenant configurations
-- `POST /api/v1/tenants/configurations/bulk_update/` - Bulk update
-- `POST /api/v1/tenants/configurations/reset_category/` - Reset category
+- `GET /api/v1/configurations/` - List tenant configurations
+- `POST /api/v1/configurations/bulk_update/` - Bulk update
+- `POST /api/v1/configurations/reset_category/` - Reset category
 
 ### Activity Logs
-- `GET /api/v1/tenants/activity-logs/` - List logs
-- `GET /api/v1/tenants/activity-logs/export/` - Export CSV
+- `GET /api/v1/activity-logs/` - List logs
+- `GET /api/v1/activity-logs/export/` - Export CSV
 
 ## 🐛 Troubleshooting
 

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -79,7 +79,7 @@ const UsersPage: React.FC = () => {
     queryKey: ['tenant-users'],
     enabled: canAccess,
     queryFn: async () => {
-      const response = await apiClient.get('/tenants/tenant-users/');
+      const response = await apiClient.get('/tenant-users/');
       const data = response.data.results || response.data;
       return Array.isArray(data) ? data : [];
     },
@@ -93,7 +93,7 @@ const UsersPage: React.FC = () => {
     queryKey: ['tenant-invitations'],
     enabled: canAccess,
     queryFn: async () => {
-      const response = await apiClient.get('/tenants/invitations/', {
+      const response = await apiClient.get('/invitations/', {
         params: { status: 'pending' },
       });
       const data = response.data.results || response.data;
@@ -147,7 +147,7 @@ const UsersPage: React.FC = () => {
   );
 
   const inviteMutation = useMutation({
-    mutationFn: async (data: { email: string; role: string }) => apiClient.post('/tenants/invitations/', data),
+    mutationFn: async (data: { email: string; role: string }) => apiClient.post('/invitations/', data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tenant-invitations'] });
       toast.success('Invitation sent successfully');
@@ -161,7 +161,7 @@ const UsersPage: React.FC = () => {
 
   const updateRoleMutation = useMutation({
     mutationFn: async (data: { id: number; role: string }) =>
-      apiClient.patch(`/tenants/tenant-users/${data.id}/`, { role: data.role }),
+      apiClient.patch(`/tenant-users/${data.id}/`, { role: data.role }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tenant-users'] });
       toast.success('User role updated');
@@ -173,7 +173,7 @@ const UsersPage: React.FC = () => {
   });
 
   const deactivateMutation = useMutation({
-    mutationFn: async (id: number) => apiClient.patch(`/tenants/tenant-users/${id}/`, { is_active: false }),
+    mutationFn: async (id: number) => apiClient.patch(`/tenant-users/${id}/`, { is_active: false }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tenant-users'] });
       toast.success('User deactivated');
@@ -185,7 +185,7 @@ const UsersPage: React.FC = () => {
   });
 
   const reactivateMutation = useMutation({
-    mutationFn: async (id: number) => apiClient.patch(`/tenants/tenant-users/${id}/`, { is_active: true }),
+    mutationFn: async (id: number) => apiClient.patch(`/tenant-users/${id}/`, { is_active: true }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tenant-users'] });
       toast.success('User reactivated');
@@ -196,7 +196,7 @@ const UsersPage: React.FC = () => {
   });
 
   const revokeMutation = useMutation({
-    mutationFn: async (id: number) => apiClient.post(`/tenants/invitations/${id}/revoke/`),
+    mutationFn: async (id: number) => apiClient.post(`/invitations/${id}/revoke/`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tenant-invitations'] });
       toast.success('Invitation revoked');
@@ -207,7 +207,7 @@ const UsersPage: React.FC = () => {
   });
 
   const resendMutation = useMutation({
-    mutationFn: async (id: number) => apiClient.post(`/tenants/invitations/${id}/resend/`),
+    mutationFn: async (id: number) => apiClient.post(`/invitations/${id}/resend/`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tenant-invitations'] });
       toast.success('Invitation resent');


### PR DESCRIPTION
Fixes Admin Workspace showing 'Access restricted' for tenant admins by correcting API endpoint paths (router is mounted at /api/v1/, not /api/v1/tenants/*).

Also hides the Admin Workspace sidebar section unless admin permissions confirm admin/owner access, so tenant users don't see the workspace at all.

Files:
- frontend/src/hooks/useAdminPermissions.ts
- frontend/src/pages/Admin/*
- frontend/src/components/Layout/Sidebar.tsx