### PR TITLE
Frontend: type-check hardening

### DIFF
--- a/frontend/src/components/FlowEditor/Modals/EntityFormStepModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/EntityFormStepModal.tsx
@@ -383,8 +383,8 @@ export const EntityFormStepModal: React.FC<EntityFormStepModalProps> = ({
   useEffect(() => {
     if (isOpen && initialData) {
       // Determine the correct step based on configuration state
-      let startStep = 1;
-      
+      let startStep: WizardStep = 1;
+
       if (initialData.mode === 'existing' && initialData.formId) {
         // Editing an existing form - skip to preview (step 3)
         startStep = 3;
@@ -393,7 +393,7 @@ export const EntityFormStepModal: React.FC<EntityFormStepModalProps> = ({
         startStep = 2;
       }
       // Otherwise, start at step 1 for new/unconfigured forms
-      
+
       setState(prev => ({
         ...prev,
         mode: initialData.mode,
@@ -440,18 +440,19 @@ export const EntityFormStepModal: React.FC<EntityFormStepModalProps> = ({
       setState(prev => ({ ...prev, loading: true, error: null }));
       try {
         const form = await workformsApi.getTenantForm(state.selectedFormId);
-        
-        // Safely extract fields from flow_data (backend uses flow_data, not form_definition)
-        const fields = form.flow_data?.fields 
-          ? form.flow_data.fields.map((field, index) => ({
-              ...field,
-              fieldId: `field-${index}`,
-            }))
-          : [];
-        
+
+        // Backward/forward compatibility: some endpoints return `form_definition`, others return `flow_data`.
+        const definition = (form as any).form_definition ?? (form as any).flow_data;
+        const rawFields: unknown[] = Array.isArray(definition?.fields) ? definition.fields : [];
+
+        const fields: FieldConfig[] = rawFields.map((field: unknown, index: number) => ({
+          ...(field as Record<string, unknown>),
+          fieldId: `field-${index}`,
+        })) as unknown as FieldConfig[];
+
         setState(prev => ({
           ...prev,
-          entityType: form.entity_type || '',
+          entityType: (form as any).entity_type || '',
           fields,
           currentStep: 3,
           loading: false,

--- a/frontend/src/components/FlowEditor/Modals/EntityMapperModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/EntityMapperModal.tsx
@@ -21,6 +21,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Modal, Select, Table, Button, Space, Typography, Alert, message, Tag } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
 import { PlusOutlined, DeleteOutlined, CheckCircleOutlined } from '@ant-design/icons';
 import { businessApi } from '@/services/businessApi';
 import styled from 'styled-components';
@@ -62,7 +63,9 @@ const StyledModal = styled(Modal)`
   }
 `;
 
-const MappingTable = styled(Table)`
+type MappingRow = FieldMapping & { key: number };
+
+const MappingTable = styled(Table<MappingRow>)`
   .mapping-row {
     &:hover {
       background-color: rgba(var(--color-primary), 0.05);
@@ -217,13 +220,13 @@ export const EntityMapperModal: React.FC<EntityMapperModalProps> = ({
     return field ? field.label : fieldId;
   };
 
-  const columns = [
+  const columns: ColumnsType<MappingRow> = [
     {
       title: 'Form Field',
       dataIndex: 'formFieldId',
       key: 'formFieldId',
       width: '40%',
-      render: (value: string, record: FieldMapping, index: number) => (
+      render: (value: string, _record: MappingRow, index: number) => (
         <Select
           style={{ width: '100%' }}
           placeholder="Select form field"
@@ -250,7 +253,7 @@ export const EntityMapperModal: React.FC<EntityMapperModalProps> = ({
       dataIndex: 'entityAttribute',
       key: 'entityAttribute',
       width: '40%',
-      render: (value: string, record: FieldMapping, index: number) => (
+      render: (value: string, _record: MappingRow, index: number) => (
         <Select
           style={{ width: '100%' }}
           placeholder="Select entity attribute"
@@ -273,7 +276,7 @@ export const EntityMapperModal: React.FC<EntityMapperModalProps> = ({
       key: 'actions',
       width: '15%',
       align: 'center' as const,
-      render: (_: any, record: FieldMapping, index: number) => (
+      render: (_: unknown, _record: MappingRow, index: number) => (
         <Button
           type="text"
           danger
@@ -370,7 +373,7 @@ export const EntityMapperModal: React.FC<EntityMapperModalProps> = ({
 
         <MappingTable
           columns={columns}
-          dataSource={mappings.map((mapping, index) => ({ ...mapping, key: index }))}
+          dataSource={mappings.map((mapping, index): MappingRow => ({ ...mapping, key: index }))}
           pagination={false}
           loading={loading}
           locale={{

--- a/frontend/src/components/FlowEditor/Modals/FlowPreviewModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FlowPreviewModal.tsx
@@ -385,7 +385,7 @@ export const FlowPreviewModal: React.FC<FlowPreviewModalProps> = React.memo(({
 
     addLog({
       nodeId: node.id,
-      nodeName: node.data?.label || node.type || 'Unknown',
+      nodeName: String((node.data as any)?.label ?? node.type ?? 'Unknown'),
       action: 'Executing node...',
       level: 'info',
     });
@@ -398,9 +398,9 @@ export const FlowPreviewModal: React.FC<FlowPreviewModalProps> = React.memo(({
     
     if (node.type?.includes('form')) {
       // Generate mock form data
-      const fields = node.data?.fields as FormField[] || [];
-      fields.forEach(field => {
-        mockData[field.name] = `Mock ${field.type} value`;
+      const fields = ((node.data as any)?.fields as FormField[] | undefined) || [];
+      fields.forEach((field) => {
+        mockData[field.id] = `Mock ${field.type} value`;
       });
     }
 
@@ -417,7 +417,7 @@ export const FlowPreviewModal: React.FC<FlowPreviewModalProps> = React.memo(({
 
     addLog({
       nodeId: node.id,
-      nodeName: node.data?.label || node.type || 'Unknown',
+      nodeName: String((node.data as any)?.label ?? node.type ?? 'Unknown'),
       action: 'Node completed successfully',
       data: mockData,
       level: 'success',
@@ -539,7 +539,7 @@ export const FlowPreviewModal: React.FC<FlowPreviewModalProps> = React.memo(({
                 return (
                   <PreviewNode key={node.id} status={state.status}>
                     <NodeHeader>
-                      <NodeName>{node.data?.label || node.type}</NodeName>
+                      <NodeName>{String((node.data as any)?.label ?? node.type ?? '')}</NodeName>
                       <StatusBadge status={state.status}>{state.status}</StatusBadge>
                     </NodeHeader>
                     {state.data && (

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -64,6 +64,7 @@ import {
   OnSelectionChangeParams,
   useReactFlow,
   MarkerType,
+  ConnectionLineType,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import './UnifiedFlowEditor.responsive.css'; // Gap Analysis Phase 1.2
@@ -131,6 +132,7 @@ import { useFormBuilder } from './hooks/useFormBuilder';
 import { ValidationDrawer } from './components/ValidationDrawer';
 import { validateWorkflow, type ValidationResult } from './utils/validationEngine';
 import { NODE_TYPE_REGISTRY, NodeCategory, CATEGORY_LABELS, CATEGORY_ORDER, getNodeTypeDefinition } from './nodeTypes';
+import type { FormStepData } from './Modals/EntityFormStepModal';
 import { schemaRegistry } from './config/schemaRegistry';
 import { calculateContainerLayout, autoConnectSequentialSteps, LAYOUT_CONSTANTS } from './utils/containerLayout'; // Phase 3-4
 import { NodeContextMenu, useContextMenu } from './NodeContextMenu'; // Phase E.3
@@ -139,7 +141,12 @@ import { saveWorkflow, loadWorkflow, listWorkflows, deleteWorkflow, type Workflo
 import { workformsApi } from '../../services/workformsApi'; // Task 2: Ghost Node Deletion
 import { sortNodesTopologically } from './utils/nodeSorting'; // Phase 2 Critical Fix
 import { normalizeNodeData, normalizeNodes } from './utils/nodeNormalization'; // Fix test imports
-import { NodeConfigPanelWithShadow, TabbedConfigPanelWithShadow } from './ConfigPanel';
+import {
+  NodeConfigPanelWithShadow,
+  TabbedConfigPanelWithShadow,
+  FormStepConfigPanel,
+  FormFieldConfigPanel,
+} from './ConfigPanel';
 import { getLayoutedElements, alignNodesHorizontally, alignNodesVertically, distributeNodesHorizontally, distributeNodesVertically } from './utils/autoLayout'; // Phase 2: UI/UX
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'; // Phase 2: UI/UX
 import { useCollaboration } from './hooks/useCollaboration'; // Phase 9.2
@@ -154,8 +161,6 @@ import { FlowEditorProvider, useFlowEditor } from './context';
 // Error Boundary (2026-02-21 Comprehensive Enhancements)
 import { ErrorBoundary } from './ErrorBoundary';
 // NUCLEAR CLEANUP: All hardcoded panels removed - DynamicConfigPanel is now the ONLY renderer
-import { FormStepConfigPanel } from './ConfigPanel/FormStepConfigPanel'; // Phase 7: Re-enabled for Smart Auto-Map
-// import { FormFieldConfigPanel } from './ConfigPanel/FormFieldConfigPanel';
 // import { SectionConfigPanel } from './ConfigPanel/SectionConfigPanel';
 // import { DocumentConfigPanel } from './ConfigPanel/DocumentConfigPanel';
 // import { CreateRecordConfigPanel } from './ConfigPanel/CreateRecordConfigPanel';
@@ -1730,9 +1735,11 @@ const ToggleSwitch = styled.button<{ $active: boolean }>`
 // ============================================================================
 
 // Static node types (not containers that need node access)
-// NOTE: NodeTypes typing is overly strict with mixed memo/FC node components;
-// we cast here to keep editor typing stable while runtime behavior remains unchanged.
-const staticNodeTypes = {
+// NOTE: React.memo() node components type as NamedExoticComponent which is not assignable to
+// React.ComponentType under strict NodeTypes. Keep a loose registry and cast at the ReactFlow boundary.
+type AnyNodeComponent = React.ComponentType<any>;
+
+const staticNodeTypes: Record<string, AnyNodeComponent> = {
   // Form nodes (Phase E - 2026-02-19)
   form: FormStepNode, // Form Step (Page)
   formStepSingle: FormStepSingleNode, // Backward compatibility
@@ -1757,11 +1764,11 @@ const staticNodeTypes = {
   document: DocumentNode,
   utility: UtilityNode,
   terminal: TerminalNode,
-} as unknown as NodeTypes;
+};
 
 // Dynamically build the full registry map statically ONCE outside the component.
 // This avoids TDZ / initialization crashes seen when building nodeTypes inside hooks.
-const dynamicNodeTypes: NodeTypes = { ...staticNodeTypes };
+const dynamicNodeTypes: Record<string, AnyNodeComponent> = { ...staticNodeTypes };
 Object.keys(NODE_TYPE_REGISTRY).forEach((typeId) => {
   if (dynamicNodeTypes[typeId]) return;
 
@@ -1876,15 +1883,18 @@ class ConfigPanelErrorBoundary extends React.Component<
   { children: React.ReactNode },
   { hasError: boolean; error: Error | null }
 > {
-  state = { hasError: false, error: null };
-  
-  static getDerivedStateFromError(error: Error) {
+  state: { hasError: boolean; error: Error | null } = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): { hasError: boolean; error: Error } {
     return { hasError: true, error };
   }
-  
+
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    logger.error('[Config Panel] Error caught:', error, errorInfo);
-    
+    logger.error('[Config Panel] Error caught', {
+      component: 'ConfigPanelErrorBoundary',
+      metadata: { componentStack: errorInfo.componentStack },
+    }, error);
+
     // Send to Sentry for monitoring
     Sentry.captureException(error, {
       extra: {
@@ -1894,8 +1904,8 @@ class ConfigPanelErrorBoundary extends React.Component<
       },
     });
   }
-  
-  render() {
+
+  render() { 
     if (this.state.hasError) {
       return (
         <div style={{
@@ -1955,8 +1965,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Normalize nodes to ensure all have required properties (maxInputs, maxOutputs)
   const normalizedInitialNodes = useMemo(() => normalizeNodes(initialNodes), [initialNodes]);
   
-  const [nodes, setNodes, onNodesChangeBase] = useNodesState(normalizedInitialNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const [nodes, setNodes, onNodesChangeBase] = useNodesState<Node<any>>(
+    normalizedInitialNodes as unknown as Node<any>[]
+  );
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge<any>>(initialEdges as unknown as Edge<any>[]);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   const generateNodeId = useCallback(() => {
@@ -2275,9 +2287,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       const containerIds = new Set(containerNodes.map(c => c.id));
       
       // Check for orphaned nodes (containerNodeId pointing to non-existent container)
-      const orphanedNodes = normalizedInitialNodes.filter(
-        n => n.data?.containerNodeId && !containerIds.has(n.data.containerNodeId)
-      );
+      const orphanedNodes = normalizedInitialNodes.filter((n) => {
+        const containerNodeId = (n.data as any)?.containerNodeId;
+        return typeof containerNodeId === 'string' && !containerIds.has(containerNodeId);
+      });
       
       if (orphanedNodes.length > 0) {
         logger.warn(
@@ -2286,15 +2299,18 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         );
         
         // Clean up orphaned nodes by removing their containerNodeId
-        setNodes((nds) => nds.map(n => {
-          if (n.data?.containerNodeId && !containerIds.has(n.data.containerNodeId)) {
-            const cleanedData = { ...n.data };
-            delete cleanedData.containerNodeId;
-            logger.debug(`[Container Restore] Cleaned orphaned node ${n.id}`);
-            return { ...n, data: cleanedData };
-          }
-          return n;
-        }));
+        setNodes((nds) =>
+          nds.map((n) => {
+            const containerNodeId = (n.data as any)?.containerNodeId;
+            if (typeof containerNodeId === 'string' && !containerIds.has(containerNodeId)) {
+              const cleanedData = { ...(n.data as any) };
+              delete cleanedData.containerNodeId;
+              logger.debug(`[Container Restore] Cleaned orphaned node ${n.id}`);
+              return { ...n, data: cleanedData };
+            }
+            return n;
+          })
+        );
       }
       
       if (containerNodes.length > 0) {
@@ -2315,11 +2331,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             nodeTypeBreakdown[nodeType] = (nodeTypeBreakdown[nodeType] || 0) + 1;
             
             // Collect form references
-            if (node.data?.formId) {
-              formReferences.push(node.data.formId);
+            const formId = (node.data as any)?.formId;
+            if (typeof formId === 'string') {
+              formReferences.push(formId);
             }
-            if (node.data?.tenantFormId) {
-              formReferences.push(node.data.tenantFormId);
+            const tenantFormId = (node.data as any)?.tenantFormId;
+            if (typeof tenantFormId === 'string') {
+              formReferences.push(tenantFormId);
             }
           });
           
@@ -2363,7 +2381,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       const uniqueTypes = [...new Set(foundDeprecated.map(n => n.type))];
       setHasDeprecatedNodes(true);
       setDeprecatedNodeTypes(uniqueTypes as string[]);
-      logger.debug('[Phase 6] Deprecated nodes detected:', uniqueTypes, foundDeprecated.length);
+      logger.debug('[Phase 6] Deprecated nodes detected', {
+        types: uniqueTypes,
+        count: foundDeprecated.length,
+      });
     } else {
       setHasDeprecatedNodes(false);
       setDeprecatedNodeTypes([]);
@@ -2842,12 +2863,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // NOTE: selectedNode and selectedNodeId moved to top of component to fix TDZ
   
   // FormStep specialized configuration (Phase 4.2.B Integration) - For nested field editing
-  const [selectedFormStep, setSelectedFormStep] = useState<Node | null>(null);
+  const [selectedFormStep, setSelectedFormStep] = useState<Node<any> | null>(null);
+  const [formStepModalOpen, setFormStepModalOpen] = useState(false);
   const [editingField, setEditingField] = useState<any | null>(null);
   
   // Container configuration (Phase 4.3) - FormProcess special handling
   const [containerModalOpen, setContainerModalOpen] = useState(false);
-  const [selectedContainer, setSelectedContainer] = useState<Node | null>(null);
+  const [selectedContainer, setSelectedContainer] = useState<Node<any> | null>(null);
   
   // Preview panel (Phase 5.1)
   const [isPreviewVisible, setIsPreviewVisible] = useState(false);
@@ -3112,7 +3134,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         id: newNodeId,
         type: nodeType,
         position: { x: 250 + wizardState.addedNodeCount * 200, y: 100 },
-        data: { label: NODE_TYPE_REGISTRY[nodeType]?.label || 'New Node' },
+        data: { label: NODE_TYPE_REGISTRY[nodeType]?.name || 'New Node' },
       };
 
       setNodes((nds) => [...nds, newNode]);
@@ -3333,12 +3355,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   }, []);
   
   // Helper function to safely get max connections from node data or type definition
-  const getNodeMaxConnections = useCallback((node: Node): { maxInputs: number; maxOutputs: number } => {
+  const getNodeMaxConnections = useCallback((node: Node<any>): { maxInputs: number; maxOutputs: number } => {
     // First try to get from node data
-    if (node.data && typeof node.data.maxInputs !== 'undefined' && typeof node.data.maxOutputs !== 'undefined') {
+    const data = node.data as any;
+    if (data && typeof data.maxInputs === 'number' && typeof data.maxOutputs === 'number') {
       return {
-        maxInputs: node.data.maxInputs,
-        maxOutputs: node.data.maxOutputs,
+        maxInputs: data.maxInputs,
+        maxOutputs: data.maxOutputs,
       };
     }
     
@@ -3361,7 +3384,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   }, []);
   
   // Real-time connection validation for React Flow
-  const isValidConnection = useCallback((connection: Connection) => {
+  const isValidConnection = useCallback((connection: Connection | Edge) => {
     const sourceNode = nodes.find(n => n.id === connection.source);
     const targetNode = nodes.find(n => n.id === connection.target);
     
@@ -3485,9 +3508,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
     // Ghost cleanup
     for (const node of deletedNodes) {
-      if (node.type === 'formMultiStepContainer' && node.data.tenantFormId) {
+      const tenantFormId = node.data?.tenantFormId;
+      if (node.type === 'formMultiStepContainer' && typeof tenantFormId === 'string' && tenantFormId.length > 0) {
         try {
-          const result = await workformsApi.decrementFormUsage(node.data.tenantFormId);
+          const result = await workformsApi.decrementFormUsage(tenantFormId);
           logger.debug(`[Ghost Cleanup] ✅ Decremented usage for container: ${result.usage_count} remaining`);
 
           if (result.can_delete) {
@@ -4512,8 +4536,18 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         setNodes(sortedNodes);
         
         // Update container dimensions if needed
-        if (layoutResult.containerWidth > (container.style?.width || 400) || 
-            layoutResult.containerHeight > (container.style?.height || 300)) {
+        const currentWidth = typeof container.style?.width === 'number'
+          ? container.style.width
+          : typeof container.style?.width === 'string'
+            ? Number(container.style.width) || 400
+            : 400;
+        const currentHeight = typeof container.style?.height === 'number'
+          ? container.style.height
+          : typeof container.style?.height === 'string'
+            ? Number(container.style.height) || 300
+            : 300;
+
+        if (layoutResult.containerWidth > currentWidth || layoutResult.containerHeight > currentHeight) {
           setNodes((nds) =>
             nds.map((n) => {
               if (n.id === container.id) {
@@ -4521,8 +4555,22 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
                   ...n,
                   style: {
                     ...n.style,
-                    width: Math.max(layoutResult.containerWidth, n.style?.width || 400),
-                    height: Math.max(layoutResult.containerHeight, n.style?.height || 300),
+                    width: Math.max(
+                      layoutResult.containerWidth,
+                      typeof n.style?.width === 'number'
+                        ? n.style.width
+                        : typeof n.style?.width === 'string'
+                          ? Number(n.style.width) || 400
+                          : 400
+                    ),
+                    height: Math.max(
+                      layoutResult.containerHeight,
+                      typeof n.style?.height === 'number'
+                        ? n.style.height
+                        : typeof n.style?.height === 'string'
+                          ? Number(n.style.height) || 300
+                          : 300
+                    ),
                   },
                 };
               }
@@ -5184,7 +5232,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       }
     };
 
-    const createId = () => (globalThis.crypto?.randomUUID ? crypto.randomUUID() : uuidv4());
+    const createId = () => {
+      const cryptoObj = globalThis.crypto;
+      if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+        return cryptoObj.randomUUID();
+      }
+      return uuidv4();
+    };
     const idMap = new Map<string, string>();
 
     for (const n of clipboardData) {
@@ -5821,7 +5875,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     const selectedNodes = params.nodes || [];
     if (selectedNodes.length === 1) {
       const node = selectedNodes[0];
-      logger.debug('[Selection] Node selected (border highlight only):', node.type, node.id);
+      logger.debug('[Selection] Node selected (border highlight only)', { nodeType: node.type, nodeId: node.id });
       
       // Track selected node ID for keyboard shortcuts and debugging
       setSelectedNodeId(node.id);
@@ -5854,7 +5908,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     const node = nodes.find(n => n.id === nodeId);
     if (!node) return;
     
-    logger.debug('✏️ [EDIT BUTTON] Opening config panel for:', node.type, nodeId);
+    logger.debug('✏️ [EDIT BUTTON] Opening config panel for', { nodeType: node.type, nodeId });
     
     // Close container modal (only legacy modal remaining)
     setContainerModalOpen(false);
@@ -5977,7 +6031,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
     const nodeToDelete = nodes.find((n) => n.id === nodeId);
     if (!nodeToDelete) {
-      toast.warning('Node not found');
+      toast.error('Node not found');
       return;
     }
 
@@ -6000,7 +6054,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       if (nodeToDelete.type === 'formProcess' || nodeToDelete.type === 'formMultiStepContainer') {
         const tenantFormId = nodeToDelete.data?.tenantFormId;
 
-        if (tenantFormId) {
+        if (typeof tenantFormId === 'string' && tenantFormId.length > 0) {
           try {
             await adminClient.post(`/api/system/forms/${tenantFormId}/decrement-usage/`);
           } catch (error) {
@@ -6032,7 +6086,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   
   // Batch 4: Handler to update node title
   const handleNodeTitleChange = useCallback((nodeId: string, newTitle: string) => {
-    logger.debug('[UnifiedFlowEditor] Updating node title:', nodeId, newTitle);
+    logger.debug('[UnifiedFlowEditor] Updating node title', { nodeId, newTitle });
     
     setNodes(nds => 
       nds.map(node => {
@@ -6204,13 +6258,17 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Convert node data to EntityFormStepModal format (Phase 3 - WF-ENH-2026-Q1)
   const convertNodeDataToFormStepData = useCallback((node: Node): FormStepData | undefined => {
     if (!node.data) return undefined;
-    
+
+    const data = node.data as any;
+
+    const formId: string | undefined = typeof data.formId === 'string' ? data.formId : undefined;
+
     return {
-      formId: node.data.formId,
-      formName: node.data.formName || node.data.stepTitle || node.data.label || 'Untitled Form',
-      entityType: node.data.entityType || 'supplier',
-      fields: node.data.fields || [],
-      mode: node.data.formId ? 'existing' : 'new',
+      formId,
+      formName: String(data.formName || data.stepTitle || data.label || 'Untitled Form'),
+      entityType: String(data.entityType || 'supplier'),
+      fields: Array.isArray(data.fields) ? data.fields : [],
+      mode: formId ? 'existing' : 'new',
     };
   }, []);
   
@@ -6241,19 +6299,23 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   }, [selectedFormStep, handleNodeUpdate]);
   
   // Convert node data to ContainerData format (Phase 4.3)
-  const convertNodeDataToContainerData = useCallback((node: Node): ContainerData | undefined => {
+  const convertNodeDataToContainerData = useCallback((node: Node<any>): ContainerData | undefined => {
     if (!node.data) return undefined;
-    
+
+    const data = node.data as any;
+    const workflowId: string | undefined = typeof data.tenantWorkFormId === 'string' ? data.tenantWorkFormId : undefined;
+
     return {
-      workflowId: node.data.tenantWorkFormId,
-      containerName: node.data.containerName || node.data.label || 'Unnamed Container',
-      containerDescription: node.data.containerDescription,
-      mode: node.data.tenantWorkFormId ? 'existing' : 'new',
-      showProgressIndicator: node.data.showProgressIndicator ?? true,
-      allowBackNavigation: node.data.allowBackNavigation ?? true,
-      allowSkipSteps: node.data.allowSkipSteps ?? false,
-      autoAdvance: node.data.autoAdvance ?? false,
-      confirmOnExit: node.data.confirmOnExit ?? true,
+      workflowId,
+      containerName: String(data.containerName || data.label || 'Unnamed Container'),
+      containerDescription:
+        typeof data.containerDescription === 'string' ? data.containerDescription : undefined,
+      mode: workflowId ? 'existing' : 'new',
+      showProgressIndicator: typeof data.showProgressIndicator === 'boolean' ? data.showProgressIndicator : true,
+      allowBackNavigation: typeof data.allowBackNavigation === 'boolean' ? data.allowBackNavigation : true,
+      allowSkipSteps: typeof data.allowSkipSteps === 'boolean' ? data.allowSkipSteps : false,
+      autoAdvance: typeof data.autoAdvance === 'boolean' ? data.autoAdvance : false,
+      confirmOnExit: typeof data.confirmOnExit === 'boolean' ? data.confirmOnExit : true,
     };
   }, []);
   
@@ -6319,7 +6381,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     );
 
     upstreamFormNodes.forEach((node) => {
-      const fields = node.data?.fields || [];
+      const fields = Array.isArray((node.data as any)?.fields) ? (node.data as any).fields : [];
       fields.forEach((field: any) => {
         allFields.push({
           ...field,
@@ -6392,13 +6454,15 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     // Map template nodes to proper React Flow node types with full metadata
     const mappedNodes = template.nodes.map(node => {
       // Get node definition from registry for metadata (color, icon, etc.)
-      const nodeDef = getNodeTypeDefinition(node.type);
-      
+      const rawType = node.type ?? '';
+
+      const nodeDef = getNodeTypeDefinition(rawType);
+
       // Ensure node has proper type mapping
-      const reactFlowType = getReactFlowNodeType(node.type);
-      
+      const reactFlowType = getReactFlowNodeType(rawType);
+
       // Merge default data + template data + registry metadata
-      const defaultData = getDefaultNodeData(node.type);
+      const defaultData = getDefaultNodeData(rawType);
       
       return {
         ...node,
@@ -7298,7 +7362,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           <Settings />
         </ViewportButton>
         <div style={{ width: '1px', height: '20px', background: 'rgb(var(--color-border))' }} />
-        <ViewportButton onClick={fitView} title="Fit to View (F)">
+        <ViewportButton onClick={() => fitView({ padding: 0.2, duration: 300 })} title="Fit to View (F)">
           <Maximize2 />
         </ViewportButton>
         <ViewportButton onClick={zoomIn} title="Zoom In">
@@ -7360,7 +7424,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         onConnect={onConnect}
         onNodesDelete={onNodesDelete}
         nodesDraggable={true}
-        nodeDragHandle=".custom-drag-handle"
         nodesConnectable={false}
         isValidConnection={isValidConnection}
         onDrop={onDrop}
@@ -7375,15 +7438,15 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           if (!reactFlowInstance?.screenToFlowPosition) return;
 
           const pos = reactFlowInstance.screenToFlowPosition({
-            x: (event as MouseEvent).clientX,
-            y: (event as MouseEvent).clientY,
+            x: event.clientX,
+            y: event.clientY,
           });
 
           collabSendCursorDebounced(pos);
         }}
         onSelectionChange={handleSelectionChange}
-        nodeTypes={dynamicNodeTypes}
-        edgeTypes={staticEdgeTypes}
+        nodeTypes={dynamicNodeTypes as unknown as NodeTypes}
+        edgeTypes={staticEdgeTypes as unknown as EdgeTypes}
         // Phase 7.5/9: Always render only visible elements for large-editor performance
         onlyRenderVisibleElements={true}
         elevateNodesOnSelect={nodes.length < 200}
@@ -7409,7 +7472,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           strokeDasharray: '5,5',
           animation: 'dash 0.5s linear infinite',
         }}
-        connectionLineType="step"
+        connectionLineType={ConnectionLineType.SmoothStep}
         snapToGrid={snapToGrid}
         snapGrid={[gridSize, gridSize]}
         connectionRadius={20}
@@ -7474,8 +7537,9 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         {isMinimapVisible && (
           <MiniMap 
             nodeColor={(node) => {
-              const registry = NODE_TYPE_REGISTRY[node.type];
-              return registry?.color || '#94a3b8';
+              const type = node.type;
+              const registry = type ? NODE_TYPE_REGISTRY[type] : undefined;
+              return registry?.color || 'rgb(var(--color-text-tertiary))';
             }}
             maskColor="rgba(0, 0, 0, 0.1)"
             style={{
@@ -7774,7 +7838,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
                           {nodeConfig.icon}
                         </NodeIconCircle>
                         <WizardNodeInfo>
-                          <WizardNodeLabel>{nodeConfig.label}</WizardNodeLabel>
+                          <WizardNodeLabel>{nodeConfig.name}</WizardNodeLabel>
                           <WizardNodeDesc>{nodeConfig.description?.slice(0, 40)}...</WizardNodeDesc>
                         </WizardNodeInfo>
                         <Plus size={16} />
@@ -8197,7 +8261,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
 
       {/* Help Modal (Workform Batch 2) */}
       {isHelpModalOpen && (
-        <HelpModal onClose={() => setIsHelpModalOpen(false)} />
+        <HelpModal isOpen={isHelpModalOpen} onClose={() => setIsHelpModalOpen(false)} />
       )}
 
       {/* FormBuilder Modal (Phase 6) */}

--- a/frontend/src/components/FlowEditor/WorkflowSharing.tsx
+++ b/frontend/src/components/FlowEditor/WorkflowSharing.tsx
@@ -31,7 +31,7 @@ import {
   CheckCircle,
   XCircle
 } from 'lucide-react';
-import { businessApi } from '../../../services/businessApi';
+import { businessApi } from '@/services/businessApi';
 
 const { Title, Text, Paragraph } = Typography;
 const { TextArea } = Input;

--- a/frontend/src/components/FlowEditor/analytics/WorkflowAnalyticsDashboard.tsx
+++ b/frontend/src/components/FlowEditor/analytics/WorkflowAnalyticsDashboard.tsx
@@ -166,7 +166,7 @@ export const WorkflowAnalyticsDashboard: React.FC<WorkflowAnalyticsDashboardProp
     };
 
     fetchMetrics();
-  }, [tenant?.id, selectedWorkflowId, dateRange, timeframe]);
+  }, [selectedWorkflowId, dateRange, timeframe]);
 
   const renderKPIs = () => {
     if (!metrics) return null;
@@ -394,7 +394,7 @@ export const WorkflowAnalyticsDashboard: React.FC<WorkflowAnalyticsDashboardProp
                   cx="50%"
                   cy="50%"
                   labelLine={false}
-                  label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
+                  label={({ name, percent }) => `${name}: ${(((percent ?? 0) * 100)).toFixed(0)}%`}
                   outerRadius={80}
                   fill="#8884d8"
                   dataKey="value"

--- a/frontend/src/components/FlowEditor/components/AISuggestionsPanel.tsx
+++ b/frontend/src/components/FlowEditor/components/AISuggestionsPanel.tsx
@@ -288,7 +288,7 @@ export const AISuggestionsPanel: React.FC<AISuggestionsPanelProps> = ({
       
       try {
         // Call backend API for AI-powered suggestions
-        const response = await workformsApi.post('/suggest-nodes/', {
+        const { suggestions: apiSuggestions, confidence, mode: responseMode, cached } = await workformsApi.suggestNodes({
           current_flow: {
             nodes: nodes.map(n => ({ id: n.id, type: n.type, data: n.data })),
             edges: edges.map(e => ({ id: e.id, source: e.source, target: e.target })),
@@ -301,8 +301,6 @@ export const AISuggestionsPanel: React.FC<AISuggestionsPanelProps> = ({
           }
         });
         
-        const { suggestions: apiSuggestions, confidence, mode: responseMode, cached } = response.data;
-        
         // Convert API suggestions to NodeSuggestion format
         const formattedSuggestions: NodeSuggestion[] = apiSuggestions.map((s: any) => ({
           nodeType: s.type || 'basic',
@@ -314,7 +312,7 @@ export const AISuggestionsPanel: React.FC<AISuggestionsPanelProps> = ({
         }));
         
         setSuggestions(formattedSuggestions);
-        setMode(responseMode);
+        setMode(responseMode === 'ai' || responseMode === 'static' ? responseMode : 'static');
         setIsCached(cached || false);
         setError(null);
         

--- a/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
+++ b/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
@@ -386,7 +386,7 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
     <DebuggerContainer>
       <DebuggerHeader>
         <NodeInfo>
-          <NodeLabel>{selectedNode.data?.label || selectedNode.id}</NodeLabel>
+          <NodeLabel>{String((selectedNode.data as any)?.label ?? selectedNode.id)}</NodeLabel>
           <NodeType>{selectedNode.type}</NodeType>
         </NodeInfo>
         <ActionButtons>

--- a/frontend/src/components/FlowEditor/components/PerformanceOverlay.tsx
+++ b/frontend/src/components/FlowEditor/components/PerformanceOverlay.tsx
@@ -8,7 +8,7 @@
  * @see Phase 7.5: Performance Optimization
  */
 
-import React, { useState, useEffect } from 'styled';
+import React, { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { usePerformanceMetrics } from '../hooks/useVirtualizedNodes';
 

--- a/frontend/src/components/FlowEditor/components/VirtualizedNodePalette.tsx
+++ b/frontend/src/components/FlowEditor/components/VirtualizedNodePalette.tsx
@@ -21,10 +21,10 @@
  */
 
 import React, { useState, useMemo, useCallback, memo } from 'react';
-import { FixedSizeList as List } from 'react-window';
+import { List, type RowComponentProps } from 'react-window';
 import styled from 'styled-components';
 import { Search, X } from 'lucide-react';
-import { NodeType } from '../types';
+
 
 // ============================================================================
 // TypeScript Interfaces
@@ -102,21 +102,16 @@ NodeItem.displayName = 'NodeItem';
 /**
  * Virtualized list row renderer
  */
-const Row = memo<{
-  index: number;
-  style: React.CSSProperties;
-  data: ListItemData;
-}>(({ index, style, data }) => {
-  const item = data.items[index];
+const Row = (props: RowComponentProps<ListItemData>): React.ReactElement => {
+  const { index, style, items, onDragStart } = props;
+  const item = items[index];
 
   return (
     <div style={style}>
-      <NodeItem item={item} onDragStart={data.onDragStart} />
+      <NodeItem item={item} onDragStart={onDragStart} />
     </div>
   );
-});
-
-Row.displayName = 'VirtualizedRow';
+};
 
 // ============================================================================
 // Main Component
@@ -244,14 +239,12 @@ export const VirtualizedNodePalette: React.FC<VirtualizedNodePaletteProps> = ({
         </EmptyState>
       ) : (
         <List
-          height={height}
-          itemCount={displayNodes.length}
-          itemSize={itemHeight}
-          width="100%"
-          itemData={itemData}
-        >
-          {Row}
-        </List>
+          rowCount={displayNodes.length}
+          rowHeight={itemHeight}
+          rowComponent={Row}
+          rowProps={itemData}
+          style={{ height, width: '100%' }}
+        />
       )}
 
       <NodeCount>

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
@@ -33,6 +33,13 @@ export function renderTextField(
 ): React.ReactNode {
   const { field, value, onChange, error } = props;
 
+  const placeholder =
+    typeof field.placeholder === 'string'
+      ? field.placeholder
+      : (field.placeholder && typeof field.placeholder === 'object' && 'value' in field.placeholder)
+        ? String((field.placeholder as any).value)
+        : undefined;
+
   return (
     <FormField key={field.id}>
       <Label>
@@ -43,7 +50,7 @@ export function renderTextField(
         <TextArea
           value={value || ''}
           onChange={(e) => onChange(e.target.value)}
-          placeholder={field.placeholder}
+          placeholder={placeholder}
           disabled={field.disabled || props.disabled}
           rows={4}
         />
@@ -57,7 +64,7 @@ export function renderTextField(
           }
           value={value || ''}
           onChange={(e) => onChange(e.target.value)}
-          placeholder={field.placeholder}
+          placeholder={placeholder}
           disabled={field.disabled || props.disabled}
         />
       )}

--- a/frontend/src/components/FlowEditor/config/types.ts
+++ b/frontend/src/components/FlowEditor/config/types.ts
@@ -399,6 +399,9 @@ export interface NodeConfigSchema {
   
   /** Human-readable name */
   displayName: string;
+
+  /** Optional category (used by schemaRegistry fallbacks + UI grouping) */
+  category?: string;
   
   /** Description of what this node does */
   description?: string;

--- a/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
@@ -8,14 +8,14 @@
  * Created: 2026-02-17
  */
 import React from 'react';
-import { EdgeProps, getBezierPath, EdgeLabelRenderer, MarkerType } from '@xyflow/react';
+import { type Edge, EdgeProps, getBezierPath, EdgeLabelRenderer, MarkerType } from '@xyflow/react';
 import styled from 'styled-components';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-interface ConditionalEdgeData {
+interface ConditionalEdgeData extends Record<string, unknown> {
   label?: string;
   condition?: string;
   animated?: boolean;
@@ -81,7 +81,7 @@ const TrueFalseIndicator = styled.div<{ isTrue?: boolean }>`
 // Component
 // ============================================================================
 
-export const ConditionalEdge = React.memo<EdgeProps<ConditionalEdgeData>>(({
+export const ConditionalEdge = React.memo<EdgeProps<Edge<ConditionalEdgeData>>>(({
   id,
   sourceX,
   sourceY,

--- a/frontend/src/components/FlowEditor/edges/CustomEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/CustomEdge.tsx
@@ -12,14 +12,14 @@
  * Created: 2026-02-04 - Phase 2.1 Batch 2
  */
 import React from 'react';
-import { EdgeProps, getBezierPath, EdgeLabelRenderer } from '@xyflow/react';
+import { type Edge, EdgeProps, getBezierPath, EdgeLabelRenderer } from '@xyflow/react';
 import styled from 'styled-components';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-interface CustomEdgeData {
+interface CustomEdgeData extends Record<string, unknown> {
   label?: string;
   edgeType?: 'default' | 'conditional' | 'success' | 'error';
   animated?: boolean;
@@ -119,7 +119,7 @@ const getEdgeStyle = (edgeType?: string, animated?: boolean) => {
 // Component
 // ============================================================================
 
-export const CustomEdge = React.memo<EdgeProps<CustomEdgeData>>(({
+export const CustomEdge = React.memo<EdgeProps<Edge<CustomEdgeData>>>(({
   id,
   source,
   target,

--- a/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
@@ -14,6 +14,7 @@
 
 import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
 import {
+  type Edge,
   EdgeProps,
   getSmoothStepPath,
   EdgeLabelRenderer,
@@ -30,7 +31,7 @@ import { CheckCircle, AlertCircle, XCircle, Info, Pencil, Trash2, Plus, AlertTri
 
 export type ConnectionStatus = 'valid' | 'invalid' | 'warning' | 'info' | 'default';
 
-export interface EnhancedEdgeData {
+export interface EnhancedEdgeData extends Record<string, unknown> {
   /** Connection validation status */
   status?: ConnectionStatus;
   /** Label text */
@@ -311,7 +312,7 @@ function getStatusIcon(status: ConnectionStatus): React.ReactNode {
  * };
  * ```
  */
-export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = memo(
+export const EnhancedConnectionEdge: React.FC<EdgeProps<Edge<EnhancedEdgeData>>> = memo(
   ({
     id,
     source,
@@ -459,7 +460,8 @@ export const EnhancedConnectionEdge: React.FC<EdgeProps<EnhancedEdgeData>> = mem
       const sourceNode = source ? getNode(source) : undefined;
       const keys: string[] = [];
 
-      const outputFields = sourceNode?.data?.outputSchema?.outputFields;
+      const sourceData = (sourceNode?.data ?? {}) as any;
+      const outputFields = sourceData?.outputSchema?.outputFields;
       if (Array.isArray(outputFields)) {
         for (const f of outputFields) {
           const key = f?.fieldName || f?.fieldId;

--- a/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
@@ -8,14 +8,14 @@
  * Created: 2026-02-17
  */
 import React, { useCallback, useState } from 'react';
-import { EdgeProps, getBezierPath, EdgeLabelRenderer, MarkerType, EdgeToolbar, useReactFlow } from '@xyflow/react';
+import { type Edge, EdgeProps, getBezierPath, EdgeLabelRenderer, MarkerType, EdgeToolbar, useReactFlow } from '@xyflow/react';
 import styled, { keyframes } from 'styled-components';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-interface ErrorEdgeData {
+interface ErrorEdgeData extends Record<string, unknown> {
   label?: string;
   errorType?: string;
   animated?: boolean;
@@ -124,7 +124,7 @@ const ErrorBadge = styled.div`
 // Component
 // ============================================================================
 
-export const ErrorEdge = React.memo<EdgeProps<ErrorEdgeData>>(({
+export const ErrorEdge = React.memo<EdgeProps<Edge<ErrorEdgeData>>>(({
   id,
   sourceX,
   sourceY,

--- a/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
@@ -8,14 +8,14 @@
  * Created: 2026-02-17
  */
 import React from 'react';
-import { EdgeProps, getBezierPath, EdgeLabelRenderer, MarkerType } from '@xyflow/react';
+import { type Edge, EdgeProps, getBezierPath, EdgeLabelRenderer, MarkerType } from '@xyflow/react';
 import styled from 'styled-components';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-interface SuccessEdgeData {
+interface SuccessEdgeData extends Record<string, unknown> {
   label?: string;
   successMessage?: string;
   animated?: boolean;
@@ -84,7 +84,7 @@ const SuccessBadge = styled.div`
 // Component
 // ============================================================================
 
-export const SuccessEdge = React.memo<EdgeProps<SuccessEdgeData>>(({
+export const SuccessEdge = React.memo<EdgeProps<Edge<SuccessEdgeData>>>(({
   id,
   sourceX,
   sourceY,

--- a/frontend/src/components/FlowEditor/hooks/useBatchOperations.ts
+++ b/frontend/src/components/FlowEditor/hooks/useBatchOperations.ts
@@ -240,7 +240,7 @@ export function useBatchOperations(
 
     // Deselect existing nodes
     setNodes((nodes) =>
-      nodes.map((node) => ({ ...node, selected: false })).concat(pastedNodes)
+      (nodes.map((node) => ({ ...node, selected: false })) as Node[]).concat(pastedNodes)
     );
     setEdges((edges) => edges.concat(pastedEdges));
 

--- a/frontend/src/components/FlowEditor/hooks/useCollaboration.ts
+++ b/frontend/src/components/FlowEditor/hooks/useCollaboration.ts
@@ -128,14 +128,17 @@ export function useCollaboration({ workflowId, tenantId }: UseCollaborationArgs)
   }, [wsUrl, clearReconnectTimer]);
 
   const handleMessage = useCallback((raw: MessageEvent) => {
-    let msg: CollaborationMessage | null = null;
+    let parsed: unknown;
 
     try {
-      msg = JSON.parse(String(raw.data));
+      parsed = JSON.parse(String(raw.data));
     } catch {
       return;
     }
 
+    if (!parsed || typeof parsed !== 'object') return;
+
+    const msg = parsed as CollaborationMessage;
     const now = Date.now();
 
     if (msg.type === 'presence_state' && msg.data && typeof msg.data === 'object') {

--- a/frontend/src/components/FlowEditor/hooks/useContainerDragAndDrop.ts
+++ b/frontend/src/components/FlowEditor/hooks/useContainerDragAndDrop.ts
@@ -126,16 +126,16 @@ export function useContainerDragAndDrop(
 
       // Find nearest snap point
       const nodeCenterY = nodePosition.y + nodeSize.height / 2;
-      let nearestPoint: XYPosition | null = null;
+      let nearestPoint: { x: number; y: number } | null = null;
       let minDistance = Infinity;
 
-      snapPoints.forEach(point => {
+      for (const point of snapPoints) {
         const distance = Math.abs(point.y - nodeCenterY);
         if (distance < minDistance && distance < snapThreshold) {
           minDistance = distance;
           nearestPoint = point;
         }
-      });
+      }
 
       if (!nearestPoint) {
         // No snap point close enough, just center horizontally

--- a/frontend/src/components/FlowEditor/hooks/useContainerManagement.ts
+++ b/frontend/src/components/FlowEditor/hooks/useContainerManagement.ts
@@ -105,7 +105,7 @@ export function useContainerManagement(): ContainerManagementResult {
         return [];
       }
 
-      const containerData = containerNode.data as ContainerNodeData;
+      const containerData = containerNode.data as unknown as ContainerNodeData;
       const childNodeIds = containerData.childNodeIds || [];
 
       return nodes.filter((node) => childNodeIds.includes(node.id));

--- a/frontend/src/components/FlowEditor/hooks/useFieldValidation.ts
+++ b/frontend/src/components/FlowEditor/hooks/useFieldValidation.ts
@@ -189,7 +189,10 @@ async function validateValue(
   
   // Pattern
   if (rule.pattern) {
-    const pattern = typeof rule.pattern === 'object' ? rule.pattern.value : rule.pattern;
+    const pattern =
+      typeof rule.pattern === 'object' && rule.pattern !== null && 'value' in rule.pattern
+        ? rule.pattern.value
+        : rule.pattern;
     if (!pattern.test(String(value))) {
       return getErrorMessage(
         rule.pattern,

--- a/frontend/src/components/FlowEditor/hooks/useFormDataMapping.ts
+++ b/frontend/src/components/FlowEditor/hooks/useFormDataMapping.ts
@@ -61,7 +61,7 @@ export interface FormOutputField {
 /**
  * Hook return type
  */
-interface UseFormDataMappingReturn {
+export interface UseFormDataMappingReturn {
   /** Generate output fields from form node data */
   generateFormOutputs: (node: Node) => FormOutputField[];
   /** Get all mappings for a form node */
@@ -100,11 +100,11 @@ export const useFormDataMapping = (): UseFormDataMappingReturn => {
         fields.forEach((field: FormField, fieldIndex: number) => {
           outputs.push({
             id: field.id,
-            name: field.name,
+            name: field.id,
             type: field.type,
-            label: field.label || field.name,
+            label: field.label || field.id,
             handleId: `output-${stepIndex}-${fieldIndex}-${field.id}`,
-            required: field.validation?.required || false,
+            required: field.required || false,
           });
         });
       });
@@ -114,11 +114,11 @@ export const useFormDataMapping = (): UseFormDataMappingReturn => {
       fields.forEach((field: FormField, index: number) => {
         outputs.push({
           id: field.id,
-          name: field.name,
+          name: field.id,
           type: field.type,
-          label: field.label || field.name,
+          label: field.label || field.id,
           handleId: `output-${index}-${field.id}`,
-          required: field.validation?.required || false,
+          required: field.required || false,
         });
       });
     }

--- a/frontend/src/components/FlowEditor/hooks/useKeyboardNavigation.tsx
+++ b/frontend/src/components/FlowEditor/hooks/useKeyboardNavigation.tsx
@@ -84,9 +84,10 @@ export const useKeyboardNavigation = (
             ]);
             
             // Focus and scroll into view
+            const nextNodeId = nextNode.id;
             setTimeout(() => {
               const nodeElement = document.querySelector(
-                `[data-id="${nextNode.id}"]`
+                `[data-id="${nextNodeId}"]`
               ) as HTMLElement;
               if (nodeElement) {
                 nodeElement.focus();

--- a/frontend/src/components/FlowEditor/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/components/FlowEditor/hooks/useKeyboardShortcuts.ts
@@ -194,10 +194,13 @@ export const useKeyboardShortcuts = (options: KeyboardShortcutsOptions = {}) => 
         const selectedNodes = nodes.filter((n) => n.selected);
 
         if (selectedNodes.length > 0) {
-          const createId = () =>
-            globalThis.crypto?.randomUUID
-              ? crypto.randomUUID()
-              : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+          const createId = () => {
+            const cryptoObj = globalThis.crypto;
+            if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+              return cryptoObj.randomUUID();
+            }
+            return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+          };
 
           const duplicates = selectedNodes.map((node) => ({
             ...node,

--- a/frontend/src/components/FlowEditor/hooks/useOnboardingTour.tsx
+++ b/frontend/src/components/FlowEditor/hooks/useOnboardingTour.tsx
@@ -54,7 +54,7 @@ export const useOnboardingTour = (tourConfig: TourConfig) => {
     (data: EventData) => {
       const { status, index, type, action } = data;
 
-      if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+      if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
         // Mark tour as completed
         const completedTours = JSON.parse(
           localStorage.getItem(TOUR_STORAGE_KEY) || '[]'

--- a/frontend/src/components/FlowEditor/hooks/usePanelState.ts
+++ b/frontend/src/components/FlowEditor/hooks/usePanelState.ts
@@ -95,7 +95,7 @@ export interface UsePanelStateReturn {
   /**
    * Ref to attach to panel container
    */
-  panelRef: React.RefObject<HTMLDivElement>;
+  panelRef: React.RefObject<HTMLDivElement | null>;
   
   /**
    * Bring panel to front (increase z-index)
@@ -144,7 +144,7 @@ export function usePanelState(options: UsePanelStateOptions = {}): UsePanelState
   
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [zIndex, setZIndex] = useState(baseZIndex);
-  const panelRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   
   const open = useCallback(() => {
     setIsOpen(true);

--- a/frontend/src/components/FlowEditor/hooks/useScreenReaderAnnouncements.ts
+++ b/frontend/src/components/FlowEditor/hooks/useScreenReaderAnnouncements.ts
@@ -8,7 +8,7 @@
  * @see Phase 7.6: Accessibility & i18n
  */
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 
 /**
  * Priority level for announcements

--- a/frontend/src/components/FlowEditor/hooks/useUpstreamVariables.ts
+++ b/frontend/src/components/FlowEditor/hooks/useUpstreamVariables.ts
@@ -66,6 +66,8 @@ export interface UpstreamVariable {
   required?: boolean;
 }
 
+export type FieldType = UpstreamVariable['fieldType'];
+
 export interface UseUpstreamVariablesParams {
   /** Current node ID to find upstream variables for */
   currentNodeId: string;
@@ -299,7 +301,7 @@ export function useUpstreamVariables({
         if (!node) continue;
         
         // Get node name (fallback to ID if no label)
-        const nodeName = node.data?.label || node.data?.name || nodeId;
+        const nodeName = String((node.data as any)?.label ?? (node.data as any)?.name ?? nodeId);
         
         // Extract fields from this node
         const fields = extractFieldsFromFormStep(node);

--- a/frontend/src/components/FlowEditor/nodes/ActionNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ActionNode.tsx
@@ -12,7 +12,7 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { getNodeTypeDefinition } from '../nodeTypes';
 
@@ -173,7 +173,7 @@ function getActionDetails(data: ActionNodeData) {
 // Component
 // ============================================================================
 
-export const ActionNode = React.memo<NodeProps<ActionNodeData>>((props) => {
+export const ActionNode = React.memo<NodeProps<Node<ActionNodeData>>>((props) => {
   const { data, selected, id } = props;
   const { actionType = 'email' } = data; // Default to 'email' if undefined
   
@@ -195,11 +195,11 @@ export const ActionNode = React.memo<NodeProps<ActionNodeData>>((props) => {
     id: 'actionEmail',
     name: 'Send Email',
     category: 'action' as const,
-    color: 'rgb(59, 130, 246)',
-    icon: 'Mail',
+    color: '#3b82f6',
+    icon: '✉️',
+    description: 'Send an email',
     maxInputs: 1,
     maxOutputs: 1,
-    config: {},
   };
   
   const { items } = getActionDetails(data);

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -21,7 +21,7 @@ import { NodeIcon, NodeIconType } from '../components/NodeIcons';
 // TypeScript Interfaces
 // ============================================================================
 
-export interface BaseNodeData {
+export interface BaseNodeData extends Record<string, unknown> {
   label?: string;
   status?: 'draft' | 'active' | 'error' | 'disabled';
   stepNumber?: number;
@@ -55,7 +55,7 @@ export interface BaseNodeProps {
   id: string;
   data: BaseNodeData;
   selected?: boolean;
-  nodeType: NodeTypeDefinition;
+  nodeType?: NodeTypeDefinition;
   /** Optional override for the header drag handle class */
   dragHandleClassName?: string;
 }
@@ -355,14 +355,26 @@ const ExpandButton = styled(ControlButton)`
 // Component
 // ============================================================================
 
+const FALLBACK_NODE_TYPE: NodeTypeDefinition = {
+  id: 'unknown',
+  name: 'Node',
+  category: 'utility',
+  icon: '⬛',
+  color: 'rgb(var(--color-border))',
+  description: 'Unknown node type',
+  maxInputs: 1,
+  maxOutputs: 1,
+};
+
 export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> = ({
   id,
   data,
   selected = false,
-  nodeType,
+  nodeType: nodeTypeProp,
   dragHandleClassName,
   children,
 }) => {
+  const nodeType = nodeTypeProp ?? FALLBACK_NODE_TYPE;
   const {
     label = nodeType.name,
     status = 'draft',

--- a/frontend/src/components/FlowEditor/nodes/ConditionIfNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ConditionIfNode.tsx
@@ -8,7 +8,7 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps, Handle, Position } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { getNodeTypeDefinition } from '../nodeTypes';
 
@@ -144,21 +144,9 @@ const OPERATOR_LABELS: Record<string, string> = {
 // Component
 // ============================================================================
 
-export const ConditionIfNode = React.memo<NodeProps<ConditionIfNodeData>>((props) => {
+export const ConditionIfNode = React.memo<NodeProps<Node<ConditionIfNodeData>>>((props) => {
   const { data, selected, id } = props;
   const nodeTypeDef = getNodeTypeDefinition('conditionIf');
-  
-  // Safety check: provide fallback if nodeType is undefined
-  const nodeType = nodeTypeDef || {
-    id: 'conditionIf',
-    name: 'If Condition',
-    category: 'logic' as const,
-    color: 'rgb(249, 115, 22)',
-    icon: 'GitBranch',
-    maxInputs: 1,
-    maxOutputs: 2,
-    config: {},
-  };
   
   const { rules = [], logicalOperator = 'AND' } = data;
 
@@ -168,7 +156,7 @@ export const ConditionIfNode = React.memo<NodeProps<ConditionIfNodeData>>((props
         id={id}
         data={{...data, label: data.label || 'If Condition'}}
         selected={selected}
-        nodeType={nodeType}
+        nodeType={nodeTypeDef}
       >
         <div>
           {rules.length === 0 ? (

--- a/frontend/src/components/FlowEditor/nodes/ConditionalBranchNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ConditionalBranchNode.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState, useCallback } from 'react';
 import styled from 'styled-components';
-import { Handle, Position, NodeProps } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { GitBranch, Plus, Trash2 } from 'lucide-react';
 
@@ -77,7 +77,7 @@ export interface ConditionalBranchData extends BaseNodeData {
   onDelete?: () => void;
 }
 
-export interface ConditionalBranchNodeProps extends NodeProps<ConditionalBranchData> {}
+export interface ConditionalBranchNodeProps extends NodeProps<Node<ConditionalBranchData>> {}
 
 // ============================================================================
 // Styled Components

--- a/frontend/src/components/FlowEditor/nodes/ContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ContainerNode.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { memo, useState, useCallback, useMemo } from 'react';
-import { NodeProps, Handle, Position } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import styled from 'styled-components';
 import { ChevronDown, ChevronRight, Maximize2, Minimize2, Folder } from 'lucide-react';
 import { Tooltip } from 'antd';
@@ -26,7 +26,7 @@ import { Tooltip } from 'antd';
 // Types
 // ============================================================================
 
-export interface ContainerNodeData {
+export interface ContainerNodeData extends Record<string, unknown> {
   label: string;
   description?: string;
   collapsed?: boolean;
@@ -232,7 +232,7 @@ const NodeCount = styled.div`
  * };
  * ```
  */
-export const ContainerNode: React.FC<NodeProps<ContainerNodeData>> = memo(
+export const ContainerNode: React.FC<NodeProps<Node<ContainerNodeData>>> = memo(
   ({ data, selected }) => {
     const {
       label,

--- a/frontend/src/components/FlowEditor/nodes/DocumentNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/DocumentNode.tsx
@@ -16,7 +16,7 @@
  * Created: 2026-02-04 - Phase 2.1 Batch 2
  */
 import React from 'react';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import styled from 'styled-components';
 import { FileText, FilePlus, FileCheck, FolderOpen, Layers } from 'lucide-react';
 import { BaseNode, BaseNodeData } from './BaseNode';
@@ -131,7 +131,7 @@ const getDocumentTypeInfo = (documentType: DocumentType) => {
 // Component
 // ============================================================================
 
-export const DocumentNode = React.memo<NodeProps<DocumentNodeData>>(({ data, id, selected }) => {
+export const DocumentNode = React.memo<NodeProps<Node<DocumentNodeData>>>(({ data, id, selected }) => {
   const {
     documentType,
     template,
@@ -222,12 +222,12 @@ export const DocumentNode = React.memo<NodeProps<DocumentNodeData>>(({ data, id,
       nodeType={{
         id: 'document',
         name: typeInfo.label,
-        category: 'action',
+        category: 'document',
         color: typeInfo.color,
-        icon: 'FileText',
+        icon: '📄',
+        description: typeInfo.label,
         maxInputs: 1,
         maxOutputs: 1,
-        config: {},
       }}
     />
   );

--- a/frontend/src/components/FlowEditor/nodes/FormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormNode.tsx
@@ -298,7 +298,7 @@ const ToolbarButton = styled.button<{ $primary?: boolean }>`
 const isFormBookStepType = (type?: string) =>
   type === 'form' || type === 'formStepSingle' || type === 'formStep' || type === 'formReference';
 
-export const FormNode = React.memo<NodeProps<FormNodeData>>(({ id, data, selected }) => {
+export const FormNode = React.memo<NodeProps<Node<FormNodeData>>>(({ id, data, selected }) => {
   const allNodes = useNodes();
   const allEdges = useEdges();
   const { setNodes, setEdges } = useReactFlow();
@@ -516,13 +516,13 @@ export const FormNode = React.memo<NodeProps<FormNodeData>>(({ id, data, selecte
 
           return {
             ...n,
-            extent: 'parent',
+            extent: 'parent' as const,
             expandParent: true,
             data: {
               ...(n.data || {}),
               order: desiredOrder,
             },
-          };
+          } as Node;
         }
 
         return n;

--- a/frontend/src/components/FlowEditor/nodes/FormProcessAddButtonNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessAddButtonNode.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import type { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import { Plus } from 'lucide-react';
 
 export type FormProcessAddButtonData = {
@@ -48,7 +48,7 @@ const CircleButton = styled.button`
   }
 `;
 
-export const FormProcessAddButtonNode = React.memo<NodeProps<FormProcessAddButtonData>>(({ data }) => {
+export const FormProcessAddButtonNode = React.memo<NodeProps<Node<FormProcessAddButtonData>>>(({ data }) => {
   return (
     <Wrap className="nodrag nopan">
       <CircleButton

--- a/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
@@ -17,7 +17,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import { BaseNodeData } from './BaseNode';
 
 // ============================================================================
@@ -37,7 +37,9 @@ export interface FormProcessChildData extends BaseNodeData {
   parentId?: string;
 }
 
-export interface FormProcessChildWrapperProps extends NodeProps<FormProcessChildData> {
+export type ChildWrapperProps = FormProcessChildWrapperProps;
+
+export interface FormProcessChildWrapperProps extends NodeProps<Node<FormProcessChildData>> {
   /** Child content to render */
   children?: React.ReactNode;
 }
@@ -223,7 +225,7 @@ export const FormProcessChildWrapper: React.FC<FormProcessChildWrapperProps> = (
  * @param WrappedComponent - The node component to wrap
  * @returns Wrapped component with child layout behavior
  */
-export function withChildWrapper<P extends NodeProps>(
+export function withChildWrapper<P extends NodeProps<Node<any>>>(
   WrappedComponent: React.ComponentType<P>
 ): React.FC<P> {
   return (props: P) => {

--- a/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
@@ -48,7 +48,7 @@ export interface ContainerNodeData extends BaseNodeData {
   isDropTarget?: boolean;
 }
 
-export interface FormProcessNodeProps extends NodeProps<ContainerNodeData> {
+export interface FormProcessNodeProps extends NodeProps<Node<ContainerNodeData>> {  
   // REFACTORED: No longer need drop handlers (handled by main ReactFlow)
   // No longer need allNodes/allEdges props (use hooks directly)
 }
@@ -504,7 +504,18 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
   const allEdges = useEdges();
   const { setNodes } = useReactFlow();
   
-  const nodeDef = getNodeTypeDefinition('formProcess');
+  const nodeDef =
+    getNodeTypeDefinition('formProcess') ??
+    ({
+      id: 'formProcess',
+      name: 'Form Process',
+      category: 'form',
+      icon: '📚',
+      color: 'rgb(var(--color-primary))',
+      description: 'Multi-step form container',
+      maxInputs: 1,
+      maxOutputs: 1,
+    } as any);
   
   // Calculate statistics from child nodes
   const stats = useMemo(() => {
@@ -524,10 +535,11 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
     childNodes.forEach(node => {
       const nodeType = node.type || 'unknown';
       nodeTypes[nodeType] = (nodeTypes[nodeType] || 0) + 1;
-      
+
       // Track form references
-      if (node.data?.tenantFormId) {
-        formRefs.add(node.data.tenantFormId);
+      const tenantFormId = (node.data as any)?.tenantFormId;
+      if (typeof tenantFormId === 'string' && tenantFormId.length > 0) {
+        formRefs.add(tenantFormId);
       }
     });
     
@@ -689,7 +701,7 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
                               <StepNumber>{stepNum}</StepNumber>
                               <StepNodeInfo>
                                 <div className="node-label">
-                                  {childNode.data?.label || 'Unnamed Node'}
+                                  {String((childNode.data as any)?.label ?? 'Unnamed Node')}
                                 </div>
                                 <div className="node-type">
                                   {childNode.type || 'unknown'}

--- a/frontend/src/components/FlowEditor/nodes/FormReferenceNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormReferenceNode.tsx
@@ -9,7 +9,7 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { FileText, ExternalLink, Edit, Eye } from 'lucide-react';
 
@@ -184,7 +184,7 @@ const Badge = styled.span<{ $type?: 'warning' | 'info' }>`
 // Form Reference Node Component
 // ============================================================================
 
-export const FormReferenceNode = React.memo<NodeProps<FormReferenceNodeData>>(({ data, selected, id }) => {
+export const FormReferenceNode = React.memo<NodeProps<Node<FormReferenceNodeData>>>(({ data, selected, id }) => {
   const hasForm = data.formId && data.formName;
   
   const handleEditForm = () => {
@@ -277,10 +277,10 @@ export const FormReferenceNode = React.memo<NodeProps<FormReferenceNodeData>>(({
         name: 'Form Reference',
         category: 'form',
         color: 'rgb(99, 102, 241)', // Indigo
-        icon: 'FileText',
+        icon: '📋',
+        description: 'Embed a reusable form inside the workflow',
         maxInputs: 1,
         maxOutputs: 1,
-        config: {},
       }}
     >
       <Container>{displayNode}</Container>

--- a/frontend/src/components/FlowEditor/nodes/FormStepNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormStepNode.tsx
@@ -8,7 +8,7 @@
 
 import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
-import { Handle, Position, useReactFlow, type NodeProps } from '@xyflow/react';
+import { Handle, Position, useReactFlow, type Node, type NodeProps } from '@xyflow/react';
 
 type PreviewField = {
   id: string;
@@ -181,7 +181,7 @@ const PreviewMore = styled.div`
   margin-top: 2px;
 `;
 
-export const FormStepNode = React.memo<NodeProps<FormStepNodeData>>(({ id, data, selected }) => {
+export const FormStepNode = React.memo<NodeProps<Node<FormStepNodeData>>>(({ id, data, selected }) => {
   const { setNodes } = useReactFlow();
 
   const fields = Array.isArray(data.fields) ? data.fields : [];

--- a/frontend/src/components/FlowEditor/nodes/FormStepSingleNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormStepSingleNode.tsx
@@ -10,7 +10,7 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { getNodeTypeDefinition } from '../nodeTypes';
 
@@ -197,7 +197,7 @@ const FIELD_TYPE_ICONS: Record<FormFieldType, string> = {
 // Component
 // ============================================================================
 
-export const FormStepSingleNode = React.memo<NodeProps<FormStepNodeData>>((props) => {
+export const FormStepSingleNode = React.memo<NodeProps<Node<FormStepNodeData>>>((props) => {
   const { data, selected, id } = props;
   const nodeTypeDef = getNodeTypeDefinition('formStepSingle');
   
@@ -209,9 +209,9 @@ export const FormStepSingleNode = React.memo<NodeProps<FormStepNodeData>>((props
     category: 'form' as const,
     color: '#3b82f6',  // Match registry color
     icon: '📋',  // Match registry icon
+    description: 'Collect information from a user via a form step',
     maxInputs: 1,
     maxOutputs: 1,
-    config: {},
   };
   
   const { stepTitle, fields = [] } = data;

--- a/frontend/src/components/FlowEditor/nodes/LoopNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/LoopNode.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import { Card } from 'antd';
 import { Repeat } from 'lucide-react';
 
@@ -62,7 +62,7 @@ export interface LoopNodeData extends BaseNodeData {
   onDelete?: () => void;
 }
 
-export interface LoopNodeProps extends NodeProps<LoopNodeData> {}
+export interface LoopNodeProps extends NodeProps<Node<LoopNodeData>> {}
 
 // ============================================================================
 // Styled Components

--- a/frontend/src/components/FlowEditor/nodes/OutlookEmailNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/OutlookEmailNode.tsx
@@ -2,7 +2,8 @@
  * OutlookEmailNode - Node for sending emails via Microsoft Outlook
  */
 import React from 'react';
-import { Handle, Position, NodeProps } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
+import type { BaseNodeData } from './BaseNode';
 import { Mail } from 'lucide-react';
 import styled from 'styled-components';
 
@@ -57,8 +58,7 @@ const RecipientsList = styled.div`
   font-size: 11px;
 `;
 
-export interface OutlookEmailNodeData {
-  label?: string;
+export interface OutlookEmailNodeData extends BaseNodeData {
   to: string[];
   subject: string;
   body: string;
@@ -67,7 +67,7 @@ export interface OutlookEmailNodeData {
   importance?: 'low' | 'normal' | 'high';
 }
 
-export const OutlookEmailNode = React.memo<NodeProps<OutlookEmailNodeData>>(({ 
+export const OutlookEmailNode = React.memo<NodeProps<Node<OutlookEmailNodeData>>>(({ 
   data, 
   selected,
   id

--- a/frontend/src/components/FlowEditor/nodes/ParallelPathNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ParallelPathNode.tsx
@@ -13,7 +13,7 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { getNodeTypeDefinition } from '../nodeTypes';
 
@@ -134,7 +134,7 @@ const EmptyState = styled.div`
 // Component
 // ============================================================================
 
-export const ParallelPathNode: React.FC<NodeProps<ParallelPathNodeData>> = (props) => {
+export const ParallelPathNode: React.FC<NodeProps<Node<ParallelPathNodeData>>> = (props) => {
   const { data } = props;
   const nodeTypeDef = getNodeTypeDefinition('parallelPath');
   

--- a/frontend/src/components/FlowEditor/nodes/SubWorkflowNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/SubWorkflowNode.tsx
@@ -14,7 +14,7 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { getNodeTypeDefinition } from '../nodeTypes';
 
@@ -236,7 +236,7 @@ const EmptyState = styled.div`
 // Component
 // ============================================================================
 
-export const SubWorkflowNode: React.FC<NodeProps<SubWorkflowNodeData>> = (props) => {
+export const SubWorkflowNode: React.FC<NodeProps<Node<SubWorkflowNodeData>>> = (props) => {
   const { data } = props;
   const nodeTypeDef = getNodeTypeDefinition('subWorkflow');
   

--- a/frontend/src/components/FlowEditor/nodes/TerminalNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/TerminalNode.tsx
@@ -15,7 +15,7 @@
  * Created: 2026-02-04 - Phase 2.1 Batch 2
  */
 import React from 'react';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import styled from 'styled-components';
 import { CheckCircle2, XCircle, Ban } from 'lucide-react';
 import { BaseNode, BaseNodeData } from './BaseNode';
@@ -128,7 +128,7 @@ const getTerminalTypeInfo = (terminalType: TerminalType) => {
 // Component
 // ============================================================================
 
-export const TerminalNode = React.memo<NodeProps<TerminalNodeData>>(({ data, id, selected }) => {
+export const TerminalNode = React.memo<NodeProps<Node<TerminalNodeData>>>(({ data, id, selected }) => {
   const {
     terminalType,
     message,
@@ -201,12 +201,12 @@ export const TerminalNode = React.memo<NodeProps<TerminalNodeData>>(({ data, id,
       nodeType={{
         id: 'terminal',
         name: typeInfo.label,
-        category: 'logic',
+        category: 'terminal',
         color: typeInfo.color,
-        icon: 'CheckCircle2',
+        icon: '🏁',
+        description: typeInfo.label,
         maxInputs: 1,
         maxOutputs: 0,
-        config: {},
       }}
     />
   );

--- a/frontend/src/components/FlowEditor/nodes/TriggerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/TriggerNode.tsx
@@ -12,7 +12,7 @@
  */
 import React from 'react';
 import styled from 'styled-components';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import { BaseNode, BaseNodeData } from './BaseNode';
 import { getNodeTypeDefinition } from '../nodeTypes';
 
@@ -101,7 +101,7 @@ const TriggerBadge = styled.span<{ $type: string }>`
 // Component
 // ============================================================================
 
-export const TriggerNode = React.memo<NodeProps<TriggerNodeData>>((props) => {
+export const TriggerNode = React.memo<NodeProps<Node<TriggerNodeData>>>((props) => {
   const { data, selected, id } = props;
   const {
     triggerType,
@@ -129,10 +129,10 @@ export const TriggerNode = React.memo<NodeProps<TriggerNodeData>>((props) => {
     name: 'Manual Trigger',
     category: 'trigger' as const,
     color: 'rgb(34, 197, 94)',
-    icon: 'Play',
+    icon: '▶️',
+    description: 'User starts the workflow manually',
     maxInputs: 0,
     maxOutputs: 1,
-    config: {},
   };
 
   return (

--- a/frontend/src/components/FlowEditor/nodes/UtilityNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/UtilityNode.tsx
@@ -16,7 +16,7 @@
  * Created: 2026-02-04 - Phase 2.1 Batch 2
  */
 import React from 'react';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import styled from 'styled-components';
 import { Shuffle, Search, GitMerge, MessageCircle, Code, Database } from 'lucide-react';
 import { BaseNode, BaseNodeData } from './BaseNode';
@@ -144,7 +144,7 @@ const getUtilityTypeInfo = (utilityType: UtilityType) => {
 // Component
 // ============================================================================
 
-export const UtilityNode = React.memo<NodeProps<UtilityNodeData>>(({ data, id, selected }) => {
+export const UtilityNode = React.memo<NodeProps<Node<UtilityNodeData>>>(({ data, id, selected }) => {
   const { utilityType, transformRules, lookupConfig, mergeStrategy, commentText, code } = data;
 
   const typeInfo = getUtilityTypeInfo(utilityType);
@@ -216,12 +216,12 @@ export const UtilityNode = React.memo<NodeProps<UtilityNodeData>>(({ data, id, s
       nodeType={{
         id: 'utility',
         name: typeInfo.label,
-        category: 'logic',
+        category: 'utility',
         color: typeInfo.color,
-        icon: 'Code',
+        icon: '🛠️',
+        description: typeInfo.label,
         maxInputs: 1,
         maxOutputs: 1,
-        config: {},
       }}
     />
   );

--- a/frontend/src/components/FlowEditor/nodes/WaitStateNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/WaitStateNode.tsx
@@ -16,7 +16,7 @@
  * Created: 2026-02-04 - Phase 2.1 Batch 2
  */
 import React from 'react';
-import { NodeProps } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
 import styled from 'styled-components';
 import { Clock, UserCheck, FileText, MessageSquare, CreditCard, AlertCircle } from 'lucide-react';
 import { BaseNode, BaseNodeData } from './BaseNode';
@@ -137,7 +137,7 @@ const formatDeadline = (deadline?: { type: string; value: number | string }) => 
 // Component
 // ============================================================================
 
-export const WaitStateNode = React.memo<NodeProps<WaitStateNodeData>>(({ data, id, selected }) => {
+export const WaitStateNode = React.memo<NodeProps<Node<WaitStateNodeData>>>(({ data, id, selected }) => {
   const { waitType, assignedTo, deadline, reminderEnabled, escalationEnabled, message } = data;
   const typeInfo = getWaitTypeInfo(waitType);
   const Icon = typeInfo.icon;
@@ -219,12 +219,12 @@ export const WaitStateNode = React.memo<NodeProps<WaitStateNodeData>>(({ data, i
       nodeType={{
         id: 'waitState',
         name: typeInfo.label,
-        category: 'logic',
+        category: 'wait',
         color: typeInfo.color,
-        icon: 'Clock',
+        icon: '⏳',
+        description: typeInfo.label,
         maxInputs: 1,
         maxOutputs: 1,
-        config: {},
       }}
     />
   );

--- a/frontend/src/components/FlowEditor/panels/NodeDebuggerPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/NodeDebuggerPanel.tsx
@@ -177,7 +177,7 @@ export const NodeDebuggerPanel: React.FC<NodeDebuggerPanelProps> = ({
       <NodeInfo>
         <NodeInfoLabel>Testing Node:</NodeInfoLabel>
         <NodeInfoValue>
-          <strong>{node.data?.label || node.id}</strong>
+          <strong>{String((node.data as any)?.label ?? node.id)}</strong>
           <small>({node.type})</small>
         </NodeInfoValue>
       </NodeInfo>
@@ -381,7 +381,7 @@ async function simulateNodeExecution(node: Node, context: any): Promise<any> {
           ...context.variables,
           submittedAt: new Date().toISOString(),
         },
-        _warnings: nodeData?.fields?.length === 0 ? ['No fields configured'] : [],
+        _warnings: Array.isArray((nodeData as any)?.fields) && (nodeData as any).fields.length === 0 ? ['No fields configured'] : [],
       };
       
     case 'condition':

--- a/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
@@ -403,9 +403,10 @@ export const PreviewPanel: React.FC<PreviewPanelProps> = ({
     
     // Find all form-related nodes
     nodes.forEach(node => {
-      if (node.type === 'formStep' && node.data?.fields) {
+      const nodeFields = (node.data as any)?.fields;
+      if (node.type === 'formStep' && Array.isArray(nodeFields)) {
         // FormStep node with multiple fields
-        node.data.fields.forEach((field: any) => {
+        nodeFields.forEach((field: any) => {
           fields.push({
             id: field.id || field.name,
             label: field.label || field.name,

--- a/frontend/src/components/FlowEditor/utils/autoMappingService.ts
+++ b/frontend/src/components/FlowEditor/utils/autoMappingService.ts
@@ -264,7 +264,8 @@ export class AutoMappingService {
    * Check if a node already has field mappings
    */
   static hasExistingMappings(node: Node): boolean {
-    return Boolean(node.data?.fieldMappings && node.data.fieldMappings.length > 0);
+    const mappings = (node.data as any)?.fieldMappings;
+    return Array.isArray(mappings) && mappings.length > 0;
   }
   
   /**
@@ -274,12 +275,11 @@ export class AutoMappingService {
     node: Node,
     targetFieldName: string
   ): any | null {
-    if (!node.data?.fieldMappings) {
+    const mappings = (node.data as any)?.fieldMappings;
+    if (!Array.isArray(mappings)) {
       return null;
     }
-    
-    return node.data.fieldMappings.find(
-      (m: any) => m.targetFieldName === targetFieldName
-    ) || null;
+
+    return mappings.find((m: any) => m?.targetFieldName === targetFieldName) || null;
   }
 }

--- a/frontend/src/components/FlowEditor/utils/fieldMatching.ts
+++ b/frontend/src/components/FlowEditor/utils/fieldMatching.ts
@@ -171,34 +171,32 @@ export function findFieldMatches(
   targetFieldTypes?: Record<string, string> // Optional: field name -> type
 ): FieldMatch[] {
   const matches: FieldMatch[] = [];
-  
-  targetFieldNames.forEach(targetFieldName => {
+
+  for (const targetFieldName of targetFieldNames) {
     let bestMatch: FieldMatch | null = null;
-    
-    sourceFields.forEach(sourceField => {
+
+    for (const sourceField of sourceFields) {
       // Calculate name similarity
       const nameSimilarity = calculateNameSimilarity(sourceField.fieldName, targetFieldName);
-      
+
       if (nameSimilarity === 0) {
-        return; // No similarity, skip
+        continue; // No similarity, skip
       }
-      
+
       // Check type compatibility if target type is known
-      let typeCompatible = true;
       let matchReason: FieldMatch['matchReason'] = 'exact_name';
-      
+
       if (targetFieldTypes && targetFieldTypes[targetFieldName]) {
         const targetType = targetFieldTypes[targetFieldName];
-        typeCompatible = areTypesCompatible(sourceField.fieldType, targetType);
-        
-        // Lower score if types are incompatible
+        const typeCompatible = areTypesCompatible(sourceField.fieldType, targetType);
+
         if (!typeCompatible) {
-          return; // Skip incompatible types
+          continue; // Skip incompatible types
         }
-        
+
         matchReason = 'type_compatible';
       }
-      
+
       // Determine match reason
       if (nameSimilarity === 1.0) {
         matchReason = 'exact_name';
@@ -207,7 +205,7 @@ export function findFieldMatches(
       } else {
         matchReason = 'fuzzy_name';
       }
-      
+
       const match: FieldMatch = {
         sourceNodeId,
         sourceField,
@@ -215,19 +213,19 @@ export function findFieldMatches(
         matchScore: nameSimilarity,
         matchReason,
       };
-      
+
       // Keep best match for this target field
       if (!bestMatch || match.matchScore > bestMatch.matchScore) {
         bestMatch = match;
       }
-    });
-    
+    }
+
     // Add best match if score is above threshold
     if (bestMatch && bestMatch.matchScore >= 0.6) {
       matches.push(bestMatch);
     }
-  });
-  
+  }
+
   return matches;
 }
 

--- a/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
@@ -63,7 +63,7 @@ export function normalizeNodeData(node: Node): Node {
   }
 
   // Get node type definition
-  const nodeTypeDef = NODE_TYPE_REGISTRY[node.type];
+  const nodeTypeDef = NODE_TYPE_REGISTRY[node.type ?? ''];
 
   // If unknown type, return as-is
   if (!nodeTypeDef) {

--- a/frontend/src/components/FlowEditor/utils/outputSchemaInference.ts
+++ b/frontend/src/components/FlowEditor/utils/outputSchemaInference.ts
@@ -39,6 +39,7 @@ export interface NodeOutputSchema {
 export function inferOutputSchemaFromFormNode(node: Node): NodeOutputSchema | null {
   try {
     const { data } = node;
+    const dataAny = data as any;
     const fields: OutputFieldSchema[] = [];
 
     // Check if node has form fields
@@ -49,7 +50,7 @@ export function inferOutputSchemaFromFormNode(node: Node): NodeOutputSchema | nu
           fieldName: field.name || field.id,
           fieldType: field.type || 'text',
           label: field.label || field.name,
-          entityType: data.entityType,
+          entityType: typeof dataAny.entityType === 'string' ? dataAny.entityType : undefined,
           required: field.required || false,
           defaultValue: field.defaultValue,
         });
@@ -66,7 +67,10 @@ export function inferOutputSchemaFromFormNode(node: Node): NodeOutputSchema | nu
               fieldName: field.name || field.id,
               fieldType: field.type || 'text',
               label: field.label || field.name,
-              entityType: step.entityType || data.entityType,
+              entityType:
+                typeof step.entityType === 'string'
+                  ? step.entityType
+                  : (typeof dataAny.entityType === 'string' ? dataAny.entityType : undefined),
               required: field.required || false,
               defaultValue: field.defaultValue,
             });
@@ -82,7 +86,7 @@ export function inferOutputSchemaFromFormNode(node: Node): NodeOutputSchema | nu
     return {
       nodeId: node.id,
       nodeType: node.type || 'form',
-      entityType: data.entityType,
+      entityType: typeof dataAny.entityType === 'string' ? dataAny.entityType : undefined,
       outputFields: fields,
       timestamp: Date.now(),
     };
@@ -97,9 +101,14 @@ export function inferOutputSchemaFromFormNode(node: Node): NodeOutputSchema | nu
  */
 export function inferOutputSchema(node: Node): NodeOutputSchema | null {
   // Use existing outputSchema if available and recent (< 5 minutes old)
-  if (node.data?.outputSchema && 
-      Date.now() - node.data.outputSchema.timestamp < 5 * 60 * 1000) {
-    return node.data.outputSchema;
+  const existing = (node.data as any)?.outputSchema;
+  if (
+    existing &&
+    typeof existing === 'object' &&
+    typeof existing.timestamp === 'number' &&
+    Date.now() - existing.timestamp < 5 * 60 * 1000
+  ) {
+    return existing as NodeOutputSchema;
   }
 
   // Infer based on node type

--- a/frontend/src/components/FlowEditor/utils/subflowManager.ts
+++ b/frontend/src/components/FlowEditor/utils/subflowManager.ts
@@ -214,14 +214,14 @@ export function importSubFlow(
     return {
       id: newId,
       type: childTemplate.type!,
-      data: childTemplate.data,
+      data: childTemplate.data ?? {},
       position: childTemplate.position!,
       parentId: containerNewId,
-      extent: childTemplate.extent || 'parent',
+      extent: (childTemplate.extent ?? 'parent') as any,
       expandParent: childTemplate.expandParent,
       width: childTemplate.width,
       height: childTemplate.height,
-    };
+    } as Node;
   });
   
   // Create edges with new IDs

--- a/frontend/src/components/FlowEditor/utils/validationEngine.ts
+++ b/frontend/src/components/FlowEditor/utils/validationEngine.ts
@@ -147,7 +147,7 @@ export function validateNodeConfig(node: Node): ValidationIssue[] {
   // Basic validation without schema dependency
   // Type-specific validations
   if (node.type === 'form' || node.type === 'formProcessGroup' || node.type === 'formBook') {
-    const fields = node.data.fields || [];
+    const fields = Array.isArray((node.data as any)?.fields) ? (node.data as any).fields : [];
     if (fields.length === 0) {
       issues.push({
         id: `no-fields-${node.id}`,
@@ -161,7 +161,7 @@ export function validateNodeConfig(node: Node): ValidationIssue[] {
   }
   
   if (node.type === 'conditionIf') {
-    const rules = node.data.rules || [];
+    const rules = Array.isArray((node.data as any)?.rules) ? (node.data as any).rules : [];
     if (rules.length === 0) {
       issues.push({
         id: `no-rules-${node.id}`,

--- a/frontend/src/components/FormSubmission/ContextBubble.tsx
+++ b/frontend/src/components/FormSubmission/ContextBubble.tsx
@@ -510,7 +510,7 @@ export const ContextBubble: React.FC<ContextBubbleProps> = ({
           {inheritanceChain.map((step, index) => (
             <InheritanceStep key={step.id}>
               <InheritanceStepHeader>
-                <span>Step {index + 1}: {step.label}</span>
+                <span>Step {index + 1}: {String(step.label ?? step.id ?? '')}</span>
                 <small>({step.type})</small>
               </InheritanceStepHeader>
               <InheritanceStepData>

--- a/frontend/src/components/FormSubmission/FormSubmissionModal.tsx
+++ b/frontend/src/components/FormSubmission/FormSubmissionModal.tsx
@@ -1023,8 +1023,12 @@ const FormSubmissionModal: React.FC<FormSubmissionModalProps> = ({
           try {
             const res = await entityOptionsService.getOptions(type);
             setEntityOptions(prev => ({ ...prev, [type]: res.options || [] }));
-          } catch (e) { 
-            logger.error('Failed to load options for', type, e); 
+          } catch (e) {
+            logger.error(
+              'Failed to load options for entity type',
+              { component: 'FormSubmissionModal', metadata: { entityType: type } },
+              e
+            );
           }
         }
       }
@@ -1325,7 +1329,7 @@ const FormSubmissionModal: React.FC<FormSubmissionModalProps> = ({
       return;
     }
     
-    logger.debug('[SaveAndExit] Saving', fieldsToSave.length, 'fields');
+    logger.debug('[SaveAndExit] Saving fields', { fieldCount: fieldsToSave.length });
     
     // Create promises for each field
     fieldsToSave.forEach(({ stepId, fieldKey, value }) => {

--- a/frontend/src/components/FormSubmission/WorkflowExecutionModal.tsx
+++ b/frontend/src/components/FormSubmission/WorkflowExecutionModal.tsx
@@ -23,6 +23,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { X, ChevronLeft, ChevronRight, Save } from 'lucide-react';
+import type { Edge, Node } from '@xyflow/react';
 import { TaskRenderer } from './TaskRenderer';
 import { useWorkflowContext } from './hooks/useWorkflowContext';
 import { notify } from '../../utils/notify';
@@ -31,20 +32,7 @@ import { notify } from '../../utils/notify';
 // TypeScript Interfaces
 // ============================================================================
 
-export interface WorkflowNode {
-  id: string;
-  type: string;
-  data: {
-    label?: string;
-    config?: Record<string, any>;
-    fields?: any[];
-    entity_type?: string;
-    interactionType?: string;
-    [key: string]: any;
-  };
-  position?: { x: number; y: number };
-  parentId?: string;
-}
+export type WorkflowNode = Node<any>;
 
 export interface WorkflowExecutionProps {
   /** Workflow definition with nodes */
@@ -53,7 +41,7 @@ export interface WorkflowExecutionProps {
     name: string;
     description?: string;
     nodes: WorkflowNode[];
-    edges?: Array<{ id: string; source: string; target: string }>;
+    edges?: Edge<any>[];
   };
   
   /** Initial workflow execution data */
@@ -321,7 +309,7 @@ const EmptyState = styled.div`
 /**
  * Build execution order from workflow nodes and edges
  */
-function buildExecutionOrder(nodes: WorkflowNode[], edges?: Array<{ id: string; source: string; target: string }>): string[] {
+function buildExecutionOrder(nodes: WorkflowNode[], edges?: Edge<any>[]): string[] {
   // Simple linear order for now
   // TODO: Implement proper topological sort based on edges
   return nodes
@@ -398,7 +386,7 @@ export const WorkflowExecutionModal: React.FC<WorkflowExecutionProps> = ({
 
   // Auto-save state
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
-  const autoSaveTimeoutRef = useRef<NodeJS.Timeout>();
+  const autoSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Auto-save handler
   const triggerAutoSave = useCallback(() => {

--- a/frontend/src/components/FormSubmission/hooks/useWorkflowContext.ts
+++ b/frontend/src/components/FormSubmission/hooks/useWorkflowContext.ts
@@ -285,7 +285,7 @@ export function useWorkflowContext(
       
       result.push({
         nodeId,
-        nodeLabel: node.data?.label || node.id,
+        nodeLabel: String((node.data as any)?.label ?? node.id),
         nodeType: node.type || 'unknown',
         fields,
       });

--- a/frontend/src/components/Integrations/EmailConnection.tsx
+++ b/frontend/src/components/Integrations/EmailConnection.tsx
@@ -48,9 +48,10 @@ export const EmailConnection: React.FC<EmailConnectionProps> = ({
 }) => {
   const [isConnecting, setIsConnecting] = useState(false);
   const config = providerConfig[provider];
+  const isComingSoon = 'comingSoon' in config && Boolean((config as any).comingSoon);
 
   const handleConnect = async () => {
-    if (config.comingSoon) {
+    if (isComingSoon) {
       toast.error('Gmail integration coming soon!');
       return;
     }
@@ -115,7 +116,7 @@ export const EmailConnection: React.FC<EmailConnectionProps> = ({
           </ConnectionInfo>
 
           {isExpired && (
-            <ReconnectButton onClick={handleConnect} disabled={isConnecting}>
+            <ReconnectButton onClick={handleConnect} disabled={isConnecting} color={config.color}>
               {isConnecting ? 'Reconnecting...' : 'Reconnect'}
             </ReconnectButton>
           )}
@@ -132,7 +133,7 @@ export const EmailConnection: React.FC<EmailConnectionProps> = ({
             the connected account.
           </HelpCopy>
 
-          {config.comingSoon ? (
+          {isComingSoon ? (
             <ComingSoonBadge>Coming Soon</ComingSoonBadge>
           ) : (
             <ConnectButton 

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -9,6 +9,7 @@ import QuickActionsEditor from '../QuickActions/QuickActionsEditor';
 import { Icon } from '../ui';
 import TenantSelector from './TenantSelector';
 import { authService } from '../../services/authService';
+import { UserProfile } from '../../types';
 import { NotificationBell } from '../Notifications';
 import debounce from 'lodash/debounce';
 
@@ -45,7 +46,12 @@ const Header: React.FC<HeaderProps> = () => {
   const quickMenuRef = useRef<HTMLDivElement>(null);
   
   // Get current user info
-  const user = authService.getCurrentUser();
+  const [user, setUser] = useState<UserProfile | null>(null);
+
+  useEffect(() => {
+    void Promise.resolve(authService.getCurrentUser()).then(setUser).catch(() => setUser(null));
+  }, []);
+
   const isSuperuser = user?.is_superuser || false;
   
   // Quick Actions context

--- a/frontend/src/components/Layout/TenantSelector.tsx
+++ b/frontend/src/components/Layout/TenantSelector.tsx
@@ -29,7 +29,7 @@ const CurrentTenantButton = styled.button<{ $theme: Theme }>`
   border: 1px solid ${props => props.$theme.colors.border};
   border-radius: 6px;
   background: ${props => props.$theme.colors.surface};
-  color: ${props => props.$theme.colors.text};
+  color: ${props => props.$theme.colors.textPrimary};
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -38,7 +38,7 @@ const CurrentTenantButton = styled.button<{ $theme: Theme }>`
   
   &:hover {
     border-color: ${props => props.$theme.colors.primary};
-    background: ${props => props.$theme.colors.backgroundAlt};
+    background: ${props => props.$theme.colors.surfaceHover};
   }
   
   span {
@@ -88,8 +88,8 @@ const TenantOption = styled.button<{ $theme: Theme; $isActive: boolean }>`
   width: 100%;
   padding: 10px 12px;
   border: none;
-  background: ${props => props.$isActive ? props.$theme.colors.primary + '15' : 'transparent'};
-  color: ${props => props.$theme.colors.text};
+  background: ${props => (props.$isActive ? 'rgba(var(--color-primary), 0.08)' : 'transparent')};
+  color: ${props => props.$theme.colors.textPrimary};
   font-size: 13px;
   text-align: left;
   cursor: pointer;
@@ -97,7 +97,7 @@ const TenantOption = styled.button<{ $theme: Theme; $isActive: boolean }>`
   gap: 10px;
   
   &:hover {
-    background: ${props => props.$theme.colors.backgroundAlt};
+    background: ${props => props.$theme.colors.surfaceHover};
   }
   
   span.name {

--- a/frontend/src/components/Navigation/CommandPalette.tsx
+++ b/frontend/src/components/Navigation/CommandPalette.tsx
@@ -474,8 +474,12 @@ const getCachedResults = (query: string): SearchResult[] | null => {
 const setCachedResults = (query: string, results: SearchResult[]): void => {
   // Limit cache size to prevent memory bloat
   if (searchCache.size > 100) {
-    const oldestKey = searchCache.keys().next().value;
-    searchCache.delete(oldestKey);
+    const oldestKey = searchCache.keys().next().value as string | undefined;
+    if (oldestKey) {
+      searchCache.delete(oldestKey);
+    } else {
+      searchCache.clear();
+    }
   }
   
   searchCache.set(query, {

--- a/frontend/src/components/Navigation/NavigationMenu.tsx
+++ b/frontend/src/components/Navigation/NavigationMenu.tsx
@@ -159,7 +159,8 @@ const NavigationMenu: React.FC<NavigationMenuProps> = ({ items, isExpanded: side
 
   // Render a simple navigation link (no children)
   const renderNavLink = (item: NavigationItem, exactActive: boolean, active: boolean) => {
-    const badgeValue = item.badge ?? getBadgeValue(counts, item.badgeKey);
+    const badgeValueRaw = item.badge ?? getBadgeValue(counts, item.badgeKey);
+    const badgeValue = typeof badgeValueRaw === 'string' ? Number(badgeValueRaw) : badgeValueRaw;
     return (
       <StyledNavLink
         to={item.path!}
@@ -181,7 +182,8 @@ const NavigationMenu: React.FC<NavigationMenuProps> = ({ items, isExpanded: side
   // Render accordion header content (icon and label)
   // Render accordion content - icon, label, badge
   const renderAccordionContent = (item: NavigationItem) => {
-    const badgeValue = item.badge ?? getBadgeValue(counts, item.badgeKey);
+    const badgeValueRaw = item.badge ?? getBadgeValue(counts, item.badgeKey);
+    const badgeValue = typeof badgeValueRaw === 'string' ? Number(badgeValueRaw) : badgeValueRaw;
     return (
       <>
         <NavIcon $color={item.color}>{item.icon}</NavIcon>

--- a/frontend/src/components/Search/ContinuousSearch.tsx
+++ b/frontend/src/components/Search/ContinuousSearch.tsx
@@ -68,12 +68,12 @@ export const ContinuousSearchInput: React.FC<{
         loading={loading}
       />
       {results.length > 0 && (
-        <div style={{ marginTop: 8, border: '1px solid #d9d9d9', borderRadius: 4 }}>
+        <div style={{ marginTop: 8, border: '1px solid rgb(var(--color-border))', borderRadius: 4 }}>
           {results.map(result => (
             <div
               key={result.id}
               onClick={() => onSelect(result)}
-              style={{ padding: 8, cursor: 'pointer', ':hover': { background: '#f5f5f5' } }}
+              style={{ padding: 8, cursor: 'pointer' }}
             >
               {result.label}
             </div>

--- a/frontend/src/components/Shared/CreateInvoiceModal.tsx
+++ b/frontend/src/components/Shared/CreateInvoiceModal.tsx
@@ -341,7 +341,7 @@ export const CreateInvoiceModal: React.FC<CreateInvoiceModalProps> = ({
               <SearchableSelect
                 label="Customer"
                 value={formData.customer}
-                options={customers}
+                options={(customers ?? []).map((c) => ({ id: c.id, name: c.name }))}
                 onChange={(value) => handleSelectChange('customer', value)}
                 placeholder="Select Customer"
                 required

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -443,7 +443,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
             )}
 
             <DynamicFormEngine
-              schema={dynamicSchema}
+              schema={dynamicSchema as any}
               initialValues={initialValues || {}}
               onSubmit={(data) => {
                 void submit(data);

--- a/frontend/src/components/Visualization/PurchaseOrderTrends.tsx
+++ b/frontend/src/components/Visualization/PurchaseOrderTrends.tsx
@@ -42,14 +42,18 @@ const PurchaseOrderTrends: React.FC<PurchaseOrderTrendsProps> = ({ data, height 
           <YAxis yAxisId="left" />
           <YAxis yAxisId="right" orientation="right" />
           <Tooltip
-            formatter={(value: number, name: string) => {
-              if (name === 'value' || name === 'averageValue') {
+            formatter={(value, name) => {
+              const numericValue = typeof value === 'number' ? value : Number(value ?? 0);
+              const label = typeof name === 'string' ? name : String(name ?? '');
+
+              if (label === 'value' || label === 'averageValue') {
                 return [
-                  `$${value.toLocaleString()}`,
-                  name === 'value' ? 'Total Value' : 'Average Value',
+                  `$${numericValue.toLocaleString()}`,
+                  label === 'value' ? 'Total Value' : 'Average Value',
                 ];
               }
-              return [value, 'Orders'];
+
+              return [numericValue, 'Orders'];
             }}
           />
           <Legend />

--- a/frontend/src/components/Visualization/SupplierPerformanceChart.tsx
+++ b/frontend/src/components/Visualization/SupplierPerformanceChart.tsx
@@ -45,10 +45,13 @@ const SupplierPerformanceChart: React.FC<SupplierPerformanceChartProps> = ({
           <YAxis yAxisId="left" />
           <YAxis yAxisId="right" orientation="right" />
           <Tooltip
-            formatter={(value: number, name: string) => {
-              if (name === 'revenue') return [`$${value.toLocaleString()}`, 'Revenue'];
-              if (name === 'rating') return [`${value}/5`, 'Rating'];
-              return [value, name];
+            formatter={(value, name) => {
+              const numericValue = typeof value === 'number' ? value : Number(value ?? 0);
+              const label = typeof name === 'string' ? name : String(name ?? '');
+
+              if (label === 'revenue') return [`$${numericValue.toLocaleString()}`, 'Revenue'];
+              if (label === 'rating') return [`${numericValue}/5`, 'Rating'];
+              return [numericValue, label];
             }}
           />
           <Legend />

--- a/frontend/src/components/Widgets/WidgetCard.tsx
+++ b/frontend/src/components/Widgets/WidgetCard.tsx
@@ -32,7 +32,7 @@ export interface WidgetCardProps {
   actions?: ReactNode;
   className?: string;
   noPadding?: boolean;
-  badge?: string;
+  badge?: string | number;
   badgeVariant?: 'default' | 'danger' | 'warning' | 'success';
 }
 

--- a/frontend/src/components/Widgets/WidgetGrid.tsx
+++ b/frontend/src/components/Widgets/WidgetGrid.tsx
@@ -14,7 +14,7 @@
  * - Uses CSS custom properties
  */
 import React, { useCallback } from 'react';
-import GridLayout, { LayoutItem } from 'react-grid-layout';
+import GridLayout, { LayoutItem, type Layout } from 'react-grid-layout';
 import styled from 'styled-components';
 import { X } from 'lucide-react';
 import 'react-grid-layout/css/styles.css';
@@ -161,8 +161,8 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
   isEditing = false,
 }) => {
   const handleLayoutChange = useCallback(
-    (newLayout: LayoutItem[]) => {
-      onLayoutChange(newLayout as WidgetLayout[]);
+    (newLayout: Layout) => {
+      onLayoutChange([...newLayout] as WidgetLayout[]);
     },
     [onLayoutChange]
   );
@@ -183,15 +183,17 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
       <GridLayout
         className="layout"
         layout={layout}
-        cols={cols}
-        rowHeight={rowHeight}
         width={width}
+        gridConfig={{
+          cols,
+          rowHeight,
+          margin: [16, 16] as const,
+          containerPadding: null,
+          maxRows: Infinity,
+        }}
+        dragConfig={{ enabled: isEditing }}
+        resizeConfig={{ enabled: isEditing }}
         onLayoutChange={handleLayoutChange}
-        isDraggable={isEditing}
-        isResizable={isEditing}
-        compactType="vertical"
-        preventCollision={false}
-        margin={[16, 16]}
       >
         {widgets.map(widget => (
           <WidgetWrapper key={widget.id} $isEditing={isEditing}>

--- a/frontend/src/components/Workflows/useStepRouting.ts
+++ b/frontend/src/components/Workflows/useStepRouting.ts
@@ -106,14 +106,16 @@ const evaluateCondition = (
   // Handle in_list
   if (operator === 'in_list') {
     const list = Array.isArray(conditionValue) ? conditionValue : [conditionValue];
+
     if (typeof fieldValue === 'string') {
-      return list.some(item => 
-        typeof item === 'string' 
-          ? item.toLowerCase() === fieldValue.toLowerCase()
-          : item === fieldValue
-      );
+      return list.some((item) => String(item).toLowerCase() === fieldValue.toLowerCase());
     }
-    return list.includes(fieldValue);
+
+    if (typeof fieldValue === 'number' || typeof fieldValue === 'boolean') {
+      return (list as Array<string | number | boolean>).includes(fieldValue);
+    }
+
+    return false;
   }
   
   return false;

--- a/frontend/src/config/tenantContext.test.ts
+++ b/frontend/src/config/tenantContext.test.ts
@@ -152,7 +152,7 @@ describe('Tenant Context', () => {
     });
     
     it('should log in development mode', () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
       
       // Set NODE_ENV to development
       const originalNodeEnv = process.env.NODE_ENV;

--- a/frontend/src/contexts/NotificationsContext.tsx
+++ b/frontend/src/contexts/NotificationsContext.tsx
@@ -59,7 +59,7 @@ export interface NotificationPreferences {
   email_enabled: boolean;
   sms_enabled: boolean;
   push_enabled: boolean;
-  type_preferences: Record<NotificationType, string[]>;
+  type_preferences: Record<NotificationType, Array<'email' | 'push' | 'in_app'>>;
   quiet_hours_enabled: boolean;
   quiet_hours_start: string | null;
   quiet_hours_end: string | null;
@@ -242,7 +242,16 @@ async function fetchActionItemsAPI(): Promise<ActionItem[]> {
 async function fetchActionItemCountsAPI(): Promise<ActionItemCounts> {
   try {
     const authToken = localStorage.getItem('authToken');
-    if (!authToken) return { pending: 0, overdue: 0, completed_today: 0 };
+    if (!authToken) {
+      return {
+        total: 0,
+        overdue: 0,
+        due_today: 0,
+        due_this_week: 0,
+        by_priority: {},
+        by_form: [],
+      };
+    }
     
     const response = await fetch(`${API_BASE}/action-items/counts/`, {
       headers: {
@@ -252,13 +261,27 @@ async function fetchActionItemCountsAPI(): Promise<ActionItemCounts> {
     });
     
     if (response.status === 401 || response.status === 404) {
-      return { pending: 0, overdue: 0, completed_today: 0 };
+      return {
+        total: 0,
+        overdue: 0,
+        due_today: 0,
+        due_this_week: 0,
+        by_priority: {},
+        by_form: [],
+      };
     }
     if (!response.ok) throw new Error('Failed to fetch action item counts');
     return response.json();
   } catch (error) {
     console.warn('[NotificationsContext] Action item counts API not available:', error);
-    return { pending: 0, overdue: 0, completed_today: 0 };
+    return {
+      total: 0,
+      overdue: 0,
+      due_today: 0,
+      due_this_week: 0,
+      by_priority: {},
+      by_form: [],
+    };
   }
 }
 
@@ -266,7 +289,20 @@ async function fetchPreferencesAPI(): Promise<NotificationPreferences> {
   try {
     const authToken = localStorage.getItem('authToken');
     if (!authToken) {
-      return { email_enabled: true, push_enabled: false, action_item_reminders: true };
+      return {
+        id: '',
+        user: 0,
+        notifications_enabled: true,
+        email_enabled: true,
+        sms_enabled: false,
+        push_enabled: false,
+        type_preferences: {} as Record<NotificationType, Array<'email' | 'push' | 'in_app'>>,
+        quiet_hours_enabled: false,
+        quiet_hours_start: null,
+        quiet_hours_end: null,
+        daily_digest_enabled: false,
+        weekly_digest_enabled: false,
+      };
     }
     
     const response = await fetch(`${API_BASE}/notification-preferences/`, {
@@ -277,13 +313,39 @@ async function fetchPreferencesAPI(): Promise<NotificationPreferences> {
     });
     
     if (response.status === 401 || response.status === 404) {
-      return { email_enabled: true, push_enabled: false, action_item_reminders: true };
+      return {
+        id: '',
+        user: 0,
+        notifications_enabled: true,
+        email_enabled: true,
+        sms_enabled: false,
+        push_enabled: false,
+        type_preferences: {} as Record<NotificationType, Array<'email' | 'push' | 'in_app'>>,
+        quiet_hours_enabled: false,
+        quiet_hours_start: null,
+        quiet_hours_end: null,
+        daily_digest_enabled: false,
+        weekly_digest_enabled: false,
+      };
     }
     if (!response.ok) throw new Error('Failed to fetch preferences');
     return response.json();
   } catch (error) {
     console.warn('[NotificationsContext] Preferences API not available:', error);
-    return { email_enabled: true, push_enabled: false, action_item_reminders: true };
+    return {
+      id: '',
+      user: 0,
+      notifications_enabled: true,
+      email_enabled: true,
+      sms_enabled: false,
+      push_enabled: false,
+      type_preferences: {} as Record<NotificationType, Array<'email' | 'push' | 'in_app'>>,
+      quiet_hours_enabled: false,
+      quiet_hours_start: null,
+      quiet_hours_end: null,
+      daily_digest_enabled: false,
+      weekly_digest_enabled: false,
+    };
   }
 }
 

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -30,6 +30,7 @@ interface QuickActionsContextType {
   // Form Submission
   activeSubmission: FormSubmission | null;
   startFormSubmission: (formId: string) => Promise<FormSubmission>;
+  resumeSubmission: (submissionId: string) => Promise<void>;
   closeSubmission: () => void;
   
   // UI State
@@ -143,6 +144,12 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
     return submission;
   }, []);
 
+  const resumeSubmission = useCallback(async (submissionId: string): Promise<void> => {
+    const submission = await formSubmissionService.get(submissionId);
+    setActiveSubmission(submission);
+    setIsFormModalOpen(true);
+  }, []);
+
   const closeSubmission = useCallback(() => {
     setActiveSubmission(null);
   }, []);
@@ -187,6 +194,7 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
     reorderQuickActions,
     activeSubmission,
     startFormSubmission,
+    resumeSubmission,
     closeSubmission,
     isEditorOpen,
     openEditor,

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -244,7 +244,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
 
     return {
       algorithm: isDarkMode ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
-      cssVar: true,
+      cssVar: { prefix: 'pm' },
       token: hasValidPrimary ? { colorPrimary: primary } : {},
       // Do NOT override colorBgBase/colorBgContainer/colorBgLayout/colorText here.
       // Those overrides can corrupt surfaces and render components pure black.

--- a/frontend/src/hooks/useAutoSave.ts
+++ b/frontend/src/hooks/useAutoSave.ts
@@ -106,7 +106,7 @@ export function useAutoSave<T>(
 
   const retryCountRef = useRef(0);
   const previousDataRef = useRef<T>(data);
-  const savedIndicatorTimerRef = useRef<NodeJS.Timeout>();
+  const savedIndicatorTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   /**
    * Core save function with retry logic

--- a/frontend/src/hooks/useCustomerProducts.ts
+++ b/frontend/src/hooks/useCustomerProducts.ts
@@ -107,14 +107,14 @@ export function useCustomerProducts(
         .map((t) => String(t).toLowerCase().trim())
         .filter(Boolean);
 
-      const response = await businessApi.get<Product[]>('system/products/', {
+      const response = await businessApi.get<{ results?: Product[] } | Product[]>('system/products/', {
         params: {
           is_active: true,
           protein: normalizedProteins,
           page_size: 500,
         },
       });
-      const data = response.data.results || response.data;
+      const data = Array.isArray(response.data) ? response.data : response.data.results;
       return Array.isArray(data) ? data : [];
     } catch (err: any) {
       console.error('Failed to fetch products by protein types:', err);
@@ -136,8 +136,10 @@ export function useCustomerProducts(
       setCustomerPreferences(preferences);
 
       // Fetch associated products
-      const associatedResponse = await businessApi.get<Product[]>(`customers/${custId}/products/`);
-      const associatedData = associatedResponse.data.results || associatedResponse.data;
+      const associatedResponse = await businessApi.get<{ results?: Product[] } | Product[]>(`customers/${custId}/products/`);
+      const associatedData = Array.isArray(associatedResponse.data)
+        ? associatedResponse.data
+        : associatedResponse.data.results;
       const associated = Array.isArray(associatedData) ? associatedData : [];
       setAssociatedProducts(associated);
 
@@ -168,10 +170,10 @@ export function useCustomerProducts(
     }
 
     try {
-      const response = await businessApi.get<Product[]>('system/products/', {
+      const response = await businessApi.get<{ results?: Product[] } | Product[]>('system/products/', {
         params: { search: query, is_active: true, page_size: 50 },
       });
-      const data = response.data.results || response.data;
+      const data = Array.isArray(response.data) ? response.data : response.data.results;
       return Array.isArray(data) ? data : [];
     } catch (err: any) {
       console.error('Failed to search products:', err);

--- a/frontend/src/hooks/useFavorites.ts
+++ b/frontend/src/hooks/useFavorites.ts
@@ -85,7 +85,12 @@ export const useFavorites = () => {
   });
 
   // Mutation for toggling favorites
-  const toggleMutation = useMutation<ToggleFavoriteResponse, Error, ToggleFavoriteParams>({
+  const toggleMutation = useMutation<
+    ToggleFavoriteResponse,
+    Error,
+    ToggleFavoriteParams,
+    { previousFavorites?: Favorite[] }
+  >({
     mutationFn: toggleFavorite,
     
     // Optimistic update

--- a/frontend/src/hooks/useNodeLocking.ts
+++ b/frontend/src/hooks/useNodeLocking.ts
@@ -23,7 +23,7 @@ const HEARTBEAT_INTERVAL = 30000; // 30 seconds (half of TTL)
 export const useNodeLocking = (workflowId: string, nodeId: string) => {
   const [lockState, setLockState] = useState<NodeLock | null>(null);
   const [loading, setLoading] = useState(false);
-  const heartbeatRef = useRef<NodeJS.Timeout>();
+  const heartbeatRef = useRef<NodeJS.Timeout | null>(null);
 
   const acquireLock = useCallback(async () => {
     if (!workflowId || !nodeId) return;

--- a/frontend/src/i18n/components/LanguageSelector.tsx
+++ b/frontend/src/i18n/components/LanguageSelector.tsx
@@ -39,8 +39,10 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
 }) => {
   const { currentLanguage, changeLanguage } = useTranslation();
 
-  const handleChange = (value: SupportedLanguage) => {
-    changeLanguage(value);
+  const handleChange = (value: unknown) => {
+    if (typeof value === 'string' && (supportedLanguages as readonly string[]).includes(value)) {
+      changeLanguage(value as SupportedLanguage);
+    }
   };
 
   const options = supportedLanguages.map((lang) => ({

--- a/frontend/src/pages/AccountsReceivables.tsx
+++ b/frontend/src/pages/AccountsReceivables.tsx
@@ -437,21 +437,23 @@ const AccountsReceivables: React.FC = () => {
     }
   };
 
+  const invoiceAmount = (r: Invoice): number => Number(r.total ?? r.subtotal ?? 0) || 0;
+
   const getTotalAmount = () =>
     Array.isArray(receivables)
-      ? receivables.reduce((sum, r) => sum + (Number(r.amount) || 0), 0)
+      ? receivables.reduce((sum, r) => sum + invoiceAmount(r), 0)
       : 0;
   const getPendingAmount = () =>
     Array.isArray(receivables)
       ? receivables
           .filter((r) => r.status === 'pending')
-          .reduce((sum, r) => sum + (Number(r.amount) || 0), 0)
+          .reduce((sum, r) => sum + invoiceAmount(r), 0)
       : 0;
   const getOverdueAmount = () =>
     Array.isArray(receivables)
       ? receivables
           .filter((r) => r.status === 'overdue')
-          .reduce((sum, r) => sum + (Number(r.amount) || 0), 0)
+          .reduce((sum, r) => sum + invoiceAmount(r), 0)
       : 0;
 
   if (loading) {

--- a/frontend/src/pages/Admin/Configurations/index.tsx
+++ b/frontend/src/pages/Admin/Configurations/index.tsx
@@ -567,7 +567,12 @@ const ConfigurationsPage: React.FC = () => {
             confirmVariant="danger"
           />
 
-          <Modal isOpen={showCreateModal} onClose={() => setShowCreateModal(false)} maxWidth="720px">
+          <Modal
+            isOpen={showCreateModal}
+            onClose={() => setShowCreateModal(false)}
+            title="Add Configuration"
+            maxWidth="720px"
+          >
             <CreateModalContent>
               <CreateHeader>
                 <CreateTitle>Add Configuration</CreateTitle>

--- a/frontend/src/pages/Admin/Home/index.tsx
+++ b/frontend/src/pages/Admin/Home/index.tsx
@@ -67,15 +67,11 @@ const AdminWorkspaceHome: React.FC = () => {
       description="Tenant administration tools for users, configuration, and auditing."
       icon="⚙️"
       actions={
-        <Button
-          as={Link as any}
-          to="/workspace/users"
-          variant="primary"
-          size="sm"
-          disabled={isLoading}
-        >
-          Manage Users
-        </Button>
+        <Link to="/workspace/users" style={{ textDecoration: 'none' }}>
+          <Button variant="primary" size="sm" disabled={isLoading}>
+            Manage Users
+          </Button>
+        </Link>
       }
       headerExtras={
         <MetaBar>

--- a/frontend/src/pages/Admin/OptionLists/OptionListModal.tsx
+++ b/frontend/src/pages/Admin/OptionLists/OptionListModal.tsx
@@ -536,7 +536,7 @@ export const OptionListModal: React.FC<OptionListModalProps> = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} maxWidth="800px">
+    <Modal isOpen={isOpen} onClose={handleClose} title="Option List" maxWidth="800px">
       <ModalContent>
         <Header>
           <Title>Edit {listName}</Title>

--- a/frontend/src/pages/Admin/Profile/index.tsx
+++ b/frontend/src/pages/Admin/Profile/index.tsx
@@ -552,9 +552,11 @@ const AdminProfilePage: React.FC = () => {
                     accept="image/*"
                     onChange={handleLogoChange}
                   />
-                  <Button as="label" htmlFor="logo" variant="outline" size="sm">
-                    Upload Logo
-                  </Button>
+                  <label htmlFor="logo">
+                    <Button type="button" variant="outline" size="sm">
+                      Upload Logo
+                    </Button>
+                  </label>
                   <Hint>PNG/JPG/WebP up to 5MB.</Hint>
                 </div>
               </LogoBlock>

--- a/frontend/src/pages/Cockpit/ProcessMonitor.tsx
+++ b/frontend/src/pages/Cockpit/ProcessMonitor.tsx
@@ -570,10 +570,6 @@ const ProcessMonitor: React.FC = () => {
                   readOnly={true}
                   initialNodes={nodes as any}
                   initialEdges={edges as any}
-                  punchIn={{
-                    activeNodeId,
-                    centerOnActiveNode: true,
-                  }}
                 />
               )}
             </EditorPane>

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -81,7 +81,7 @@ const Customers: React.FC = () => {
     country: '',
     industry_array: [] as string[], // Phase 4: ArrayField integration
     preferred_protein_types: [] as string[], // Phase 4: ArrayField integration
-    products: [] as string[], // Product UUIDs for M2M
+    products: [] as string[], // Product IDs for M2M
   });
 
   // Auto-open form if ?action=create in URL
@@ -277,9 +277,15 @@ const Customers: React.FC = () => {
     e.preventDefault();
     try {
       if (editingCustomer) {
-        await apiService.updateCustomer(editingCustomer.id, formData);
+        await apiService.updateCustomer(editingCustomer.id, {
+          ...formData,
+          products: formData.products.map((v) => Number(v)),
+        });
       } else {
-        await apiService.createCustomer(formData);
+        await apiService.createCustomer({
+          ...formData,
+          products: formData.products.map((v) => Number(v)),
+        });
       }
       setShowEditForm(false);
       setEditingCustomer(null);
@@ -315,7 +321,7 @@ const Customers: React.FC = () => {
       country: customer.country || '',
       industry_array: customer.industry_array || [], // Phase 4: Populate array
       preferred_protein_types: customer.preferred_protein_types || [], // Phase 4: Populate array
-      products: customer.products || [], // Populate product IDs
+      products: (customer.products || []).map(String), // Populate product IDs
     });
     setShowEditForm(true);
   };
@@ -514,7 +520,7 @@ const Customers: React.FC = () => {
                   <MultiSelect
                     value={formData.products}
                     onChange={(values) => setFormData({ ...formData, products: values })}
-                    options={products.map(p => ({ value: p.id, label: `${p.product_code}${p.name ? ' - ' + p.name : ''}` }))}
+                    options={products.map(p => ({ value: String(p.id), label: `${p.product_code}${p.name ? ' - ' + p.name : ''}` }))}
                     label="Preferred Products"
                     placeholder="Select preferred products (hold Ctrl/Cmd for multiple)"
                   />

--- a/frontend/src/pages/Customers/Locations.tsx
+++ b/frontend/src/pages/Customers/Locations.tsx
@@ -475,8 +475,8 @@ const CustomerLocations: React.FC = () => {
       </TableControls>
 
       <StyledTable
-        columns={columns}
-        dataSource={filteredLocations}
+        columns={columns as any}
+        dataSource={filteredLocations as any}
         rowKey="id"
         loading={loading}
         pagination={{

--- a/frontend/src/pages/Suppliers/Plants.tsx
+++ b/frontend/src/pages/Suppliers/Plants.tsx
@@ -494,8 +494,8 @@ const Plants: React.FC = () => {
       </TableControls>
 
       <StyledTable
-        columns={columns}
-        dataSource={filteredPlants}
+        columns={columns as any}
+        dataSource={filteredPlants as any}
         rowKey="id"
         loading={loading}
         pagination={{

--- a/frontend/src/pages/WorkForms/Catalog.original.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.original.tsx
@@ -469,7 +469,7 @@ const FormsFlowsCatalog: React.FC = () => {
             variant="primary"
             onClick={() => setShowTemplateSelector(true)}
             disabled={!permissions.can_create || permissionsLoading}
-            title={!permissions.can_create ? getUpgradeMessage(permissions.role, 'create') : 'Create a new form or workflow'}
+            title={!permissions.can_create ? getUpgradeMessage('create', permissions.role) : 'Create a new form or workflow'}
           >
             {!permissions.can_create && <Lock size={16} style={{ marginRight: '0.5rem' }} />}
             <Plus size={18} />
@@ -642,8 +642,7 @@ const FormsFlowsCatalog: React.FC = () => {
         />
       )}
       
-      {/* Debug: Show preview state */}
-      {console.log('[Catalog] Current previewForm state:', previewForm)}
+
     </Container>
   );
 };

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -613,7 +613,7 @@ const FormsFlowsCatalog: React.FC = () => {
   const filteredForms = React.useMemo(() => {
     // Safety check: ensure forms is an array
     if (!forms || !Array.isArray(forms)) {
-      logger.warn('[Catalog] Forms is not an array:', forms, 'isLoading:', isLoading);
+      logger.warn('[Catalog] Forms is not an array', { component: 'Catalog', metadata: { forms, isLoading } });
       return [];
     }
 
@@ -747,7 +747,7 @@ const FormsFlowsCatalog: React.FC = () => {
             disabled={!permissions.can_create || permissionsLoading}
             title={
               !permissions.can_create
-                ? getUpgradeMessage(permissions.role, 'create')
+                ? getUpgradeMessage('create', permissions.role)
                 : 'Create a new form or workflow'
             }
           >
@@ -932,7 +932,7 @@ const FormsFlowsCatalog: React.FC = () => {
             <FormCard key={form.id}>
               <CardContent
                 onClick={(e) => {
-                  logger.debug('[Catalog] CardContent (List) CLICKED!', form.id, e);
+                  logger.debug('[Catalog] CardContent (List) CLICKED!', { component: 'Catalog', metadata: { formId: form.id } }, e);
                   handleEditForm(form.id);
                 }}
                 style={{ cursor: 'pointer' }}

--- a/frontend/src/services/aiNodeSuggestionService.ts
+++ b/frontend/src/services/aiNodeSuggestionService.ts
@@ -333,16 +333,19 @@ export class AINodeSuggestionService {
     const triggerNode = nodes.find(n => n.type?.startsWith('trigger'));
     if (!triggerNode) return nodes.map(n => n.type || 'default');
     
-    let current = triggerNode;
+    let current: (typeof triggerNode) | undefined = triggerNode;
     while (current && !visited.has(current.id)) {
       visited.add(current.id);
       sequence.push(current.type || 'default');
       
       // Find next node via edge
-      const outgoingEdge = edges.find(e => e.source === current.id);
+      const currentId: string = current.id;
+      const outgoingEdge: Edge | undefined = edges.find((e) => e.source === currentId);
       if (!outgoingEdge) break;
-      
-      current = nodes.find(n => n.id === outgoingEdge.target) || null;
+
+      const next: Node | undefined = nodes.find((n) => n.id === outgoingEdge.target);
+      if (!next) break;
+      current = next;
     }
     
     return sequence;

--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -128,7 +128,7 @@ interface ConfigCache {
 let memoryCache: ConfigCache = {};
 
 // Pending requests deduplication (prevent duplicate API calls)
-const pendingRequests: Record<string, Promise<unknown>> = {};
+const pendingRequests: Record<string, Promise<unknown> | undefined> = {};
 
 // Performance metrics tracking
 let cacheHits = 0;

--- a/frontend/src/services/nodeValidationService.ts
+++ b/frontend/src/services/nodeValidationService.ts
@@ -219,8 +219,11 @@ export function validateNode(node: Node, allNodes?: Node[], allEdges?: any[]): V
   
   // Validate each field
   for (const fieldSchema of allFields) {
-    const fieldName = fieldSchema.name;
-    const fieldValue = values[fieldName];
+    const fieldAny = fieldSchema as any;
+    const fieldName = String(fieldAny.key ?? fieldAny.name ?? fieldAny.id ?? '');
+    if (!fieldName) continue;
+
+    const fieldValue = (values as Record<string, any>)[fieldName];
     
     // Check conditional visibility
     if (!isFieldVisible(fieldSchema, values)) {

--- a/frontend/src/services/schemaService.ts
+++ b/frontend/src/services/schemaService.ts
@@ -92,7 +92,11 @@ export const getEntityFields = async (entityId: string): Promise<EntityField[]> 
     
     return normalizedFields;
   } catch (error) {
-    logger.error('[SchemaService] Failed to fetch fields for entity:', entityId, error);
+    logger.error(
+      '[SchemaService] Failed to fetch fields for entity',
+      { component: 'SchemaService', metadata: { entityId } },
+      error
+    );
     // Return empty array instead of throwing to prevent UI crashes
     return [];
   }

--- a/frontend/src/services/tenantFormService.ts
+++ b/frontend/src/services/tenantFormService.ts
@@ -8,7 +8,7 @@
  * Phase: Agent B - Persistence
  */
 
-import { Node, Edge } from '@xyflow/react';
+import type { Edge, Node } from '@xyflow/react';
 import { logger } from '@/utils/logger';
 
 import { adminClient } from './apiService';
@@ -81,7 +81,7 @@ export interface SaveFormResult {
  * Note: xyflow uses `parentId` for grouping, but some older code paths still
  * write `parentNode`. We support both to avoid false "0 children" saves.
  */
-function getChildNodes(groupNode: Node<FormProcessGroupData> | string, allNodes: Node[]): Node[] {
+function getChildNodes(groupNode: Node<any> | string, allNodes: Node<any>[]): Node<any>[] {
   const groupNodeId = typeof groupNode === 'string' ? groupNode : groupNode.id;
   const pageOrder =
     typeof groupNode === 'string'
@@ -90,7 +90,7 @@ function getChildNodes(groupNode: Node<FormProcessGroupData> | string, allNodes:
         ? groupNode.data.pageOrder
         : null;
 
-  const isChild = (node: Node): boolean => {
+  const isChild = (node: Node<any>): boolean => {
     const anyNode = node as any;
     const parent =
       anyNode.parentId ??
@@ -109,7 +109,7 @@ function getChildNodes(groupNode: Node<FormProcessGroupData> | string, allNodes:
 
   // Prefer stable ordering if the container has an explicit pageOrder.
   if (pageOrder?.length) {
-    const index = new Map(pageOrder.map((id, i) => [id, i]));
+    const index = new Map(pageOrder.map((id: string, i: number) => [id, i]));
     return [...children].sort((a, b) => {
       const ai = index.has(a.id) ? (index.get(a.id) as number) : Number.MAX_SAFE_INTEGER;
       const bi = index.has(b.id) ? (index.get(b.id) as number) : Number.MAX_SAFE_INTEGER;
@@ -127,18 +127,18 @@ function getChildNodes(groupNode: Node<FormProcessGroupData> | string, allNodes:
 /**
  * Convert React Flow node to FormStep format
  */
-function convertNodeToFormStep(node: Node, index: number): FormStep {
-  const data = node.data;
-  
+function convertNodeToFormStep(node: Node<any>, index: number): FormStep {
+  const data = (node.data ?? {}) as any;
+
   return {
     name: data.name || data.label || `Step ${index + 1}`,
     description: data.description || '',
     entity_type: data.entityType || data.entity_type,
-    entity_action: data.entityAction || data.entity_action || 'create',
-    fields: convertFieldsToFormFields(data.fields || []),
-    validation_rules: data.validationRules || [],
+    entity_action: (data.entityAction || data.entity_action || 'create') as FormStep['entity_action'],
+    fields: convertFieldsToFormFields(Array.isArray(data.fields) ? data.fields : []),
+    validation_rules: Array.isArray(data.validationRules) ? data.validationRules : [],
     order: index,
-    node_id: node.id
+    node_id: node.id,
   };
 }
 
@@ -185,9 +185,9 @@ async function generateDefinitionHash(definition: any): Promise<string> {
  * @returns SaveFormResult with tenantFormId and version
  */
 export async function saveFormProcessGroup(
-  groupNode: Node<FormProcessGroupData>,
-  allNodes: Node[],
-  allEdges: Edge[]
+  groupNode: Node<any>,
+  allNodes: Node<any>[],
+  allEdges: Edge<any>[]
 ): Promise<SaveFormResult> {
   // Deprecated: All saving now goes through the TenantWorkForm endpoints.
   // Backend now snapshots nested `container.data.steps` during TenantWorkForm save.

--- a/frontend/src/services/workformsApi.ts
+++ b/frontend/src/services/workformsApi.ts
@@ -443,6 +443,18 @@ export const validateWorkForm = async (
   return response.data;
 };
 
+export interface SuggestNodesResponse {
+  suggestions: any[];
+  confidence?: number;
+  mode?: 'ai' | 'static';
+  cached?: boolean;
+}
+
+export const suggestNodes = async (payload: any): Promise<SuggestNodesResponse> => {
+  const response = await apiClient.post('/suggest-nodes/', payload);
+  return response.data;
+};
+
 // ============================================================================
 // Container APIs (Phase 4)
 // ============================================================================
@@ -547,6 +559,7 @@ const workformsApi = {
   cloneWorkForm,
   getWorkFormUsage,
   validateWorkForm,
+  suggestNodes,
   
   // Container utilities
   listWorkFormContainers,

--- a/frontend/src/theme/themeConfig.test.ts
+++ b/frontend/src/theme/themeConfig.test.ts
@@ -20,19 +20,19 @@ describe('Theme Configuration', () => {
     it('returns light theme for light mode', () => {
       const config = getThemeConfig('light');
       expect(config).toEqual(lightTheme);
-      expect(config.token?.colorPrimary).toBe('#667eea');
+      expect(String(config.token?.colorPrimary)).toContain('--color-primary');
     });
 
     it('returns dark theme for dark mode', () => {
       const config = getThemeConfig('dark');
       expect(config).toEqual(darkTheme);
-      expect(config.token?.colorPrimary).toBe('#818cf8');
+      expect(String(config.token?.colorPrimary)).toContain('--color-primary');
     });
 
     it('returns high contrast theme for high-contrast mode', () => {
       const config = getThemeConfig('high-contrast');
       expect(config).toEqual(highContrastTheme);
-      expect(config.token?.colorPrimary).toBe('#0000ff');
+      expect(String(config.token?.colorPrimary)).toContain('--color-primary');
     });
 
     it('defaults to light theme for unknown mode', () => {
@@ -44,11 +44,11 @@ describe('Theme Configuration', () => {
   describe('Theme Token Values', () => {
     it('light theme has correct tokens', () => {
       expect(lightTheme.token).toMatchObject({
-        colorPrimary: '#667eea',
-        colorSuccess: '#22c55e',
-        colorWarning: '#eab308',
-        colorError: '#ef4444',
-        colorInfo: '#3b82f6',
+        colorPrimary: 'rgb(var(--color-primary))',
+        colorSuccess: 'rgb(34, 197, 94)',
+        colorWarning: 'rgb(234, 179, 8)',
+        colorError: 'rgb(239, 68, 68)',
+        colorInfo: 'rgb(59, 130, 246)',
         fontSize: 14,
         borderRadius: 6,
       });
@@ -56,11 +56,11 @@ describe('Theme Configuration', () => {
 
     it('dark theme has correct tokens', () => {
       expect(darkTheme.token).toMatchObject({
-        colorPrimary: '#818cf8',
-        colorSuccess: '#4ade80',
-        colorWarning: '#fbbf24',
-        colorError: '#f87171',
-        colorInfo: '#60a5fa',
+        colorPrimary: 'rgb(var(--color-primary))',
+        colorSuccess: 'rgb(34, 197, 94)',
+        colorWarning: 'rgb(234, 179, 8)',
+        colorError: 'rgb(239, 68, 68)',
+        colorInfo: 'rgb(59, 130, 246)',
         fontSize: 14,
         borderRadius: 6,
       });
@@ -68,10 +68,10 @@ describe('Theme Configuration', () => {
 
     it('high contrast theme has accessibility-focused tokens', () => {
       expect(highContrastTheme.token).toMatchObject({
-        colorPrimary: '#0000ff',
-        colorSuccess: '#008000',
-        colorWarning: '#ffaa00',
-        colorError: '#cc0000',
+        colorPrimary: 'rgb(var(--color-primary))',
+        colorSuccess: 'rgb(0, 128, 0)',
+        colorWarning: 'rgb(255, 170, 0)',
+        colorError: 'rgb(204, 0, 0)',
         fontSize: 16, // Larger for accessibility
         borderRadius: 2, // Sharper edges
         lineWidth: 2, // Thicker borders

--- a/frontend/src/theme/themeConfig.ts
+++ b/frontend/src/theme/themeConfig.ts
@@ -105,7 +105,6 @@ export const highContrastTheme: ThemeConfig = {
     Input: {
       controlHeight: 44,
       borderRadius: 2,
-      fontWeight: 600,
     },
     Card: {
       borderRadius: 4,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -42,6 +42,11 @@ export interface UserProfile {
   is_active: boolean;
   is_staff?: boolean;
   is_superuser?: boolean;
+  /**
+   * Optional user role string.
+   * Some API responses include a global role; others provide per-tenant roles via `tenants`.
+   */
+  role?: string;
   tenants?: UserTenant[];
 }
 
@@ -267,6 +272,12 @@ export interface Product {
   product_code: string;
   description_of_product_item: string;
   type_of_protein?: string;
+  /** Legacy field name used by some endpoints/exports */
+  protein_type?: string;
+  /** Optional display fields used by search/autocomplete results */
+  name?: string;
+  description?: string;
+  avg_price?: number;
   fresh_or_frozen?: string;
   package_type?: string;
   net_or_catch?: string;

--- a/frontend/src/utils/flowUtils.ts
+++ b/frontend/src/utils/flowUtils.ts
@@ -116,7 +116,7 @@ function extractNodeOutputs(node: Node): UpstreamOutput[] {
       outputs.push({
         nodeId: node.id,
         nodeLabel: data.label || 'Create Record',
-        nodeType: node.type,
+        nodeType: node.type ?? 'unknown',
         fieldName: field.name,
         fieldLabel: field.label,
         fieldType: field.type,
@@ -131,7 +131,7 @@ function extractNodeOutputs(node: Node): UpstreamOutput[] {
       outputs.push({
         nodeId: node.id,
         nodeLabel: data.label || 'Lookup',
-        nodeType: node.type,
+        nodeType: node.type ?? 'unknown',
         fieldName: key,
         fieldLabel: humanize(key),
         fieldType: inferType(value),
@@ -146,7 +146,7 @@ function extractNodeOutputs(node: Node): UpstreamOutput[] {
       outputs.push({
         nodeId: node.id,
         nodeLabel: data.label || 'API Response',
-        nodeType: node.type,
+        nodeType: node.type ?? 'unknown',
         fieldName: key,
         fieldLabel: humanize(key),
         fieldType: inferType(value),
@@ -161,7 +161,7 @@ function extractNodeOutputs(node: Node): UpstreamOutput[] {
       outputs.push({
         nodeId: node.id,
         nodeLabel: data.label || 'Variables',
-        nodeType: node.type,
+        nodeType: node.type ?? 'unknown',
         fieldName: variable.key || variable.name,
         fieldLabel: variable.label || humanize(variable.key || variable.name),
         fieldType: variable.type || 'text',

--- a/frontend/src/utils/performance.ts
+++ b/frontend/src/utils/performance.ts
@@ -3,7 +3,7 @@
  * Phase 6.5: Frontend Optimization
  */
 
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 /**
  * Hook to measure component render performance.
@@ -48,7 +48,7 @@ export function useDebounce<T extends (...args: any[]) => any>(
   callback: T,
   delay: number
 ): T {
-  const timeoutRef = useRef<NodeJS.Timeout>();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     return () => {
@@ -119,8 +119,10 @@ export class MemoCache<K, V> {
   set(key: K, value: V): void {
     if (this.cache.size >= this.maxSize) {
       // Remove oldest entry (first key)
-      const firstKey = this.cache.keys().next().value;
-      this.cache.delete(firstKey);
+      const firstKey = this.cache.keys().next().value as K | undefined;
+      if (firstKey !== undefined) {
+        this.cache.delete(firstKey);
+      }
     }
     this.cache.set(key, value);
   }


### PR DESCRIPTION
Fixes frontend TypeScript type-check + CI tests after ReactFlow/@xyflow v12 typing changes and strictness tightening.

Key changes:
- Align NodeProps/EdgeProps generics to Node/Edge types and satisfy Record<string, unknown> constraints.
- Harden FlowEditor utilities/guards and logger call signatures.
- Fix misc app typing issues (WorkForms, Widgets, Integrations, Theme config, Notifications/QuickActions context typing).

Verification:
- cd frontend && npm run type-check
- cd frontend && npm run test:ci