### PR TITLE
Chore: remove unused eslint-disable and console usage

### DIFF
--- a/frontend/src/components/AIAssistant/Omnibox.tsx
+++ b/frontend/src/components/AIAssistant/Omnibox.tsx
@@ -41,8 +41,6 @@ const Omnibox: React.FC<OmniboxProps> = ({ isOpen, onClose, onSubmit }) => {
       setSuggestions([]);
     }
     setSelectedSuggestionIndex(-1);
-    // sampleCommands is static and doesn't need to be in dependencies
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [command]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/frontend/src/config/runtime.ts
+++ b/frontend/src/config/runtime.ts
@@ -13,6 +13,7 @@
  */
 
 import { getTenantContext } from './tenantContext';
+import { logger } from '../utils/logger';
 
 // Extend Window interface to include ENV
 declare global {
@@ -148,19 +149,17 @@ export { getRuntimeConfig, getRuntimeConfigBoolean, getRuntimeConfigNumber };
 // Log configuration source in development
 // Note: This only runs once when the module is first imported
 if (isDevelopment) {
-  // eslint-disable-next-line no-console
-  console.log('[Runtime Config] Loaded from:', 
-    window.ENV ? 'window.ENV (runtime)' : 'import.meta.env (build-time)'
-  );
-  
+  logger.debug('[Runtime Config] Loaded', {
+    source: window.ENV ? 'window.ENV (runtime)' : 'import.meta.env (build-time)',
+  });
+
   try {
     const tenantContext = getTenantContext();
-    // eslint-disable-next-line no-console
-    console.log('[Runtime Config] Multi-tenancy:', {
+    logger.debug('[Runtime Config] Multi-tenancy', {
       tenant: tenantContext.tenant || 'none',
       environment: tenantContext.environment,
     });
-  } catch (error) {
+  } catch {
     // Ignore errors in development logging
   }
 }

--- a/frontend/src/config/tenantContext.ts
+++ b/frontend/src/config/tenantContext.ts
@@ -15,6 +15,8 @@
  * - custom-tenant.com -> { tenant: 'custom-tenant', environment: 'production' }
  */
 
+import { logger } from '../utils/logger';
+
 export interface TenantInfo {
   tenant: string | null;
   environment: 'development' | 'uat' | 'production';
@@ -209,12 +211,10 @@ export function initializeTenantContext(): TenantInfo {
   
   // Log in development mode only (without exposing full API URL)
   if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.log('[Tenant Context] Initialized:', {
+    logger.debug('[Tenant Context] Initialized', {
       hostname: window.location.hostname,
       tenant: context.tenant || 'none',
       environment: context.environment,
-      // Don't log full API URL to avoid exposing endpoint structure
     });
   }
   

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -11,6 +11,7 @@
  */
 import axios, { AxiosError as AxiosErrorType, InternalAxiosRequestConfig } from 'axios';
 import { config } from '../config/runtime';
+import { logger } from '../utils/logger';
 import {
   getAuthHeader,
   needsRefresh,
@@ -559,32 +560,37 @@ export class ApiService {
 
   async createSupplier(supplier: Partial<Supplier>): Promise<Supplier> {
     try {
-      // Log request details for debugging (excluding sensitive data)
-      // eslint-disable-next-line no-console
-      console.debug('[API] Creating supplier:', {
-        endpoint: '/suppliers/',
-        hasAuth: !!localStorage.getItem('authToken'),
-        hasTenant: !!localStorage.getItem('tenantId'),
-        baseURL: API_BASE_URL,
+      logger.debug('[API] Creating supplier', {
+        component: 'ApiService',
+        metadata: {
+          endpoint: '/suppliers/',
+          hasAuth: !!localStorage.getItem('authToken'),
+          hasTenant: !!localStorage.getItem('tenantId'),
+          baseURL: API_BASE_URL,
+        },
       });
       
       const response = await apiClient.post('/suppliers/', supplier);
-      // eslint-disable-next-line no-console
-      console.debug('[API] Supplier created successfully:', response.data);
+      logger.debug('[API] Supplier created successfully', {
+        component: 'ApiService',
+        metadata: { endpoint: '/suppliers/' },
+      }, response.data);
       return response.data;
     } catch (error: unknown) {
       // Log detailed error information for debugging
       const axiosError = error as AxiosError;
-      // eslint-disable-next-line no-console
-      console.error('[API] Failed to create supplier:', {
-        message: getErrorMessage(error),
-        status: axiosError.response?.status,
-        statusText: axiosError.response?.statusText,
-        errorCode: axiosError.code,
-        url: axiosError.config?.url,
-        baseURL: axiosError.config?.baseURL,
-        hasResponse: !!axiosError.response,
-        hasRequest: !!axiosError.request,
+      logger.error('[API] Failed to create supplier', {
+        component: 'ApiService',
+        metadata: {
+          message: getErrorMessage(error),
+          status: axiosError.response?.status,
+          statusText: axiosError.response?.statusText,
+          errorCode: axiosError.code,
+          url: axiosError.config?.url,
+          baseURL: axiosError.config?.baseURL,
+          hasResponse: !!axiosError.response,
+          hasRequest: !!axiosError.request,
+        },
       });
       
       // Re-throw with enhanced error message
@@ -594,24 +600,30 @@ export class ApiService {
 
   async updateSupplier(id: number, supplier: Partial<Supplier>): Promise<Supplier> {
     try {
-      // eslint-disable-next-line no-console
-      console.debug('[API] Updating supplier:', {
-        id,
-        endpoint: `/suppliers/${id}/`,
-        baseURL: API_BASE_URL,
+      logger.debug('[API] Updating supplier', {
+        component: 'ApiService',
+        metadata: {
+          id,
+          endpoint: `/suppliers/${id}/`,
+          baseURL: API_BASE_URL,
+        },
       });
       
       const response = await apiClient.patch(`/suppliers/${id}/`, supplier);
-      // eslint-disable-next-line no-console
-      console.debug('[API] Supplier updated successfully:', response.data);
+      logger.debug('[API] Supplier updated successfully', {
+        component: 'ApiService',
+        metadata: { id, endpoint: `/suppliers/${id}/` },
+      }, response.data);
       return response.data;
     } catch (error: unknown) {
       const axiosError = error as AxiosError;
-      // eslint-disable-next-line no-console
-      console.error('[API] Failed to update supplier:', {
-        message: getErrorMessage(error),
-        status: axiosError.response?.status,
-        errorCode: axiosError.code,
+      logger.error('[API] Failed to update supplier', {
+        component: 'ApiService',
+        metadata: {
+          message: getErrorMessage(error),
+          status: axiosError.response?.status,
+          errorCode: axiosError.code,
+        },
       });
       
       throw new Error(getErrorMessage(error));


### PR DESCRIPTION
Cleans up lint warnings and avoids direct console usage in core config/service modules.\n\n- Omnibox: remove unused exhaustive-deps disable\n- runtime/tenantContext: replace dev console logs with logger.debug\n- apiService: replace supplier debug/error console calls with logger + remove no-console disables\n\nVerification:\n- frontend: npm run lint