### PR TITLE
WorkForms: native fullscreen toggle + toolbar button

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -69,7 +69,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 - 2026-03-23 — Quick Create Context Hydration & Foreign Key ORM fix (400 Bad Request resolution) — PR: #3854.
 - 2026-03-23 — Fixed Microsoft Graph OData 400 error (Migrated to Python-level subject filtering) & hardened UX — PR: #3855.
 - 2026-03-23 — AI Vector Engine integration (pgvector + Django RAG pipeline) — PR: #3859.
-- 2026-03-23 — Enabled HITL review commands in AIAgentWidget (/pending, /resolve) with staff-only queue support — PR: #3857.
+- 2026-03-23 — Enabled HITL review commands in AIAgentWidget (/pending, /resolve) with staff-only queue support — PR: #3863.
 
 - 2026-03-22T16:39:58Z — EMERGENCY ROLLBACK: Reverted Workform Container UI to stable Friday baseline due to UX degradation.
 

--- a/docs/WORKFORMS_USER_GUIDE.md
+++ b/docs/WORKFORMS_USER_GUIDE.md
@@ -87,6 +87,12 @@ WorkForms is a visual workflow editor that combines forms and automation logic i
 | `+` / `-` | Zoom in/out |
 | `0` | Reset zoom |
 
+### Fullscreen Mode
+
+- Use the **Fullscreen** button in the editor toolbar (top-right) to enter/exit fullscreen.
+- Press **ESC** to exit fullscreen.
+- Your preference is saved per browser in `localStorage` (`workforms_fullscreen_enabled`).
+
 ### Adding Nodes
 
 1. **Find Node**: Browse the node palette on the left, organized by category:

--- a/docs/features/WORKFORMS_ENHANCEMENT_PROJECT.md
+++ b/docs/features/WORKFORMS_ENHANCEMENT_PROJECT.md
@@ -217,27 +217,25 @@ Multiple form nodes with overlapping functionality:
 Fix fullscreen button accessibility and implement proper fullscreen mode.
 
 #### Tasks
-- [ ] **0.1** Move fullscreen button from hidden position to top-right toolbar
-  - **Current:** Hidden under redo/save buttons (line 2326)
+- [x] **0.1** Move fullscreen button from hidden position to top-right toolbar
   - **Target:** Separate button group, top-right corner
   - **File:** `UnifiedFlowEditor.tsx`
   
-- [ ] **0.2** Implement fullscreen API
-  - Use `document.documentElement.requestFullscreen()`
-  - Add ESC handler with `document.exitFullscreen()`
-  - Track state in React: `const [isFullscreen, setIsFullscreen] = useState(false)`
-  - Toggle icon: `Maximize2` → `Minimize2`
+- [x] **0.2** Implement fullscreen API
+  - Prefer native Fullscreen API (`requestFullscreen` / `exitFullscreen`), with CSS fullscreen fallback
+  - ESC exit supported
+  - Toggle icon: `Maximize2` ↔ `Minimize2`
   
-- [ ] **0.3** Test all capabilities in fullscreen
+- [x] **0.3** Test all capabilities in fullscreen
   - ✅ Node palette accessible
   - ✅ Config panels functional
   - ✅ Keyboard shortcuts work (Ctrl+S, Ctrl+Z, Ctrl+Y)
   - ✅ Drag-and-drop from palette
   - ✅ Undo/redo operational
   
-- [ ] **0.4** Persist fullscreen preference
+- [x] **0.4** Persist fullscreen preference
   - Save to `localStorage`: `workforms_fullscreen_enabled`
-  - Restore on editor mount
+  - Keep preference in sync via `fullscreenchange`
   - Handle ESC exit gracefully
 
 #### Acceptance Criteria

--- a/docs/workforms/WORKFORMS_USER_GUIDE.md
+++ b/docs/workforms/WORKFORMS_USER_GUIDE.md
@@ -87,6 +87,12 @@ WorkForms is a visual workflow editor that combines forms and automation logic i
 | `+` / `-` | Zoom in/out |
 | `0` | Reset zoom |
 
+### Fullscreen Mode
+
+- Use the **Fullscreen** button in the editor toolbar (top-right) to enter/exit fullscreen.
+- Press **ESC** to exit fullscreen.
+- Your preference is saved per browser in `localStorage` (`workforms_fullscreen_enabled`).
+
 ### Adding Nodes
 
 1. **Find Node**: Browse the node palette on the left, organized by category:

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2381,6 +2381,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Fullscreen State & Handlers (Phase 0: WF-ENH-2026-Q1)
   // ============================================================================
   
+  const editorContainerRef = useRef<HTMLDivElement | null>(null);
+
   const [isFullscreen, setIsFullscreen] = useState<boolean>(() => {
     try {
       const stored = localStorage.getItem('workforms_fullscreen_enabled');
@@ -2389,12 +2391,40 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       return false;
     }
   });
-  
-  const toggleFullscreen = useCallback(() => {
-    const newFullscreenState = !isFullscreen;
-    setIsFullscreen(newFullscreenState);
-    localStorage.setItem('workforms_fullscreen_enabled', newFullscreenState ? 'true' : 'false');
+
+  const toggleFullscreen = useCallback(async () => {
+    const next = !isFullscreen;
+
+    // Prefer native browser fullscreen when available; fall back to CSS fullscreen.
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+        return;
+      }
+
+      const el = editorContainerRef.current;
+      if (next && el && typeof (el as any).requestFullscreen === 'function') {
+        await (el as any).requestFullscreen();
+        return;
+      }
+    } catch (err) {
+      logger.warn('[UnifiedFlowEditor] Fullscreen API failed, falling back to CSS fullscreen', err);
+    }
+
+    setIsFullscreen(next);
+    localStorage.setItem('workforms_fullscreen_enabled', next ? 'true' : 'false');
   }, [isFullscreen]);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      const active = !!document.fullscreenElement;
+      setIsFullscreen(active);
+      localStorage.setItem('workforms_fullscreen_enabled', active ? 'true' : 'false');
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
   
   // ESC key handler for CSS-based fullscreen exit
   // 🔧 Portal Container Creation (2026-02-24: Permanent Fix)
@@ -6776,7 +6806,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       availableFields={selectedFormStep?.data?.fields || []}
       currentNodeId={selectedFormStep?.id || null}
     >
-      <EditorContainer $isFullscreen={isFullscreen}>
+      <EditorContainer ref={editorContainerRef} $isFullscreen={isFullscreen}>
       {/* Deprecation Banner (Phase 6.1) */}
       {hasDeprecatedNodes && !bannerDismissed && (
         <DeprecationBanner>
@@ -7140,6 +7170,16 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             <AlignVerticalDistributeCenter size={14} style={{ marginRight: '4px' }} />
             Layout
           </ToolbarButton>
+
+          <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
+          <ToolbarButton onClick={toggleFullscreen} title={isFullscreen ? 'Exit Fullscreen (ESC)' : 'Enter Fullscreen'}>
+            {(isFullscreen || !!document.fullscreenElement) ? (
+              <Minimize2 size={14} style={{ marginRight: '4px' }} />
+            ) : (
+              <Maximize2 size={14} style={{ marginRight: '4px' }} />
+            )}
+            Fullscreen
+          </ToolbarButton>
         </Toolbar>
       )}
 
@@ -7172,10 +7212,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           } : {}}
         >
           <Settings />
-        </ViewportButton>
-        <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
-        <ViewportButton onClick={toggleFullscreen} title={isFullscreen ? 'Exit Fullscreen (ESC)' : 'Enter Fullscreen'}>
-          {isFullscreen ? <Minimize2 /> : <Maximize2 />}
         </ViewportButton>
         <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
         <ViewportButton onClick={fitView} title="Fit to View (F)">


### PR DESCRIPTION
- Moves the fullscreen button to the top-right editor toolbar.\n- Uses browser Fullscreen API (requestFullscreen/exitFullscreen) with CSS fallback.\n- Updates WorkForms user guide + enhancement plan checkboxes.\n- Fixes .github/MASTER_PLAN HITL PR reference to #3863.