### PR TITLE
Release: Promote development to uat (dependabot schema fix)

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -859,7 +859,7 @@ Deliverables:
   - [x] DryRunDebugger: added **Step Into**, **Step Over**, **Continue**, with FlowEditorContext-backed debug session state.
   - [x] Continue halts at breakpoints or terminal nodes.
 
-- PR: TBD (feat/workforms): Implement visual breakpoints, execution timeline, and step-through debugger
+- PR: #3878 (feat/workforms): Debugger panel polish (visual breakpoints + execution timeline + step-through)
 
 ## Phase 9.6: Canvas UX Overhaul
 
@@ -877,7 +877,7 @@ Deliverables:
 - [x] Dual-direction auto-layout:
   - [x] autoLayout.getLayoutedElements: root graph laid out Top-to-Bottom (TB) while container children lay out Left-to-Right (LR) and containers auto-resize to fit.
 
-- PR: TBD (refactor/workforms): overhaul canvas UX, dual-direction auto-layout, and fix handle targets
+- PR: #3616 (refactor/workforms): overhaul canvas UX, dual-direction auto-layout, and fix handle targets
 
 ## Phase 9.7: Preemptive Hardening & State Sync
 
@@ -895,7 +895,7 @@ Deliverables:
   - [x] UnifiedFlowEditor: deletes clean up edges for deleted nodes and all descendants (container deletes).
   - [x] NodeContextMenu prefers centralized delete logic (with a safe fallback).
 
-- PR: TBD (refactor/workforms): Phase 9.7 hardening & state sync
+- PR: #3617 (refactor/workforms): Phase 9.7 hardening & state sync
 
 
 
@@ -904,4 +904,5 @@ Deliverables:
 
 ## PR Log (append-only) — Workforms UI Hardening (merge-safe)
 
+- 2026-03-23 — Workforms Debugger polish: docked panel + execution timeline for stepping + breakpoint-first entry selection — PR: #3878.
 - 2026-03-22T19:05:59Z — UI Hardening: Restored standard default container for 'formProcess' nodes, disabling 'formProcessGroup' purple canonicalization/styling overrides.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,15 +89,16 @@ updates:
       - dependency-name: "@storybook/*"
         update-types: ["version-update:semver-major"]
       # CRITICAL: Known major version breaking changes (block auto-merge)
+      # Note: Dependabot ignore entries do not support a `reason` field; keep rationale as comments.
       - dependency-name: "tailwindcss"
         update-types: ["version-update:semver-major"]
-        reason: "Tailwind v4 requires @tailwindcss/postcss + config changes"
+        # Tailwind v4 requires @tailwindcss/postcss + config changes
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
-        reason: "React major versions require manual migration"
+        # React major versions require manual migration
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
-        reason: "Vite major versions often have plugin breaking changes"
+        # Vite major versions often have plugin breaking changes
       # OWASP: Document ignored vulnerabilities
       # Example:
       # - dependency-name: "axios"

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -78,6 +78,7 @@ import {
   ZoomOut, 
   Wand2, 
   Eye, 
+  Bug,
  
   Download, 
   Upload, 
@@ -126,7 +127,6 @@ import { CustomEdge, ConditionalEdge, ErrorEdge, SuccessEdge, InsertNodeEdge, En
 import { FormBuilder } from '../form-builder';
 import { useFormBuilder } from './hooks/useFormBuilder';
 import { ValidationDrawer } from './components/ValidationDrawer';
-import { DryRunDebugger } from './components/DryRunDebugger';
 import { validateWorkflow, type ValidationResult } from './utils/validationEngine';
 import { NODE_TYPE_REGISTRY, NodeCategory, CATEGORY_LABELS, CATEGORY_ORDER, getNodeTypeDefinition } from './nodeTypes';
 import { schemaRegistry } from './config/schemaRegistry';
@@ -167,6 +167,7 @@ import { FormProcessModal, type ContainerData } from './Modals/FormProcessModal'
 import { WorkflowManagementModal, type WorkflowMetadata } from './Modals/WorkflowManagementModal'; // Phase 8.2
 import { WorkflowExecutionModal } from '../FormSubmission/WorkflowExecutionModal'; // Task 1: Integration
 import { PreviewPanel } from './panels/PreviewPanel';
+import { DryRunDebuggerPanel } from './panels/DryRunDebuggerPanel';
 import { FlowPreviewModal } from './Modals/FlowPreviewModal'; // Phase 1: Hybrid Functionality
 import { DataMappingPanel } from './ConfigPanel/DataMappingPanel'; // Phase 1: Hybrid Functionality
 
@@ -2544,10 +2545,18 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // ============================================================================
   
   const [showDebugger, setShowDebugger] = useState(false);
-  const selectedNodeForDebug = useMemo(() => 
-    nodes.find(n => n.id === selectedNodeId) || null,
-    [nodes, selectedNodeId]
-  );
+  const selectedNodeForDebug = useMemo(() => {
+    const selected = nodes.find((n) => n.id === selectedNodeId) || null;
+    if (selected) return selected;
+
+    const entry = nodes.find((n) => {
+      const nodeTypeId = (((n.data as any)?.nodeType as string | undefined) ?? n.type ?? '').toString();
+      const def = getNodeTypeDefinition(nodeTypeId);
+      return def?.category === 'trigger' || nodeTypeId.startsWith('trigger');
+    });
+
+    return entry || nodes[0] || null;
+  }, [nodes, selectedNodeId]);
 
   // ============================================================================
   // Onboarding Tour (Gap Analysis Phase 1.1)
@@ -7160,6 +7169,20 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             Preview Flow
           </ToolbarButton>
           
+          {/* Phase 9.5: Debugger */}
+          <ToolbarButton
+            onClick={() => setShowDebugger((prev) => !prev)}
+            title="Toggle Debugger (Ctrl+D)"
+            disabled={nodes.length === 0}
+            style={{
+              fontWeight: 600,
+              color: 'rgb(var(--color-primary))',
+            }}
+          >
+            <Bug size={14} style={{ marginRight: '4px' }} />
+            Debugger
+          </ToolbarButton>
+
           {/* Phase 2: Auto-Layout */}
           <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
           <ToolbarButton 
@@ -7974,13 +7997,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         </ConfirmModal>
       )}
       
-      {/* Phase 7/9.4: Dry Run Debugger */}
-      {showDebugger && (
-        <DryRunDebugger
-          selectedNode={selectedNodeForDebug}
-          onClose={() => setShowDebugger(false)}
-        />
-      )}
+      {/* Phase 7/9.5: Dry Run Debugger Panel */}
+      <DryRunDebuggerPanel
+        isVisible={showDebugger}
+        selectedNode={selectedNodeForDebug}
+        onClose={() => setShowDebugger(false)}
+      />
 
       {/* Phase 8.6: Keyboard Shortcuts Help Modal */}
       {showKeyboardShortcuts && (

--- a/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
+++ b/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
@@ -21,6 +21,9 @@ interface DryRunDebuggerProps {
 }
 
 interface ExecutionStep {
+  id: string;
+  timestamp: number;
+  action: 'test-step' | 'step-into' | 'step-over' | 'continue' | 'breakpoint' | 'reset';
   nodeId: string;
   nodeName: string;
   status: 'pending' | 'running' | 'success' | 'error';
@@ -123,6 +126,31 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
     return outgoing[0]?.target ?? null;
   }, [getContainerChildIds, getEdges, getNodeById, isContainerNode]);
 
+  const recordTimelineStep = useCallback(
+    (nodeId: string, action: ExecutionStep['action'], status: ExecutionStep['status'] = 'success') => {
+      const node = getNodeById(nodeId);
+      if (!node) return;
+
+      const entry: ExecutionStep = {
+        id: `step_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+        timestamp: Date.now(),
+        action,
+        nodeId,
+        nodeName: (node.data?.label as string | undefined) || nodeId,
+        status,
+        input: mockInput,
+        output: generateMockOutput(node, mockInput),
+        duration: 0,
+      };
+
+      setExecutionHistory((prev) => {
+        const next = [...prev, entry];
+        return next.length > 200 ? next.slice(next.length - 200) : next;
+      });
+    },
+    [getNodeById, mockInput]
+  );
+
   const stepInto = useCallback(() => {
     if (!selectedNode) return;
 
@@ -142,6 +170,7 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
 
     // "Execute" current node
     markNodesExecuted([currentId]);
+    recordTimelineStep(currentId, 'step-into');
 
     const nextId = getNextNodeIdStepInto(currentId);
     if (!nextId) {
@@ -155,8 +184,11 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
     // Move cursor to next node; if it's a breakpoint, pause there.
     setDebugActiveNodeId(nextId);
 
-    if (hasBreakpoint) return;
-  }, [debug.activeNodeId, debug.isActive, getNextNodeIdStepInto, getNodeById, isTerminalNode, markNodesExecuted, selectedNode, setDebugActiveNodeId, startDebugSession, stopDebugSession]);
+    if (hasBreakpoint) {
+      recordTimelineStep(nextId, 'breakpoint', 'pending');
+      return;
+    }
+  }, [debug.activeNodeId, debug.isActive, getNextNodeIdStepInto, getNodeById, isTerminalNode, markNodesExecuted, recordTimelineStep, selectedNode, setDebugActiveNodeId, startDebugSession, stopDebugSession]);
 
   const stepOver = useCallback(() => {
     if (!selectedNode) return;
@@ -176,6 +208,7 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
     }
 
     markNodesExecuted([currentId]);
+    recordTimelineStep(currentId, 'step-over');
 
     const nextId = getNextNodeIdStepOver(currentId);
     if (!nextId) {
@@ -186,8 +219,11 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
     const nextNode = getNodeById(nextId);
     const hasBreakpoint = Boolean((nextNode?.data as any)?.hasBreakpoint);
     setDebugActiveNodeId(nextId);
-    if (hasBreakpoint) return;
-  }, [debug.activeNodeId, debug.isActive, getNextNodeIdStepOver, getNodeById, isTerminalNode, markNodesExecuted, selectedNode, setDebugActiveNodeId, startDebugSession, stopDebugSession]);
+    if (hasBreakpoint) {
+      recordTimelineStep(nextId, 'breakpoint', 'pending');
+      return;
+    }
+  }, [debug.activeNodeId, debug.isActive, getNextNodeIdStepOver, getNodeById, isTerminalNode, markNodesExecuted, recordTimelineStep, selectedNode, setDebugActiveNodeId, startDebugSession, stopDebugSession]);
 
   const handleContinue = useCallback(() => {
     if (!selectedNode) return;
@@ -227,6 +263,7 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
       // Update cursor to next and stop if breakpoint
       setDebugActiveNodeId(nextId);
       if (hasBreakpoint) {
+        recordTimelineStep(nextId, 'breakpoint', 'pending');
         break;
       }
 
@@ -234,8 +271,11 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
       steps += 1;
     }
 
-    markNodesExecuted(executedNow);
-  }, [debug.activeNodeId, debug.isActive, getNextNodeIdStepInto, getNodeById, isTerminalNode, markNodesExecuted, selectedNode, setDebugActiveNodeId, startDebugSession, stopDebugSession]);
+    if (executedNow.length > 0) {
+      executedNow.forEach((id) => recordTimelineStep(id, 'continue'));
+      markNodesExecuted(executedNow);
+    }
+  }, [debug.activeNodeId, debug.isActive, getNextNodeIdStepInto, getNodeById, isTerminalNode, markNodesExecuted, recordTimelineStep, selectedNode, setDebugActiveNodeId, startDebugSession, stopDebugSession]);
 
   const handleRunStep = async () => {
     if (!selectedNode) return;
@@ -247,16 +287,24 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
     setIsRunning(true);
     const startTime = Date.now();
 
+    const stepId = `step_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+
     // Simulate execution
     const step: ExecutionStep = {
+      id: stepId,
+      timestamp: Date.now(),
+      action: 'test-step',
       nodeId: selectedNode.id,
-      nodeName: selectedNode.data?.label || selectedNode.id,
+      nodeName: (selectedNode.data?.label as string | undefined) || selectedNode.id,
       status: 'running',
       input: mockInput,
       output: {},
     };
 
-    setExecutionHistory((prev) => [...prev, step]);
+    setExecutionHistory((prev) => {
+      const next = [...prev, step];
+      return next.length > 200 ? next.slice(next.length - 200) : next;
+    });
 
     // Simulate processing delay
     await new Promise((resolve) => setTimeout(resolve, 600));
@@ -266,11 +314,7 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
     const duration = Date.now() - startTime;
 
     setExecutionHistory((prev) =>
-      prev.map((s) =>
-        s.nodeId === selectedNode.id && s.status === 'running'
-          ? { ...s, status: 'success', output, duration }
-          : s
-      )
+      prev.map((s) => (s.id === stepId ? { ...s, status: 'success', output, duration } : s))
     );
 
     markNodesExecuted([selectedNode.id]);
@@ -280,6 +324,14 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
   
   const handleReset = () => {
     setExecutionHistory([]);
+
+    if (debug.isActive) {
+      resetDebugSession();
+    }
+
+    if (selectedNode) {
+      recordTimelineStep(selectedNode.id, 'reset', 'pending');
+    }
   };
   
   const handleExportResults = () => {
@@ -471,8 +523,8 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
           </StepButton>
 
           <StepButton
-            onClick={resetDebugSession}
-            disabled={!debug.isActive}
+            onClick={handleReset}
+            disabled={isRunning}
             title="Reset timeline"
           >
             <RotateCcw size={18} />
@@ -533,23 +585,25 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
           </Section>
         )}
         
-        {/* Execution History */}
+        {/* Execution Timeline */}
         {executionHistory.length > 0 && (
           <Section>
-            <SectionTitle>Execution History ({executionHistory.length})</SectionTitle>
+            <SectionTitle>Execution Timeline ({executionHistory.length})</SectionTitle>
             <HistoryList>
-              {executionHistory.map((step, index) => (
-                <HistoryItem key={index} $status={step.status}>
+              {executionHistory.map((step) => (
+                <HistoryItem key={step.id} $status={step.status}>
                   <HistoryIcon $status={step.status}>
                     {step.status === 'running' && '⏳'}
                     {step.status === 'success' && '✓'}
                     {step.status === 'error' && '✗'}
+                    {step.status === 'pending' && '•'}
                   </HistoryIcon>
                   <HistoryDetails>
                     <HistoryName>{step.nodeName}</HistoryName>
-                    {step.duration && (
-                      <HistoryDuration>{step.duration}ms</HistoryDuration>
-                    )}
+                    <HistoryDuration>
+                      {step.action}
+                      {step.duration ? ` · ${step.duration}ms` : ''}
+                    </HistoryDuration>
                   </HistoryDetails>
                 </HistoryItem>
               ))}

--- a/frontend/src/components/FlowEditor/panels/DryRunDebuggerPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/DryRunDebuggerPanel.tsx
@@ -1,0 +1,103 @@
+/**
+ * Dry Run Debugger Panel (Phase 9.5)
+ *
+ * Fixed-position slide-in panel wrapper for the existing DryRunDebugger.
+ *
+ * Goal: make breakpoints + execution timeline + step-through debugging
+ * discoverable and usable without disturbing the canvas layout.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { X, Bug } from 'lucide-react';
+import type { Node } from '@xyflow/react';
+
+import { DryRunDebugger } from '../components/DryRunDebugger';
+
+export interface DryRunDebuggerPanelProps {
+  isVisible: boolean;
+  selectedNode: Node | null;
+  onClose: () => void;
+}
+
+const PanelOverlay = styled.div<{ $isVisible: boolean }>`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: ${(props) => (props.$isVisible ? '520px' : '0')};
+  background: rgb(var(--color-background));
+  border-left: 1px solid rgb(var(--color-border));
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
+  z-index: 120;
+  transition: width 0.25s ease;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-surface));
+`;
+
+const HeaderTitle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  color: rgb(var(--color-text-primary));
+`;
+
+const CloseButton = styled.button`
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: rgb(var(--color-text-secondary));
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: rgb(var(--color-background));
+    color: rgb(var(--color-text-primary));
+  }
+`;
+
+const PanelBody = styled.div`
+  flex: 1;
+  overflow: auto;
+`;
+
+export const DryRunDebuggerPanel: React.FC<DryRunDebuggerPanelProps> = ({
+  isVisible,
+  selectedNode,
+  onClose,
+}) => {
+  return (
+    <PanelOverlay $isVisible={isVisible} aria-hidden={!isVisible}>
+      <PanelHeader>
+        <HeaderTitle>
+          <Bug size={16} aria-hidden="true" />
+          Debugger
+        </HeaderTitle>
+        <CloseButton onClick={onClose} aria-label="Close debugger">
+          <X size={18} aria-hidden="true" />
+        </CloseButton>
+      </PanelHeader>
+
+      <PanelBody>
+        <DryRunDebugger selectedNode={selectedNode} onClose={onClose} />
+      </PanelBody>
+    </PanelOverlay>
+  );
+};


### PR DESCRIPTION
Promotes latest development into uat so release PR #3193 (uat→main) picks up the Dependabot schema compliance fix.

Notably:
- Removes unsupported Dependabot ignore key (reason) from .github/dependabot.yml (kept as comments).
- Includes recent Workforms debugger panel polish (#3878) and MASTER_PLAN backfills.