### PR TITLE
Fix: Email sync now + logs

### DIFF
--- a/backend/apps/integrations/views.py
+++ b/backend/apps/integrations/views.py
@@ -304,24 +304,12 @@ def disconnect_provider(request):
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def sync_emails(request):
-    """
-    Manually trigger email sync for current tenant.
-    
-    This endpoint allows users to manually sync their inbox instead of
-    waiting for the scheduled 5-minute Celery task.
-    
-    Returns:
-        - emails_fetched: Number of emails retrieved from API
-        - emails_saved: Number of new emails saved to database
-        - errors: List of any errors encountered
-    """
-    if not request.tenant:
-        return Response(
-            {"error": "Tenant not found"},
-            status=status.HTTP_400_BAD_REQUEST
-        )
-    
-    tenant_id = str(request.tenant.id)
+    """Manually trigger email sync for current tenant."""
+    tenant = getattr(request, 'tenant', None)
+    if not tenant:
+        return Response({"error": "Tenant not found"}, status=status.HTTP_400_BAD_REQUEST)
+
+    tenant_id = str(tenant.id)
 
     try:
         from apps.integrations.tasks import sync_single_tenant
@@ -363,53 +351,48 @@ def sync_emails(request):
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def get_email_logs(request):
-    """
-    Get recent email ingestion logs for current tenant.
-    
-    Query params:
-        limit: Number of emails to return (default: 10, max: 50)
-        status: Filter by status (logged, ai_parsing, order_created, failed, ignored)
-    """
-    if not request.tenant:
-        return Response(
-            {"error": "Tenant not found"},
-            status=status.HTTP_400_BAD_REQUEST
-        )
-    
+    """Get recent email ingestion logs for current tenant."""
+    tenant = getattr(request, 'tenant', None)
+    if not tenant:
+        return Response({"error": "Tenant not found"}, status=status.HTTP_400_BAD_REQUEST)
+
     # Get query params
     limit = min(int(request.GET.get('limit', 10)), 50)
     status_filter = request.GET.get('status')
-    
+
     # Build queryset
     from .models import EmailLog
-    queryset = EmailLog.objects.filter(tenant=request.tenant)
-    
+    queryset = EmailLog.objects.filter(tenant=tenant)
+
     if status_filter:
         queryset = queryset.filter(status=status_filter)
-    
+
     # Get recent emails
     emails = queryset.order_by('-created_at')[:limit]
-    
-    # Serialize
+
+    # Serialize (contract expected by frontend IngestionMonitor.tsx)
     email_data = []
     for email in emails:
-        email_data.append({
-            "id": str(email.id),
-            "message_id": email.message_id,
-            "subject": email.subject,
-            "sender": email.sender,
-            "status": email.status,
-            "provider_type": email.provider.provider_type if email.provider else None,
-            "has_attachments": email.has_attachments,
-            "extracted_data": email.extracted_data,
-            "related_order_id": email.related_order_id,
-            "error_message": email.error_message,
-            "created_at": email.created_at.isoformat(),
-            "processed_at": email.processed_at.isoformat() if email.processed_at else None,
-        })
-    
-    return Response({
-        "emails": email_data,
-        "count": len(email_data),
-    })
+        sender = email.sender_email
+        if email.sender_name:
+            sender = f"{email.sender_name} <{email.sender_email}>"
+
+        email_data.append(
+            {
+                "id": str(email.id),
+                "message_id": email.message_id,
+                "subject": email.subject,
+                "sender": sender,
+                "status": email.status,
+                "provider_type": email.provider.provider_type if email.provider else None,
+                "has_attachments": email.has_attachments,
+                "extracted_data": email.extracted_data,
+                "related_order_id": email.related_order_id,
+                "error_message": email.processing_error,
+                "created_at": email.created_at.isoformat(),
+                "processed_at": email.processed_at.isoformat() if email.processed_at else None,
+            }
+        )
+
+    return Response({"emails": email_data, "count": len(email_data)})
 

--- a/frontend/src/components/Integrations/IngestionMonitor.tsx
+++ b/frontend/src/components/Integrations/IngestionMonitor.tsx
@@ -76,9 +76,9 @@ export const IngestionMonitor: React.FC = () => {
         `/integrations/email/logs/?limit=10`
       );
       setEmails(response.data.emails);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to fetch email logs:', error);
-      message.error('Failed to load email logs');
+      message.error(error?.response?.data?.error || 'Failed to load email logs');
     } finally {
       setLoading(false);
     }
@@ -93,16 +93,16 @@ export const IngestionMonitor: React.FC = () => {
 
     setSyncing(true);
     try {
-      await businessApi.post(`/integrations/email/sync/`);
-      message.success('Email sync started. This may take a few moments...');
-      
+      const response = await businessApi.post(`/integrations/email/sync/`);
+      message.success(response.data?.message || 'Email sync started. This may take a few moments...');
+
       // Refresh logs after 3 seconds
       setTimeout(() => {
         fetchEmailLogs();
       }, 3000);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to trigger sync:', error);
-      message.error('Failed to start email sync');
+      message.error(error?.response?.data?.error || 'Failed to start email sync');
     } finally {
       setSyncing(false);
     }


### PR DESCRIPTION
Fixes Settings > Email Ingestion Monitor errors after successful Outlook connection.\n\nBackend:\n- get_email_logs no longer references non-existent EmailLog fields (sender/error_message)\n- uses tenant safely (getattr)\n\nFrontend:\n- Sync Now + Logs calls now surface backend error message in toast\n- success toast uses server message when present\n\nThis should eliminate 500s and make Sync Now actionable.