### PR TITLE
fix(workforms): restore Publish button

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -43,6 +43,7 @@ This file is the **PR-referenceable execution log** for ongoing initiatives. It 
 
 ### PR Log (append-only)
 
+- 2026-03-24 — Workforms: restored Publish button (status=active) in FlowEditor toolbar — PR: #3923.
 - 2026-03-24 — Restored and Expanded AI Tool Registry: Microsoft Graph Email Sync, Outlook Email Drafting, and Database Search natively connected to the Swarm — PR: #3922.
 - 2026-03-24 — Fixed theme token fallbacks (Defined missing CSS vars to prevent UI elements rendering black) — PR: #3921.
 - 2026-03-24 — Hardened network request resiliency (Fixed trailing slashes causing 502 loops & added 500 error circuit breakers) — PR: #3920.

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -199,7 +199,7 @@ interface UnifiedFlowEditorProps {
   initialWorkflowName?: string;
   initialWorkflowDescription?: string;
   initialWorkflowStatus?: 'draft' | 'active' | 'archived';
-  onWorkflowSaved?: (workflow: { id: string; name: string }) => void;
+  onWorkflowSaved?: (workflow: { id: string; name: string; status?: 'draft' | 'active' | 'archived' }) => void;
 
   readOnly?: boolean;
   editorMode?: EditorMode;
@@ -4945,7 +4945,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   /**
    * Save workflow to backend
    */
-  const handleSaveWorkflow = useCallback(async () => {
+  const handleSaveWorkflow = useCallback(async (opts?: { status?: 'draft' | 'active' | 'archived' }) => {
     if (isSaving) return; // Prevent double-save
     
     // Phase 8.5: Validate containers before saving
@@ -4960,9 +4960,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     
     setIsSaving(true);
     
+    const statusToSave = opts?.status ?? currentWorkflowStatus;
+
     // Show loading toast
     const loadingToast = toast.loading(
-      currentWorkflowId ? 'Updating workflow...' : 'Creating workflow...'
+      statusToSave === 'active'
+        ? (currentWorkflowId ? 'Publishing workflow...' : 'Publishing new workflow...')
+        : (currentWorkflowId ? 'Updating workflow...' : 'Creating workflow...')
     );
     
     try {
@@ -4977,7 +4981,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         viewport,
         currentWorkflowId, // Undefined = create new, string = update existing
         currentWorkflowDescription, // Phase 8.2: Use description from state
-        currentWorkflowStatus // Phase 8.2: Use status from state
+        statusToSave // Phase 8.2: Use status from action (save vs publish)
       );
       
       // Update current workflow ID if this was a new workflow
@@ -4985,7 +4989,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         setCurrentWorkflowId(savedWorkflow.id);
       }
 
-      onWorkflowSaved?.({ id: savedWorkflow.id, name: savedWorkflow.name });
+      setCurrentWorkflowStatus((savedWorkflow.status as 'draft' | 'active' | 'archived') || statusToSave);
+      onWorkflowSaved?.({
+        id: savedWorkflow.id,
+        name: savedWorkflow.name,
+        status: (savedWorkflow.status as 'draft' | 'active' | 'archived') || statusToSave,
+      });
 
       // Refresh any UI surfaces that list available forms/workforms.
       queryClient.invalidateQueries({ queryKey: ['tenant-forms'] });
@@ -4994,9 +5003,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       setHasUnsavedChanges(false);
       logger.debug('✅ Workflow saved:', savedWorkflow.name);
       
+      const verb = statusToSave === 'active'
+        ? 'published'
+        : (currentWorkflowId ? 'updated' : 'created');
+
       // Show success toast
       toast.success(
-        `Workflow "${savedWorkflow.name}" ${currentWorkflowId ? 'updated' : 'created'} successfully!`,
+        `Workflow "${savedWorkflow.name}" ${verb} successfully!`,
         { id: loadingToast }
       );
     } catch (error) {
@@ -5011,6 +5024,16 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       setIsSaving(false);
     }
   }, [nodes, edges, currentWorkflowId, currentWorkflowName, isSaving, reactFlowInstance, validateContainers, currentWorkflowDescription, currentWorkflowStatus, onWorkflowSaved, queryClient]);
+
+  const handlePublishWorkflow = useCallback(async () => {
+    if (validationResult.errorCount > 0) {
+      setShowValidationDrawer(true);
+      toast.error('Fix validation errors before publishing.');
+      return;
+    }
+
+    await handleSaveWorkflow({ status: 'active' });
+  }, [handleSaveWorkflow, validationResult.errorCount]);
 
   // Populate forward ref now that the real save handler exists.
   handleSaveRef.current = () => {
@@ -7137,7 +7160,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             )}
           </LoadMenuContainer>
           <ToolbarButton 
-            onClick={handleSaveWorkflow} 
+            onClick={() => handleSaveWorkflow()} 
             title="Save Workflow (Ctrl+S)"
             disabled={isSaving}
             style={hasUnsavedChanges ? {
@@ -7148,6 +7171,32 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           >
             <Save size={14} style={{ marginRight: '4px' }} />
             {isSaving ? 'Saving...' : 'Save'}
+          </ToolbarButton>
+
+          <ToolbarButton
+            onClick={handlePublishWorkflow}
+            title={
+              currentWorkflowStatus === 'active'
+                ? 'Workflow is published'
+                : (validationResult.errorCount > 0
+                    ? 'Fix validation errors before publishing'
+                    : 'Publish Workflow')
+            }
+            disabled={
+              isSaving ||
+              nodes.length === 0 ||
+              currentWorkflowStatus === 'active' ||
+              validationResult.errorCount > 0
+            }
+            style={currentWorkflowStatus !== 'active' ? {
+              background: 'rgb(var(--color-success) / 0.12)',
+              color: 'rgb(var(--color-success))',
+              borderColor: 'rgb(var(--color-success) / 0.35)',
+              fontWeight: 700,
+            } : {}}
+          >
+            <CheckCircle size={14} style={{ marginRight: '4px' }} />
+            {currentWorkflowStatus === 'active' ? 'Published' : 'Publish'}
           </ToolbarButton>
           
           {/* Task 1: Workflow Execution Integration */}

--- a/frontend/src/pages/WorkForms/Editor.tsx
+++ b/frontend/src/pages/WorkForms/Editor.tsx
@@ -325,7 +325,7 @@ export const WorkFormsEditor: React.FC = () => {
   const readOnly = useMemo(() => previewMode || !permissions.can_edit, [previewMode, permissions.can_edit]);
 
   const handleWorkflowSaved = useCallback(
-    (workflow: { id: string; name: string }) => {
+    (workflow: { id: string; name: string; status?: WorkFormStatus }) => {
       setHasUnsavedChanges(false);
 
       // After create/clone, move URL into edit mode so refresh works.
@@ -337,6 +337,10 @@ export const WorkFormsEditor: React.FC = () => {
 
       // Keep header title stable if user saved under a different name inside the editor.
       setFlowName(workflow.name);
+
+      if (workflow.status) {
+        setStatus(workflow.status);
+      }
     },
     [id, isCloneMode, navigate]
   );


### PR DESCRIPTION
Adds a visible Publish button to the FlowEditor toolbar. Publish saves the current workflow with status=active (after validation). Also propagates the saved status back to the WorkForms editor page so the header badge updates to active.