### PR TITLE
ci: restore auto-promotion PR creation

### DIFF
--- a/.github/workflows/41-auto-promote-dev-to-uat.yml
+++ b/.github/workflows/41-auto-promote-dev-to-uat.yml
@@ -1,0 +1,150 @@
+name: Auto Promote: Dev → UAT
+
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' && format('Manual Promote: {0} → {1}', inputs.head, inputs.base) ||
+    format('Auto Promote: {0} → {1}', github.event.workflow_run.head_branch, 'uat')
+  }}
+
+on:
+  workflow_run:
+    workflows: ["Master Pipeline"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      head:
+        description: 'Head branch to promote'
+        required: true
+        default: 'development'
+        type: string
+      base:
+        description: 'Base branch to open PR into'
+        required: true
+        default: 'uat'
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: auto-promote-dev-uat
+  cancel-in-progress: false
+
+jobs:
+  create-promotion-pr:
+    name: Create PR (development → uat)
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'development'
+        ) ||
+        github.event_name == 'workflow_dispatch'
+      }}
+
+    steps:
+      - name: Resolve branches
+        id: branches
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WF_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          INPUT_HEAD: ${{ inputs.head }}
+          INPUT_BASE: ${{ inputs.base }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "head=$INPUT_HEAD" >> "$GITHUB_OUTPUT"
+            echo "base=$INPUT_BASE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "head=$WF_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "base=uat" >> "$GITHUB_OUTPUT"
+
+      - name: Verify deploy-dev succeeded (avoid false promotions)
+        if: ${{ github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the specific env deploy job succeeded in the triggering pipeline.
+          jobs_json=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100")
+
+          echo "$jobs_json" | jq -e '.jobs[]? | select(.name | test("deploy-dev"; "i")) | select(.conclusion == "success")' > /dev/null \
+            || {
+              echo "deploy-dev job not found or not successful; skipping promotion";
+              exit 0;
+            }
+
+      - name: Check for commits to promote
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ steps.branches.outputs.base }}
+          HEAD: ${{ steps.branches.outputs.head }}
+        run: |
+          set -euo pipefail
+
+          ahead=$(gh api "repos/$REPO/compare/$BASE...$HEAD" --jq '.ahead_by')
+          if [ "$ahead" -eq 0 ]; then
+            echo "No commits to promote ($HEAD is not ahead of $BASE)."
+            exit 0
+          fi
+
+      - name: Skip if PR already exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE: ${{ steps.branches.outputs.base }}
+          HEAD: ${{ steps.branches.outputs.head }}
+        run: |
+          set -euo pipefail
+
+          existing=$(gh pr list --base "$BASE" --head "$HEAD" --state open --json number --jq 'length')
+          if [ "$existing" -ne 0 ]; then
+            echo "Promotion PR already open ($HEAD -> $BASE); skipping."
+            exit 0
+          fi
+
+      - name: Create promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE: ${{ steps.branches.outputs.base }}
+          HEAD: ${{ steps.branches.outputs.head }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          title="Promote $HEAD → $BASE"
+          body=$(cat <<- 'EOF'
+          Auto-created promotion PR.
+
+          Trigger:
+          - Workflow run: RUN_URL
+          - Run ID: RUN_ID
+          - SHA: SHA
+
+          Notes:
+          - This PR does NOT bypass any gates. UAT validation + deployment checks must pass.
+          - Review required before merge.
+          EOF
+          )
+
+          body=${body//RUN_URL/$RUN_URL}
+          body=${body//RUN_ID/$RUN_ID}
+          body=${body//SHA/$SHA}
+
+          gh pr create \
+            --base "$BASE" \
+            --head "$HEAD" \
+            --title "$title" \
+            --body "$body"

--- a/.github/workflows/41-auto-promote-dev-to-uat.yml
+++ b/.github/workflows/41-auto-promote-dev-to-uat.yml
@@ -1,4 +1,4 @@
-name: Auto Promote: Dev → UAT
+name: "Auto Promote: Dev → UAT"
 
 run-name: >-
   ${{

--- a/.github/workflows/42-auto-promote-uat-to-main.yml
+++ b/.github/workflows/42-auto-promote-uat-to-main.yml
@@ -1,4 +1,4 @@
-name: Auto Promote: UAT → Main
+name: "Auto Promote: UAT → Main"
 
 run-name: >-
   ${{

--- a/.github/workflows/42-auto-promote-uat-to-main.yml
+++ b/.github/workflows/42-auto-promote-uat-to-main.yml
@@ -1,0 +1,149 @@
+name: Auto Promote: UAT → Main
+
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' && format('Manual Promote: {0} → {1}', inputs.head, inputs.base) ||
+    format('Auto Promote: {0} → {1}', github.event.workflow_run.head_branch, 'main')
+  }}
+
+on:
+  workflow_run:
+    workflows: ["Master Pipeline"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      head:
+        description: 'Head branch to promote'
+        required: true
+        default: 'uat'
+        type: string
+      base:
+        description: 'Base branch to open PR into'
+        required: true
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: auto-promote-uat-main
+  cancel-in-progress: false
+
+jobs:
+  create-promotion-pr:
+    name: Create PR (uat → main)
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'uat'
+        ) ||
+        github.event_name == 'workflow_dispatch'
+      }}
+
+    steps:
+      - name: Resolve branches
+        id: branches
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WF_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          INPUT_HEAD: ${{ inputs.head }}
+          INPUT_BASE: ${{ inputs.base }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "head=$INPUT_HEAD" >> "$GITHUB_OUTPUT"
+            echo "base=$INPUT_BASE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "head=$WF_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "base=main" >> "$GITHUB_OUTPUT"
+
+      - name: Verify deploy-uat succeeded (avoid false promotions)
+        if: ${{ github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          jobs_json=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100")
+
+          echo "$jobs_json" | jq -e '.jobs[]? | select(.name | test("deploy-uat"; "i")) | select(.conclusion == "success")' > /dev/null \
+            || {
+              echo "deploy-uat job not found or not successful; skipping promotion";
+              exit 0;
+            }
+
+      - name: Check for commits to promote
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ steps.branches.outputs.base }}
+          HEAD: ${{ steps.branches.outputs.head }}
+        run: |
+          set -euo pipefail
+
+          ahead=$(gh api "repos/$REPO/compare/$BASE...$HEAD" --jq '.ahead_by')
+          if [ "$ahead" -eq 0 ]; then
+            echo "No commits to promote ($HEAD is not ahead of $BASE)."
+            exit 0
+          fi
+
+      - name: Skip if PR already exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE: ${{ steps.branches.outputs.base }}
+          HEAD: ${{ steps.branches.outputs.head }}
+        run: |
+          set -euo pipefail
+
+          existing=$(gh pr list --base "$BASE" --head "$HEAD" --state open --json number --jq 'length')
+          if [ "$existing" -ne 0 ]; then
+            echo "Promotion PR already open ($HEAD -> $BASE); skipping."
+            exit 0
+          fi
+
+      - name: Create promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE: ${{ steps.branches.outputs.base }}
+          HEAD: ${{ steps.branches.outputs.head }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          title="Promote $HEAD → $BASE"
+          body=$(cat <<- 'EOF'
+          Auto-created promotion PR.
+
+          Trigger:
+          - Workflow run: RUN_URL
+          - Run ID: RUN_ID
+          - SHA: SHA
+
+          Notes:
+          - This PR does NOT bypass any gates. Production validation + deployment checks must pass.
+          - Manual review + required approvals remain enforced.
+          EOF
+          )
+
+          body=${body//RUN_URL/$RUN_URL}
+          body=${body//RUN_ID/$RUN_ID}
+          body=${body//SHA/$SHA}
+
+          gh pr create \
+            --base "$BASE" \
+            --head "$HEAD" \
+            --title "$title" \
+            --body "$body"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -62,7 +62,7 @@ These workflows help with project management and automation:
 These workflows automate PR creation between environments while enforcing CI/CD gates:
 
 ### 41-auto-promote-dev-to-uat.yml
-- **Trigger**: After successful `11-dev-deployment.yml` completion
+- **Trigger**: After successful `Master Pipeline` dev deployment completion
 - **Purpose**: Creates PR from `development` → `uat`
 - **Process**:
   1. Triggered when dev deployment succeeds
@@ -75,7 +75,7 @@ These workflows automate PR creation between environments while enforcing CI/CD 
   - CI/CD tests must pass
 
 ### 42-auto-promote-uat-to-main.yml
-- **Trigger**: After successful `12-uat-deployment.yml` completion
+- **Trigger**: After successful `Master Pipeline` UAT deployment completion
 - **Purpose**: Creates PR from `uat` → `main`
 - **Process**:
   1. Triggered when UAT deployment succeeds


### PR DESCRIPTION
Restores automated environment promotion PR creation.

- Adds 41-auto-promote-dev-to-uat.yml (creates PR development→uat after successful Master Pipeline deploy-dev)
- Adds 42-auto-promote-uat-to-main.yml (creates PR uat→main after successful Master Pipeline deploy-uat)
- Skips if no commits to promote or PR already exists
- Does NOT bypass gates; PRs still require review + CI

Docs: updates workflow README trigger notes to match Master Pipeline.
