### PR TITLE
fix(ci): dependabot.yml schema compliance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,15 +89,16 @@ updates:
       - dependency-name: "@storybook/*"
         update-types: ["version-update:semver-major"]
       # CRITICAL: Known major version breaking changes (block auto-merge)
+      # Note: Dependabot ignore entries do not support a `reason` field; keep rationale as comments.
       - dependency-name: "tailwindcss"
         update-types: ["version-update:semver-major"]
-        reason: "Tailwind v4 requires @tailwindcss/postcss + config changes"
+        # Tailwind v4 requires @tailwindcss/postcss + config changes
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
-        reason: "React major versions require manual migration"
+        # React major versions require manual migration
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
-        reason: "Vite major versions often have plugin breaking changes"
+        # Vite major versions often have plugin breaking changes
       # OWASP: Document ignored vulnerabilities
       # Example:
       # - dependency-name: "axios"


### PR DESCRIPTION
Fixes Dependabot config schema validation by removing unsupported keys from ignore entries.

- Drops the reason field (not supported by Dependabot) and preserves rationale as YAML comments.

This should clear the failing check named .github/dependabot.yml seen on the uat-to-main release PR (#3193) once promoted to uat.