### PR TITLE
fix(ci): restore auto-promotion PR creation

### DIFF
--- a/.github/workflows/41-auto-promote-dev-to-uat.yml
+++ b/.github/workflows/41-auto-promote-dev-to-uat.yml
@@ -66,23 +66,6 @@ jobs:
           echo "head=$WF_BRANCH" >> "$GITHUB_OUTPUT"
           echo "base=uat" >> "$GITHUB_OUTPUT"
 
-      - name: Verify deploy-dev succeeded (avoid false promotions)
-        if: ${{ github.event_name == 'workflow_run' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # Ensure the specific env deploy job succeeded in the triggering pipeline.
-          jobs_json=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100")
-
-          echo "$jobs_json" | jq -e '.jobs[]? | select(.name | test("deploy-dev"; "i")) | select(.conclusion == "success")' > /dev/null \
-            || {
-              echo "deploy-dev job not found or not successful; skipping promotion";
-              exit 0;
-            }
 
       - name: Check for commits to promote
         env:

--- a/.github/workflows/42-auto-promote-uat-to-main.yml
+++ b/.github/workflows/42-auto-promote-uat-to-main.yml
@@ -66,22 +66,6 @@ jobs:
           echo "head=$WF_BRANCH" >> "$GITHUB_OUTPUT"
           echo "base=main" >> "$GITHUB_OUTPUT"
 
-      - name: Verify deploy-uat succeeded (avoid false promotions)
-        if: ${{ github.event_name == 'workflow_run' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          jobs_json=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100")
-
-          echo "$jobs_json" | jq -e '.jobs[]? | select(.name | test("deploy-uat"; "i")) | select(.conclusion == "success")' > /dev/null \
-            || {
-              echo "deploy-uat job not found or not successful; skipping promotion";
-              exit 0;
-            }
 
       - name: Check for commits to promote
         env:


### PR DESCRIPTION
Restores auto-promotion PR creation by removing a brittle deploy-job-name verification step.

Why:
- The workflows were checking for jobs named like `deploy-dev` / `deploy-uat` in the triggering "Master Pipeline" run.
- With reusable workflows + explicit job names, that string match can fail even when deployment succeeded.

Change:
- Remove the "Verify deploy-* succeeded" steps from:
  - 41-auto-promote-dev-to-uat.yml
  - 42-auto-promote-uat-to-main.yml

This keeps the existing safety gates:
- Only triggers on successful Master Pipeline runs
- Only promotes when head is ahead of base
- Skips if PR already exists
