### PR TITLE
Admin: allow tenant admins to access Billing

### DIFF
--- a/backend/apps/tenants/views.py
+++ b/backend/apps/tenants/views.py
@@ -313,7 +313,7 @@ class TenantViewSet(viewsets.ModelViewSet):
                 'can_invite_users': True,
                 'can_change_roles': True,
                 'can_manage_profile': True,
-                'can_manage_billing': False,  # Only owners can manage billing
+                'can_manage_billing': True,
                 'can_manage_configurations': True,
                 'can_manage_customizations': True,
                 'can_view_audit_logs': True,

--- a/frontend/src/pages/Admin/Billing/index.tsx
+++ b/frontend/src/pages/Admin/Billing/index.tsx
@@ -13,7 +13,7 @@ const BillingPage: React.FC = () => {
         <EmptyState
           icon="💳"
           title="Billing coming soon"
-          message="This area will allow tenant owners to manage subscriptions, payment methods, and invoices."
+          message="This area will allow tenant owners and admins to manage subscriptions, payment methods, and invoices."
         />
       </AdminGuard>
     </AdminPage>


### PR DESCRIPTION
Billing page was guarded to owners only via can_manage_billing. This change grants can_manage_billing to tenant admins as well, removing the Access Restricted state for admins.