### PR TITLE
Cockpit: fix New Supplier save

### DIFF
--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -1306,13 +1306,34 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
               inline={true}
               contextData={quickCreateConfig.context}
               onClose={closeQuickCreate}
-              onCreated={() => {
+              onCreated={(created) => {
+                const createdId = String(created?.value ?? '').trim();
+                const rawType = String(quickCreateConfig.type ?? '').toLowerCase();
+                const createdType = rawType === 'customers' ? 'customer' : rawType === 'suppliers' ? 'supplier' : rawType;
+
+                // If this was a top-level create (no active entity context), navigate directly to the new record.
+                if (!activeEntity && createdId) {
+                  handleSelectEntity({
+                    id: createdId,
+                    type: createdType,
+                    name: String(created?.label ?? `New ${formatEntityLabel(createdType)}`),
+                  });
+
+                  if (query?.trim()) {
+                    void searchEntities(query);
+                  }
+
+                  closeQuickCreate();
+                  return;
+                }
+
                 if (activeEntity) {
                   if (activeRelationTab !== 'more') {
                     void loadRelationshipTab(activeRelationTab, activeEntity);
                   }
                   void loadRelationalChunks(activeEntity);
                 }
+
                 closeQuickCreate();
               }}
             />

--- a/frontend/src/components/FormSubmission/QuickCreateModal.tsx
+++ b/frontend/src/components/FormSubmission/QuickCreateModal.tsx
@@ -454,6 +454,11 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
       });
 
       const response = await entityOptionsService.quickCreate(entityType, payload);
+
+      if (!response || response.success !== true || !response.value) {
+        throw new Error('Failed to create record');
+      }
+
       onCreated({ value: response.value, label: response.label });
       onClose();
     } catch (err: any) {


### PR DESCRIPTION
Fixes Cockpit SmartSearch + New Supplier flow where Save would close the form but users couldn’t confirm the record was created.\n\nChanges:\n- QuickCreateModal validates quick-create response (requires success + value) before closing\n- SmartSearch uses onCreated payload to navigate to the newly created record (top-level create) and refreshes results\n\nVerification:\n- frontend: npm run lint