### PR TITLE
Fix tenant list create 500

### DIFF
--- a/backend/tenant_apps/workflows/serializers.py
+++ b/backend/tenant_apps/workflows/serializers.py
@@ -19,9 +19,9 @@ from .models import (
 
 class TenantListSerializer(serializers.ModelSerializer):
     """Serializer for TenantList model."""
-    
+
     option_count = serializers.SerializerMethodField()
-    
+
     class Meta:
         model = TenantList
         fields = [
@@ -29,9 +29,60 @@ class TenantListSerializer(serializers.ModelSerializer):
             'is_active', 'created_at', 'updated_at'
         ]
         read_only_fields = ['id', 'created_at', 'updated_at']
-    
+
     def get_option_count(self, obj):
         return len(obj.options) if obj.options else 0
+
+    def validate_name(self, value):
+        """Enforce per-tenant list name uniqueness and avoid IntegrityError 500s."""
+        request = self.context.get('request')
+        tenant = getattr(request, 'tenant', None) if request else None
+
+        if not tenant:
+            raise serializers.ValidationError('Tenant context is required to create option lists.')
+
+        normalized = str(value or '').strip()
+        if not normalized:
+            raise serializers.ValidationError('Name is required.')
+
+        qs = TenantList.objects.filter(tenant=tenant, name=normalized)
+        if self.instance is not None:
+            qs = qs.exclude(pk=self.instance.pk)
+
+        if qs.exists():
+            raise serializers.ValidationError('A custom list with this name already exists for this tenant.')
+
+        return normalized
+
+    def validate_options(self, value):
+        """Validate and normalize option rows."""
+        if value is None:
+            return []
+
+        if not isinstance(value, list):
+            raise serializers.ValidationError('Options must be a list of {value,label} objects.')
+
+        normalized = []
+        seen = set()
+
+        for opt in value:
+            if not isinstance(opt, dict):
+                raise serializers.ValidationError('Each option must be an object with value and label.')
+
+            v = str(opt.get('value', '')).strip()
+            l = str(opt.get('label', '')).strip()
+
+            if not v or not l:
+                raise serializers.ValidationError('Each option must include a non-empty value and label.')
+
+            key = v.lower()
+            if key in seen:
+                raise serializers.ValidationError(f'Duplicate option value: "{v}"')
+            seen.add(key)
+
+            normalized.append({'value': v, 'label': l})
+
+        return normalized
 
 
 # =============================================================================

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -9,11 +9,12 @@ import logging
 from datetime import timedelta
 
 from django.contrib.auth.models import User
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import Avg, Count, F, Max, Prefetch, Q
 from django.utils import timezone
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -853,12 +854,20 @@ class TenantFilteredModelViewSet(viewsets.ModelViewSet):
         return qs.none()
 
     def perform_create(self, serializer):
-        """Set tenant and created_by on create."""
-        save_kwargs = {}
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            save_kwargs["tenant"] = self.request.tenant
-        if hasattr(serializer.Meta.model, "created_by"):
+        """Set tenant and created_by on create.
+
+        Important: tenant context is mandatory for all tenant-scoped models.
+        Without this, the DB unique constraints / RLS can surface as 500s.
+        """
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            raise ValidationError({"tenant": "Tenant context is required (X-Tenant-ID header)."})
+
+        save_kwargs = {"tenant": tenant}
+
+        if hasattr(serializer.Meta.model, "created_by") and getattr(self.request, "user", None):
             save_kwargs["created_by"] = self.request.user
+
         serializer.save(**save_kwargs)
 
 
@@ -877,6 +886,16 @@ class TenantListViewSet(TenantFilteredModelViewSet):
     queryset = TenantList.objects.all()
     serializer_class = TenantListSerializer
     permission_classes = [IsTenantAdminOrOwnerOrReadOnly]
+
+    def create(self, request, *args, **kwargs):
+        """Create list with a friendly error instead of 500 on IntegrityError."""
+        try:
+            return super().create(request, *args, **kwargs)
+        except IntegrityError:
+            return Response(
+                {"error": "A custom list with this name already exists for this tenant."},
+                status=status.HTTP_409_CONFLICT,
+            )
 
     def get_queryset(self):
         qs = super().get_queryset()


### PR DESCRIPTION
Fixes admin workspace Option Lists create failing with 500.\n\n- Require tenant context for tenant-scoped create (returns 400 instead of 500)\n- Validate TenantList name/options and return 409 on duplicates\n\nUser-facing impact: Create Custom Tenant List no longer 500s; duplicate names show a friendly error.