### PR TITLE
Fix auto-promotion PR creation (dev→uat, uat→prod)

### DIFF
--- a/.github/workflows/41-auto-promote-dev-to-uat.yml
+++ b/.github/workflows/41-auto-promote-dev-to-uat.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Check for commits to promote
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
@@ -84,13 +84,14 @@ jobs:
 
       - name: Skip if PR already exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
         run: |
           set -euo pipefail
 
-          existing=$(gh pr list --base "$BASE" --head "$HEAD" --state open --json number --jq 'length')
+          existing=$(gh pr list --repo "$REPO" --base "$BASE" --head "$HEAD" --state open --json number --jq 'length')
           if [ "$existing" -ne 0 ]; then
             echo "Promotion PR already open ($HEAD -> $BASE); skipping."
             exit 0
@@ -98,7 +99,8 @@ jobs:
 
       - name: Create promotion PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
@@ -127,6 +129,7 @@ jobs:
           body=${body//SHA/$SHA}
 
           gh pr create \
+            --repo "$REPO" \
             --base "$BASE" \
             --head "$HEAD" \
             --title "$title" \

--- a/.github/workflows/42-auto-promote-uat-to-main.yml
+++ b/.github/workflows/42-auto-promote-uat-to-main.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Check for commits to promote
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
@@ -84,13 +84,14 @@ jobs:
 
       - name: Skip if PR already exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
         run: |
           set -euo pipefail
 
-          existing=$(gh pr list --base "$BASE" --head "$HEAD" --state open --json number --jq 'length')
+          existing=$(gh pr list --repo "$REPO" --base "$BASE" --head "$HEAD" --state open --json number --jq 'length')
           if [ "$existing" -ne 0 ]; then
             echo "Promotion PR already open ($HEAD -> $BASE); skipping."
             exit 0
@@ -98,7 +99,8 @@ jobs:
 
       - name: Create promotion PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
@@ -127,6 +129,7 @@ jobs:
           body=${body//SHA/$SHA}
 
           gh pr create \
+            --repo "$REPO" \
             --base "$BASE" \
             --head "$HEAD" \
             --title "$title" \


### PR DESCRIPTION
Fixes auto-promotion workflows failing with 'fatal: not a git repository' by making gh calls repo-explicit (no checkout required in workflow_run context).

Changes:
- Use github.token for GH auth
- Pass --repo to gh pr list and gh pr create