### PR TITLE
Fix OAuth authorize CORS (return auth_url JSON)

### DIFF
--- a/backend/integrations/views/oauth.py
+++ b/backend/integrations/views/oauth.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode, quote
 
 from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import redirect
 from django.utils import timezone
 from rest_framework.permissions import AllowAny
@@ -31,7 +31,7 @@ def _oauth_cookie_name(key: str, provider: str) -> str:
     return f'{_OAUTH_COOKIE_PREFIX}_{key}_{provider}'
 
 
-def _set_signed_oauth_cookie(response: HttpResponseRedirect, *, name: str, value: str, request) -> None:
+def _set_signed_oauth_cookie(response: HttpResponse, *, name: str, value: str, request) -> None:
     secure = bool(getattr(settings, 'SESSION_COOKIE_SECURE', False))
     if not secure:
         secure = request.is_secure()
@@ -182,7 +182,21 @@ class OAuthAuthorizeView(APIView):
 
         auth_url = f'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?{urlencode(params)}'
 
-        response = HttpResponseRedirect(auth_url)
+        wants_redirect = str(request.query_params.get('redirect', '')).lower() in {'1', 'true', 'yes'}
+        accept_header = (request.META.get('HTTP_ACCEPT') or '').lower()
+        is_xhr = (request.META.get('HTTP_X_REQUESTED_WITH') or '').lower() == 'xmlhttprequest'
+
+        # IMPORTANT: If this is called from the SPA via Axios/fetch, we must NOT 302 to Microsoft.
+        # Browsers will follow as XHR and trigger CORS failures. Instead, return JSON with auth_url,
+        # and let the frontend perform a top-level navigation (window.location.href).
+        wants_json = (not wants_redirect) or ('application/json' in accept_header) or is_xhr
+
+        response: HttpResponse
+        if wants_json:
+            response = JsonResponse({'auth_url': auth_url, 'provider': provider})
+        else:
+            response = HttpResponseRedirect(auth_url)
+
         _set_signed_oauth_cookie(
             response,
             name=_oauth_cookie_name('state', provider),

--- a/frontend/src/components/Widgets/EmailIntegrationWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIntegrationWidget.tsx
@@ -336,13 +336,15 @@ export const EmailIntegrationWidget: React.FC<EmailIntegrationWidgetProps> = ({ 
 
   const handleConnect = async (provider: 'outlook' | 'gmail') => {
     try {
-      // Use secure apiClient to get the Microsoft URL, preserving JWT and Tenant headers
+      const backendProvider = provider === 'outlook' ? 'microsoft' : 'google';
+
+      // Use secure apiClient to get the OAuth URL, preserving JWT and Tenant headers.
+      // Backend returns JSON { auth_url } (not a redirect) so the SPA can do a top-level navigation.
       const response = await apiClient.get('/integrations/oauth/authorize/', {
-        params: { provider },
+        params: { provider: backendProvider },
       });
 
       if (response.data?.auth_url) {
-        // Safely redirect directly to Microsoft
         window.location.href = response.data.auth_url;
       } else {
         throw new Error('Authorization URL not received from server');


### PR DESCRIPTION
Fixes CORS errors during Microsoft OAuth initiation.

Root cause: /api/v1/integrations/oauth/authorize/ was returning a 302 redirect to login.microsoftonline.com. When called via Axios/XHR from the SPA, the browser followed the redirect as XHR and blocked it via CORS.

Change: When requested via XHR/JSON (default), return JSON { auth_url, provider } and let the frontend do window.location.href. Keep redirect behavior behind ?redirect=1 for legacy flows.

Also maps EmailIntegrationWidget providers (outlook/gmail) -> (microsoft/google) to match backend provider names.