### PR TITLE
Fix Quick Create 400s (FK _id + context hydration)

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -43,7 +43,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
-- 2026-03-23 — Improved Email Ingestion UX (Exposed Graph API fetch stats to UI to clarify empty states) — PR: #TBD.
+- 2026-03-23 — Improved Email Ingestion UX (Exposed Graph API fetch stats to UI to clarify empty states) — PR: #3853.
 - 2026-03-23 — AI Assistant hardened (direct OpenAI chat completion + stable tools/review compatibility endpoints + system entity summarizer action) — PR: #3843.
 - 2026-03-23 — Data Architecture: Replaced scaffolded product seeds with the official Master Products (3.22.26) list, establishing the Tier 1 Golden Catalog as the single source of truth. 661 products across 40+ protein types (Beef, Pork, Chicken, Turkey, Duck, Goose, Quail, Pheasant, Squab, Guinea Fowl, Lamb, Goat, Veal, Bison, Elk, Venison, Rabbit, Kangaroo, Ostrich, Emu, Wild Boar, Camel, Yak, Antelope, Salmon, Cod, Pollock, Haddock, Tilapia, Catfish, Trout, Mahi-Mahi, Tuna, Halibut, Snapper, Grouper, Sardines, Anchovy, Whitefish, Carp, Perch, Walleye, Rendered, Pet Food, Specialty) covering primal cuts, organs, bones, by-products, and rendered goods. Each entry maps Protein → Item Name → Variations per the Master Products 3.22.26 diagram, with auto-generated product codes (e.g. BEEF-CHUCK-ROLL), category, and protein_type fields aligned to the diagram's pre-filter cascade (Protein → Item Name → Type → Trim).
 
@@ -66,6 +66,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 - 2026-03-23 — Suppliers/Customers: punch-in drill-down navigation (Suppliers→Plants + details + Contacts; Customers→Locations + details + Contacts) — PR: #3846.
 - 2026-03-23 — Cockpit: Preferred/Active Products sections (editable, searchable multi-select) + “New Inquiry/PO/SO” CTAs open full create forms — PR: #3847.
 - 2026-03-23 — V3 Phase 1 DRY Purge: UniversalEntityForm replaces legacy Create* modals (CreateOrder/CreateClaim/CreateInquiry removed) — PR: #3850.
+- 2026-03-23 — Quick Create Context Hydration & Foreign Key ORM fix (400 Bad Request resolution) — PR: #3854.
 
 - 2026-03-22T16:39:58Z — EMERGENCY ROLLBACK: Reverted Workform Container UI to stable Friday baseline due to UX degradation.
 

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2748,13 +2748,28 @@ class QuickCreateEntityAPIView(APIView):
         try:
             # Build kwargs from request data
             create_kwargs = {}
+            m2m_to_set = {}
             data = request.data
 
             for field in model._meta.get_fields():
                 if not hasattr(field, "name"):
                     continue
+
+                # Skip reverse/auto-created relations
+                if getattr(field, "auto_created", False) and not getattr(field, "concrete", False):
+                    continue
+
                 if field.name in data:
-                    create_kwargs[field.name] = data[field.name]
+                    # If it's a ManyToManyField, set after instance is created
+                    if getattr(field, "many_to_many", False) and not getattr(field, "auto_created", False):
+                        m2m_to_set[field.name] = data[field.name]
+                        continue
+
+                    # If it's a ForeignKey/relation, assign via _id to accept string UUIDs
+                    if field.is_relation and (getattr(field, "many_to_one", False) or getattr(field, "one_to_one", False)):
+                        create_kwargs[f"{field.name}_id"] = data[field.name]
+                    else:
+                        create_kwargs[field.name] = data[field.name]
 
             # Add tenant if model has it
             if hasattr(model, "tenant"):
@@ -2767,6 +2782,14 @@ class QuickCreateEntityAPIView(APIView):
             # Create the record
             with transaction.atomic():
                 obj = model.objects.create(**create_kwargs)
+
+                for field_name, raw_vals in m2m_to_set.items():
+                    vals = raw_vals
+                    if vals is None:
+                        vals = []
+                    if not isinstance(vals, (list, tuple)):
+                        vals = [vals]
+                    getattr(obj, field_name).set(list(vals))
 
             # Get display label
             label = str(obj)

--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -1178,7 +1178,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
               entityType={inlineAction.entityType}
               isOpen={true}
               inline={true}
-              initialValues={inlineAction.contextData}
+              contextData={inlineAction.contextData}
               onClose={() => onInlineCancel?.()}
               onCreated={() => {
                 if (activeEntity) {

--- a/frontend/src/components/FormSubmission/QuickCreateModal.tsx
+++ b/frontend/src/components/FormSubmission/QuickCreateModal.tsx
@@ -24,6 +24,8 @@ interface QuickCreateModalProps {
   inline?: boolean;
   /** Optional initial values for context-aware prefill (e.g., customer/supplier FK). */
   initialValues?: Record<string, any>;
+  /** Context data used to pre-populate and hide fields (e.g., raw UUIDs from Cockpit). */
+  contextData?: Record<string, any>;
 }
 
 const Overlay = styled.div`
@@ -260,6 +262,7 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
   onCreated,
   inline = false,
   initialValues,
+  contextData,
 }) => {
   const [fields, setFields] = useState<QuickCreateField[]>([]);
   const [formData, setFormData] = useState<Record<string, any>>({});
@@ -278,11 +281,16 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
   const [isLoadingProducts, setIsLoadingProducts] = useState(false);
   const debouncedProductSearchRef = useRef<ReturnType<typeof debounce> | null>(null);
 
+  const mergedContext = useMemo(
+    () => ({ ...(initialValues || {}), ...(contextData || {}) }),
+    [initialValues, contextData]
+  );
+
   useEffect(() => {
     if (isOpen && entityType) {
       loadFields();
     }
-  }, [isOpen, entityType, initialValues]);
+  }, [isOpen, entityType, mergedContext]);
 
   const loadFields = async () => {
     setIsLoading(true);
@@ -292,11 +300,12 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
       setFields(response.fields);
       setEntityLabel(response.entity_label);
       
-      // Initialize form data with empty values (plus optional initialValues prefill)
-      const initialData: Record<string, any> = {};
-      response.fields.forEach(f => {
-        const seeded = initialValues ? initialValues[f.key] : undefined;
-        initialData[f.key] = seeded ?? '';
+      // Initialize form data with empty values (plus optional context prefill)
+      const initialData: Record<string, any> = { ...(mergedContext || {}) };
+      response.fields.forEach((f) => {
+        if (initialData[f.key] === undefined) {
+          initialData[f.key] = '';
+        }
       });
       setFormData(initialData);
     } catch (err) {
@@ -439,49 +448,56 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
                   {errors._general}
                 </ErrorText>
               )}
-              {fields.map(field => (
-                <FieldGroup key={field.key}>
-                  <Label required={field.required} htmlFor={`quick-create-${field.key}`}>
-                    {field.label}
-                  </Label>
-                  {field.key === 'preferred_protein_types' ? (
-                    <Select
-                      mode="multiple"
-                      value={proteinTypeValue}
-                      onChange={(vals) => handleInputChange(field.key, vals)}
-                      options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
-                      placeholder="Select protein types"
-                      disabled={isSubmitting}
-                      style={{ width: '100%' }}
-                    />
-                  ) : field.key === 'products' && (entityType === 'customer' || entityType === 'supplier') ? (
-                    <Select
-                      mode="multiple"
-                      value={Array.isArray(formData[field.key]) ? formData[field.key] : []}
-                      onChange={(vals) => handleInputChange(field.key, vals)}
-                      options={productOptions}
-                      placeholder={proteinTypeValue.length ? 'Search products (filtered by protein types)...' : 'Search products...'}
-                      showSearch
-                      filterOption={false}
-                      onSearch={(q) => debouncedProductSearchRef.current?.(q)}
-                      notFoundContent={isLoadingProducts ? <Spin size="small" /> : null}
-                      disabled={isSubmitting}
-                      style={{ width: '100%' }}
-                    />
-                  ) : (
-                    <Input
-                      id={`quick-create-${field.key}`}
-                      type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : 'text'}
-                      value={formData[field.key] || ''}
-                      onChange={e => handleInputChange(field.key, e.target.value)}
-                      className={errors[field.key] ? 'error' : ''}
-                      disabled={isSubmitting}
-                      autoFocus={fields.indexOf(field) === 0}
-                    />
-                  )}
-                  {errors[field.key] && <ErrorText>{errors[field.key]}</ErrorText>}
-                </FieldGroup>
-              ))}
+              {fields.map((field) => {
+                // Hide fields that are pre-populated from context
+                if (contextData && contextData[field.key] !== undefined) {
+                  return null;
+                }
+
+                return (
+                  <FieldGroup key={field.key}>
+                    <Label required={field.required} htmlFor={`quick-create-${field.key}`}>
+                      {field.label}
+                    </Label>
+                    {field.key === 'preferred_protein_types' ? (
+                      <Select
+                        mode="multiple"
+                        value={proteinTypeValue}
+                        onChange={(vals) => handleInputChange(field.key, vals)}
+                        options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
+                        placeholder="Select protein types"
+                        disabled={isSubmitting}
+                        style={{ width: '100%' }}
+                      />
+                    ) : field.key === 'products' && (entityType === 'customer' || entityType === 'supplier') ? (
+                      <Select
+                        mode="multiple"
+                        value={Array.isArray(formData[field.key]) ? formData[field.key] : []}
+                        onChange={(vals) => handleInputChange(field.key, vals)}
+                        options={productOptions}
+                        placeholder={proteinTypeValue.length ? 'Search products (filtered by protein types)...' : 'Search products...'}
+                        showSearch
+                        filterOption={false}
+                        onSearch={(q) => debouncedProductSearchRef.current?.(q)}
+                        notFoundContent={isLoadingProducts ? <Spin size="small" /> : null}
+                        disabled={isSubmitting}
+                        style={{ width: '100%' }}
+                      />
+                    ) : (
+                      <Input
+                        id={`quick-create-${field.key}`}
+                        type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : 'text'}
+                        value={formData[field.key] || ''}
+                        onChange={(e) => handleInputChange(field.key, e.target.value)}
+                        className={errors[field.key] ? 'error' : ''}
+                        disabled={isSubmitting}
+                        autoFocus={fields.indexOf(field) === 0}
+                      />
+                    )}
+                    {errors[field.key] && <ErrorText>{errors[field.key]}</ErrorText>}
+                  </FieldGroup>
+                );
+              })}
             </>
           )}
         </ModalBody>
@@ -539,49 +555,56 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
                   {errors._general}
                 </ErrorText>
               )}
-              {fields.map(field => (
-                <FieldGroup key={field.key}>
-                  <Label required={field.required} htmlFor={`quick-create-${field.key}`}>
-                    {field.label}
-                  </Label>
-                  {field.key === 'preferred_protein_types' ? (
-                    <Select
-                      mode="multiple"
-                      value={proteinTypeValue}
-                      onChange={(vals) => handleInputChange(field.key, vals)}
-                      options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
-                      placeholder="Select protein types"
-                      disabled={isSubmitting}
-                      style={{ width: '100%' }}
-                    />
-                  ) : field.key === 'products' && (entityType === 'customer' || entityType === 'supplier') ? (
-                    <Select
-                      mode="multiple"
-                      value={Array.isArray(formData[field.key]) ? formData[field.key] : []}
-                      onChange={(vals) => handleInputChange(field.key, vals)}
-                      options={productOptions}
-                      placeholder={proteinTypeValue.length ? 'Search products (filtered by protein types)...' : 'Search products...'}
-                      showSearch
-                      filterOption={false}
-                      onSearch={(q) => debouncedProductSearchRef.current?.(q)}
-                      notFoundContent={isLoadingProducts ? <Spin size="small" /> : null}
-                      disabled={isSubmitting}
-                      style={{ width: '100%' }}
-                    />
-                  ) : (
-                    <Input
-                      id={`quick-create-${field.key}`}
-                      type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : 'text'}
-                      value={formData[field.key] || ''}
-                      onChange={e => handleInputChange(field.key, e.target.value)}
-                      className={errors[field.key] ? 'error' : ''}
-                      disabled={isSubmitting}
-                      autoFocus={fields.indexOf(field) === 0}
-                    />
-                  )}
-                  {errors[field.key] && <ErrorText>{errors[field.key]}</ErrorText>}
-                </FieldGroup>
-              ))}
+              {fields.map((field) => {
+                // Hide fields that are pre-populated from context
+                if (contextData && contextData[field.key] !== undefined) {
+                  return null;
+                }
+
+                return (
+                  <FieldGroup key={field.key}>
+                    <Label required={field.required} htmlFor={`quick-create-${field.key}`}>
+                      {field.label}
+                    </Label>
+                    {field.key === 'preferred_protein_types' ? (
+                      <Select
+                        mode="multiple"
+                        value={proteinTypeValue}
+                        onChange={(vals) => handleInputChange(field.key, vals)}
+                        options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
+                        placeholder="Select protein types"
+                        disabled={isSubmitting}
+                        style={{ width: '100%' }}
+                      />
+                    ) : field.key === 'products' && (entityType === 'customer' || entityType === 'supplier') ? (
+                      <Select
+                        mode="multiple"
+                        value={Array.isArray(formData[field.key]) ? formData[field.key] : []}
+                        onChange={(vals) => handleInputChange(field.key, vals)}
+                        options={productOptions}
+                        placeholder={proteinTypeValue.length ? 'Search products (filtered by protein types)...' : 'Search products...'}
+                        showSearch
+                        filterOption={false}
+                        onSearch={(q) => debouncedProductSearchRef.current?.(q)}
+                        notFoundContent={isLoadingProducts ? <Spin size="small" /> : null}
+                        disabled={isSubmitting}
+                        style={{ width: '100%' }}
+                      />
+                    ) : (
+                      <Input
+                        id={`quick-create-${field.key}`}
+                        type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : 'text'}
+                        value={formData[field.key] || ''}
+                        onChange={(e) => handleInputChange(field.key, e.target.value)}
+                        className={errors[field.key] ? 'error' : ''}
+                        disabled={isSubmitting}
+                        autoFocus={fields.indexOf(field) === 0}
+                      />
+                    )}
+                    {errors[field.key] && <ErrorText>{errors[field.key]}</ErrorText>}
+                  </FieldGroup>
+                );
+              })}
             </>
           )}
         </ModalBody>


### PR DESCRIPTION
Fixes Quick Create 400 Bad Request issues by:

- Backend: QuickCreateEntityAPIView assigns FK fields via <field>_id and sets M2M fields after create (supports Customer.products selection).
- Frontend: QuickCreateModal supports contextData hydration and hides context-injected fields so users don't see raw UUID inputs.
- Cockpit SmartSearch: passes contextData for inline quick-create.
- Tests: wrap CommandPalette in CockpitNavigationProvider.

MASTER_PLAN entry added: Quick Create Context Hydration & Foreign Key ORM fix (PR: #TBD).