### PR TITLE
Reports: business dashboard + backend aggregates

### DIFF
--- a/backend/apps/core/report_views.py
+++ b/backend/apps/core/report_views.py
@@ -1,0 +1,247 @@
+"""Reports API endpoints.
+
+Purpose: Provide business-friendly aggregated metrics for the Reports page without
+forcing the frontend to pull entire entity lists (performance + correctness).
+
+All endpoints are tenant-scoped via request.tenant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, Optional, Tuple
+
+from django.db.models import Avg, Count, Sum
+from django.db.models.functions import TruncMonth
+from django.utils import timezone
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+@dataclass(frozen=True)
+class DateRange:
+    start: date
+    end: date
+
+
+def _parse_iso_date(raw: Optional[str]) -> Optional[date]:
+    if not raw:
+        return None
+    try:
+        return date.fromisoformat(str(raw))
+    except ValueError:
+        return None
+
+
+def _get_date_range(request) -> DateRange:
+    """Get date range from query params (start/end), default last 30 days."""
+    start = _parse_iso_date(request.query_params.get("start"))
+    end = _parse_iso_date(request.query_params.get("end"))
+
+    today = timezone.localdate()
+    if not end:
+        end = today
+    if not start:
+        start = end - timedelta(days=30)
+
+    if start > end:
+        start, end = end, start
+
+    return DateRange(start=start, end=end)
+
+
+class ReportsSummaryAPIView(APIView):
+    """High-level business summary for Reports."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        tenant = getattr(request, "tenant", None)
+        if not tenant:
+            return Response({"error": "Tenant context required"}, status=400)
+
+        dr = _get_date_range(request)
+        now = timezone.now()
+
+        # Local imports (avoid import cycles)
+        from tenant_apps.purchase_orders.models import PurchaseOrder
+        from tenant_apps.sales_orders.models import SalesOrder
+        from tenant_apps.inquiries.models import Inquiry
+        from tenant_apps.cockpit.models import ScheduledCall
+        from tenant_apps.suppliers.models import Supplier
+        from tenant_apps.customers.models import Customer
+        from tenant_apps.contacts.models import Contact
+        from tenant_apps.workflows.models import FormSubmission, FormSubmissionStatus
+
+        po_qs = PurchaseOrder.objects.for_tenant(tenant).filter(order_date__gte=dr.start, order_date__lte=dr.end)
+        po_agg = po_qs.aggregate(
+            count=Count("id"),
+            total_amount=Sum("total_amount"),
+            avg_amount=Avg("total_amount"),
+        )
+
+        so_qs = SalesOrder.objects.for_tenant(tenant).filter(
+            date_time_stamp__date__gte=dr.start,
+            date_time_stamp__date__lte=dr.end,
+        )
+        so_agg = so_qs.aggregate(
+            count=Count("id"),
+            total_amount=Sum("total_amount"),
+            total_weight=Sum("total_weight"),
+            avg_amount=Avg("total_amount"),
+        )
+
+        inquiry_qs = Inquiry.objects.filter(tenant=tenant, inquiry_date__date__gte=dr.start, inquiry_date__date__lte=dr.end)
+        inquiry_total = inquiry_qs.count()
+        inquiry_won = inquiry_qs.filter(status="accepted").count()
+        inquiry_lost = inquiry_qs.filter(status="rejected").count()
+        inquiry_closed = inquiry_won + inquiry_lost
+        inquiry_win_rate = (inquiry_won / inquiry_closed * 100) if inquiry_closed else 0
+
+        # Calls
+        calls_qs = ScheduledCall.objects.filter(tenant=tenant, scheduled_for__date__gte=dr.start, scheduled_for__date__lte=dr.end)
+        calls_total = calls_qs.count()
+        calls_completed = calls_qs.filter(is_completed=True).count()
+        calls_overdue = calls_qs.filter(is_completed=False, scheduled_for__lt=now).count()
+        calls_upcoming = calls_qs.filter(is_completed=False, scheduled_for__gte=now).count()
+        calls_completion_rate = (calls_completed / calls_total * 100) if calls_total else 0
+
+        # WorkForms submissions
+        submissions_qs = FormSubmission.objects.filter(tenant=tenant, created_at__date__gte=dr.start, created_at__date__lte=dr.end)
+        submissions_total = submissions_qs.count()
+        submissions_completed = submissions_qs.filter(status=FormSubmissionStatus.COMPLETED).count()
+        submissions_in_progress = submissions_qs.filter(status=FormSubmissionStatus.IN_PROGRESS).count()
+        submissions_completion_rate = (submissions_completed / submissions_total * 100) if submissions_total else 0
+
+        # Master data
+        suppliers_count = Supplier.objects.for_tenant(tenant).count()
+        customers_count = Customer.objects.for_tenant(tenant).count()
+        contacts_count = Contact.objects.for_tenant(tenant).count()
+
+        return Response(
+            {
+                "date_range": {"start": dr.start.isoformat(), "end": dr.end.isoformat()},
+                "summary": {
+                    "purchase_orders": {
+                        "count": int(po_agg.get("count") or 0),
+                        "total_amount": float(po_agg.get("total_amount") or 0),
+                        "avg_amount": float(po_agg.get("avg_amount") or 0),
+                    },
+                    "sales_orders": {
+                        "count": int(so_agg.get("count") or 0),
+                        "total_amount": float(so_agg.get("total_amount") or 0),
+                        "total_weight": float(so_agg.get("total_weight") or 0),
+                        "avg_amount": float(so_agg.get("avg_amount") or 0),
+                    },
+                    "inquiries": {
+                        "total": int(inquiry_total),
+                        "won": int(inquiry_won),
+                        "lost": int(inquiry_lost),
+                        "win_rate": round(inquiry_win_rate, 1),
+                    },
+                    "calls": {
+                        "total": int(calls_total),
+                        "completed": int(calls_completed),
+                        "upcoming": int(calls_upcoming),
+                        "overdue": int(calls_overdue),
+                        "completion_rate": round(calls_completion_rate, 1),
+                    },
+                    "workforms": {
+                        "submissions_total": int(submissions_total),
+                        "completed": int(submissions_completed),
+                        "in_progress": int(submissions_in_progress),
+                        "completion_rate": round(submissions_completion_rate, 1),
+                    },
+                    "master_data": {
+                        "suppliers": int(suppliers_count),
+                        "customers": int(customers_count),
+                        "contacts": int(contacts_count),
+                    },
+                },
+            }
+        )
+
+
+class PurchaseOrderTrendsAPIView(APIView):
+    """Trend series for purchase orders (month buckets)."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        tenant = getattr(request, "tenant", None)
+        if not tenant:
+            return Response({"error": "Tenant context required"}, status=400)
+
+        dr = _get_date_range(request)
+
+        from tenant_apps.purchase_orders.models import PurchaseOrder
+
+        qs = (
+            PurchaseOrder.objects.for_tenant(tenant)
+            .filter(order_date__gte=dr.start, order_date__lte=dr.end)
+            .annotate(bucket=TruncMonth("order_date"))
+            .values("bucket")
+            .annotate(
+                orders=Count("id"),
+                value=Sum("total_amount"),
+                averageValue=Avg("total_amount"),
+            )
+            .order_by("bucket")
+        )
+
+        data = [
+            {
+                "date": (row["bucket"].date().isoformat() if isinstance(row["bucket"], datetime) else str(row["bucket"])),
+                "orders": int(row["orders"] or 0),
+                "value": float(row["value"] or 0),
+                "averageValue": float(row["averageValue"] or 0),
+            }
+            for row in qs
+        ]
+
+        return Response({"date_range": {"start": dr.start.isoformat(), "end": dr.end.isoformat()}, "data": data})
+
+
+class TopSuppliersAPIView(APIView):
+    """Top suppliers by PO value for a date range."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        tenant = getattr(request, "tenant", None)
+        if not tenant:
+            return Response({"error": "Tenant context required"}, status=400)
+
+        dr = _get_date_range(request)
+        try:
+            limit = int(request.query_params.get("limit", 10))
+        except ValueError:
+            limit = 10
+        limit = max(1, min(limit, 25))
+
+        from tenant_apps.purchase_orders.models import PurchaseOrder
+
+        rows = (
+            PurchaseOrder.objects.for_tenant(tenant)
+            .filter(order_date__gte=dr.start, order_date__lte=dr.end)
+            .values("supplier__name")
+            .annotate(
+                orders=Count("id"),
+                revenue=Sum("total_amount"),
+            )
+            .order_by("-revenue")[:limit]
+        )
+
+        data = [
+            {
+                "name": r["supplier__name"] or "Unknown",
+                "orders": int(r["orders"] or 0),
+                "revenue": float(r["revenue"] or 0),
+                "rating": 0,
+            }
+            for r in rows
+        ]
+
+        return Response({"date_range": {"start": dr.start.isoformat(), "end": dr.end.isoformat()}, "data": data})

--- a/backend/apps/core/urls.py
+++ b/backend/apps/core/urls.py
@@ -5,6 +5,7 @@ from . import views
 from .jwt_serializers import TenantAwareTokenObtainPairView
 from . import entity_views  # Phase 1: WorkForms Enhancement
 from . import calendar_views
+from . import report_views
 from apps.system import workform_views  # Phase 1: WorkForms Enhancement
 
 # Create a router for ViewSets
@@ -50,6 +51,11 @@ urlpatterns = [
     path("workspace/stats/quick/", views.WorkspaceStatsView.as_view(), name="workspace-stats"),
     path("workspace/activity/recent/", views.WorkspaceActivityView.as_view(), name="workspace-activity"),
     path("workspace/calls/upcoming/", views.WorkspaceCallsView.as_view(), name="workspace-calls"),
+
+    # Reports API (Cockpit)
+    path("reports/summary/", report_views.ReportsSummaryAPIView.as_view(), name="reports-summary"),
+    path("reports/trends/purchase-orders/", report_views.PurchaseOrderTrendsAPIView.as_view(), name="reports-po-trends"),
+    path("reports/top/suppliers/", report_views.TopSuppliersAPIView.as_view(), name="reports-top-suppliers"),
 
     # Calendar API (placeholder until Phase 5 integrations are configured)
     path("calendar/events/", calendar_views.CalendarEventsView.as_view(), name="calendar-events"),

--- a/frontend/src/components/Visualization/PurchaseOrderTrends.tsx
+++ b/frontend/src/components/Visualization/PurchaseOrderTrends.tsx
@@ -57,7 +57,7 @@ const PurchaseOrderTrends: React.FC<PurchaseOrderTrendsProps> = ({ data, height 
             yAxisId="left"
             type="monotone"
             dataKey="orders"
-            stroke="#3498db"
+            stroke={`rgb(var(--color-info))`}
             strokeWidth={2}
             name="Number of Orders"
           />
@@ -65,7 +65,7 @@ const PurchaseOrderTrends: React.FC<PurchaseOrderTrendsProps> = ({ data, height 
             yAxisId="right"
             type="monotone"
             dataKey="value"
-            stroke="#2ecc71"
+            stroke={`rgb(var(--color-success))`}
             strokeWidth={2}
             name="Total Value ($)"
           />
@@ -73,7 +73,7 @@ const PurchaseOrderTrends: React.FC<PurchaseOrderTrendsProps> = ({ data, height 
             yAxisId="right"
             type="monotone"
             dataKey="averageValue"
-            stroke="#f39c12"
+            stroke={`rgb(var(--color-warning))`}
             strokeWidth={2}
             strokeDasharray="5 5"
             name="Average Order Value ($)"

--- a/frontend/src/components/Visualization/SupplierPerformanceChart.tsx
+++ b/frontend/src/components/Visualization/SupplierPerformanceChart.tsx
@@ -52,9 +52,9 @@ const SupplierPerformanceChart: React.FC<SupplierPerformanceChartProps> = ({
             }}
           />
           <Legend />
-          <Bar yAxisId="left" dataKey="orders" fill="#3498db" name="Orders" />
-          <Bar yAxisId="left" dataKey="revenue" fill="#2ecc71" name="Revenue ($)" />
-          <Bar yAxisId="right" dataKey="rating" fill="#f39c12" name="Rating (1-5)" />
+          <Bar yAxisId="left" dataKey="orders" fill={`rgb(var(--color-info))`} name="Orders" />
+          <Bar yAxisId="left" dataKey="revenue" fill={`rgb(var(--color-success))`} name="Revenue ($)" />
+          <Bar yAxisId="right" dataKey="rating" fill={`rgb(var(--color-warning))`} name="Rating (1-5)" />
         </BarChart>
       </ResponsiveContainer>
     </ChartContainer>
@@ -71,7 +71,7 @@ const ChartContainer = styled.div`
 
 const ChartTitle = styled.h3`
   margin: 0 0 20px 0;
-  color: #2c3e50;
+  color: rgb(var(--color-text-primary));
   font-size: 18px;
   font-weight: 600;
 `;

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -1,311 +1,337 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
-import { useTheme } from '../contexts/ThemeContext';
-import { Theme } from '../config/theme';
-import { apiService } from '../services/apiService';
+import dayjs from 'dayjs';
+import { Alert, Button, DatePicker, Segmented, Spin, Tabs } from 'antd';
+import type { TabsProps } from 'antd';
 
-interface ReportSummary {
-  totalOrders: number;
-  totalRevenue: number;
-  totalWeight: number;
-  averageOrderValue: number;
-  supplierCount: number;
-  customerCount: number;
-}
+import PurchaseOrderTrends from '../components/Visualization/PurchaseOrderTrends';
+import SupplierPerformanceChart from '../components/Visualization/SupplierPerformanceChart';
+import {
+  reportsService,
+  type PurchaseOrderTrendPoint,
+  type ReportsSummaryResponse,
+  type SupplierPerformancePoint,
+} from '../services/reportsService';
+
+const { RangePicker } = DatePicker;
+
+type RangePreset = '30d' | '90d' | 'ytd' | 'custom';
 
 const Reports: React.FC = () => {
-  const { theme } = useTheme();
-  const [summary, setSummary] = useState<ReportSummary>({
-    totalOrders: 0,
-    totalRevenue: 0,
-    totalWeight: 0,
-    averageOrderValue: 0,
-    supplierCount: 0,
-    customerCount: 0,
-  });
+  const [preset, setPreset] = useState<RangePreset>('30d');
+  const [customRange, setCustomRange] = useState<[string, string] | null>(null);
+
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchReportData();
-  }, []);
+  const [summary, setSummary] = useState<ReportsSummaryResponse | null>(null);
+  const [poTrends, setPoTrends] = useState<PurchaseOrderTrendPoint[]>([]);
+  const [topSuppliers, setTopSuppliers] = useState<SupplierPerformancePoint[]>([]);
 
-  const fetchReportData = async () => {
+  const range = useMemo(() => {
+    const today = dayjs();
+
+    if (preset === 'custom' && customRange) {
+      return { start: customRange[0], end: customRange[1] };
+    }
+
+    if (preset === '90d') {
+      return {
+        start: today.subtract(90, 'day').format('YYYY-MM-DD'),
+        end: today.format('YYYY-MM-DD'),
+      };
+    }
+
+    if (preset === 'ytd') {
+      return {
+        start: today.startOf('year').format('YYYY-MM-DD'),
+        end: today.format('YYYY-MM-DD'),
+      };
+    }
+
+    // default: 30d
+    return {
+      start: today.subtract(30, 'day').format('YYYY-MM-DD'),
+      end: today.format('YYYY-MM-DD'),
+    };
+  }, [customRange, preset]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    const params = { start: range.start, end: range.end };
+
     try {
-      setLoading(true);
-      setError(null);
-
-      const [purchaseOrders, suppliers, customers] = await Promise.all([
-        apiService.getPurchaseOrders().catch(() => []),
-        apiService.getSuppliers().catch(() => []),
-        apiService.getCustomers().catch(() => []),
+      const [s, t, ts] = await Promise.all([
+        reportsService.getSummary(params),
+        reportsService.getPurchaseOrderTrends(params),
+        reportsService.getTopSuppliers(params, 10),
       ]);
 
-      const totalRevenue = purchaseOrders.reduce(
-        (sum, po) => sum + Number(po.total_amount),
-        0
-      );
-      const totalWeight = purchaseOrders.reduce(
-        (sum, po) => sum + (Number(po.total_weight) || 0),
-        0
-      );
-      const averageOrderValue =
-        purchaseOrders.length > 0 ? totalRevenue / purchaseOrders.length : 0;
-
-      setSummary({
-        totalOrders: purchaseOrders.length,
-        totalRevenue: Math.round(totalRevenue),
-        totalWeight: Math.round(totalWeight),
-        averageOrderValue: Math.round(averageOrderValue),
-        supplierCount: suppliers.length,
-        customerCount: customers.length,
-      });
-    } catch (err) {
-      console.error('Error fetching report data:', err);
-      setError('Failed to load report data');
+      setSummary(s);
+      setPoTrends(t.data || []);
+      setTopSuppliers(ts.data || []);
+    } catch (err: any) {
+      const msg = err?.response?.data?.error || err?.response?.data?.detail || err?.message;
+      setError(typeof msg === 'string' ? msg : 'Failed to load reports');
     } finally {
       setLoading(false);
     }
-  };
+  }, [range.end, range.start]);
 
-  if (loading) {
-    return (
-      <Container>
-        <LoadingMessage $theme={theme}>Loading reports...</LoadingMessage>
-      </Container>
-    );
-  }
+  useEffect(() => {
+    void load();
+  }, [load]);
 
-  if (error) {
-    return (
-      <Container>
-        <ErrorMessage $theme={theme}>⚠️ {error}</ErrorMessage>
-      </Container>
-    );
-  }
+  const kpis = summary?.summary;
+
+  const items: TabsProps['items'] = [
+    {
+      key: 'overview',
+      label: 'Overview',
+      children: (
+        <>
+          <KpiGrid>
+            <KpiCard>
+              <KpiLabel>Purchase Orders</KpiLabel>
+              <KpiValue>{kpis?.purchase_orders.count ?? 0}</KpiValue>
+              <KpiSub>${(kpis?.purchase_orders.total_amount ?? 0).toLocaleString()}</KpiSub>
+            </KpiCard>
+            <KpiCard>
+              <KpiLabel>Sales Orders</KpiLabel>
+              <KpiValue>{kpis?.sales_orders.count ?? 0}</KpiValue>
+              <KpiSub>${(kpis?.sales_orders.total_amount ?? 0).toLocaleString()}</KpiSub>
+            </KpiCard>
+            <KpiCard>
+              <KpiLabel>Inquiries (Win Rate)</KpiLabel>
+              <KpiValue>{kpis ? `${kpis.inquiries.win_rate}%` : '0%'}</KpiValue>
+              <KpiSub>
+                Won {kpis?.inquiries.won ?? 0} / Lost {kpis?.inquiries.lost ?? 0}
+              </KpiSub>
+            </KpiCard>
+            <KpiCard>
+              <KpiLabel>Calls</KpiLabel>
+              <KpiValue>{kpis?.calls.completed ?? 0}</KpiValue>
+              <KpiSub>
+                Completed · Upcoming {kpis?.calls.upcoming ?? 0} · Overdue {kpis?.calls.overdue ?? 0}
+              </KpiSub>
+            </KpiCard>
+            <KpiCard>
+              <KpiLabel>WorkForms (Completion)</KpiLabel>
+              <KpiValue>{kpis ? `${kpis.workforms.completion_rate}%` : '0%'}</KpiValue>
+              <KpiSub>
+                {kpis?.workforms.completed ?? 0} completed · {kpis?.workforms.in_progress ?? 0} in progress
+              </KpiSub>
+            </KpiCard>
+            <KpiCard>
+              <KpiLabel>Master Data</KpiLabel>
+              <KpiValue>{(kpis?.master_data.customers ?? 0) + (kpis?.master_data.suppliers ?? 0)}</KpiValue>
+              <KpiSub>
+                {kpis?.master_data.customers ?? 0} customers · {kpis?.master_data.suppliers ?? 0} suppliers
+              </KpiSub>
+            </KpiCard>
+          </KpiGrid>
+
+          <Section>
+            <SectionHeader>
+              <SectionTitle>Purchase Order Trends</SectionTitle>
+              <Button
+                onClick={() => reportsService.downloadCsv('purchase-order-trends.csv', poTrends)}
+                disabled={!poTrends.length}
+              >
+                Export CSV
+              </Button>
+            </SectionHeader>
+            <PurchaseOrderTrends data={poTrends} height={320} />
+          </Section>
+
+          <Section>
+            <SectionHeader>
+              <SectionTitle>Top Suppliers (by PO value)</SectionTitle>
+              <Button
+                onClick={() => reportsService.downloadCsv('top-suppliers.csv', topSuppliers)}
+                disabled={!topSuppliers.length}
+              >
+                Export CSV
+              </Button>
+            </SectionHeader>
+            <SupplierPerformanceChart data={topSuppliers} height={320} />
+          </Section>
+        </>
+      ),
+    },
+  ];
 
   return (
     <Container>
       <Header>
-        <Title $theme={theme}>📊 Reports - Business Analytics</Title>
-        <Subtitle $theme={theme}>
-          Comprehensive business intelligence and reporting
-        </Subtitle>
+        <HeaderLeft>
+          <Title>Reports</Title>
+          <Subtitle>
+            Business performance snapshots ({range.start} → {range.end})
+          </Subtitle>
+        </HeaderLeft>
+
+        <HeaderRight>
+          <Segmented
+            value={preset}
+            onChange={(v) => setPreset(v as RangePreset)}
+            options={[
+              { label: '30D', value: '30d' },
+              { label: '90D', value: '90d' },
+              { label: 'YTD', value: 'ytd' },
+              { label: 'Custom', value: 'custom' },
+            ]}
+          />
+          {preset === 'custom' && (
+            <RangePicker
+              allowClear={false}
+              value={customRange ? [dayjs(customRange[0]), dayjs(customRange[1])] : null}
+              onChange={(vals) => {
+                if (!vals || vals.length !== 2 || !vals[0] || !vals[1]) return;
+                setCustomRange([vals[0].format('YYYY-MM-DD'), vals[1].format('YYYY-MM-DD')]);
+              }}
+            />
+          )}
+          <Button onClick={() => void load()} disabled={loading}>
+            Refresh
+          </Button>
+        </HeaderRight>
       </Header>
 
-      <ReportGrid>
-        <ReportCard $theme={theme}>
-          <CardHeader $theme={theme}>
-            <CardIcon>📋</CardIcon>
-            <CardTitle $theme={theme}>Total Orders</CardTitle>
-          </CardHeader>
-          <CardValue $theme={theme}>{summary.totalOrders}</CardValue>
-          <CardFooter $theme={theme}>All-time purchase orders</CardFooter>
-        </ReportCard>
+      {error && <Alert type="error" message={error} showIcon style={{ marginBottom: 12 }} />}
 
-        <ReportCard $theme={theme}>
-          <CardHeader $theme={theme}>
-            <CardIcon>💰</CardIcon>
-            <CardTitle $theme={theme}>Total Revenue</CardTitle>
-          </CardHeader>
-          <CardValue $theme={theme}>
-            ${summary.totalRevenue.toLocaleString()}
-          </CardValue>
-          <CardFooter $theme={theme}>Cumulative order value</CardFooter>
-        </ReportCard>
-
-        <ReportCard $theme={theme}>
-          <CardHeader $theme={theme}>
-            <CardIcon>⚖️</CardIcon>
-            <CardTitle $theme={theme}>Total Weight</CardTitle>
-          </CardHeader>
-          <CardValue $theme={theme}>
-            {summary.totalWeight.toLocaleString()} lbs
-          </CardValue>
-          <CardFooter $theme={theme}>Total product weight</CardFooter>
-        </ReportCard>
-
-        <ReportCard $theme={theme}>
-          <CardHeader $theme={theme}>
-            <CardIcon>📈</CardIcon>
-            <CardTitle $theme={theme}>Avg Order Value</CardTitle>
-          </CardHeader>
-          <CardValue $theme={theme}>
-            ${summary.averageOrderValue.toLocaleString()}
-          </CardValue>
-          <CardFooter $theme={theme}>Per purchase order</CardFooter>
-        </ReportCard>
-
-        <ReportCard $theme={theme}>
-          <CardHeader $theme={theme}>
-            <CardIcon>🏭</CardIcon>
-            <CardTitle $theme={theme}>Suppliers</CardTitle>
-          </CardHeader>
-          <CardValue $theme={theme}>{summary.supplierCount}</CardValue>
-          <CardFooter $theme={theme}>Active supplier network</CardFooter>
-        </ReportCard>
-
-        <ReportCard $theme={theme}>
-          <CardHeader $theme={theme}>
-            <CardIcon>👥</CardIcon>
-            <CardTitle $theme={theme}>Customers</CardTitle>
-          </CardHeader>
-          <CardValue $theme={theme}>{summary.customerCount}</CardValue>
-          <CardFooter $theme={theme}>Customer base</CardFooter>
-        </ReportCard>
-      </ReportGrid>
-
-      <Section $theme={theme}>
-        <SectionTitle $theme={theme}>Report Insights</SectionTitle>
-        <InsightsList>
-          <InsightItem $theme={theme}>
-            <InsightBullet>•</InsightBullet>
-            <InsightText $theme={theme}>
-              Average order value: ${summary.averageOrderValue.toLocaleString()}
-            </InsightText>
-          </InsightItem>
-          <InsightItem $theme={theme}>
-            <InsightBullet>•</InsightBullet>
-            <InsightText $theme={theme}>
-              Total business volume: {summary.totalWeight.toLocaleString()} lbs
-              processed
-            </InsightText>
-          </InsightItem>
-          <InsightItem $theme={theme}>
-            <InsightBullet>•</InsightBullet>
-            <InsightText $theme={theme}>
-              Business network: {summary.supplierCount} suppliers serving{' '}
-              {summary.customerCount} customers
-            </InsightText>
-          </InsightItem>
-        </InsightsList>
-      </Section>
+      {loading ? (
+        <LoadingBlock>
+          <Spin />
+          <span>Loading reports…</span>
+        </LoadingBlock>
+      ) : (
+        <Tabs defaultActiveKey="overview" items={items} />
+      )}
     </Container>
   );
 };
 
 const Container = styled.div`
-  max-width: 1200px;
-  padding: 20px;
+  padding: 1.5rem;
+  max-width: 1400px;
+  margin: 0 auto;
 `;
 
 const Header = styled.div`
-  margin-bottom: 30px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
 `;
 
-const Title = styled.h1<{ $theme: Theme }>`
-  font-size: 32px;
-  font-weight: 700;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  margin: 0 0 8px 0;
+const HeaderLeft = styled.div``;
+
+const HeaderRight = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 `;
 
-const Subtitle = styled.p<{ $theme: Theme }>`
-  font-size: 16px;
-  color: ${(props) => props.$theme.colors.textSecondary};
+const Title = styled.h1`
   margin: 0;
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: rgb(var(--color-text-primary));
 `;
 
-const LoadingMessage = styled.div<{ $theme: Theme }>`
-  text-align: center;
-  padding: 60px;
-  font-size: 18px;
-  color: ${(props) => props.$theme.colors.textSecondary};
+const Subtitle = styled.div`
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+  color: rgb(var(--color-text-secondary));
 `;
 
-const ErrorMessage = styled.div<{ $theme: Theme }>`
-  text-align: center;
-  padding: 60px;
-  font-size: 18px;
-  color: ${(props) => props.$theme.colors.error};
+const LoadingBlock = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  justify-content: center;
+  color: rgb(var(--color-text-secondary));
 `;
 
-const ReportGrid = styled.div`
+const KpiGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 20px;
-  margin-bottom: 30px;
-`;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 0.75rem;
+  margin-bottom: 1rem;
 
-const ReportCard = styled.div<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.surface};
-  border-radius: 12px;
-  padding: 25px;
-  box-shadow: 0 2px 10px ${(props) => props.$theme.colors.shadow};
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-
-  &:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px ${(props) => props.$theme.colors.shadowMedium};
+  @media (max-width: 1100px) {
+    grid-template-columns: repeat(6, 1fr);
+  }
+  @media (max-width: 650px) {
+    grid-template-columns: repeat(1, 1fr);
   }
 `;
 
-const CardHeader = styled.div<{ $theme: Theme }>`
+const KpiCard = styled.div`
+  grid-column: span 4;
+  background: rgb(var(--color-surface));
+  border: 1px solid rgb(var(--color-border));
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+
+  @media (max-width: 1100px) {
+    grid-column: span 3;
+  }
+  @media (max-width: 650px) {
+    grid-column: span 1;
+  }
+`;
+
+const KpiLabel = styled.div`
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: rgb(var(--color-text-secondary));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+`;
+
+const KpiValue = styled.div`
+  margin-top: 0.25rem;
+  font-size: 1.6rem;
+  font-weight: 900;
+  color: rgb(var(--color-text-primary));
+`;
+
+const KpiSub = styled.div`
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: rgb(var(--color-text-secondary));
+`;
+
+const Section = styled.div`
+  background: rgb(var(--color-surface));
+  border: 1px solid rgb(var(--color-border));
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  margin-bottom: 1rem;
+`;
+
+const SectionHeader = styled.div`
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
 `;
 
-const CardIcon = styled.div`
-  font-size: 32px;
-`;
-
-const CardTitle = styled.h3<{ $theme: Theme }>`
-  font-size: 16px;
-  font-weight: 600;
-  color: ${(props) => props.$theme.colors.textPrimary};
+const SectionTitle = styled.h2`
   margin: 0;
-`;
-
-const CardValue = styled.div<{ $theme: Theme }>`
-  font-size: 32px;
-  font-weight: 700;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  margin-bottom: 8px;
-`;
-
-const CardFooter = styled.div<{ $theme: Theme }>`
-  font-size: 14px;
-  color: ${(props) => props.$theme.colors.textSecondary};
-`;
-
-const Section = styled.div<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.surface};
-  border-radius: 12px;
-  padding: 25px;
-  box-shadow: 0 2px 10px ${(props) => props.$theme.colors.shadow};
-`;
-
-const SectionTitle = styled.h2<{ $theme: Theme }>`
-  font-size: 20px;
-  font-weight: 600;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  margin: 0 0 20px 0;
-`;
-
-const InsightsList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-`;
-
-const InsightItem = styled.div<{ $theme: Theme }>`
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-`;
-
-const InsightBullet = styled.div`
-  font-size: 20px;
-  font-weight: bold;
-  line-height: 1;
-`;
-
-const InsightText = styled.div<{ $theme: Theme }>`
-  font-size: 14px;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  line-height: 1.5;
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: rgb(var(--color-text-primary));
 `;
 
 export default Reports;

--- a/frontend/src/services/reportsService.ts
+++ b/frontend/src/services/reportsService.ts
@@ -1,0 +1,84 @@
+import { apiClient } from './apiService';
+
+export type ReportsDateRange = {
+  start: string; // YYYY-MM-DD
+  end: string;   // YYYY-MM-DD
+};
+
+export type ReportsSummaryResponse = {
+  date_range: ReportsDateRange;
+  summary: {
+    purchase_orders: { count: number; total_amount: number; avg_amount: number };
+    sales_orders: { count: number; total_amount: number; total_weight: number; avg_amount: number };
+    inquiries: { total: number; won: number; lost: number; win_rate: number };
+    calls: { total: number; completed: number; upcoming: number; overdue: number; completion_rate: number };
+    workforms: { submissions_total: number; completed: number; in_progress: number; completion_rate: number };
+    master_data: { suppliers: number; customers: number; contacts: number };
+  };
+};
+
+export type PurchaseOrderTrendPoint = {
+  date: string;
+  orders: number;
+  value: number;
+  averageValue: number;
+};
+
+export type PurchaseOrderTrendsResponse = {
+  date_range: ReportsDateRange;
+  data: PurchaseOrderTrendPoint[];
+};
+
+export type SupplierPerformancePoint = {
+  name: string;
+  orders: number;
+  revenue: number;
+  rating: number;
+};
+
+export type TopSuppliersResponse = {
+  date_range: ReportsDateRange;
+  data: SupplierPerformancePoint[];
+};
+
+export const reportsService = {
+  async getSummary(range: ReportsDateRange): Promise<ReportsSummaryResponse> {
+    const resp = await apiClient.get('/reports/summary/', { params: range });
+    return resp.data;
+  },
+
+  async getPurchaseOrderTrends(range: ReportsDateRange): Promise<PurchaseOrderTrendsResponse> {
+    const resp = await apiClient.get('/reports/trends/purchase-orders/', { params: range });
+    return resp.data;
+  },
+
+  async getTopSuppliers(range: ReportsDateRange, limit = 10): Promise<TopSuppliersResponse> {
+    const resp = await apiClient.get('/reports/top/suppliers/', { params: { ...range, limit } });
+    return resp.data;
+  },
+
+  downloadCsv(filename: string, rows: Array<Record<string, unknown>>): void {
+    const headers = Array.from(
+      rows.reduce((acc, r) => {
+        Object.keys(r).forEach((k) => acc.add(k));
+        return acc;
+      }, new Set<string>())
+    );
+
+    const escape = (v: unknown) => {
+      const s = v == null ? '' : String(v);
+      if (/[\n\r,\"]/g.test(s)) return `"${s.replace(/"/g, '""')}"`;
+      return s;
+    };
+
+    const csv = [headers.join(','), ...rows.map((r) => headers.map((h) => escape(r[h])).join(','))].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  },
+};


### PR DESCRIPTION
Implements a business-friendly Reports page (KPIs + trends + CSV export) backed by tenant-scoped aggregation endpoints.\n\nBackend\n- GET /api/v1/reports/summary/?start=YYYY-MM-DD&end=YYYY-MM-DD\n- GET /api/v1/reports/trends/purchase-orders/?start=...&end=...\n- GET /api/v1/reports/top/suppliers/?start=...&end=...&limit=10\n\nFrontend\n- New reportsService wrapper\n- Revamped Reports page UI (date presets + custom range + refresh)\n- Charts updated to use theme CSS variables (no hardcoded colors)\n\nVerification\n- frontend: npm run lint\n- backend: python -m compileall