### PR TITLE
Preferred Products: use system master catalog

### DIFF
--- a/backend/apps/system/views/entity_viewset.py
+++ b/backend/apps/system/views/entity_viewset.py
@@ -724,6 +724,19 @@ class EntityViewSet(viewsets.ViewSet):
             metadata = {
                 "labels": EntityLabels.get_labels(entity, entity_type),
             }
+
+            # Customer Preferred Products (system.Product) — used by Cockpit EntityProfileHeader
+            # Keep payload intentionally small (names/codes only) to avoid heavy M2M serialization.
+            if entity_type == 'customer' and hasattr(entity, 'products'):
+                try:
+                    preferred = list(
+                        entity.products.filter(is_active=True)
+                        .order_by('product_code')
+                        .values('id', 'product_code', 'name')[:50]
+                    )
+                    metadata['preferred_products'] = preferred
+                except Exception:
+                    metadata['preferred_products'] = []
             
             # Add last activity timestamp
             if hasattr(entity, 'modified_on'):

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -342,8 +342,8 @@ const Customers: React.FC = () => {
                     value={formData.products}
                     onChange={(values) => setFormData({ ...formData, products: values })}
                     options={products.map(p => ({ value: p.id, label: `${p.product_code}${p.name ? ' - ' + p.name : ''}` }))}
-                    label="Products"
-                    placeholder="Select products to associate (hold Ctrl/Cmd for multiple)"
+                    label="Preferred Products"
+                    placeholder="Select preferred products (hold Ctrl/Cmd for multiple)"
                   />
                   {formData.preferred_protein_types.length > 0 && (
                     <HelperText $theme={theme}>

--- a/frontend/src/pages/Customers/Products.tsx
+++ b/frontend/src/pages/Customers/Products.tsx
@@ -1,5 +1,5 @@
 /**
- * Customer Products Management Page
+ * Customer Preferred Products Management Page
  * 
  * Features:
  * - Display products associated with a specific customer
@@ -317,9 +317,9 @@ const CustomerProducts: React.FC = () => {
     <PageContainer>
       <PageHeader>
         <TitleSection>
-          <PageTitle>Customer Products</PageTitle>
+          <PageTitle>Preferred Products</PageTitle>
           <PageSubtitle>
-            Products associated with {customer?.name || 'this customer'}
+            Preferred products for {customer?.name || 'this customer'}
           </PageSubtitle>
         </TitleSection>
         <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/customers')}>


### PR DESCRIPTION
Ensures the new system master product catalog is used for Customer Preferred Products end-to-end.\n\n- Cockpit: Entity metadata now includes customer preferred_products from system.Product (id/code/name) so EntityProfileHeader renders the Preferred Products section.\n- Customers UI: label + page copy renamed to Preferred Products to match intent.\n\nPlant available products already uses /system/products and /plants/:id/available-products/.