### PR TITLE
Cockpit: remove legacy /cockpit/entity URLs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -88,7 +88,7 @@ import { ErrorBoundary as ProductionErrorBoundary } from './components/common/Er
 import { logger } from './utils/logger';
 import CockpitPage from './pages/Cockpit';
 import ProcessMonitor from './pages/Cockpit/ProcessMonitor';
-import CockpitDetailViewPage from './pages/Cockpit/CockpitDetailView';
+import CockpitEntityRedirect from './pages/Cockpit/CockpitEntityRedirect';
 import { NotificationPreferences } from './pages/Settings/index';
 // WorkForms pages - Phase 1 Enhancement (renamed from Forms & Flows)
 import WorkFormsLayout from './pages/WorkForms';
@@ -353,7 +353,8 @@ const App: React.FC = () => {
                 {/* Cockpit (Command Center Dashboard) */}
                 <Route path="cockpit" element={<CockpitPage />} />
                 <Route path="cockpit/process-monitor" element={<ProcessMonitor />} />
-                <Route path="cockpit/entity/:entityType/:entityId" element={<CockpitDetailViewPage />} />
+                {/* Legacy deep-link route (redirects into /cockpit breadcrumb UX) */}
+                <Route path="cockpit/entity/:entityType/:entityId" element={<CockpitEntityRedirect />} />
                 {/* Note: /workspace now points to Admin Workspace, not Cockpit */}
               </Route>
             </Routes>

--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -679,20 +679,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
       return;
     }
 
-    // Canonical Cockpit Detail View trigger (customer/supplier)
-    const rawType = String(entity.type ?? '').toLowerCase();
-    const canonicalType = rawType === 'customer' || rawType === 'customers'
-      ? 'customer'
-      : rawType === 'supplier' || rawType === 'suppliers'
-      ? 'supplier'
-      : null;
-
-    if (canonicalType) {
-      navigate(`/cockpit/entity/${canonicalType}/${encodeURIComponent(entity.id)}`, {
-        state: { initialLabel: entity.name },
-      });
-    }
-  }, [navigate, navigation, onSelectEntity]);
+  }, [navigation, onSelectEntity]);
 
 
   /**

--- a/frontend/src/components/Navigation/CommandPalette.tsx
+++ b/frontend/src/components/Navigation/CommandPalette.tsx
@@ -17,6 +17,7 @@ import styled from 'styled-components';
 import { Search, X, ArrowUp, ArrowDown, CornerDownLeft, Plus, FileText, Users, Building2, Package, Truck } from 'lucide-react';
 import { apiClient } from '../../services/apiService';
 import { useNavigate } from 'react-router-dom';
+import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
 import { EntityDetailModal } from '../Shared/EntityDetailModal';
 
 // ============================================================================
@@ -501,6 +502,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
   
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
+  const cockpitNavigation = useCockpitNavigation();
 
   // Focus input when opened
   useEffect(() => {
@@ -657,12 +659,18 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
         ? 'supplier'
         : null;
 
-    // Cockpit default: open the canonical 3-column detail view for customers/suppliers.
+    // Cockpit default: open the canonical breadcrumb-driven view on /cockpit.
     if (canonicalType) {
-      onClose();
-      navigate(`/cockpit/entity/${canonicalType}/${encodeURIComponent(String(item.id))}`, {
-        state: { initialLabel: item.title },
+      cockpitNavigation.clearPath();
+      cockpitNavigation.addStep({
+        id: String(item.id),
+        type: canonicalType,
+        label: item.title,
+        subtitle: item.subtitle,
       });
+
+      onClose();
+      navigate('/cockpit');
       return;
     }
 

--- a/frontend/src/components/Widgets/EntityExplorerWidget.tsx
+++ b/frontend/src/components/Widgets/EntityExplorerWidget.tsx
@@ -330,9 +330,7 @@ export const EntityExplorerWidget: React.FC<EntityExplorerWidgetProps> = ({
         subtitle: entity.subtitle,
       });
 
-      navigate(`/cockpit/entity/${canonicalType}/${encodeURIComponent(String(entity.id))}`, {
-        state: { initialLabel: entity.name },
-      });
+      navigate('/cockpit');
       return;
     }
 

--- a/frontend/src/pages/Cockpit/CockpitDetailView.tsx
+++ b/frontend/src/pages/Cockpit/CockpitDetailView.tsx
@@ -1,3 +1,6 @@
+// NOTE: This page is deprecated in favor of the breadcrumb/state-driven Cockpit UX on /cockpit.
+// Kept for potential future reuse, but is no longer routed from App.tsx.
+
 import React from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 

--- a/frontend/src/pages/Cockpit/CockpitEntityRedirect.tsx
+++ b/frontend/src/pages/Cockpit/CockpitEntityRedirect.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+
+import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
+
+type LocationState = {
+  initialLabel?: string;
+};
+
+/**
+ * Legacy route handler.
+ *
+ * We no longer want Cockpit entity selection to navigate to /cockpit/entity/...
+ * (the Cockpit UX is breadcrumb/state-driven on /cockpit), but we keep this
+ * route as a redirect for old links/bookmarks.
+ */
+export const CockpitEntityRedirect: React.FC = () => {
+  const { entityType = '', entityId = '' } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const cockpitNavigation = useCockpitNavigation();
+
+  useEffect(() => {
+    const rawType = String(entityType ?? '').toLowerCase();
+    const canonicalType = rawType === 'customer' || rawType === 'customers'
+      ? 'customer'
+      : rawType === 'supplier' || rawType === 'suppliers'
+        ? 'supplier'
+        : null;
+
+    if (!canonicalType || !entityId) {
+      navigate('/cockpit', { replace: true });
+      return;
+    }
+
+    const state = (location.state ?? {}) as LocationState;
+    const label = state.initialLabel || `${canonicalType === 'customer' ? 'Customer' : 'Supplier'} ${entityId}`;
+
+    cockpitNavigation.clearPath();
+    cockpitNavigation.addStep({
+      id: String(entityId),
+      type: canonicalType,
+      label,
+    });
+
+    navigate('/cockpit', { replace: true });
+  }, [cockpitNavigation, entityId, entityType, location.state, navigate]);
+
+  return null;
+};
+
+export default CockpitEntityRedirect;


### PR DESCRIPTION
Stops Cockpit entity selection from navigating to /cockpit/entity/... (legacy page). Selection now stays on /cockpit and uses breadcrumb navigation state. Legacy deep-links redirect into /cockpit with breadcrumb context.