### PR TITLE
Golden sweep (frontend): lazy routes + logging/type hardening

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,9 @@
  * ProjectMeats3 React Application
  * Full Business Management System with AI Assistant
  */
-import React, { useEffect } from 'react';
+import React, { Suspense, lazy, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { Skeleton } from 'antd';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
 import { NavigationProvider } from './contexts/NavigationContext';
@@ -87,7 +88,7 @@ import AdminWorkspaceHome from './pages/Admin/Home';
 import AdminErrorBoundary from './components/Admin/AdminErrorBoundary';
 import { ErrorBoundary as ProductionErrorBoundary } from './components/common/ErrorBoundary';
 import { logger } from './utils/logger';
-import CockpitPage from './pages/Cockpit';
+const CockpitPage = lazy(() => import('./pages/Cockpit'));
 import ProcessMonitor from './pages/Cockpit/ProcessMonitor';
 import CockpitEntityRedirect from './pages/Cockpit/CockpitEntityRedirect';
 import { NotificationPreferences } from './pages/Settings/index';
@@ -96,7 +97,7 @@ import WorkFormsLayout from './pages/WorkForms';
 import WorkFormsCatalog from './pages/WorkForms/Catalog';
 import WorkFormsInProgress from './pages/WorkForms/InProgress';
 import WorkFormsHistory from './pages/WorkForms/History';
-import WorkFormsEditor from './pages/WorkForms/Editor';
+const WorkFormsEditor = lazy(() => import('./pages/WorkForms/Editor'));
 import WorkFormsMonitoring from './pages/WorkForms/Monitoring';
 
 // Wrapper component to access QuickActions context
@@ -292,8 +293,22 @@ const App: React.FC = () => {
                   <Route path="monitoring" element={<WorkFormsMonitoring />} />
                   <Route path="catalog" element={<WorkFormsCatalog />} />
                   <Route path="history" element={<WorkFormsHistory />} />
-                  <Route path="editor" element={<WorkFormsEditor />} />
-                  <Route path="editor/:id" element={<WorkFormsEditor />} />
+                  <Route
+                    path="editor"
+                    element={
+                      <Suspense fallback={<Skeleton active />}> 
+                        <WorkFormsEditor />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="editor/:id"
+                    element={
+                      <Suspense fallback={<Skeleton active />}> 
+                        <WorkFormsEditor />
+                      </Suspense>
+                    }
+                  />
                 </Route>
                 
                 {/* Legacy routes - redirect to WorkForms */}
@@ -353,7 +368,14 @@ const App: React.FC = () => {
                 <Route path="admin/*" element={<Navigate to={`/workspace/${window.location.pathname.replace('/admin/', '')}`} replace />} />
                 
                 {/* Cockpit (Command Center Dashboard) */}
-                <Route path="cockpit" element={<CockpitPage />} />
+                <Route
+                  path="cockpit"
+                  element={
+                    <Suspense fallback={<Skeleton active />}> 
+                      <CockpitPage />
+                    </Suspense>
+                  }
+                />
                 <Route path="cockpit/process-monitor" element={<ProcessMonitor />} />
                 {/* Legacy deep-link route (redirects into /cockpit breadcrumb UX) */}
                 <Route path="cockpit/entity/:entityType/:entityId" element={<CockpitEntityRedirect />} />

--- a/frontend/src/components/Shared/MultiSelect.tsx
+++ b/frontend/src/components/Shared/MultiSelect.tsx
@@ -69,7 +69,6 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         }
         value={value}
         onChange={(newValues) => {
-          console.debug('[MultiSelect] New values:', newValues);
           onChange(newValues as string[]);
         }}
         options={options}

--- a/frontend/src/components/Shared/SearchableSelect.tsx
+++ b/frontend/src/components/Shared/SearchableSelect.tsx
@@ -35,7 +35,7 @@ import styled from 'styled-components';
 export interface SearchableSelectOption {
   id: number | string;
   name: string;
-  [key: string]: any; // Allow additional fields
+  [key: string]: unknown; // Allow additional fields
 }
 
 interface SearchableSelectProps {

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -14,7 +14,7 @@ interface LogContext {
   component?: string;
   user?: string;
   tenant?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 type LogContextOrData = LogContext | unknown;
@@ -55,15 +55,18 @@ class Logger {
     level: LogLevel,
     message: string,
     context?: LogContext,
-    data?: any
+    data?: unknown
   ): void {
     const formattedMessage = this.formatMessage(level, message, context);
     
-    const consoleMethod = level === 'debug' || level === 'info' 
-      ? console.log 
-      : level === 'warn' 
-        ? console.warn 
-        : console.error;
+    const consoleMethod =
+      level === 'debug'
+        ? console.debug
+        : level === 'info'
+          ? console.info
+          : level === 'warn'
+            ? console.warn
+            : console.error;
 
     if (data !== undefined) {
       if (context?.metadata) {
@@ -81,9 +84,9 @@ class Logger {
   /**
    * Debug-level logging (development only)
    */
-  debug(message: string, data?: any): void;
-  debug(message: string, context?: LogContext, data?: any): void;
-  debug(message: string, contextOrData?: LogContextOrData, data?: any): void {
+  debug(message: string, data?: unknown): void;
+  debug(message: string, context?: LogContext, data?: unknown): void;
+  debug(message: string, contextOrData?: LogContextOrData, data?: unknown): void {
     if (!this.shouldLog('debug')) return;
 
     if (contextOrData && typeof contextOrData === 'object' && !Array.isArray(contextOrData)) {
@@ -101,9 +104,9 @@ class Logger {
   /**
    * Info-level logging (development only by default)
    */
-  info(message: string, data?: any): void;
-  info(message: string, context?: LogContext, data?: any): void;
-  info(message: string, contextOrData?: LogContextOrData, data?: any): void {
+  info(message: string, data?: unknown): void;
+  info(message: string, context?: LogContext, data?: unknown): void;
+  info(message: string, contextOrData?: LogContextOrData, data?: unknown): void {
     if (!this.shouldLog('info')) return;
 
     if (contextOrData && typeof contextOrData === 'object' && !Array.isArray(contextOrData)) {
@@ -121,9 +124,9 @@ class Logger {
   /**
    * Warning-level logging (always logged)
    */
-  warn(message: string, data?: any): void;
-  warn(message: string, context?: LogContext, data?: any): void;
-  warn(message: string, contextOrData?: LogContextOrData, data?: any): void {
+  warn(message: string, data?: unknown): void;
+  warn(message: string, context?: LogContext, data?: unknown): void;
+  warn(message: string, contextOrData?: LogContextOrData, data?: unknown): void {
     if (!this.shouldLog('warn')) return;
 
     const ctx =
@@ -156,9 +159,9 @@ class Logger {
   /**
    * Error-level logging (always logged)
    */
-  error(message: string, data?: any): void;
-  error(message: string, context?: LogContext, data?: any): void;
-  error(message: string, contextOrData?: LogContextOrData, data?: any): void {
+  error(message: string, data?: unknown): void;
+  error(message: string, context?: LogContext, data?: unknown): void;
+  error(message: string, contextOrData?: LogContextOrData, data?: unknown): void {
     if (!this.shouldLog('error')) return;
 
     const ctx =


### PR DESCRIPTION
Golden Standard Sweep (Frontend tranche):

- Router-level code splitting with React.lazy + Suspense:
  - Lazy-load Cockpit and WorkForms Editor routes with AntD Skeleton fallback.
- Logging hardening: logger no longer uses console.log (uses console.debug/info/warn/error by level).
- Typing hardening: SearchableSelectOption index signature now uses unknown.
- Removed leftover MultiSelect console.debug.

Verification:
- npm --prefix frontend run build
