### PR TITLE
fix(nginx): raise upload limit to 50M

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -27,6 +27,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### 2026-03-20 — Phase 8.0: Autonomous Multi-Agent Swarm & Continuous RLHF
 - Milestone: PM-AS (ProjectMeats Multi-Agent Swarm) scaffolding.
+- 2026-03-23 — Increased Nginx client_max_body_size to 50M across all proxies to support AI document uploads.
 - Specialized agents:
   - Orchestrator (semantic router)
   - Extractor

--- a/deploy/nginx/frontend-ssl.conf
+++ b/deploy/nginx/frontend-ssl.conf
@@ -22,6 +22,7 @@ server {
     listen 443 ssl;
     http2 on;
     server_name ${DOMAIN_NAME};
+    client_max_body_size 50M;
     
     root /usr/share/nginx/html;
     index index.html;

--- a/deploy/nginx/frontend.conf
+++ b/deploy/nginx/frontend.conf
@@ -4,6 +4,7 @@
 server {
     listen 80;
     server_name _;
+    client_max_body_size 50M;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/deploy/nginx/host-reverse-proxy.conf.template
+++ b/deploy/nginx/host-reverse-proxy.conf.template
@@ -31,6 +31,7 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_name ${DOMAIN_NAME};
+    client_max_body_size 50M;
     
     # MIME types configuration for proper content type handling
     include /etc/nginx/mime.types;


### PR DESCRIPTION
Raises Nginx upload limit to 50M (client_max_body_size) across host reverse proxy + frontend nginx configs to prevent 413 Content Too Large on document uploads. Also logs change in .github/MASTER_PLAN.md (Phase 8.0).