### PR TITLE
FlowEditor: show Apply Changes after auto-map

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -404,8 +404,11 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       suggestion
     );
 
-    setFormData(updatedNode.data || {});
-    onUpdateNode(node.id, updatedNode.data || {});
+    const nextData = (updatedNode.data || {}) as Record<string, unknown>;
+    setFormData(nextData);
+
+    // updateShadow expects a patch; keep this minimal so we reliably mark the panel dirty.
+    onUpdateNode(node.id, { fieldMappings: nextData.fieldMappings || [] });
 
     // UX: hide applied suggestions so the user gets immediate feedback.
     setRejectedSuggestionIds((prev) => {
@@ -431,8 +434,11 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       autoMap
     );
 
-    setFormData(updatedNode.data || {});
-    onUpdateNode(node.id, updatedNode.data || {});
+    const nextData = (updatedNode.data || {}) as Record<string, unknown>;
+    setFormData(nextData);
+
+    // updateShadow expects a patch; keep this minimal so we reliably mark the panel dirty.
+    onUpdateNode(node.id, { fieldMappings: nextData.fieldMappings || [] });
 
     // UX: hide the auto-applied suggestions from the list.
     const autoAppliedIds = (autoMap.suggestions || []).filter((s) => s.autoApply).map((s) => s.id);


### PR DESCRIPTION
Fixes Smart Auto-Map Apply not surfacing the bottom Apply Changes bar in the node configure panel.\n\nChange:\n- DynamicConfigPanel auto-map Apply/Apply All now calls onUpdateNode with a minimal { fieldMappings } patch to reliably mark shadow state dirty.\n\nVerification:\n- frontend: npm run lint