### PR TITLE
Auto-promotion: skip PR create when nothing to promote

### DIFF
--- a/.github/workflows/41-auto-promote-dev-to-uat.yml
+++ b/.github/workflows/41-auto-promote-dev-to-uat.yml
@@ -68,6 +68,7 @@ jobs:
 
 
       - name: Check for commits to promote
+        id: compare
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
@@ -77,12 +78,19 @@ jobs:
           set -euo pipefail
 
           ahead=$(gh api "repos/$REPO/compare/$BASE...$HEAD" --jq '.ahead_by')
+          echo "ahead_by=$ahead" >> "$GITHUB_OUTPUT"
+
           if [ "$ahead" -eq 0 ]; then
             echo "No commits to promote ($HEAD is not ahead of $BASE)."
+            echo "should_promote=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "should_promote=true" >> "$GITHUB_OUTPUT"
+
       - name: Skip if PR already exists
+        id: pr_check
+        if: ${{ steps.compare.outputs.should_promote == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
@@ -94,10 +102,14 @@ jobs:
           existing=$(gh pr list --repo "$REPO" --base "$BASE" --head "$HEAD" --state open --json number --jq 'length')
           if [ "$existing" -ne 0 ]; then
             echo "Promotion PR already open ($HEAD -> $BASE); skipping."
+            echo "pr_exists=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "pr_exists=false" >> "$GITHUB_OUTPUT"
+
       - name: Create promotion PR
+        if: ${{ steps.compare.outputs.should_promote == 'true' && steps.pr_check.outputs.pr_exists != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/42-auto-promote-uat-to-main.yml
+++ b/.github/workflows/42-auto-promote-uat-to-main.yml
@@ -68,6 +68,7 @@ jobs:
 
 
       - name: Check for commits to promote
+        id: compare
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
@@ -77,12 +78,19 @@ jobs:
           set -euo pipefail
 
           ahead=$(gh api "repos/$REPO/compare/$BASE...$HEAD" --jq '.ahead_by')
+          echo "ahead_by=$ahead" >> "$GITHUB_OUTPUT"
+
           if [ "$ahead" -eq 0 ]; then
             echo "No commits to promote ($HEAD is not ahead of $BASE)."
+            echo "should_promote=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "should_promote=true" >> "$GITHUB_OUTPUT"
+
       - name: Skip if PR already exists
+        id: pr_check
+        if: ${{ steps.compare.outputs.should_promote == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
@@ -94,10 +102,14 @@ jobs:
           existing=$(gh pr list --repo "$REPO" --base "$BASE" --head "$HEAD" --state open --json number --jq 'length')
           if [ "$existing" -ne 0 ]; then
             echo "Promotion PR already open ($HEAD -> $BASE); skipping."
+            echo "pr_exists=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "pr_exists=false" >> "$GITHUB_OUTPUT"
+
       - name: Create promotion PR
+        if: ${{ steps.compare.outputs.should_promote == 'true' && steps.pr_check.outputs.pr_exists != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
Prevents auto-promotion workflows from failing when there are no commits to promote.

- Compare step sets should_promote output
- PR-check and PR-create steps only run when should_promote=true
- Prevents gh pr create failures (No commits between base and head)