### PR TITLE
Fix auto-promotion PR creation: use PAT

### DIFF
--- a/.github/workflows/41-auto-promote-dev-to-uat.yml
+++ b/.github/workflows/41-auto-promote-dev-to-uat.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Check for commits to promote
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Skip if PR already exists
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create promotion PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}

--- a/.github/workflows/42-auto-promote-uat-to-main.yml
+++ b/.github/workflows/42-auto-promote-uat-to-main.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Check for commits to promote
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Skip if PR already exists
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create promotion PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
           BASE: ${{ steps.branches.outputs.base }}
           HEAD: ${{ steps.branches.outputs.head }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -64,6 +64,7 @@ These workflows automate PR creation between environments while enforcing CI/CD 
 ### 41-auto-promote-dev-to-uat.yml
 - **Trigger**: After successful `Master Pipeline` dev deployment completion
 - **Purpose**: Creates PR from `development` → `uat`
+- **Auth**: Uses the `PAT` repo secret for PR creation (GITHUB_TOKEN PR creation may be blocked by repo settings).
 - **Process**:
   1. Triggered when dev deployment succeeds
   2. Checks if PR already exists
@@ -77,6 +78,7 @@ These workflows automate PR creation between environments while enforcing CI/CD 
 ### 42-auto-promote-uat-to-main.yml
 - **Trigger**: After successful `Master Pipeline` UAT deployment completion
 - **Purpose**: Creates PR from `uat` → `main`
+- **Auth**: Uses the `PAT` repo secret for PR creation (GITHUB_TOKEN PR creation may be blocked by repo settings).
 - **Process**:
   1. Triggered when UAT deployment succeeds
   2. Checks if PR already exists


### PR DESCRIPTION
GitHub blocks PR creation with Actions GITHUB_TOKEN in this repo (GraphQL: GitHub Actions is not permitted to create or approve pull requests).

This switches auto-promotion workflows to use the existing PAT repo secret for gh operations (compare, PR list, PR create).