### PR TITLE
fix(admin): persist tenant context for Admin Workspace

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -65,6 +65,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 - 2026-03-23 — Product selection filtered by preferred_protein_types (Master Data compliance) — PR: #3841.
 - 2026-03-23 — Modal create flows aligned to Master Products (Cockpit quick-create + product-association modals w/ protein filtering) — PR: #TBD.
 - 2026-03-23 — Admin Workspace: Configurations create/reset/delete + permissions tenant-context auto-repair (fixes missing Admin Workspace sidebar for valid users) — PR: #3844.
+- 2026-03-23 — Admin Workspace: persist resolved tenant context from admin_permissions (prevents Billing/Option Lists/Customizations/Configurations from appearing “broken” due to missing X-Tenant-ID) — PR: #TBD.
 - 2026-03-23 — Email ingestion manual sync converted to synchronous execution (500 fix) — PR: #3845.
 - 2026-03-23 — Suppliers/Customers: punch-in drill-down navigation (Suppliers→Plants + details + Contacts; Customers→Locations + details + Contacts) — PR: #3846.
 - 2026-03-23 — Cockpit: Preferred/Active Products sections (editable, searchable multi-select) + “New Inquiry/PO/SO” CTAs open full create forms — PR: #3847.

--- a/backend/apps/tenants/views.py
+++ b/backend/apps/tenants/views.py
@@ -270,6 +270,13 @@ class TenantViewSet(viewsets.ModelViewSet):
         Used by frontend to show/hide admin workspace features.
         """
         if request.user.is_superuser:
+            tenant = getattr(request, 'tenant', None)
+            tenant_user = None
+
+            if not tenant:
+                tenant_user = TenantUser.objects.filter(user=request.user, is_active=True).select_related('tenant').first()
+                tenant = tenant_user.tenant if tenant_user else None
+
             return Response({
                 'can_manage_users': True,
                 'can_invite_users': True,
@@ -281,6 +288,10 @@ class TenantViewSet(viewsets.ModelViewSet):
                 'can_view_audit_logs': True,
                 'can_manage_option_lists': True,
                 'role': 'superuser',
+                # Include resolved tenant context to help frontend persist X-Tenant-ID
+                'tenant_id': str(tenant.id) if tenant else None,
+                'tenant_name': getattr(tenant, 'name', None) if tenant else None,
+                'tenant_slug': getattr(tenant, 'slug', None) if tenant else None,
             })
 
         tenant = getattr(request, 'tenant', None)
@@ -357,6 +368,9 @@ class TenantViewSet(viewsets.ModelViewSet):
         # Get permissions for user's role, default to empty permissions
         permissions = permissions_map.get(role, permissions_map['readonly'])
         permissions['role'] = role
+        permissions['tenant_id'] = str(tenant_user.tenant.id)
+        permissions['tenant_name'] = tenant_user.tenant.name
+        permissions['tenant_slug'] = tenant_user.tenant.slug
         
         return Response(permissions)
     

--- a/frontend/src/components/Layout/Sidebar.test.tsx
+++ b/frontend/src/components/Layout/Sidebar.test.tsx
@@ -50,6 +50,28 @@ vi.mock('../../config/navigation', () => ({
   ],
 }));
 
+// Mock admin permissions hook so Sidebar tests don't require React Query provider
+vi.mock('../../hooks/useAdminPermissions', () => ({
+  useAdminPermissions: () => ({
+    permissions: {
+      can_manage_users: true,
+      can_invite_users: true,
+      can_change_roles: true,
+      can_manage_profile: true,
+      can_manage_billing: true,
+      can_manage_configurations: true,
+      can_manage_customizations: true,
+      can_view_audit_logs: true,
+      can_manage_option_lists: true,
+      role: 'admin',
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  isAdminOrOwner: () => true,
+}));
+
 // Helper to render with Router
 const renderSidebar = (props: Partial<React.ComponentProps<typeof Sidebar>> = {}) => {
   const defaultProps = {

--- a/frontend/src/hooks/useAdminPermissions.ts
+++ b/frontend/src/hooks/useAdminPermissions.ts
@@ -28,6 +28,11 @@ export interface AdminPermissions {
   can_view_audit_logs: boolean;
   can_manage_option_lists: boolean;
   role: 'user' | 'readonly' | 'manager' | 'admin' | 'owner' | 'superuser';
+
+  /** Resolved tenant context (used to persist X-Tenant-ID for admin calls). */
+  tenant_id?: string | null;
+  tenant_name?: string | null;
+  tenant_slug?: string | null;
 }
 
 /**
@@ -43,6 +48,16 @@ export function useAdminPermissions() {
         // NOTE: TenantViewSet is registered at /api/v1/tenants/
         // so the admin permissions action is /api/v1/tenants/admin_permissions/
         const response = await apiClient.get('/tenants/admin_permissions/');
+
+        // Ensure tenant context is persisted for downstream Admin Workspace calls.
+        // This avoids "admin pages not working" when localStorage.tenantId is missing/stale.
+        const tenantIdFromApi = response.data?.tenant_id;
+        if (tenantIdFromApi) {
+          localStorage.setItem('tenantId', String(tenantIdFromApi));
+          if (response.data?.tenant_name) localStorage.setItem('tenantName', String(response.data.tenant_name));
+          if (response.data?.tenant_slug) localStorage.setItem('tenantSlug', String(response.data.tenant_slug));
+        }
+
         return response.data;
       } catch (error: any) {
         // If 401, let the axios interceptor handle it

--- a/frontend/src/pages/Admin/Home/index.tsx
+++ b/frontend/src/pages/Admin/Home/index.tsx
@@ -47,17 +47,15 @@ const CARDS: WorkspaceCard[] = [
   },
   {
     title: 'Billing',
-    description: 'Subscription, invoices, and payment methods.',
+    description: 'Subscription status and billing contact details.',
     path: '/workspace/billing',
     icon: '💳',
-    comingSoon: true,
   },
   {
     title: 'Customizations',
-    description: 'Tenant-specific UI preferences and workflow templates.',
+    description: 'Tenant-specific dropdown/choice customizations and overrides.',
     path: '/workspace/customizations',
     icon: '🎨',
-    comingSoon: true,
   },
 ];
 


### PR DESCRIPTION
## What\n- Backend: /api/v1/tenants/admin_permissions/ now returns resolved tenant_id/name/slug.\n- Frontend: useAdminPermissions persists that tenant context to localStorage to ensure X-Tenant-ID is always present.\n- Admin Workspace Home: Billing/Customizations no longer marked Coming soon.\n\n## Why\nAdmin Workspace pages (Billing, Option Lists, Customizations, Configurations, Users & Invitations) can appear broken when localStorage.tenantId is missing/stale, because downstream admin calls rely on X-Tenant-ID.\n\n## Verification\n- python backend/manage.py check\n- frontend: vitest src/components/Layout/Sidebar.test.tsx\n\n## Notes\n- Django test suite could not run locally due to missing pgvector extension in this environment.