### PR TITLE
fix(theme): stop AntD components rendering black

### DIFF
--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -11,10 +11,11 @@
  * Components now reference CSS variables (--color-primary) instead of hardcoded colors.
  * This allows the same component to look completely different for each tenant.
  */
-import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react';
-import { ConfigProvider } from 'antd';
+import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback, useMemo } from 'react';
+import { ConfigProvider, theme as antdTheme } from 'antd';
+import type { ThemeConfig } from 'antd';
 import { Theme, themes, injectTenantColors } from '../config/theme';
-import { getThemeConfig, applyCanvasTheme } from '../theme/themeConfig';
+import { applyCanvasTheme } from '../theme/themeConfig';
 import { getRuntimeConfig } from '../config/runtime';
 import { apiClient } from '../services/apiService';
 import { useAuth } from './AuthContext';
@@ -230,12 +231,30 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
     tenantBranding,
   };
 
-  // Get AntD theme configuration based on current theme mode
-  const antdTheme = getThemeConfig(themeName);
+  const antdConfig: ThemeConfig = useMemo(() => {
+    const isDarkMode = themeName === 'dark';
+
+    // CRITICAL: Let Ant Design algorithms own background/surface tokens.
+    // We only override the brand (primary) color.
+    const primary = tenantBranding
+      ? (isDarkMode ? tenantBranding.primaryColorDark : tenantBranding.primaryColorLight)
+      : null;
+
+    const hasValidPrimary = typeof primary === 'string' && /^#[0-9A-Fa-f]{6}$/.test(primary);
+
+    return {
+      algorithm: isDarkMode ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+      cssVar: true,
+      token: hasValidPrimary ? { colorPrimary: primary } : {},
+      // Do NOT override colorBgBase/colorBgContainer/colorBgLayout/colorText here.
+      // Those overrides can corrupt surfaces and render components pure black.
+      components: {},
+    };
+  }, [tenantBranding, themeName]);
 
   return (
     <ThemeContext.Provider value={value}>
-      <ConfigProvider theme={antdTheme}>
+      <ConfigProvider theme={antdConfig}>
         {children}
       </ConfigProvider>
     </ThemeContext.Provider>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -135,8 +135,11 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: rgb(var(--color-background));
-  color: rgb(var(--color-text-primary));
+
+  /* Prefer Ant Design theme variables when cssVar is enabled; fall back to our design-system vars. */
+  background-color: var(--ant-color-bg-layout, rgb(var(--color-background)));
+  color: var(--ant-color-text, rgb(var(--color-text-primary)));
+
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 


### PR DESCRIPTION
Fixes corrupted Ant Design theming where shared components rendered black by:
- Using correct algorithm mapping (defaultAlgorithm vs darkAlgorithm)
- Removing background/text token overrides (let algorithm own surfaces)
- Overriding only brand colorPrimary (from tenant branding when available)
- Enabling cssVar and preferring --ant-color-* variables in global body styling

Validation: npm --prefix frontend run build