### PR TITLE
fix(theme): stop UI elements rendering black

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -43,6 +43,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
+- 2026-03-24 — Fixed theme token fallbacks (Defined missing CSS vars to prevent UI elements rendering black) — PR: #3921.
 - 2026-03-24 — Hardened network request resiliency (Fixed trailing slashes causing 502 loops & added 500 error circuit breakers) — PR: #3920.
 - 2026-03-24 — Fixed Workform Editor CSS viewport height + layout overlaps (Eliminated blank bottom space; NodePalette cushions; Toolbar flex-wrapping) — PR: #3919.
 - 2026-03-24 — Fixed Workform Editor React Crash #310 (Migrated from sequential counters to unique IDs to prevent hook collisions) — PR: #3918.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,7 +33,14 @@
   
   --color-text-primary: 44, 62, 80;
   --color-text-secondary: 108, 117, 125;
+  --color-text-muted: var(--color-text-secondary);
   --color-text-disabled: 173, 181, 189;
+
+  /* Tailwind theme vars (must exist or utilities will fall back to defaults like black) */
+  --color-accent: var(--color-primary);
+
+  /* Back-compat alias used by some pages (e.g. FlowEditor) */
+  --color-bg-layout: var(--color-background);
   
   --color-border: 222, 226, 230; /* gray-300 */
   --color-border-light: 233, 236, 239; /* gray-200 */
@@ -96,7 +103,14 @@
   
   --color-text-primary: 224, 224, 224;
   --color-text-secondary: 160, 160, 160;
+  --color-text-muted: var(--color-text-secondary);
   --color-text-disabled: 96, 96, 96;
+
+  /* Tailwind theme vars */
+  --color-accent: var(--color-primary);
+
+  /* Back-compat alias */
+  --color-bg-layout: var(--color-background);
   
   --color-border: 61, 61, 61;
   --color-border-light: 77, 77, 77;


### PR DESCRIPTION
Defines missing CSS variables used by Tailwind/theme tokens (e.g., --color-text-muted, --color-accent, --color-bg-layout) so components don’t fall back to default black styling when vars are undefined.