### PR TITLE
Admin Option Lists: allow admins to view

### DIFF
--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -339,7 +339,13 @@ const OptionListsPage: React.FC = () => {
     >
       <AdminGuard
         feature="option_lists"
-        allow={(p) => p.can_manage_option_lists || p.role === 'manager'}
+        allow={(p) =>
+          p.can_manage_option_lists ||
+          p.role === 'manager' ||
+          p.role === 'owner' ||
+          p.role === 'admin' ||
+          p.role === 'superuser'
+        }
         loadingFallback={<LoadingSkeleton type="card" rows={2} />}
       >
         {loading ? (


### PR DESCRIPTION
Hardening: the Option Lists page was gated by AdminGuard to only allow can_manage_option_lists or manager. If an owner/admin/superuser role lacks that flag, the page could appear blocked/empty.

This PR broadens the allow-list to include owner/admin/superuser for view access.
