### PR TITLE
Admin: fix Option Lists + Customizations metadata

### DIFF
--- a/backend/apps/system/serializers.py
+++ b/backend/apps/system/serializers.py
@@ -67,12 +67,28 @@ class SystemChoiceListSerializer(serializers.ModelSerializer):
 
 
 class SystemChoiceListMinimalSerializer(serializers.ModelSerializer):
-    """Minimal serializer for listing choice lists without items."""
+    """Lightweight serializer for listing choice lists (no nested items).
+
+    The Admin Workspace Option Lists and Customizations UI needs a few metadata
+    fields to render locked/extensible state and provide useful searching.
+    """
+
     items_count = serializers.ReadOnlyField()
-    
+
     class Meta:
         model = SystemChoiceList
-        fields = ['id', 'slug', 'name', 'items_count']
+        fields = [
+            'id',
+            'slug',
+            'name',
+            'description',
+            'model_field_path',
+            'is_extensible',
+            'is_reorderable',
+            'items_count',
+            'created_at',
+            'updated_at',
+        ]
 
 
 class SystemFieldSchemaSerializer(serializers.ModelSerializer):

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -127,16 +127,17 @@ const OptionListsPage: React.FC = () => {
     loadChoiceLists();
   };
 
-  const filteredLists = useMemo(
-    () =>
-      lists.filter(
-        (list) =>
-          list.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          list.slug.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          list.description.toLowerCase().includes(searchQuery.toLowerCase())
-      ),
-    [lists, searchQuery]
-  );
+  const filteredLists = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return lists;
+
+    return lists.filter((list) => {
+      const name = (list.name || '').toLowerCase();
+      const slug = (list.slug || '').toLowerCase();
+      const desc = (list.description || '').toLowerCase();
+      return name.includes(q) || slug.includes(q) || desc.includes(q);
+    });
+  }, [lists, searchQuery]);
 
   return (
     <AdminPage


### PR DESCRIPTION
Fixes Admin Workspace Option Lists/Customizations relying on /system/choice-lists/ list metadata. Backend minimal serializer now includes description/model_field_path/is_extensible/is_reorderable; frontend search is hardened against missing fields.