### PR TITLE
fix(integrations): email ingestion 14d + AI email context

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -43,6 +43,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
+- 2026-03-24 — Fixed Email OData 400 crash patterns (14-day local filtering) & wired Real OpenAI Chatbot with Email Context injection — PR: #3915.
 - 2026-03-24 — Admin Workspace: fixed Invite User 500 by hardening invitation create validation + IntegrityError handling — PR: #3914.
 - 2026-03-24 — Admin Workspace: Billing “Manage Plan” modal wired to Tenant Configurations — PR: #3913.
 - 2026-03-24 — Admin Workspace: consolidate Customizations into Option Lists (Tenant Overrides tab) — PR: #3912.

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -178,13 +178,40 @@ class ChatBotAPIViewSet(viewsets.ViewSet):
 
             try:
                 from apps.system.services.ai_model_resolver import get_active_openai_model_id
+                from apps.integrations.models import EmailLog
 
                 model_name = get_active_openai_model_id(fallback='gpt-4o-mini')
+
+                # --- RAG-lite context injection: last 5 ingested emails for this tenant ---
+                tenant = getattr(request, 'tenant', None)
+                recent_emails = (
+                    EmailLog.objects.filter(tenant=tenant).order_by('-received_at')[:5]
+                    if tenant
+                    else EmailLog.objects.none()
+                )
+
+                email_context = 'Here are the most recently received emails in the system:\n'
+                for email in recent_emails:
+                    body_snippet = (email.body_text or '')[:300]
+                    email_context += (
+                        f"- Date: {email.received_at}, From: {email.sender_name} <{email.sender_email}>\n"
+                        f"  Subject: {email.subject}\n"
+                        f"  Has Attachments: {email.has_attachments}\n"
+                        f"  Body Snippet: {body_snippet}...\n\n"
+                    )
+
+                system_prompt = (
+                    'You are a helpful AI assistant for meat market operations. '
+                    "You have direct access to the user's recently ingested emails. "
+                    'Always use the context below when answering email-related questions.\n\n'
+                    f'{email_context}\n'
+                    f'{SWARM_SYSTEM_PROMPT}'
+                )
 
                 completion = client.chat.completions.create(
                     model=model_name,
                     messages=[
-                        {'role': 'system', 'content': SWARM_SYSTEM_PROMPT},
+                        {'role': 'system', 'content': system_prompt},
                         {'role': 'user', 'content': user_message},
                     ],
                 )

--- a/backend/tenant_apps/integrations/services/email_ingestion.py
+++ b/backend/tenant_apps/integrations/services/email_ingestion.py
@@ -119,8 +119,8 @@ class EmailIngestionService:
         # Initialize Microsoft Graph provider
         graph_provider = MicrosoftGraphProvider(tenant.id)
         
-        # Fetch recent emails (last 7 days)
-        cutoff_date = timezone.now() - timedelta(days=7)
+        # Fetch recent emails (last 14 days)
+        cutoff_date = timezone.now() - timedelta(days=14)
         emails = self._fetch_inbox_messages(
             graph_provider,
             access_token,
@@ -188,19 +188,23 @@ class EmailIngestionService:
             
             messages = data.get('value', [])
 
-            # Local Python filtering
+            # Local Python filtering (defensive against Graph filtering quirks)
             filtered_messages = []
             for msg in messages:
                 subject = msg.get('subject', '').lower()
+                body_preview = msg.get('bodyPreview', '').lower()
                 has_attachments = msg.get('hasAttachments', False)
 
-                matches_keyword = any(keyword in subject for keyword in self.ORDER_KEYWORDS)
-                if matches_keyword or has_attachments:
+                # Check if order keywords exist in subject OR body, OR if it has attachments
+                is_order_related = any(
+                    (kw in subject) or (kw in body_preview)
+                    for kw in self.ORDER_KEYWORDS
+                )
+
+                if is_order_related or has_attachments:
                     filtered_messages.append(msg)
 
-            logger.info(
-                f"Fetched {len(messages)} total, filtered down to {len(filtered_messages)} order-related messages"
-            )
+            logger.info(f"Fetched {len(messages)} total, filtered down to {len(filtered_messages)} target emails")
             return filtered_messages
             
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Backend hardening for the email ingestion + AI assistant loop:

- Email ingestion polls last 14 days (7→14)
- Local keyword filter now checks subject OR bodyPreview (plus attachments)
- AI assistant chat injects last 5 ingested EmailLog entries as RAG-lite context
