### PR TITLE
fix(ai): HITL feedback submit + learning metrics

### DIFF
--- a/backend/tenant_apps/ai_assistant/serializers.py
+++ b/backend/tenant_apps/ai_assistant/serializers.py
@@ -44,6 +44,38 @@ class PendingReviewResolveRequestSerializer(serializers.Serializer):
         return value
 
 
+class AIFeedbackSubmitSerializer(serializers.Serializer):
+    """Public-ish write path for HITL corrections.
+
+    The frontend HITL card posts corrected key/value fields here.
+    """
+
+    document_id = serializers.UUIDField()
+    document_type = serializers.CharField(required=False, allow_blank=True, default='unknown', max_length=64)
+
+    original_extracted_data = serializers.JSONField(required=False, default=dict)
+    user_corrected_data = serializers.JSONField(required=False, default=dict)
+
+    confidence_score = serializers.FloatField(required=False, default=0.0)
+
+    def validate_original_extracted_data(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError('original_extracted_data must be an object')
+        return value
+
+    def validate_user_corrected_data(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError('user_corrected_data must be an object')
+        return value
+
+
+class AILearningMetricsSerializer(serializers.Serializer):
+    totalDocumentsParsed = serializers.IntegerField(min_value=0)
+    correctionsLearned = serializers.IntegerField(min_value=0)
+    precisionScore = serializers.FloatField(min_value=0.0, max_value=1.0)
+    confidenceTrend = serializers.ListField(child=serializers.DictField(), required=False)
+
+
 class ChatSessionListSerializer(serializers.ModelSerializer):
     """Serializer for chat session list view."""
 

--- a/backend/tenant_apps/ai_assistant/urls.py
+++ b/backend/tenant_apps/ai_assistant/urls.py
@@ -13,6 +13,7 @@ from .views import (
     AIDocumentViewSet,
     AIFeedbackViewSet,
     AIAgentChatView,
+    AILearningMetricsAPIView,
     ChatBotAPIViewSet,
     ChatMessageViewSet,
     ChatSessionViewSet,
@@ -42,6 +43,7 @@ urlpatterns = [
 
     # Clean endpoints
     path('chat/', AIAgentChatView.as_view(), name='ai-chat'),
+    path('metrics/', AILearningMetricsAPIView.as_view(), name='ai-metrics'),
     path('review/pending/', PendingReviewView.as_view(), name='pending-review'),
     path('tools/openapi/', ToolsOpenAPIView.as_view(), name='tools-openapi'),
 

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -6,12 +6,15 @@ and AI-powered business intelligence for meat market operations.
 """
 import logging
 import time
+from datetime import timedelta
 
 from django.conf import settings
+from django.db.models import Avg
+from django.db.models.functions import TruncDate
 from django.utils import timezone
 from openai import OpenAI
 from pgvector.django import CosineDistance
-from rest_framework import filters, permissions, status, viewsets
+from rest_framework import filters, mixins, permissions, status, viewsets
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
@@ -23,6 +26,8 @@ from .models import AIDocument, AIFeedbackLog, AIConfiguration, ChatMessage, Cha
 from .serializers import (
     AIDocumentSerializer,
     AIFeedbackLogSerializer,
+    AIFeedbackSubmitSerializer,
+    AILearningMetricsSerializer,
     AIConfigurationSerializer,
     ChatBotRequestSerializer,
     ChatBotResponseSerializer,
@@ -267,6 +272,51 @@ class ChatBotAPIViewSet(viewsets.ViewSet):
                 },
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+
+class AILearningMetricsAPIView(APIView):
+    """Tenant-scoped learning metrics for the Cockpit dashboard."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        tenant = getattr(request, 'tenant', None)
+        tenant_id = getattr(tenant, 'id', None)
+        if not tenant_id:
+            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        total_docs = AIDocument.objects.filter(tenant_id=tenant_id).count()
+
+        resolved = AIFeedbackLog.objects.filter(tenant_id=tenant_id, resolved_by__isnull=False)
+        corrections = resolved.exclude(user_corrected_data={}).count()
+
+        avg_precision_delta = resolved.aggregate(avg=Avg('precision_delta')).get('avg')
+        precision_score = 1.0 - float(avg_precision_delta or 0.0)
+        precision_score = max(0.0, min(1.0, precision_score))
+
+        start = timezone.now() - timedelta(days=29)
+        trend_qs = (
+            AIFeedbackLog.objects.filter(tenant_id=tenant_id, created_on__gte=start)
+            .annotate(day=TruncDate('created_on'))
+            .values('day')
+            .annotate(confidence=Avg('confidence_score'))
+            .order_by('day')
+        )
+        confidence_trend = [
+            {'day': str(row['day']), 'confidence': float(row.get('confidence') or 0.0)}
+            for row in trend_qs
+        ]
+
+        payload = {
+            'totalDocumentsParsed': int(total_docs),
+            'correctionsLearned': int(corrections),
+            'precisionScore': float(precision_score),
+            'confidenceTrend': confidence_trend,
+        }
+        # Defensive schema validation
+        out = AILearningMetricsSerializer(data=payload)
+        out.is_valid(raise_exception=True)
+        return Response(out.data, status=status.HTTP_200_OK)
 
 
 class AIDocumentViewSet(viewsets.ModelViewSet):
@@ -575,14 +625,32 @@ class PendingReviewAPIView(APIView):
         return Response({'results': payload}, status=status.HTTP_200_OK)
 
 
-class AIFeedbackViewSet(viewsets.ReadOnlyModelViewSet):
-    """Staff-only read access to AIFeedbackLog (for debugging/auditing)."""
+class AIFeedbackViewSet(mixins.CreateModelMixin, mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    """Feedback endpoint for HITL.
+
+    - `POST /api/v1/ai-assistant/feedback/`: tenant-scoped correction submission (used by HITLReviewCard)
+    - `GET /api/v1/ai-assistant/feedback/`: staff-only auditing
+
+    NOTE: We keep reads staff-only to avoid leaking internal training payloads.
+    """
 
     serializer_class = AIFeedbackLogSerializer
-    permission_classes = [IsAdminUser]
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ['created_on']
     ordering = ['-created_on']
+
+    throttle_classes = [AnonRateThrottle, UserRateThrottle, ScopedRateThrottle]
+    throttle_scope = 'ai_feedback'
+
+    def get_permissions(self):
+        if self.action in ['create']:
+            return [IsAuthenticated()]
+        return [IsAdminUser()]
+
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return AIFeedbackSubmitSerializer
+        return AIFeedbackLogSerializer
 
     def get_queryset(self):
         tenant = getattr(self.request, 'tenant', None)
@@ -596,6 +664,53 @@ class AIFeedbackViewSet(viewsets.ReadOnlyModelViewSet):
             return AIFeedbackLog.objects.none()
 
         return qs.filter(tenant_id=tenant_id)
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        tenant = getattr(request, 'tenant', None)
+        tenant_id = getattr(tenant, 'id', None)
+        if not tenant_id:
+            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        document_id = serializer.validated_data['document_id']
+        document_type = (serializer.validated_data.get('document_type') or 'unknown').strip() or 'unknown'
+        original = serializer.validated_data.get('original_extracted_data') or {}
+        corrected = serializer.validated_data.get('user_corrected_data') or {}
+        confidence = float(serializer.validated_data.get('confidence_score') or 0.0)
+
+        row = (
+            AIFeedbackLog.objects.filter(tenant_id=tenant_id, document_id=document_id)
+            .order_by('-created_on')
+            .first()
+        )
+        created = False
+        if row is None:
+            row = AIFeedbackLog.objects.create(
+                tenant_id=tenant_id,
+                document_id=document_id,
+                document_type=document_type,
+                original_extracted_data=original,
+                user_corrected_data=corrected,
+                confidence_score=confidence,
+                resolved_by=request.user,
+            )
+            created = True
+        else:
+            row.document_type = row.document_type or document_type
+            row.original_extracted_data = original or (row.original_extracted_data or {})
+            row.user_corrected_data = corrected
+            row.confidence_score = confidence or row.confidence_score
+            row.resolved_by = request.user
+            row.save()
+
+        payload = {
+            'id': str(row.id),
+            'created': created,
+            'document_id': str(row.document_id),
+        }
+        return Response(payload, status=status.HTTP_201_CREATED if created else status.HTTP_200_OK)
 
 
 class ToolsOpenAPIView(APIView):

--- a/frontend/src/components/AIAssistant/HITLReviewCard.tsx
+++ b/frontend/src/components/AIAssistant/HITLReviewCard.tsx
@@ -86,8 +86,25 @@ export const HITLReviewCard: React.FC<HITLReviewCardProps> = ({
         }
       }
 
-      // NOTE: /ai-assistant/feedback/ is staff-only read-only in this repo.
-      // Resolving a pending review item is the supported write path.
+      // Preferred write path per prompt contract.
+      try {
+        await businessApi.post('/ai-assistant/feedback/', {
+          document_id: documentId,
+          document_type: String((extractedData as any)?.document_type || 'unknown'),
+          original_extracted_data: extractedData,
+          user_corrected_data: corrected,
+        });
+
+        message.success('Thanks — saved your corrections and queued them for learning.');
+        onEmitChatMessage?.('✅ Confirmed. I saved your corrections and will use them to improve future extractions.');
+        onSubmitted?.();
+        return;
+      } catch (e: any) {
+        const code = e?.response?.status;
+        // Backward-compatible fallback for older deployments.
+        if (![404, 405].includes(code)) throw e;
+      }
+
       const resolvedId = await resolveFeedbackId();
       if (!resolvedId) {
         message.error('Unable to submit corrections (no review item found / insufficient permissions).');

--- a/frontend/src/components/Cockpit/AILearningMetricsWidget.tsx
+++ b/frontend/src/components/Cockpit/AILearningMetricsWidget.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { Card, Col, Row, Statistic, Typography } from 'antd';
+import { useQuery } from '@tanstack/react-query';
 import {
   Line,
   LineChart,
@@ -8,6 +9,8 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+
+import { businessApi } from '@/services/businessApi';
 
 const { Text } = Typography;
 
@@ -33,8 +36,22 @@ export const AILearningMetricsWidget: React.FC<AILearningMetricsWidgetProps> = (
     });
   }, []);
 
+  const { data, isLoading } = useQuery({
+    queryKey: ['ai-learning-metrics'],
+    queryFn: async () => {
+      const res = await businessApi.get<NonNullable<AILearningMetricsWidgetProps['metrics']>>(
+        '/ai-assistant/metrics/',
+      );
+      return res.data;
+    },
+    enabled: !metrics,
+    staleTime: 60_000,
+    retry: 1,
+  });
+
   const m =
     metrics ??
+    data ??
     ({
       totalDocumentsParsed: 312,
       correctionsLearned: 47,
@@ -47,6 +64,7 @@ export const AILearningMetricsWidget: React.FC<AILearningMetricsWidgetProps> = (
       title="AI Learning Metrics"
       style={{ width: '100%' }}
       styles={{ body: { padding: 16 } }}
+      loading={isLoading}
     >
       <Row gutter={[16, 16]}>
         <Col xs={24} sm={8}>


### PR DESCRIPTION
Implements the prompt-accurate HITL submission path and real Cockpit AI learning metrics.

- Adds POST /api/v1/ai-assistant/feedback/ for tenant-scoped corrections (keeps reads staff-only).
- Adds GET /api/v1/ai-assistant/metrics/ to power Cockpit AI Learning Metrics widget.
- Updates HITLReviewCard to POST corrected data to /ai-assistant/feedback/ (with backward-compatible fallback).
- Updates AILearningMetricsWidget to fetch live metrics when no props are provided.

Notes:
- Backend tests requiring pgvector extension cannot run in this dev container; Python compilation + lint were run.
