### PR TITLE
Fix Admin Option Lists (tenant lists CRUD)

### DIFF
--- a/backend/tenant_apps/workflows/permissions.py
+++ b/backend/tenant_apps/workflows/permissions.py
@@ -14,35 +14,35 @@ from .models import TenantForm, TenantWorkflow
 
 
 class IsTenantAdminOrOwner(permissions.BasePermission):
-    """
-    Permission class for admin-level operations.
-    Grants access to users with 'owner' or 'admin' role.
-    """
-    
+    """Allow access for users with 'owner' or 'admin' role."""
+
     def has_permission(self, request, view):
-        """Check if user has admin or owner role."""
         if not request.user or not request.user.is_authenticated:
             return False
-        
-        # Superusers always have access
+
         if request.user.is_superuser:
             return True
-        
-        # Check tenant role
+
         if not hasattr(request, 'tenant') or not request.tenant:
             return False
-        
-        # Get user's role in this tenant
+
         from apps.tenants.models import TenantUser
+
         try:
-            tenant_user = TenantUser.objects.get(
-                user=request.user,
-                tenant=request.tenant,
-                is_active=True
-            )
+            tenant_user = TenantUser.objects.get(user=request.user, tenant=request.tenant, is_active=True)
             return tenant_user.role in ['owner', 'admin']
         except TenantUser.DoesNotExist:
             return False
+
+
+class IsTenantAdminOrOwnerOrReadOnly(permissions.BasePermission):
+    """Read-only for authenticated users; write for tenant admins/owners."""
+
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return bool(request.user and request.user.is_authenticated)
+
+        return IsTenantAdminOrOwner().has_permission(request, view)
 
 
 class CanEditWorkForm(permissions.BasePermission):

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -36,7 +36,13 @@ from .models import (
     WorkflowExecutionLog,
     WorkflowStatus,
 )
-from .permissions import CanEditWorkForm, CanPublishWorkForm, IsTenantAdminOrOwner, WorkFormPermissionHelper
+from .permissions import (
+    CanEditWorkForm,
+    CanPublishWorkForm,
+    IsTenantAdminOrOwner,
+    IsTenantAdminOrOwnerOrReadOnly,
+    WorkFormPermissionHelper,
+)
 from .serializers import (
     TenantFormCreateSerializer,
     TenantFormEntitySerializer,
@@ -870,6 +876,7 @@ class TenantListViewSet(TenantFilteredModelViewSet):
 
     queryset = TenantList.objects.all()
     serializer_class = TenantListSerializer
+    permission_classes = [IsTenantAdminOrOwnerOrReadOnly]
 
     def get_queryset(self):
         qs = super().get_queryset()

--- a/frontend/src/pages/Admin/OptionLists/TenantListModal.tsx
+++ b/frontend/src/pages/Admin/OptionLists/TenantListModal.tsx
@@ -1,0 +1,243 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Button, Form, Input, Modal, Space, Switch, Table, Typography, message } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+
+import { apiClient } from '@/services/apiService';
+
+const { Text } = Typography;
+
+export interface TenantListOption {
+  value: string;
+  label: string;
+}
+
+export interface TenantList {
+  id: string;
+  name: string;
+  description: string;
+  options: TenantListOption[];
+  option_count: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+type EditableOptionRow = TenantListOption & { key: string };
+
+export interface TenantListModalProps {
+  isOpen: boolean;
+  canEdit: boolean;
+  initial?: TenantList | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export const TenantListModal: React.FC<TenantListModalProps> = ({
+  isOpen,
+  canEdit,
+  initial,
+  onClose,
+  onSaved,
+}) => {
+  const [form] = Form.useForm();
+  const [saving, setSaving] = useState(false);
+  const [options, setOptions] = useState<EditableOptionRow[]>([]);
+
+  const isEdit = Boolean(initial?.id);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    form.setFieldsValue({
+      name: initial?.name ?? '',
+      description: initial?.description ?? '',
+      is_active: initial?.is_active ?? true,
+    });
+
+    const initialOptions = Array.isArray(initial?.options) ? initial!.options : [];
+    setOptions(
+      initialOptions.map((opt, idx) => ({
+        key: `${idx}-${opt.value}`,
+        value: opt.value ?? '',
+        label: opt.label ?? '',
+      }))
+    );
+  }, [form, initial, isOpen]);
+
+  const optionErrors = useMemo(() => {
+    const errors: string[] = [];
+    const seen = new Set<string>();
+
+    for (const row of options) {
+      const v = String(row.value ?? '').trim();
+      const l = String(row.label ?? '').trim();
+
+      if (!v || !l) {
+        errors.push('All options must have both a value and a label.');
+        break;
+      }
+
+      const key = v.toLowerCase();
+      if (seen.has(key)) {
+        errors.push(`Duplicate option value: "${v}"`);
+        break;
+      }
+      seen.add(key);
+    }
+
+    return errors;
+  }, [options]);
+
+  const addOption = () => {
+    setOptions((prev) => [
+      ...prev,
+      { key: `new-${Date.now()}-${Math.random().toString(16).slice(2)}`, value: '', label: '' },
+    ]);
+  };
+
+  const removeOption = (key: string) => {
+    setOptions((prev) => prev.filter((o) => o.key !== key));
+  };
+
+  const updateOption = (key: string, patch: Partial<TenantListOption>) => {
+    setOptions((prev) => prev.map((o) => (o.key === key ? { ...o, ...patch } : o)));
+  };
+
+  const handleSave = async () => {
+    if (!canEdit) {
+      message.info('Only tenant administrators can manage option lists.');
+      return;
+    }
+
+    try {
+      const values = await form.validateFields();
+
+      if (optionErrors.length > 0) {
+        message.error(optionErrors[0]);
+        return;
+      }
+
+      const payload = {
+        name: String(values.name ?? '').trim(),
+        description: String(values.description ?? ''),
+        is_active: Boolean(values.is_active),
+        options: options.map(({ value, label }) => ({
+          value: String(value).trim(),
+          label: String(label).trim(),
+        })),
+      };
+
+      setSaving(true);
+
+      if (isEdit && initial?.id) {
+        await apiClient.patch(`/workflows/lists/${initial.id}/`, payload);
+      } else {
+        await apiClient.post('/workflows/lists/', payload);
+      }
+
+      message.success(isEdit ? 'Custom list updated' : 'Custom list created');
+      onSaved();
+      onClose();
+    } catch (err: any) {
+      if (err?.errorFields) return; // antd validation
+      message.error(err?.response?.data?.error || 'Failed to save custom list');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const columns: ColumnsType<EditableOptionRow> = [
+    {
+      title: 'Value',
+      dataIndex: 'value',
+      key: 'value',
+      render: (value: string, record) => (
+        <Input
+          value={value}
+          disabled={!canEdit}
+          onChange={(e) => updateOption(record.key, { value: e.target.value })}
+        />
+      ),
+    },
+    {
+      title: 'Label',
+      dataIndex: 'label',
+      key: 'label',
+      render: (value: string, record) => (
+        <Input
+          value={value}
+          disabled={!canEdit}
+          onChange={(e) => updateOption(record.key, { label: e.target.value })}
+        />
+      ),
+    },
+    {
+      title: '',
+      key: 'actions',
+      width: 54,
+      render: (_: unknown, record) => (
+        <Button
+          danger
+          type="text"
+          icon={<DeleteOutlined />}
+          disabled={!canEdit}
+          onClick={() => removeOption(record.key)}
+          aria-label="Remove option"
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Modal
+      title={isEdit ? `Edit Custom List: ${initial?.name ?? ''}` : 'Create Custom Tenant List'}
+      open={isOpen}
+      onCancel={onClose}
+      onOk={handleSave}
+      okButtonProps={{ disabled: !canEdit || saving, loading: saving }}
+      cancelButtonProps={{ disabled: saving }}
+      okText={isEdit ? 'Save' : 'Create'}
+      width={780}
+      destroyOnClose
+    >
+      <Form form={form} layout="vertical">
+        <Form.Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }]}
+        >
+          <Input disabled={!canEdit} placeholder="e.g., Delivery Methods" />
+        </Form.Item>
+
+        <Form.Item label="Description" name="description">
+          <Input.TextArea disabled={!canEdit} rows={2} placeholder="Optional description" />
+        </Form.Item>
+
+        <Form.Item label="Active" name="is_active" valuePropName="checked">
+          <Switch disabled={!canEdit} />
+        </Form.Item>
+
+        <Space direction="vertical" style={{ width: '100%' }} size={8}>
+          <Space style={{ width: '100%', justifyContent: 'space-between' }}>
+            <Text strong>Options</Text>
+            <Button icon={<PlusOutlined />} onClick={addOption} disabled={!canEdit}>
+              Add option
+            </Button>
+          </Space>
+
+          <Table
+            rowKey="key"
+            size="small"
+            columns={columns}
+            dataSource={options}
+            pagination={false}
+            locale={{ emptyText: 'No options yet' }}
+          />
+
+          {optionErrors.length > 0 && <Text type="danger">{optionErrors[0]}</Text>}
+        </Space>
+      </Form>
+    </Modal>
+  );
+};

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -20,6 +20,7 @@ import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 import { TenantChoiceOverride } from '@/components/Admin/TenantChoiceOverride';
 
 import { OptionListModal } from './OptionListModal';
+import { TenantListModal, type TenantList } from './TenantListModal';
 
 const { Text } = Typography;
 
@@ -38,14 +39,7 @@ interface SystemChoiceList {
   updated_at: string;
 }
 
-interface CustomTenantList {
-  id: string;
-  slug: string;
-  name: string;
-  description?: string;
-  items_count: number;
-  updated_at: string;
-}
+type CustomTenantList = TenantList;
 
 const OptionListsPage: React.FC = () => {
   const { permissions } = useAdminPermissions();
@@ -64,8 +58,10 @@ const OptionListsPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [editingList, setEditingList] = useState<SystemChoiceList | null>(null);
 
-  // Mock data placeholder for Custom Tenant Lists (workflow-specific dropdowns)
-  const [customLists] = useState<CustomTenantList[]>([]);
+  const [customLists, setCustomLists] = useState<CustomTenantList[]>([]);
+  const [customLoading, setCustomLoading] = useState(false);
+  const [editingCustomList, setEditingCustomList] = useState<CustomTenantList | null>(null);
+  const [customModalOpen, setCustomModalOpen] = useState(false);
 
   useEffect(() => {
     const tab = searchParams.get('tab');
@@ -78,6 +74,7 @@ const OptionListsPage: React.FC = () => {
   useEffect(() => {
     if (!canView) return;
     void loadChoiceLists();
+    void loadCustomLists();
   }, [canView]);
 
   const loadChoiceLists = async () => {
@@ -89,10 +86,26 @@ const OptionListsPage: React.FC = () => {
       setLists(data);
     } catch (error) {
       console.error('Failed to load choice lists:', error);
-      message.error('Failed to load option lists');
+      message.error('Failed to load system option lists');
       setLists([]);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const loadCustomLists = async () => {
+    setCustomLoading(true);
+    try {
+      const response = await apiClient.get('/workflows/lists/');
+      const raw = response.data as any;
+      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
+      setCustomLists(data);
+    } catch (error) {
+      console.error('Failed to load custom tenant lists:', error);
+      message.error('Failed to load custom tenant lists');
+      setCustomLists([]);
+    } finally {
+      setCustomLoading(false);
     }
   };
 
@@ -114,25 +127,46 @@ const OptionListsPage: React.FC = () => {
 
     return customLists.filter((list) => {
       const name = (list.name || '').toLowerCase();
-      const slug = (list.slug || '').toLowerCase();
       const desc = (list.description || '').toLowerCase();
-      return name.includes(q) || slug.includes(q) || desc.includes(q);
+      const id = String(list.id || '').toLowerCase();
+      return name.includes(q) || desc.includes(q) || id.includes(q);
     });
   }, [customLists, searchQuery]);
 
   const openCreateCustomList = () => {
-    Modal.info({
-      title: 'Create Custom Tenant List (Coming Soon)',
-      content: (
-        <div>
-          <p>
-            Custom Tenant Lists will support workflow-specific dropdown fields (tenant-owned choice lists).
-          </p>
-          <p>
-            For now, this is a placeholder. If/when a TenantListModal exists, we can wire it here.
-          </p>
-        </div>
-      ),
+    if (!canEdit) {
+      Modal.info({
+        title: 'Access restricted',
+        content: 'Only tenant administrators can create custom option lists.',
+      });
+      return;
+    }
+
+    setEditingCustomList(null);
+    setCustomModalOpen(true);
+  };
+
+  const confirmDeleteCustomList = (record: CustomTenantList) => {
+    if (!canEdit) {
+      message.info('Only tenant administrators can delete custom option lists.');
+      return;
+    }
+
+    Modal.confirm({
+      title: `Delete custom list "${record.name}"?`,
+      content: 'This will permanently delete the list and all of its options.',
+      okText: 'Delete',
+      okButtonProps: { danger: true },
+      cancelText: 'Cancel',
+      onOk: async () => {
+        try {
+          await apiClient.delete(`/workflows/lists/${record.id}/`);
+          message.success('Custom list deleted');
+          await loadCustomLists();
+        } catch (err: any) {
+          message.error(err?.response?.data?.error || 'Failed to delete custom list');
+        }
+      },
     });
   };
 
@@ -216,7 +250,7 @@ const OptionListsPage: React.FC = () => {
         <Space direction="vertical" size={0}>
           <Text strong>{value}</Text>
           <Text type="secondary" style={{ fontSize: 12 }}>
-            <code>{record.slug}</code>
+            <code>{record.id}</code>
           </Text>
         </Space>
       ),
@@ -229,10 +263,18 @@ const OptionListsPage: React.FC = () => {
     },
     {
       title: 'Items',
-      dataIndex: 'items_count',
-      key: 'items_count',
+      dataIndex: 'option_count',
+      key: 'option_count',
       width: 90,
-      render: (count: number) => <Text>{count}</Text>,
+      render: (count: number) => <Text>{count ?? 0}</Text>,
+    },
+    {
+      title: 'Active',
+      dataIndex: 'is_active',
+      key: 'is_active',
+      width: 90,
+      render: (isActive: boolean) =>
+        isActive ? <Tag color="green">Active</Tag> : <Tag>Inactive</Tag>,
     },
     {
       title: 'Updated',
@@ -240,6 +282,28 @@ const OptionListsPage: React.FC = () => {
       key: 'updated_at',
       width: 140,
       render: (iso: string) => <Text>{iso ? new Date(iso).toLocaleDateString() : '—'}</Text>,
+    },
+    {
+      title: 'Actions',
+      key: 'actions',
+      width: 200,
+      render: (_: unknown, record) => (
+        <Space>
+          <Button
+            type="default"
+            disabled={!canEdit}
+            onClick={() => {
+              setEditingCustomList(record);
+              setCustomModalOpen(true);
+            }}
+          >
+            Edit
+          </Button>
+          <Button danger disabled={!canEdit} onClick={() => confirmDeleteCustomList(record)}>
+            Delete
+          </Button>
+        </Space>
+      ),
     },
   ];
 
@@ -262,7 +326,14 @@ const OptionListsPage: React.FC = () => {
             onChange={(e) => setSearchQuery(e.target.value)}
             style={{ width: 320 }}
           />
-          <Button icon={<ReloadOutlined />} onClick={loadChoiceLists} loading={loading} />
+          <Button
+            icon={<ReloadOutlined />}
+            onClick={() => {
+              void loadChoiceLists();
+              void loadCustomLists();
+            }}
+            loading={loading || customLoading}
+          />
         </Space>
       }
     >
@@ -316,8 +387,12 @@ const OptionListsPage: React.FC = () => {
                     filteredCustomLists.length === 0 ? (
                       <EmptyState
                         icon="🧩"
-                        title="No custom lists yet"
-                        message="Create custom tenant lists for workflow-specific dropdown fields."
+                        title={searchQuery ? 'No matches' : 'No custom lists yet'}
+                        message={
+                          searchQuery
+                            ? 'No custom tenant lists match your search.'
+                            : 'Create custom tenant lists for workflow-specific dropdown fields.'
+                        }
                       />
                     ) : (
                       <Table
@@ -325,6 +400,7 @@ const OptionListsPage: React.FC = () => {
                         columns={customColumns}
                         dataSource={filteredCustomLists}
                         pagination={{ pageSize: 10, showSizeChanger: true }}
+                        loading={customLoading}
                       />
                     ),
                 },
@@ -366,6 +442,17 @@ const OptionListsPage: React.FC = () => {
             }}
           />
         )}
+
+        <TenantListModal
+          isOpen={customModalOpen}
+          canEdit={canEdit}
+          initial={editingCustomList}
+          onClose={() => {
+            setCustomModalOpen(false);
+            setEditingCustomList(null);
+          }}
+          onSaved={() => void loadCustomLists()}
+        />
       </AdminGuard>
     </AdminPage>
   );


### PR DESCRIPTION
Fixes Admin Workspace → Option Lists so Custom Tenant Lists are fully functional.

- Wire Custom Tenant Lists tab to /api/v1/workflows/lists/
- Add create/edit modal with inline option editing
- Add delete action with confirmation
- Backend: allow read for any authenticated user; restrict create/update/delete to tenant owner/admin

Notes:
- System choice lists continue to load from /api/v1/system/choice-lists/.
