### PR TITLE
UX: Email ingestion sync stats messaging

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -48,6 +48,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
+- 2026-03-23 — Improved Email Ingestion UX (Exposed Graph API fetch stats to UI to clarify empty states) — PR: #TBD.
 - 2026-03-23 — AI Assistant hardened (direct OpenAI chat completion + stable tools/review compatibility endpoints + system entity summarizer action) — PR: #3843.
 - 2026-03-23 — Data Architecture: Replaced scaffolded product seeds with the official Master Products (3.22.26) list, establishing the Tier 1 Golden Catalog as the single source of truth. 661 products across 40+ protein types (Beef, Pork, Chicken, Turkey, Duck, Goose, Quail, Pheasant, Squab, Guinea Fowl, Lamb, Goat, Veal, Bison, Elk, Venison, Rabbit, Kangaroo, Ostrich, Emu, Wild Boar, Camel, Yak, Antelope, Salmon, Cod, Pollock, Haddock, Tilapia, Catfish, Trout, Mahi-Mahi, Tuna, Halibut, Snapper, Grouper, Sardines, Anchovy, Whitefish, Carp, Perch, Walleye, Rendered, Pet Food, Specialty) covering primal cuts, organs, bones, by-products, and rendered goods. Each entry maps Protein → Item Name → Variations per the Master Products 3.22.26 diagram, with auto-generated product codes (e.g. BEEF-CHUCK-ROLL), category, and protein_type fields aligned to the diagram's pre-filter cascade (Protein → Item Name → Type → Trim).
 

--- a/frontend/src/components/Integrations/IngestionMonitor.tsx
+++ b/frontend/src/components/Integrations/IngestionMonitor.tsx
@@ -89,14 +89,51 @@ export const IngestionMonitor: React.FC = () => {
    */
   const handleSyncNow = async () => {
     const tenantId = getTenantId();
-    if (!tenantId) return;
+    if (!tenantId) {
+      message.error('Tenant context missing. Please re-login or re-select your tenant.');
+      return;
+    }
 
     setSyncing(true);
     try {
-      const response = await businessApi.post(`/integrations/email/sync/`);
-      message.success(response.data?.message || 'Email sync started. This may take a few moments...');
+      // Backward compatible: prefer tenant-scoped route if present, fall back to canonical.
+      const urls = [`/tenants/${tenantId}/integrations/email/sync/`, `/integrations/email/sync/`];
+      let response: any = null;
+      let lastErr: any = null;
 
-      // Refresh logs after 3 seconds
+      for (const url of urls) {
+        try {
+          response = await businessApi.post(url);
+          break;
+        } catch (err: any) {
+          lastErr = err;
+          if (err?.response?.status === 404 && url.startsWith('/tenants/')) {
+            continue;
+          }
+          throw err;
+        }
+      }
+
+      if (!response) throw lastErr;
+
+      const stats = response.data?.stats;
+
+      if (stats) {
+        const emailsSaved = Number(stats.emails_saved ?? 0);
+        const emailsFetched = Number(stats.emails_fetched ?? 0);
+
+        if (emailsSaved > 0) {
+          message.success(`Sync complete: ${emailsSaved} new emails ingested.`);
+        } else if (emailsFetched === 0) {
+          message.info('Sync complete: No new order-related emails found in the last 7 days.');
+        } else {
+          message.success(`Sync complete: ${emailsFetched} emails checked, no new ones to save.`);
+        }
+      } else {
+        message.success(response.data?.message || 'Email sync completed.');
+      }
+
+      // Refresh logs after a short delay
       setTimeout(() => {
         fetchEmailLogs();
       }, 3000);

--- a/frontend/src/components/Navigation/CommandPalette.test.tsx
+++ b/frontend/src/components/Navigation/CommandPalette.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import React from 'react';
+import { CockpitNavigationProvider } from '../../contexts/CockpitNavigationContext';
 
 // Mock axios with create method
 vi.mock('axios', () => ({
@@ -36,9 +37,11 @@ import { CommandPalette } from './CommandPalette';
 // This file is a module (required for TypeScript isolatedModules)
 export {};
 
-// Test wrapper with router context
+// Test wrapper with router + cockpit navigation context
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <BrowserRouter>{children}</BrowserRouter>
+  <BrowserRouter>
+    <CockpitNavigationProvider>{children}</CockpitNavigationProvider>
+  </BrowserRouter>
 );
 
 describe('CommandPalette', () => {

--- a/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
@@ -9,6 +9,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { message } from 'antd';
 import { Mail, RefreshCw, CheckCircle, AlertCircle, Clock, Zap } from 'lucide-react';
 import { businessApi } from '../../services/businessApi';
 
@@ -268,18 +269,57 @@ export const EmailIngestionMonitorWidget: React.FC<EmailIngestionMonitorWidgetPr
    */
   const handleSyncNow = async () => {
     const tenantId = getTenantId();
-    if (!tenantId) return;
+    if (!tenantId) {
+      message.error('Tenant context missing. Please re-login or re-select your tenant.');
+      return;
+    }
 
     setSyncing(true);
     try {
-      await businessApi.post(`/integrations/email/sync/`);
-      
+      // Backward compatible: prefer tenant-scoped route if present, fall back to canonical.
+      const urls = [`/tenants/${tenantId}/integrations/email/sync/`, `/integrations/email/sync/`];
+      let response: any = null;
+      let lastErr: any = null;
+
+      for (const url of urls) {
+        try {
+          response = await businessApi.post(url);
+          break;
+        } catch (err: any) {
+          lastErr = err;
+          if (err?.response?.status === 404 && url.startsWith('/tenants/')) {
+            continue;
+          }
+          throw err;
+        }
+      }
+
+      if (!response) throw lastErr;
+
+      const stats = response.data?.stats;
+
+      if (stats) {
+        const emailsSaved = Number(stats.emails_saved ?? 0);
+        const emailsFetched = Number(stats.emails_fetched ?? 0);
+
+        if (emailsSaved > 0) {
+          message.success(`Sync complete: ${emailsSaved} new emails ingested.`);
+        } else if (emailsFetched === 0) {
+          message.info('Sync complete: No new order-related emails found in the last 7 days.');
+        } else {
+          message.success(`Sync complete: ${emailsFetched} emails checked, no new ones to save.`);
+        }
+      } else {
+        message.success('Email sync completed.');
+      }
+
       // Refresh logs after 2 seconds
       setTimeout(() => {
         fetchEmailLogs();
       }, 2000);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to trigger sync:', error);
+      message.error(error?.response?.data?.error || 'Failed to start email sync');
     } finally {
       setSyncing(false);
     }
@@ -335,7 +375,7 @@ export const EmailIngestionMonitorWidget: React.FC<EmailIngestionMonitorWidgetPr
         ) : emails.length === 0 ? (
           <EmptyState>
             <Mail />
-            <p>No emails ingested yet</p>
+            <p>No order-related emails found in the last 7 days.</p>
             <p style={{ marginTop: '4px', fontSize: '10px' }}>
               Click "Sync" to fetch order-related emails
             </p>


### PR DESCRIPTION
Improves Email Ingestion Monitor UX by exposing sync stats in contextual toasts so users understand empty results caused by filters.

- IngestionMonitor: toast based on stats.emails_saved / stats.emails_fetched
- EmailIngestionMonitorWidget: same toast logic + improved empty state hint
- MASTER_PLAN: log entry

Notes:
- Uses tenant-scoped sync URL if present, falls back to canonical /integrations/email/sync/ (backward compatible)

Verification:
- npm -C frontend run -s test -- --run