### PR TITLE
AI widget: enable HITL /pending + /resolve

### DIFF
--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -574,15 +574,49 @@ class ToolsOpenAPIView(APIView):
 
 
 class PendingReviewView(APIView):
-    """Compatibility endpoint for the frontend widget.
+    """Pending-review queue for the frontend widget.
 
-    This must be safe for non-staff users; it returns an empty queue for now.
+    Safety rule:
+    - Non-staff users must not be able to access the HITL queue, so they always
+      receive an empty list.
+    - Staff users receive the same underlying queue as PendingReviewAPIView.
     """
 
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        return Response({'pending_reviews': []}, status=status.HTTP_200_OK)
+        if not (request.user.is_staff or request.user.is_superuser):
+            return Response({'pending_reviews': []}, status=status.HTTP_200_OK)
+
+        tenant = getattr(request, 'tenant', None)
+        tenant_id = str(getattr(tenant, 'id', '') or '')
+        if not tenant_id:
+            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        qs = (
+            AIFeedbackLog.objects.filter(
+                tenant_id=tenant_id,
+                resolved_by__isnull=True,
+                confidence_score__lt=0.85,
+            )
+            .order_by('-created_on')
+        )
+
+        items = [
+            {
+                'id': row.id,
+                'document_id': row.document_id,
+                'document_type': row.document_type,
+                'confidence_score': float(row.confidence_score or 0.0),
+                'precision_delta': float(row.precision_delta or 0.0),
+                'created_on': row.created_on,
+                'original_extracted_data': row.original_extracted_data or {},
+            }
+            for row in qs[:25]
+        ]
+
+        payload = PendingReviewItemSerializer(items, many=True).data
+        return Response({'pending_reviews': payload, 'results': payload}, status=status.HTTP_200_OK)
 
 
 class AIAgentChatView(APIView):

--- a/frontend/src/components/AIAssistant/AIAgentWidget.tsx
+++ b/frontend/src/components/AIAssistant/AIAgentWidget.tsx
@@ -934,21 +934,106 @@ export const AIAgentWidget: React.FC = () => {
       setMessages((m) => [...m, { id: newId(), role: 'user', content: text, createdAt: Date.now() }]);
     }
 
-    // Local slash commands (staff-only endpoints)
-    if (text === '/help') {
+    const appendAssistant = (content: string) => {
       setMessages((m) => [
         ...m,
         {
           id: newId(),
           role: 'assistant',
-          content:
-            'Commands:\n' +
-            '- /pending — list pending review items\n' +
-            '- /resolve [idPrefix] [json] — resolve item (optional corrected JSON)\n' +
-            '- /resolve — resolves latest pending item\n',
+          content,
           createdAt: Date.now(),
         },
       ]);
+    };
+
+    // Local slash commands (HITL staff endpoints)
+    if (text === '/help') {
+      appendAssistant(
+        'Commands:\n' +
+          '- /pending — list pending review items\n' +
+          '- /resolve [idPrefix] [json] — resolve item (optional corrected JSON)\n' +
+          '- /resolve — resolves latest pending item\n',
+      );
+      return;
+    }
+
+    if (text === '/pending') {
+      setState('thinking');
+      try {
+        const res = await businessApi.get<any>('/ai-assistant/review/pending/');
+        const items = (res.data?.pending_reviews || res.data?.results || []) as any[];
+
+        if (!items.length) {
+          appendAssistant('No pending review items (or you are not staff).');
+          setState('idle');
+          return;
+        }
+
+        const lines = items.slice(0, 10).map((it) => {
+          const id = String(it.id || '');
+          const prefix = id ? `${id.slice(0, 8)}…` : '—';
+          const docType = it.document_type || 'unknown';
+          const conf = typeof it.confidence_score === 'number' ? it.confidence_score.toFixed(2) : '—';
+          return `- ${prefix} ${docType} (confidence=${conf})`;
+        });
+
+        appendAssistant(`Pending review items:\n${lines.join('\n')}`);
+        setState('idle');
+      } catch (e: any) {
+        appendAssistant('Pending review queue unavailable (requires staff permissions).');
+        setState('idle');
+      }
+      return;
+    }
+
+    if (text.startsWith('/resolve')) {
+      setState('thinking');
+      try {
+        const rest = text.slice('/resolve'.length).trim();
+        const prefix = rest ? rest.split(/\s+/)[0] : '';
+        const jsonStr = rest ? rest.slice(prefix.length).trim() : '';
+
+        const pendingRes = await businessApi.get<any>('/ai-assistant/review/pending/');
+        const items = (pendingRes.data?.pending_reviews || pendingRes.data?.results || []) as any[];
+
+        if (!items.length) {
+          appendAssistant('No pending review items (or you are not staff).');
+          setState('idle');
+          return;
+        }
+
+        const target = prefix
+          ? items.find((it) => String(it.id || '').startsWith(prefix))
+          : items[0];
+
+        if (!target) {
+          appendAssistant(`No pending review item found matching prefix: ${prefix}`);
+          setState('idle');
+          return;
+        }
+
+        let corrected: any = undefined;
+        if (jsonStr) {
+          try {
+            corrected = JSON.parse(jsonStr);
+          } catch {
+            appendAssistant('Invalid JSON for /resolve. Example: /resolve abcd1234 {"key":"value"}');
+            setState('idle');
+            return;
+          }
+        }
+
+        const feedbackId = String(target.id);
+        await businessApi.post(`/ai-assistant/review/${feedbackId}/resolve/`, {
+          user_corrected_data: corrected ?? null,
+        });
+
+        appendAssistant(`Resolved review item: ${feedbackId.slice(0, 8)}…`);
+        setState('idle');
+      } catch (e: any) {
+        appendAssistant('Resolve failed (requires staff permissions).');
+        setState('idle');
+      }
       return;
     }
 


### PR DESCRIPTION
Adds staff-only HITL queue endpoint behavior and implements /pending and /resolve slash commands in the AI widget.\n\nNotes:\n- Non-staff users always get an empty queue.\n- /resolve accepts optional corrected JSON.