### PR TITLE
Fix(admin): consolidate customizations into option lists

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -43,6 +43,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
+- 2026-03-24 — Admin Workspace: consolidate Customizations into Option Lists (Tenant Overrides tab) — PR: #3912.
 - 2026-03-24 — FlowEditor: System Choice Lists selectable for dropdown field options — PR: #3909.
 - 2026-03-24 — Workforms: Custom Tenant Lists "Coming Soon" placeholder CTA (ready to wire TenantListModal) — PR: #3907.
 - 2026-03-24 — Frontend unified dependency bumps (supersedes Dependabot #3886) — PR: #3905.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -79,7 +79,6 @@ import InquiryTemplates from './pages/InquiryTemplates';
 import InquiryAnalytics from './pages/InquiryAnalytics';
 import OptionListsPage from './pages/Admin/OptionLists';
 import ConfigurationsPage from './pages/Admin/Configurations';
-import CustomizationsPage from './pages/Admin/Customizations';
 import UsersPage from './pages/Admin/Users';
 import AdminProfilePage from './pages/Admin/Profile';
 import BillingPage from './pages/Admin/Billing';
@@ -338,11 +337,10 @@ const App: React.FC = () => {
                     <ConfigurationsPage />
                   </AdminErrorBoundary>
                 } />
-                <Route path="workspace/customizations" element={
-                  <AdminErrorBoundary fallbackTitle="Customizations Error">
-                    <CustomizationsPage />
-                  </AdminErrorBoundary>
-                } />
+                <Route
+                  path="workspace/customizations"
+                  element={<Navigate to="/workspace/option-lists?tab=overrides" replace />}
+                />
                 <Route path="workspace/users" element={
                   <AdminErrorBoundary fallbackTitle="Users Management Error">
                     <UsersPage />

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -243,11 +243,6 @@ export const adminWorkspaceNavigation: NavigationItem[] = [
         path: '/workspace/configurations',
       },
       {
-        label: 'Customizations',
-        icon: '🎨',
-        path: '/workspace/customizations',
-      },
-      {
         label: 'Users & Invitations',
         icon: '👥',
         path: '/workspace/users',

--- a/frontend/src/pages/Admin/Home/index.tsx
+++ b/frontend/src/pages/Admin/Home/index.tsx
@@ -51,12 +51,6 @@ const CARDS: WorkspaceCard[] = [
     path: '/workspace/billing',
     icon: '💳',
   },
-  {
-    title: 'Customizations',
-    description: 'Tenant-specific dropdown/choice customizations and overrides.',
-    path: '/workspace/customizations',
-    icon: '🎨',
-  },
 ];
 
 const AdminWorkspaceHome: React.FC = () => {

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -8,6 +8,7 @@
  * - System Choice Lists vs Custom Tenant Lists
  */
 import React, { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Button, Card, Input, Modal, Space, Table, Tabs, Tag, Typography, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
@@ -16,11 +17,13 @@ import { apiClient } from '@/services/apiService';
 import { AdminGuard, AdminPage, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 
+import { TenantChoiceOverride } from '@/components/Admin/TenantChoiceOverride';
+
 import { OptionListModal } from './OptionListModal';
 
 const { Text } = Typography;
 
-type ActiveTabKey = 'system' | 'custom';
+type ActiveTabKey = 'system' | 'custom' | 'overrides';
 
 interface SystemChoiceList {
   id: string;
@@ -54,6 +57,7 @@ const OptionListsPage: React.FC = () => {
     permissions.role === 'admin' ||
     permissions.role === 'superuser';
 
+  const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<ActiveTabKey>('system');
   const [lists, setLists] = useState<SystemChoiceList[]>([]);
   const [loading, setLoading] = useState(true);
@@ -62,6 +66,14 @@ const OptionListsPage: React.FC = () => {
 
   // Mock data placeholder for Custom Tenant Lists (workflow-specific dropdowns)
   const [customLists] = useState<CustomTenantList[]>([]);
+
+  useEffect(() => {
+    const tab = searchParams.get('tab');
+    if (tab === 'system' || tab === 'custom' || tab === 'overrides') {
+      setActiveTab(tab);
+    }
+    // Only run on mount / tab param change
+  }, [searchParams]);
 
   useEffect(() => {
     if (!canView) return;
@@ -265,7 +277,14 @@ const OptionListsPage: React.FC = () => {
           <Card>
             <Tabs
               activeKey={activeTab}
-              onChange={(key) => setActiveTab(key as ActiveTabKey)}
+              onChange={(key) => {
+                const next = key as ActiveTabKey;
+                setActiveTab(next);
+
+                const nextParams = new URLSearchParams(searchParams);
+                nextParams.set('tab', next);
+                setSearchParams(nextParams, { replace: true });
+              }}
               items={[
                 {
                   key: 'system',
@@ -308,6 +327,25 @@ const OptionListsPage: React.FC = () => {
                         pagination={{ pageSize: 10, showSizeChanger: true }}
                       />
                     ),
+                },
+                {
+                  key: 'overrides',
+                  label: 'Tenant Overrides',
+                  children: !permissions.tenant_id ? (
+                    <EmptyState
+                      icon="🏢"
+                      title="Tenant unavailable"
+                      message="We couldn't resolve the current tenant for overrides. Try reloading the page."
+                    />
+                  ) : permissions.can_manage_customizations ? (
+                    <TenantChoiceOverride tenantId={String(permissions.tenant_id)} />
+                  ) : (
+                    <EmptyState
+                      icon="🔒"
+                      title="No access"
+                      message="Only tenant administrators can manage choice list overrides."
+                    />
+                  ),
                 },
               ]}
             />

--- a/frontend/src/pages/Admin/README.md
+++ b/frontend/src/pages/Admin/README.md
@@ -102,8 +102,10 @@ frontend/src/pages/Admin/
 
 **Permissions**: Owners only
 
-### 7. Customizations (Placeholder)
-**Route**: `/workspace/customizations`
+### 7. Customizations (Consolidated)
+Customizations have been consolidated into **Option Lists** under the "Tenant Overrides" tab.
+
+**Route Redirect**: `/workspace/customizations` → `/workspace/option-lists?tab=overrides`
 
 - UI customization options (coming soon)
 - Custom fields (coming soon)


### PR DESCRIPTION
Consolidates the broken **Admin Workspace → Customizations** page into **Option Lists**.

Changes:
- Removes "Customizations" from Admin Workspace nav + home cards
- Redirects `/workspace/customizations` → `/workspace/option-lists?tab=overrides`
- Adds a new **Tenant Overrides** tab inside Option Lists (reusing `TenantChoiceOverride`)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
