### PR TITLE
FlowEditor: broaden config schema types (type-check cleanup)

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
@@ -322,7 +322,11 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
                                 type="text"
                                 value={child[childField.id] || ''}
                                 onChange={(e) => handleUpdateChild(index, { ...child, [childField.id]: e.target.value })}
-                                placeholder={childField.placeholder}
+                                placeholder={
+                                  typeof childField.placeholder === 'string'
+                                    ? childField.placeholder
+                                    : childField.placeholder?.value
+                                }
                                 style={{
                                   width: '100%',
                                   padding: '8px 12px',
@@ -336,7 +340,11 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
                               <textarea
                                 value={child[childField.id] || ''}
                                 onChange={(e) => handleUpdateChild(index, { ...child, [childField.id]: e.target.value })}
-                                placeholder={childField.placeholder}
+                                placeholder={
+                                  typeof childField.placeholder === 'string'
+                                    ? childField.placeholder
+                                    : childField.placeholder?.value
+                                }
                                 rows={3}
                                 style={{
                                   width: '100%',

--- a/frontend/src/components/FlowEditor/ConfigPanel/OutlookEmailConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/OutlookEmailConfigPanel.tsx
@@ -29,6 +29,7 @@ import {
   TextArea,
   Select,
   IconButton,
+  HelpText,
 } from './shared/StyledComponents';
 
 // Local styled components (email-specific)

--- a/frontend/src/components/FlowEditor/ConfigPanel/shared/StyledComponents.ts
+++ b/frontend/src/components/FlowEditor/ConfigPanel/shared/StyledComponents.ts
@@ -514,6 +514,31 @@ export const SecondaryButton = styled(Button).attrs({ $variant: 'secondary' as c
 export const DangerButton = styled(Button).attrs({ $variant: 'danger' as const })``;
 
 /**
+ * Icon Button - Small square button for icons
+ */
+export const IconButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-background));
+  color: rgb(var(--color-text-secondary));
+  cursor: pointer;
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: rgb(var(--color-primary));
+    color: rgb(var(--color-primary));
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+`;
+
+/**
  * Add Button - Button for adding items
  */
 export const AddButton = styled.button`

--- a/frontend/src/components/FlowEditor/config/types.ts
+++ b/frontend/src/components/FlowEditor/config/types.ts
@@ -69,16 +69,18 @@ export type FieldType =
  * Comparison operators for conditional rules
  */
 export type ConditionalOperator =
-  | 'equals'       // Field value equals target value
-  | 'notEquals'    // Field value does not equal target value
-  | 'contains'     // Field value contains target value (arrays/strings)
-  | 'notContains'  // Field value does not contain target value
-  | 'greaterThan'  // Field value > target value (numbers/dates)
-  | 'lessThan'     // Field value < target value (numbers/dates)
+  | 'equals' // Field value equals target value
+  | 'notEquals' // Field value does not equal target value
+  | 'contains' // Field value contains target value (arrays/strings)
+  | 'notContains' // Field value does not contain target value
+  | 'greaterThan' // Field value > target value (numbers/dates)
+  | 'lessThan' // Field value < target value (numbers/dates)
   | 'greaterThanOrEqual' // Field value >= target value
-  | 'lessThanOrEqual'    // Field value <= target value
-  | 'isEmpty'      // Field value is null/undefined/empty string
-  | 'isNotEmpty';  // Field value is not null/undefined/empty string
+  | 'lessThanOrEqual' // Field value <= target value
+  | 'isEmpty' // Field value is null/undefined/empty string
+  | 'isNotEmpty' // Field value is not null/undefined/empty string
+  | 'in' // Field value is contained in a provided list
+  | 'notIn'; // Field value is not contained in a provided list
 
 /**
  * Logical operators for combining multiple conditions
@@ -131,15 +133,16 @@ export interface ConditionalRule {
  * Built-in validation rule types
  */
 export type ValidationRuleType =
-  | 'required'       // Field must have a value
-  | 'minLength'      // Minimum string length
-  | 'maxLength'      // Maximum string length
-  | 'min'            // Minimum number value
-  | 'max'            // Maximum number value
-  | 'regex'          // Regular expression match
-  | 'email'          // Valid email format
-  | 'url'            // Valid URL format
-  | 'custom';        // Custom validation function
+  | 'required' // Field must have a value
+  | 'minLength' // Minimum string length
+  | 'maxLength' // Maximum string length
+  | 'min' // Minimum number value
+  | 'max' // Maximum number value
+  | 'regex' // Regular expression match
+  | 'pattern' // Alias for regex (legacy schemas)
+  | 'email' // Valid email format
+  | 'url' // Valid URL format
+  | 'custom'; // Custom validation function
 
 /**
  * Validation rule definition
@@ -218,7 +221,7 @@ export interface ConfigField {
   label: string;
   
   /** Placeholder text (for text inputs) */
-  placeholder?: string;
+  placeholder?: string | { key: string; value: string };
   
   /** Help text (shown in tooltip or below field) */
   helpText?: string;
@@ -231,6 +234,9 @@ export interface ConfigField {
   
   /** Options for select/multiselect fields */
   options?: SelectOption[];
+
+  /** UI hint: enable/disable auto-suggest (used by search-like fields) */
+  showAutoSuggest?: boolean;
   
   /** Validation rules */
   validation?: ValidationRule[];
@@ -240,7 +246,37 @@ export interface ConfigField {
   
   /** Disabled state */
   disabled?: boolean;
-  
+
+  /** Read-only state (renderer should prevent edits) */
+  readOnly?: boolean;
+
+  /** Allow multiple values (used by keyValue/multiselect-like fields) */
+  multiple?: boolean;
+
+  /** UI hint: button styling / severity */
+  variant?: string;
+
+  /** UI hint: language for code editors */
+  language?: string;
+
+  /** UI hint: minimum numeric value */
+  min?: number;
+
+  /** UI hint: maximum numeric value */
+  max?: number;
+
+  /** Key-value field: label for add button */
+  addButtonText?: string;
+
+  /** Entity-field picker: pre-selected field id */
+  entityFieldId?: string;
+
+  /** Array-like fields: schema for items */
+  itemSchema?: Record<string, any>;
+
+  /** Button fields: click handler (dynamic config panels may wrap/augment this) */
+  onClick?: (...args: any[]) => any;
+
   /** Custom component (for type='custom') */
   component?: ComponentType<any>;
   


### PR DESCRIPTION
Type-check cleanup batch: make FlowEditor config schemas type-compatible (additive)\n\n- Expand ConfigField/ConditionalOperator/ValidationRuleType to match existing schemas\n- Add missing shared IconButton export + import HelpText in OutlookEmailConfigPanel\n- Handle non-string placeholders in NestedChildrenRenderer\n\nVerification:\n- frontend: npm run lint