### PR TITLE
FlowEditor: System Choice Lists for dropdown fields

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
@@ -86,8 +86,9 @@ export interface FormField {
   
   // Multi-option fields (select, radio, multi-select)
   options?: {
-    source: 'manual' | 'tenant-list' | 'entity';
+    source: 'manual' | 'system-choice-list' | 'tenant-list' | 'entity';
     manualOptions?: string[];
+    systemChoiceListSlug?: string;
     tenantListId?: string;
     entityType?: string;
     entityField?: string;
@@ -353,7 +354,7 @@ export const FormFieldConfigPanel: React.FC<FormFieldConfigPanelProps> = ({
   onChange,
   onClose,
 }) => {
-  const { tenantLists, availableFields, currentNodeId } = useFlowEditor();
+  const { tenantLists, systemChoiceLists, availableFields, currentNodeId } = useFlowEditor();
   // Ensure required arrays are always initialized
   const [localField, setLocalField] = useState<FormField>({
     ...field,
@@ -661,6 +662,7 @@ export const FormFieldConfigPanel: React.FC<FormFieldConfigPanelProps> = ({
                   }
                 >
                   <option value="manual">Manual Entry</option>
+                  <option value="system-choice-list">System Choice List</option>
                   <option value="tenant-list">Tenant List</option>
                   <option value="entity">Entity (Database)</option>
                 </Select>
@@ -682,6 +684,31 @@ export const FormFieldConfigPanel: React.FC<FormFieldConfigPanelProps> = ({
                     placeholder="Option 1&#10;Option 2&#10;Option 3"
                   />
                   <HelpText>Enter each option on a new line</HelpText>
+                </FormField>
+              )}
+
+              {localField.options?.source === 'system-choice-list' && (
+                <FormField>
+                  <Label>Select System Choice List</Label>
+                  <Select
+                    value={localField.options?.systemChoiceListSlug || ''}
+                    onChange={(e) =>
+                      handleUpdate({
+                        options: {
+                          ...(localField.options ?? { source: 'system-choice-list' }),
+                          systemChoiceListSlug: e.target.value,
+                        },
+                      })
+                    }
+                  >
+                    <option value="">Choose a list...</option>
+                    {systemChoiceLists.map((list) => (
+                      <option key={list.id} value={list.slug}>
+                        {list.name}
+                      </option>
+                    ))}
+                  </Select>
+                  <HelpText>Options will be loaded from the selected system choice list.</HelpText>
                 </FormField>
               )}
 

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2858,6 +2858,23 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     staleTime: 5 * 60 * 1000, // 5 minutes
     enabled: !!editingField, // Only fetch when needed
   });
+
+  // Fetch system choice lists for dropdown options (SystemChoiceList)
+  const { data: systemChoiceLists = [] } = useQuery({
+    queryKey: ['system', 'choice-lists'],
+    queryFn: async () => {
+      const response = await adminClient.get('/system/choice-lists/');
+      const raw = response.data as unknown;
+      if (Array.isArray(raw)) return raw;
+      if (raw && typeof raw === 'object') {
+        const obj = raw as Record<string, unknown>;
+        if (Array.isArray(obj.results)) return obj.results;
+      }
+      return [];
+    },
+    staleTime: 5 * 60 * 1000,
+    enabled: !!editingField,
+  });
   
   // Drag-drop state for ghost preview and smart snapping
   const [isDragging, setIsDragging] = useState(false);
@@ -6814,6 +6831,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     <FormBuilderProvider onNodeDataUpdate={handleNodeDataUpdate}>
     <FlowEditorProvider
       tenantLists={tenantLists}
+      systemChoiceLists={systemChoiceLists}
       availableFields={selectedFormStep?.data?.fields || []}
       currentNodeId={selectedFormStep?.id || null}
     >

--- a/frontend/src/components/FlowEditor/context/FlowEditorContext.tsx
+++ b/frontend/src/components/FlowEditor/context/FlowEditorContext.tsx
@@ -117,6 +117,7 @@ export interface FlowEditorContextValue {
 
   // Config panel context (Phase E.1): eliminate prop drilling for panel-specific data
   tenantLists: Array<{ id: string; name: string }>;
+  systemChoiceLists: Array<{ id: string; slug: string; name: string }>;
   availableFields: Array<{ key: string; label: string; type: string }>;
   currentNodeId: string | null;
 }
@@ -139,6 +140,7 @@ export interface FlowEditorProviderProps {
 
   // Config panel context
   tenantLists?: Array<{ id: string; name: string }>;
+  systemChoiceLists?: Array<{ id: string; slug: string; name: string }>;
   availableFields?: Array<{ key: string; label: string; type: string }>;
   currentNodeId?: string | null;
 }
@@ -153,6 +155,7 @@ export const FlowEditorProvider: React.FC<FlowEditorProviderProps> = ({
   onModeChange,
   onSelectionChange,
   tenantLists = [],
+  systemChoiceLists = [],
   availableFields = [],
   currentNodeId = null,
 }) => {
@@ -415,6 +418,7 @@ export const FlowEditorProvider: React.FC<FlowEditorProviderProps> = ({
 
     // Config panel context
     tenantLists,
+    systemChoiceLists,
     availableFields,
     currentNodeId,
   };


### PR DESCRIPTION
Expose **System Choice Lists** where users configure workflow dropdown fields.

Changes:
- FlowEditor FormFieldConfigPanel: add Options Source = "System Choice List" and a selector
- Load system choice lists from `/api/v1/system/choice-lists/` (via adminClient)
- Pass `systemChoiceLists` through FlowEditorProvider context

Verification:
- Local frontend build: `npm run build`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
