### PR TITLE
Admin branding: fix logo color extraction

### DIFF
--- a/frontend/src/utils/themeUtils.ts
+++ b/frontend/src/utils/themeUtils.ts
@@ -63,6 +63,14 @@ const resolveLogoSrc = async (logoUrl: string): Promise<{ src: string; revoke: (
     const headers: HeadersInit = {};
     if (authHeader) headers['Authorization'] = authHeader;
 
+    // Tenant-aware hardening: tenant media endpoints may require X-Tenant-ID.
+    try {
+      const tenantId = localStorage.getItem('tenantId');
+      if (tenantId) headers['X-Tenant-ID'] = tenantId;
+    } catch {
+      // ignore (e.g. storage blocked)
+    }
+
     const res = await fetch(logoUrl, { credentials: 'include', headers });
     if (res.ok) {
       const blob = await res.blob();


### PR DESCRIPTION
## What
- Fixes tenant logo brand color extraction by including X-Tenant-ID when fetching the logo blob used for canvas/color sampling.

## Why
Some tenant media/logo endpoints require tenant context; without X-Tenant-ID the fetch 403/404s, the image never loads, and the UI shows "Failed to extract colors from logo".

## Scope
Frontend-only; additive hardening.
