### PR TITLE
fix(tenants): prevent invitations create 500

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -43,6 +43,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
+- 2026-03-24 — Admin Workspace: fixed Invite User 500 by hardening invitation create validation + IntegrityError handling — PR: #3914.
 - 2026-03-24 — Admin Workspace: Billing “Manage Plan” modal wired to Tenant Configurations — PR: #3913.
 - 2026-03-24 — Admin Workspace: consolidate Customizations into Option Lists (Tenant Overrides tab) — PR: #3912.
 - 2026-03-24 — FlowEditor: System Choice Lists selectable for dropdown field options — PR: #3909.

--- a/backend/apps/tenants/invitation_serializers.py
+++ b/backend/apps/tenants/invitation_serializers.py
@@ -10,6 +10,17 @@ from apps.tenants.models import Tenant, TenantUser, TenantInvitation
 class TenantInvitationCreateSerializer(serializers.ModelSerializer):
     """Serializer for creating tenant invitations."""
 
+    def _get_is_reusable(self) -> bool:
+        """Parse the is_reusable flag from initial_data safely.
+
+        DRF may provide booleans as strings (e.g. "false"), which are truthy in Python.
+        """
+        raw = self.initial_data.get('is_reusable', False)
+        try:
+            return serializers.BooleanField().to_internal_value(raw)
+        except serializers.ValidationError:
+            return bool(raw)
+
     def validate_role(self, value: str) -> str:
         """Restrict role assignment on invitations.
 
@@ -58,55 +69,48 @@ class TenantInvitationCreateSerializer(serializers.ModelSerializer):
         """Ensure email doesn't already belong to a user in this tenant."""
         tenant = self.context.get('tenant')
         if not tenant:
-            raise serializers.ValidationError("Tenant context is required")
-        
-        # Skip email validation for reusable invitations
-        # (checked via initial_data to avoid needing email field to be passed)
-        is_reusable = self.initial_data.get('is_reusable', False)
+            raise serializers.ValidationError('Tenant context is required')
+
+        is_reusable = self._get_is_reusable()
+
+        # For reusable invitations we treat blank email as NULL to avoid accidental uniqueness constraints.
         if is_reusable:
-            return value  # Allow None/blank for reusable
-        
+            normalized = (value or '').strip().lower()
+            return normalized or None
+
         # For regular invitations, email is required
-        if not value:
-            raise serializers.ValidationError("Email is required for non-reusable invitations")
-        
+        normalized = (value or '').strip().lower()
+        if not normalized:
+            raise serializers.ValidationError('Email is required for non-reusable invitations')
+
         # Check if user with this email already exists in the tenant
-        existing_user = User.objects.filter(email=value).first()
+        existing_user = User.objects.filter(email__iexact=normalized).first()
         if existing_user:
-            tenant_user = TenantUser.objects.filter(
-                tenant=tenant,
-                user=existing_user,
-                is_active=True
-            ).first()
+            tenant_user = TenantUser.objects.filter(tenant=tenant, user=existing_user, is_active=True).first()
             if tenant_user:
-                raise serializers.ValidationError(
-                    f"User with this email is already a member of {tenant.name}"
-                )
-        
-        # Check for pending invitation
-        pending_invitation = TenantInvitation.objects.filter(
-            tenant=tenant,
-            email=value,
-            status='pending'
-        ).first()
+                raise serializers.ValidationError(f'User with this email is already a member of {tenant.name}')
+
+        # Check for pending invitation (case-insensitive)
+        pending_invitation = (
+            TenantInvitation.objects.filter(tenant=tenant, email__iexact=normalized, status='pending')
+            .order_by('-created_at')
+            .first()
+        )
         if pending_invitation and not pending_invitation.is_expired:
-            raise serializers.ValidationError(
-                "A pending invitation already exists for this email"
-            )
-        
-        return value
+            raise serializers.ValidationError('A pending invitation already exists for this email')
+
+        return normalized
     
     def create(self, validated_data):
         """Create invitation with tenant and inviter from context."""
         tenant = self.context.get('tenant')
         request = self.context.get('request')
         invited_by = request.user if request else None
-        
-        invitation = TenantInvitation.objects.create(
-            tenant=tenant,
-            invited_by=invited_by,
-            **validated_data
-        )
+
+        if not tenant:
+            raise serializers.ValidationError({'tenant': 'Tenant context is required'})
+
+        invitation = TenantInvitation.objects.create(tenant=tenant, invited_by=invited_by, **validated_data)
         return invitation
 
 

--- a/backend/apps/tenants/invitation_views.py
+++ b/backend/apps/tenants/invitation_views.py
@@ -6,7 +6,7 @@ from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from django.contrib.auth.models import User
-from django.db import transaction
+from django.db import transaction, IntegrityError
 from typing import Any, Type
 from rest_framework.serializers import Serializer
 from django.db.models import QuerySet
@@ -110,7 +110,29 @@ class TenantInvitationViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_403_FORBIDDEN
             )
         
-        return super().create(request, *args, **kwargs)
+        try:
+            return super().create(request, *args, **kwargs)
+        except IntegrityError as e:
+            logger.warning(
+                "Invitation create failed due to database constraint",
+                extra={"tenant_id": str(tenant.id), "error": str(e)},
+                exc_info=True,
+            )
+            # Most common cause: duplicate pending invitation for same tenant/email.
+            return Response(
+                {'error': 'Unable to create invitation. A pending invitation may already exist for this email.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except Exception as e:
+            logger.error(
+                "Unexpected error creating invitation",
+                extra={"tenant_id": str(tenant.id), "payload": request.data},
+                exc_info=True,
+            )
+            return Response(
+                {'error': 'Failed to create invitation'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
     
     @action(detail=True, methods=['post'])
     def resend(self, request, pk=None):


### PR DESCRIPTION
Hardens POST /api/v1/invitations/ to avoid 500s:

- Parse is_reusable safely (handles "false" string)
- Normalize emails (strip/lower) + case-insensitive duplicate checks
- Treat reusable blank email as NULL to avoid uniqueness constraint edge cases
- Catch IntegrityError in viewset create and return 400 with helpful message
