### PR TITLE
fix(modals): master products + protein filtering

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -61,7 +61,8 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 - 2026-03-23 — Backend API endpoint for AI Overview Card (Cockpit 404 fix) — PR: #3829
 - 2026-03-23 — Cockpit inline action routing & smart contextual auto-population — PR: #3830
 - 2026-03-23 — Beautified Cockpit Entity Profile Header (Inline edit UX + Preferred Products) — PR: #3833.
-- 2026-03-23 — Product selection filtered by preferred_protein_types (Master Data compliance) — PR: #TBD.
+- 2026-03-23 — Product selection filtered by preferred_protein_types (Master Data compliance) — PR: #3841.
+- 2026-03-23 — Modal create flows aligned to Master Products (Cockpit quick-create + product-association modals w/ protein filtering) — PR: #TBD.
 
 - 2026-03-22T16:39:58Z — EMERGENCY ROLLBACK: Reverted Workform Container UI to stable Friday baseline due to UX degradation.
 

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2615,6 +2615,13 @@ class QuickCreateEntityAPIView(APIView):
 
         # Get required fields (excluding system fields)
         required_fields = []
+
+        # Optional quick-create fields we still want to expose for better UX.
+        # These are especially important for Master Product compliance.
+        extra_fields_by_entity = {
+            "customer": {"preferred_protein_types", "products"},
+            "supplier": {"preferred_protein_types", "products"},
+        }
         excluded = {
             "id",
             "pk",
@@ -2653,6 +2660,10 @@ class QuickCreateEntityAPIView(APIView):
                     form_type = "checkbox"
                 elif field_type == "DateField":
                     form_type = "date"
+                elif field_type == "ArrayField":
+                    form_type = "multiselect"
+                elif getattr(field, "many_to_many", False):
+                    form_type = "multiselect"
 
                 required_fields.append(
                     {
@@ -2670,11 +2681,51 @@ class QuickCreateEntityAPIView(APIView):
                     required_fields.append({"key": "name", "label": "Name", "type": "text", "required": True})
                     break
 
+        # Add a small allowlisted set of optional fields (non-breaking additive change).
+        # These fields are not required but are critical for the create flow UX.
+        extras = []
+        allow = extra_fields_by_entity.get(entity_type, set())
+        if allow:
+            already = {f["key"] for f in required_fields}
+            for field in model._meta.get_fields():
+                if not hasattr(field, "name"):
+                    continue
+                if field.name in excluded:
+                    continue
+                if field.name not in allow:
+                    continue
+                if field.name in already:
+                    continue
+
+                field_type = type(field).__name__
+                form_type = "text"
+                if field_type in ("IntegerField", "DecimalField", "FloatField"):
+                    form_type = "number"
+                elif field_type == "EmailField":
+                    form_type = "email"
+                elif field_type == "BooleanField":
+                    form_type = "checkbox"
+                elif field_type == "DateField":
+                    form_type = "date"
+                elif field_type == "ArrayField":
+                    form_type = "multiselect"
+                elif getattr(field, "many_to_many", False):
+                    form_type = "multiselect"
+
+                extras.append(
+                    {
+                        "key": field.name,
+                        "label": str(getattr(field, "verbose_name", field.name)).replace("_", " ").title(),
+                        "type": form_type,
+                        "required": False,
+                    }
+                )
+
         return Response(
             {
                 "entity_type": entity_type,
                 "entity_label": entity_type.replace("_", " ").title(),
-                "fields": required_fields,
+                "fields": required_fields + extras,
             }
         )
 

--- a/frontend/src/components/FormSubmission/QuickCreateModal.tsx
+++ b/frontend/src/components/FormSubmission/QuickCreateModal.tsx
@@ -4,13 +4,16 @@
  * Modal for quick-creating entity records from within forms.
  * Shows only the required/essential fields for fast creation.
  */
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import styled from 'styled-components';
-import { 
-  entityOptionsService, 
-  QuickCreateField, 
-  QuickCreateResponse 
+import { Select, Spin } from 'antd';
+import debounce from 'lodash/debounce';
+import {
+  entityOptionsService,
+  QuickCreateField,
 } from '../../services/quickActionsService';
+import { apiClient } from '../../services/apiService';
+import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
 
 interface QuickCreateModalProps {
   entityType: string;
@@ -265,6 +268,16 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [entityLabel, setEntityLabel] = useState('');
 
+  const proteinTypeValue: string[] = useMemo(() => {
+    const raw = formData?.preferred_protein_types;
+    if (!raw) return [];
+    return (Array.isArray(raw) ? raw : [raw]).map((v) => String(v)).filter(Boolean);
+  }, [formData]);
+
+  const [productOptions, setProductOptions] = useState<Array<{ value: string; label: string }>>([]);
+  const [isLoadingProducts, setIsLoadingProducts] = useState(false);
+  const debouncedProductSearchRef = useRef<ReturnType<typeof debounce> | null>(null);
+
   useEffect(() => {
     if (isOpen && entityType) {
       loadFields();
@@ -305,6 +318,58 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
       });
     }
   }, [errors]);
+
+  const fetchMasterProducts = useCallback(async (search?: string) => {
+    setIsLoadingProducts(true);
+    try {
+      const normalizedProteins = proteinTypeValue
+        .map((t) => String(t).toLowerCase().trim())
+        .filter(Boolean);
+
+      const response = await apiClient.get('/system/products/', {
+        params: {
+          search: search || undefined,
+          is_active: true,
+          page_size: 50,
+          ...(normalizedProteins.length ? { protein: normalizedProteins } : {}),
+        },
+      });
+
+      const raw = response.data as any;
+      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
+
+      setProductOptions(
+        data.map((p: any) => ({
+          value: String(p.id),
+          label: `${p.product_code}${p.name ? ` - ${p.name}` : ''}`,
+        }))
+      );
+    } catch (err) {
+      // Silent fail: quick create should still work for basic fields.
+      console.error('[QuickCreateModal] Failed to load master products:', err);
+      setProductOptions([]);
+    } finally {
+      setIsLoadingProducts(false);
+    }
+  }, [proteinTypeValue]);
+
+  useEffect(() => {
+    // Re-load product options whenever protein filters change.
+    if (fields.some((f) => f.key === 'products')) {
+      void fetchMasterProducts();
+    }
+  }, [fetchMasterProducts, fields, proteinTypeValue.join('|')]);
+
+  useEffect(() => {
+    // Setup debounced search handler
+    debouncedProductSearchRef.current = debounce((q: string) => {
+      void fetchMasterProducts(q);
+    }, 300);
+    return () => {
+      debouncedProductSearchRef.current?.cancel();
+      debouncedProductSearchRef.current = null;
+    };
+  }, [fetchMasterProducts]);
 
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -379,15 +444,41 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
                   <Label required={field.required} htmlFor={`quick-create-${field.key}`}>
                     {field.label}
                   </Label>
-                  <Input
-                    id={`quick-create-${field.key}`}
-                    type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : 'text'}
-                    value={formData[field.key] || ''}
-                    onChange={e => handleInputChange(field.key, e.target.value)}
-                    className={errors[field.key] ? 'error' : ''}
-                    disabled={isSubmitting}
-                    autoFocus={fields.indexOf(field) === 0}
-                  />
+                  {field.key === 'preferred_protein_types' ? (
+                    <Select
+                      mode="multiple"
+                      value={proteinTypeValue}
+                      onChange={(vals) => handleInputChange(field.key, vals)}
+                      options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
+                      placeholder="Select protein types"
+                      disabled={isSubmitting}
+                      style={{ width: '100%' }}
+                    />
+                  ) : field.key === 'products' && (entityType === 'customer' || entityType === 'supplier') ? (
+                    <Select
+                      mode="multiple"
+                      value={Array.isArray(formData[field.key]) ? formData[field.key] : []}
+                      onChange={(vals) => handleInputChange(field.key, vals)}
+                      options={productOptions}
+                      placeholder={proteinTypeValue.length ? 'Search products (filtered by protein types)...' : 'Search products...'}
+                      showSearch
+                      filterOption={false}
+                      onSearch={(q) => debouncedProductSearchRef.current?.(q)}
+                      notFoundContent={isLoadingProducts ? <Spin size="small" /> : null}
+                      disabled={isSubmitting}
+                      style={{ width: '100%' }}
+                    />
+                  ) : (
+                    <Input
+                      id={`quick-create-${field.key}`}
+                      type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : 'text'}
+                      value={formData[field.key] || ''}
+                      onChange={e => handleInputChange(field.key, e.target.value)}
+                      className={errors[field.key] ? 'error' : ''}
+                      disabled={isSubmitting}
+                      autoFocus={fields.indexOf(field) === 0}
+                    />
+                  )}
                   {errors[field.key] && <ErrorText>{errors[field.key]}</ErrorText>}
                 </FieldGroup>
               ))}
@@ -453,15 +544,41 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
                   <Label required={field.required} htmlFor={`quick-create-${field.key}`}>
                     {field.label}
                   </Label>
-                  <Input
-                    id={`quick-create-${field.key}`}
-                    type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : 'text'}
-                    value={formData[field.key] || ''}
-                    onChange={e => handleInputChange(field.key, e.target.value)}
-                    className={errors[field.key] ? 'error' : ''}
-                    disabled={isSubmitting}
-                    autoFocus={fields.indexOf(field) === 0}
-                  />
+                  {field.key === 'preferred_protein_types' ? (
+                    <Select
+                      mode="multiple"
+                      value={proteinTypeValue}
+                      onChange={(vals) => handleInputChange(field.key, vals)}
+                      options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
+                      placeholder="Select protein types"
+                      disabled={isSubmitting}
+                      style={{ width: '100%' }}
+                    />
+                  ) : field.key === 'products' && (entityType === 'customer' || entityType === 'supplier') ? (
+                    <Select
+                      mode="multiple"
+                      value={Array.isArray(formData[field.key]) ? formData[field.key] : []}
+                      onChange={(vals) => handleInputChange(field.key, vals)}
+                      options={productOptions}
+                      placeholder={proteinTypeValue.length ? 'Search products (filtered by protein types)...' : 'Search products...'}
+                      showSearch
+                      filterOption={false}
+                      onSearch={(q) => debouncedProductSearchRef.current?.(q)}
+                      notFoundContent={isLoadingProducts ? <Spin size="small" /> : null}
+                      disabled={isSubmitting}
+                      style={{ width: '100%' }}
+                    />
+                  ) : (
+                    <Input
+                      id={`quick-create-${field.key}`}
+                      type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : 'text'}
+                      value={formData[field.key] || ''}
+                      onChange={e => handleInputChange(field.key, e.target.value)}
+                      className={errors[field.key] ? 'error' : ''}
+                      disabled={isSubmitting}
+                      autoFocus={fields.indexOf(field) === 0}
+                    />
+                  )}
                   {errors[field.key] && <ErrorText>{errors[field.key]}</ErrorText>}
                 </FieldGroup>
               ))}

--- a/frontend/src/pages/Customers/Products.tsx
+++ b/frontend/src/pages/Customers/Products.tsx
@@ -11,10 +11,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styled from 'styled-components';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { Table, Input, Button, Modal, message, Tag, Space, Spin } from 'antd';
+import { Table, Input, Button, Modal, message, Tag, Space, Spin, Select } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, DeleteOutlined, ArrowLeftOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
+import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
 
 interface Product {
   id: string;
@@ -184,11 +185,14 @@ const CustomerProducts: React.FC = () => {
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // system.Product is a shared tenant-agnostic catalog — no tenant filter needed
+  const [proteinFilter, setProteinFilter] = useState<string[]>([]);
+
   const fetchSystemProducts = useCallback(async (search?: string) => {
     setLoadingSystemProducts(true);
     try {
-      const params: Record<string, string> = { page_size: '200' };
+      const params: Record<string, any> = { page_size: '500', is_active: true };
       if (search) params.search = search;
+      if (proteinFilter.length) params.protein = proteinFilter.map((t) => String(t).toLowerCase());
       const response = await apiClient.get('/system/products/', { params });
       const data = Array.isArray(response.data) ? response.data : (response.data?.results || []);
       setSystemProducts(data);
@@ -198,12 +202,18 @@ const CustomerProducts: React.FC = () => {
     } finally {
       setLoadingSystemProducts(false);
     }
-  }, []); // apiClient, message, and state setters are all stable references
+  }, [proteinFilter]); // apiClient, message, and state setters are all stable references
 
   const debouncedFetchSystemProducts = useCallback((search: string) => {
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
     searchDebounceRef.current = setTimeout(() => fetchSystemProducts(search), 350);
   }, [fetchSystemProducts]);
+
+  useEffect(() => {
+    if (addModalVisible) {
+      void fetchSystemProducts(productSearchText);
+    }
+  }, [addModalVisible, fetchSystemProducts, productSearchText, proteinFilter.join('|')]);
 
   const handleAddProducts = async () => {
     if (!selectedProductIds.length) {
@@ -381,22 +391,38 @@ const CustomerProducts: React.FC = () => {
         title="Add Products to Customer"
         open={addModalVisible}
         onOk={handleAddProducts}
-        onCancel={() => { setAddModalVisible(false); setSelectedProductIds([]); setProductSearchText(''); }}
+        onCancel={() => { setAddModalVisible(false); setSelectedProductIds([]); setProductSearchText(''); setProteinFilter([]); }}
         okText="Add Selected"
         confirmLoading={addingProducts}
         width={700}
       >
-        <Input
-          placeholder="Search products..."
-          prefix={<SearchOutlined />}
-          value={productSearchText}
-          onChange={(e) => {
-            setProductSearchText(e.target.value);
-            debouncedFetchSystemProducts(e.target.value);
-          }}
-          style={{ marginBottom: 16 }}
-          allowClear
-        />
+        <div style={{ display: 'flex', gap: 12, marginBottom: 16, alignItems: 'center' }}>
+          <Input
+            placeholder="Search products..."
+            prefix={<SearchOutlined />}
+            value={productSearchText}
+            onChange={(e) => {
+              setProductSearchText(e.target.value);
+              debouncedFetchSystemProducts(e.target.value);
+            }}
+            style={{ flex: 1 }}
+            allowClear
+          />
+          <div style={{ width: 260 }}>
+            <span style={{ display: 'block', fontSize: 12, marginBottom: 6, color: 'rgb(var(--color-text-secondary))' }}>
+              Protein filter
+            </span>
+            <Select
+              mode="multiple"
+              value={proteinFilter}
+              onChange={(vals) => setProteinFilter(vals)}
+              options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
+              placeholder="All proteins"
+              style={{ width: '100%' }}
+            />
+          </div>
+        </div>
+
         <Table
           size="small"
           loading={loadingSystemProducts}
@@ -410,6 +436,7 @@ const CustomerProducts: React.FC = () => {
             { title: 'Code', dataIndex: 'product_code', key: 'product_code', width: 150 },
             { title: 'Name', dataIndex: 'name', key: 'name' },
             { title: 'Protein Type', dataIndex: 'protein_type', key: 'protein_type', width: 120 },
+            { title: 'Category', dataIndex: 'category', key: 'category', width: 140 },
           ]}
           pagination={{ pageSize: 10 }}
           scroll={{ y: 300 }}

--- a/frontend/src/pages/Plants/Products.tsx
+++ b/frontend/src/pages/Plants/Products.tsx
@@ -7,10 +7,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styled from 'styled-components';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { Table, Input, Button, Modal, message, Tag, Space, Spin } from 'antd';
+import { Table, Input, Button, Modal, message, Tag, Space, Spin, Select } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, DeleteOutlined, ArrowLeftOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
+import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
 
 interface SystemProduct {
   id: string;
@@ -174,11 +175,14 @@ const PlantProducts: React.FC = () => {
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // system.Product is a shared tenant-agnostic catalog — no tenant filter needed
+  const [proteinFilter, setProteinFilter] = useState<string[]>([]);
+
   const fetchSystemProducts = useCallback(async (search?: string) => {
     setLoadingSystemProducts(true);
     try {
-      const params: Record<string, string> = { page_size: '200' };
+      const params: Record<string, any> = { page_size: '500', is_active: true };
       if (search) params.search = search;
+      if (proteinFilter.length) params.protein = proteinFilter.map((t) => String(t).toLowerCase());
       const response = await apiClient.get('/system/products/', { params });
       const data = Array.isArray(response.data) ? response.data : (response.data?.results || []);
       setSystemProducts(data);
@@ -188,12 +192,18 @@ const PlantProducts: React.FC = () => {
     } finally {
       setLoadingSystemProducts(false);
     }
-  }, []); // apiClient, message, and state setters are all stable references
+  }, [proteinFilter]); // apiClient, message, and state setters are all stable references
 
   const debouncedFetchSystemProducts = useCallback((search: string) => {
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
     searchDebounceRef.current = setTimeout(() => fetchSystemProducts(search), 350);
   }, [fetchSystemProducts]);
+
+  useEffect(() => {
+    if (addModalVisible) {
+      void fetchSystemProducts(productSearchText);
+    }
+  }, [addModalVisible, fetchSystemProducts, productSearchText, proteinFilter.join('|')]);
 
   const handleAddProducts = async () => {
     if (!selectedProductIds.length) {
@@ -369,19 +379,34 @@ const PlantProducts: React.FC = () => {
         title="Add Products to Plant"
         open={addModalVisible}
         onOk={handleAddProducts}
-        onCancel={() => { setAddModalVisible(false); setSelectedProductIds([]); setProductSearchText(''); }}
+        onCancel={() => { setAddModalVisible(false); setSelectedProductIds([]); setProductSearchText(''); setProteinFilter([]); }}
         okText="Add Selected"
         confirmLoading={addingProducts}
         width={700}
       >
-        <Input
-          placeholder="Search products..."
-          prefix={<SearchOutlined />}
-          value={productSearchText}
-          onChange={(e) => { setProductSearchText(e.target.value); debouncedFetchSystemProducts(e.target.value); }}
-          style={{ marginBottom: 16 }}
-          allowClear
-        />
+        <div style={{ display: 'flex', gap: 12, marginBottom: 16, alignItems: 'center' }}>
+          <Input
+            placeholder="Search products..."
+            prefix={<SearchOutlined />}
+            value={productSearchText}
+            onChange={(e) => { setProductSearchText(e.target.value); debouncedFetchSystemProducts(e.target.value); }}
+            style={{ flex: 1 }}
+            allowClear
+          />
+          <div style={{ width: 260 }}>
+            <span style={{ display: 'block', fontSize: 12, marginBottom: 6, color: 'rgb(var(--color-text-secondary))' }}>
+              Protein filter
+            </span>
+            <Select
+              mode="multiple"
+              value={proteinFilter}
+              onChange={(vals) => setProteinFilter(vals)}
+              options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
+              placeholder="All proteins"
+              style={{ width: '100%' }}
+            />
+          </div>
+        </div>
         <Table
           size="small"
           loading={loadingSystemProducts}
@@ -395,6 +420,7 @@ const PlantProducts: React.FC = () => {
             { title: 'Code', dataIndex: 'product_code', key: 'product_code', width: 150 },
             { title: 'Name', dataIndex: 'name', key: 'name' },
             { title: 'Protein Type', dataIndex: 'protein_type', key: 'protein_type', width: 120 },
+            { title: 'Category', dataIndex: 'category', key: 'category', width: 140 },
           ]}
           pagination={{ pageSize: 10 }}
           scroll={{ y: 300 }}

--- a/frontend/src/pages/Suppliers/Products.tsx
+++ b/frontend/src/pages/Suppliers/Products.tsx
@@ -7,10 +7,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styled from 'styled-components';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { Table, Input, Button, Modal, message, Tag, Space, Spin } from 'antd';
+import { Table, Input, Button, Modal, message, Tag, Space, Spin, Select } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, DeleteOutlined, ArrowLeftOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
+import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
 
 interface AvailableItem {
   id: number;
@@ -179,11 +180,14 @@ const SupplierProducts: React.FC = () => {
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // system.Product is a shared tenant-agnostic catalog — no tenant filter needed
+  const [proteinFilter, setProteinFilter] = useState<string[]>([]);
+
   const fetchSystemProducts = useCallback(async (search?: string) => {
     setLoadingSystemProducts(true);
     try {
-      const params: Record<string, string> = { page_size: '200' };
+      const params: Record<string, any> = { page_size: '500', is_active: true };
       if (search) params.search = search;
+      if (proteinFilter.length) params.protein = proteinFilter.map((t) => String(t).toLowerCase());
       const response = await apiClient.get('/system/products/', { params });
       const data = Array.isArray(response.data) ? response.data : (response.data?.results || []);
       setSystemProducts(data);
@@ -193,12 +197,18 @@ const SupplierProducts: React.FC = () => {
     } finally {
       setLoadingSystemProducts(false);
     }
-  }, []); // apiClient, message, and state setters are all stable references
+  }, [proteinFilter]); // apiClient, message, and state setters are all stable references
 
   const debouncedFetchSystemProducts = useCallback((search: string) => {
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
     searchDebounceRef.current = setTimeout(() => fetchSystemProducts(search), 350);
   }, [fetchSystemProducts]);
+
+  useEffect(() => {
+    if (addModalVisible) {
+      void fetchSystemProducts(productSearchText);
+    }
+  }, [addModalVisible, fetchSystemProducts, productSearchText, proteinFilter.join('|')]);
 
   const handleAddProducts = async () => {
     if (!selectedProductIds.length) {
@@ -367,19 +377,34 @@ const SupplierProducts: React.FC = () => {
         title="Add Available Products"
         open={addModalVisible}
         onOk={handleAddProducts}
-        onCancel={() => { setAddModalVisible(false); setSelectedProductIds([]); setProductSearchText(''); }}
+        onCancel={() => { setAddModalVisible(false); setSelectedProductIds([]); setProductSearchText(''); setProteinFilter([]); }}
         okText="Add Selected"
         confirmLoading={addingProducts}
         width={700}
       >
-        <Input
-          placeholder="Search products..."
-          prefix={<SearchOutlined />}
-          value={productSearchText}
-          onChange={(e) => { setProductSearchText(e.target.value); debouncedFetchSystemProducts(e.target.value); }}
-          style={{ marginBottom: 16 }}
-          allowClear
-        />
+        <div style={{ display: 'flex', gap: 12, marginBottom: 16, alignItems: 'center' }}>
+          <Input
+            placeholder="Search products..."
+            prefix={<SearchOutlined />}
+            value={productSearchText}
+            onChange={(e) => { setProductSearchText(e.target.value); debouncedFetchSystemProducts(e.target.value); }}
+            style={{ flex: 1 }}
+            allowClear
+          />
+          <div style={{ width: 260 }}>
+            <span style={{ display: 'block', fontSize: 12, marginBottom: 6, color: 'rgb(var(--color-text-secondary))' }}>
+              Protein filter
+            </span>
+            <Select
+              mode="multiple"
+              value={proteinFilter}
+              onChange={(vals) => setProteinFilter(vals)}
+              options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
+              placeholder="All proteins"
+              style={{ width: '100%' }}
+            />
+          </div>
+        </div>
         <Table
           size="small"
           loading={loadingSystemProducts}
@@ -393,6 +418,7 @@ const SupplierProducts: React.FC = () => {
             { title: 'Code', dataIndex: 'product_code', key: 'product_code', width: 150 },
             { title: 'Name', dataIndex: 'name', key: 'name' },
             { title: 'Protein Type', dataIndex: 'protein_type', key: 'protein_type', width: 120 },
+            { title: 'Category', dataIndex: 'category', key: 'category', width: 140 },
           ]}
           pagination={{ pageSize: 10 }}
           scroll={{ y: 300 }}


### PR DESCRIPTION
Fixes modal-based flows to reflect the Master Product catalog and protein filtering.

Frontend:
- Cockpit QuickCreateModal now supports preferred_protein_types (multi-select) and products (async multi-select from /system/products/ filtered by protein).
- Customer/Supplier/Plant product-association modals now include search + protein filter UI and load a larger page_size from /system/products/.

Backend:
- Workflows quick-create fields endpoint now includes allowlisted optional fields for customer/supplier (non-breaking additive).

Docs:
- Updates .github/MASTER_PLAN.md entry for protein filtering (PR #3841) and adds a new log line for this modal alignment.