### PR TITLE
fix(ai): restore and expand Swarm tool registry

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -43,6 +43,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
+- 2026-03-24 — Restored and Expanded AI Tool Registry: Microsoft Graph Email Sync, Outlook Email Drafting, and Database Search natively connected to the Swarm — PR: #3922.
 - 2026-03-24 — Fixed theme token fallbacks (Defined missing CSS vars to prevent UI elements rendering black) — PR: #3921.
 - 2026-03-24 — Hardened network request resiliency (Fixed trailing slashes causing 502 loops & added 500 error circuit breakers) — PR: #3920.
 - 2026-03-24 — Fixed Workform Editor CSS viewport height + layout overlaps (Eliminated blank bottom space; NodePalette cushions; Toolbar flex-wrapping) — PR: #3919.

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -17,17 +17,51 @@ from typing import Any, Callable, Dict
 logger = logging.getLogger(__name__)
 
 
-# Safe default tool list for agent discovery + ChatCompletions tools parameter.
-# Keep this intentionally minimal to prevent schema/introspection crashes.
+# OpenAI tool schemas (ChatCompletions-compatible).
+# Keep this stable: both the frontend widget and Swarm router rely on it.
 DEFAULT_OPENAI_TOOLS = [
     {
         'type': 'function',
         'function': {
             'name': 'check_unread_emails',
-            'description': 'Check the tenant\'s connected Microsoft Outlook inbox for unread emails and attachments.',
+            'description': "Checks the user's connected Microsoft Outlook inbox for unread emails and document attachments.",
             'parameters': {'type': 'object', 'properties': {}},
         },
-    }
+    },
+    {
+        'type': 'function',
+        'function': {
+            'name': 'draft_outlook_email',
+            'description': "Drafts and sends an email via the user's connected Microsoft Outlook account.",
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'to_address': {'type': 'string', 'description': 'Recipient email address'},
+                    'subject': {'type': 'string', 'description': 'Email subject'},
+                    'body': {'type': 'string', 'description': 'Email body (plain text)'},
+                },
+                'required': ['to_address', 'subject', 'body'],
+            },
+        },
+    },
+    {
+        'type': 'function',
+        'function': {
+            'name': 'search_cockpit_records',
+            'description': 'Searches the ERP database for Suppliers, Customers, or Purchase Orders based on a query.',
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'entity_type': {
+                        'type': 'string',
+                        'description': 'Entity type to search (e.g., supplier, customer, purchase_order)',
+                    },
+                    'search_term': {'type': 'string', 'description': 'Free-text search term'},
+                },
+                'required': ['entity_type', 'search_term'],
+            },
+        },
+    },
 ]
 
 
@@ -35,11 +69,13 @@ class ToolExecutor:
     """Execute registered tools for a given tenant."""
 
     def __init__(self):
-        self._tools: Dict[str, Callable[[Dict[str, Any], Any], Any]] = {
+        self._tools: Dict[str, Callable[[Dict[str, Any], Any, Any], Any]] = {
             'check_unread_emails': self._check_unread_emails,
+            'draft_outlook_email': self._draft_outlook_email,
+            'search_cockpit_records': self._search_cockpit_records,
         }
 
-    def execute(self, tool_name: str, arguments: Dict[str, Any] | None, tenant: Any) -> str:
+    def execute(self, tool_name: str, arguments: Dict[str, Any] | None, tenant: Any, user: Any = None) -> str:
         """Execute a tool and return a JSON string result.
 
         Args:
@@ -55,13 +91,13 @@ class ToolExecutor:
             if not fn:
                 return json.dumps({'error': f"Unknown tool: {tool_name}"})
 
-            result = fn(arguments or {}, tenant)
+            result = fn(arguments or {}, tenant, user)
             return json.dumps({'ok': True, 'tool': tool_name, 'data': result}, default=str)
         except Exception as e:
             logger.warning('Tool execution failed tool=%s: %s', tool_name, str(e), exc_info=True)
             return json.dumps({'ok': False, 'tool': tool_name, 'error': str(e)}, default=str)
 
-    def _check_unread_emails(self, arguments: Dict[str, Any], tenant: Any) -> Any:
+    def _check_unread_emails(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
         from apps.integrations.models import ExternalAuthProvider
         from tenant_apps.integrations.services.email_ingestion import EmailIngestionService
 
@@ -84,3 +120,98 @@ class ToolExecutor:
             raise ValueError('Outlook connection expired. Reconnect in Settings → Email Integrations.')
 
         return EmailIngestionService(tenant).fetch_unread_actionable_emails()
+
+    def _draft_outlook_email(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        """Send an email using the tenant's Microsoft Graph connection."""
+        from apps.integrations.models import ExternalAuthProvider
+        from apps.integrations.providers.microsoft import MicrosoftGraphProvider
+
+        tenant_id = getattr(tenant, 'id', None)
+        if not tenant_id:
+            raise ValueError('Tenant not resolved; cannot access email tools')
+
+        to_address = (arguments.get('to_address') or '').strip()
+        subject = (arguments.get('subject') or '').strip()
+        body = (arguments.get('body') or '').strip()
+
+        if not to_address or not subject or not body:
+            raise ValueError('Missing required parameters: to_address, subject, body')
+
+        provider_row = (
+            ExternalAuthProvider.objects.filter(
+                tenant=tenant,
+                provider_type='microsoft',
+                is_active=True,
+            )
+            .select_related('tenant')
+            .first()
+        )
+        if not provider_row:
+            raise ValueError('Outlook not connected. Connect it in Settings → Email Integrations.')
+
+        # Best-effort refresh; if no refresh token exists we keep going and let Graph respond.
+        try:
+            provider_row.refresh_if_needed()
+        except Exception:
+            pass
+
+        if provider_row.is_token_expired():
+            raise ValueError('Outlook connection expired. Reconnect in Settings → Email Integrations.')
+
+        access_token = provider_row.get_decrypted_token('access')
+        graph = MicrosoftGraphProvider(tenant.id)
+
+        result = graph.send_email(
+            access_token,
+            {
+                'to': [to_address],
+                'subject': subject,
+                'body': body,
+            },
+        )
+
+        return {
+            'status': result.get('status') or 'sent',
+            'to': to_address,
+            'subject': subject,
+            'provider': result.get('provider') or 'microsoft',
+        }
+
+    def _search_cockpit_records(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        """Safe placeholder search over tenant-scoped business models."""
+        from tenant_apps.suppliers.models import Supplier
+
+        tenant_id = getattr(tenant, 'id', None)
+        if not tenant_id:
+            raise ValueError('Tenant not resolved; cannot search records')
+
+        entity_type = (arguments.get('entity_type') or '').strip().lower()
+        search_term = (arguments.get('search_term') or '').strip()
+        if not entity_type or not search_term:
+            raise ValueError('Missing required parameters: entity_type, search_term')
+
+        if entity_type not in {'supplier'}:
+            return {
+                'entity_type': entity_type,
+                'search_term': search_term,
+                'results': [],
+                'note': 'search_cockpit_records placeholder currently supports entity_type=supplier only',
+            }
+
+        qs = Supplier.objects.filter(tenant=tenant, name__icontains=search_term).order_by('name')
+        results = [
+            {
+                'id': s.id,
+                'name': s.name,
+                'email': s.email,
+                'phone': s.phone,
+            }
+            for s in qs[:10]
+        ]
+
+        return {
+            'entity_type': 'supplier',
+            'search_term': search_term,
+            'count': len(results),
+            'results': results,
+        }

--- a/backend/tenant_apps/ai_assistant/swarm/router.py
+++ b/backend/tenant_apps/ai_assistant/swarm/router.py
@@ -167,7 +167,14 @@ class SwarmOrchestrator:
     def build_context(self, *, event_type: EventType, payload: Dict[str, Any], correlation_id: Optional[str] = None) -> AgentContext:
         return AgentContext(tenant_id=self.tenant_id, event_type=event_type, payload=payload, correlation_id=correlation_id)
 
-    def run_tool_loop(self, *, user_message: str, tenant: Any, history: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+    def run_tool_loop(
+        self,
+        *,
+        user_message: str,
+        tenant: Any,
+        user: Any = None,
+        history: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
         """Run bounded tool loop and return final assistant response + trace.
 
         Returns:
@@ -222,7 +229,14 @@ class SwarmOrchestrator:
         outlook_expired = bool(provider.is_token_expired()) if provider else False
         outlook_connected = bool(provider and not outlook_expired)
 
-        tools = DEFAULT_OPENAI_TOOLS if outlook_connected else []
+        # Always allow safe internal search tools; only advertise Outlook tools when connected.
+        if outlook_connected:
+            tools = DEFAULT_OPENAI_TOOLS
+        else:
+            tools = [
+                t for t in DEFAULT_OPENAI_TOOLS
+                if t.get('function', {}).get('name') == 'search_cockpit_records'
+            ]
 
         messages: List[Dict[str, Any]] = [
             {
@@ -298,7 +312,7 @@ class SwarmOrchestrator:
                 except Exception:
                     args = {}
 
-                result = executor.execute(tool_name, args, tenant)
+                result = executor.execute(tool_name, args, tenant, user)
                 messages.append(
                     {
                         'role': 'tool',

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -367,8 +367,16 @@ class SwarmToolsOpenAPIView(APIView):
         except Exception:
             logger.warning('tools/openapi: failed to load outlook connection status', exc_info=True)
 
+        if outlook['connected']:
+            tools = DEFAULT_OPENAI_TOOLS
+        else:
+            tools = [
+                t for t in DEFAULT_OPENAI_TOOLS
+                if t.get('function', {}).get('name') == 'search_cockpit_records'
+            ]
+
         payload = {
-            'tools': DEFAULT_OPENAI_TOOLS if outlook['connected'] else [],
+            'tools': tools,
             'capabilities': {'outlook': outlook},
         }
 
@@ -593,14 +601,46 @@ class AIFeedbackViewSet(viewsets.ReadOnlyModelViewSet):
 class ToolsOpenAPIView(APIView):
     """Compatibility endpoint for the frontend widget.
 
-    Returns a stable, minimal payload so polling never hard-fails if tool schemas
-    or external integrations are unavailable.
+    Returns OpenAI ChatCompletions-compatible tool schemas.
+
+    Reliability mandate:
+    - Always return a safe list (never 500)
+    - Do not advertise email tools unless Outlook is connected for this tenant
     """
 
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        return Response({'tools': []}, status=status.HTTP_200_OK)
+        tenant = getattr(request, 'tenant', None)
+
+        try:
+            from apps.integrations.models import ExternalAuthProvider
+
+            provider = (
+                ExternalAuthProvider.objects.filter(
+                    tenant=tenant,
+                    provider_type='microsoft',
+                    is_active=True,
+                )
+                .select_related('tenant')
+                .first()
+                if tenant
+                else None
+            )
+
+            outlook_connected = bool(provider and not provider.is_token_expired())
+        except Exception:
+            outlook_connected = False
+
+        if outlook_connected:
+            tools = DEFAULT_OPENAI_TOOLS
+        else:
+            tools = [
+                t for t in DEFAULT_OPENAI_TOOLS
+                if t.get('function', {}).get('name') == 'search_cockpit_records'
+            ]
+
+        return Response({'tools': tools}, status=status.HTTP_200_OK)
 
 
 class PendingReviewView(APIView):


### PR DESCRIPTION
Restores real OpenAI tool schemas and wires execution:

- ToolsOpenAPIView now returns OpenAI ChatCompletions-compatible function schemas for:
  - check_unread_emails
  - draft_outlook_email
  - search_cockpit_records
- ToolExecutor executes check_unread_emails via EmailIngestionService and draft_outlook_email via MicrosoftGraphProvider.
- Adds a safe placeholder DB search (tenant-scoped Supplier name search).
- Swarm router passes tools into OpenAI calls and only advertises Outlook tools when connected.