### PR TITLE
Fix Admin Option Lists (seed defaults + RLS-safe writes)

### DIFF
--- a/backend/apps/system/management/commands/seed_choice_lists.py
+++ b/backend/apps/system/management/commands/seed_choice_lists.py
@@ -161,7 +161,6 @@ class Command(BaseCommand):
                             'model_field_path': list_def.get('model_field_path', ''),
                             'is_extensible': list_def.get('is_extensible', True),
                             'is_reorderable': list_def.get('is_reorderable', True),
-                            'is_active': True,
                         }
                     )
                     

--- a/backend/apps/system/migrations/0013_seed_default_choice_lists.py
+++ b/backend/apps/system/migrations/0013_seed_default_choice_lists.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+
+def seed_default_choice_lists(apps, schema_editor):
+    SystemChoiceList = apps.get_model('system', 'SystemChoiceList')
+    SystemChoiceItem = apps.get_model('system', 'SystemChoiceItem')
+
+    # Minimal Tier-1 defaults so Admin Workspace Option Lists isn't empty.
+    # Idempotent: update_or_create (does not delete existing records).
+    choice_lists = [
+        {
+            'slug': 'protein_type',
+            'name': 'Protein Type',
+            'description': 'Types of protein products (beef, pork, poultry, etc.)',
+            'model_field_path': 'products.product.protein_type',
+            'is_extensible': True,
+            'is_reorderable': True,
+            'items': [
+                {'value': 'beef', 'label': 'Beef', 'order': 1, 'extra_data': {'filter_key': 'beef'}},
+                {'value': 'pork', 'label': 'Pork', 'order': 2, 'extra_data': {'filter_key': 'pork'}},
+                {'value': 'poultry', 'label': 'Poultry', 'order': 3, 'extra_data': {'filter_key': 'poultry'}},
+                {'value': 'seafood', 'label': 'Seafood', 'order': 4, 'extra_data': {'filter_key': 'seafood'}},
+                {'value': 'lamb', 'label': 'Lamb', 'order': 5, 'extra_data': {'filter_key': 'lamb'}},
+                {'value': 'other', 'label': 'Other', 'order': 99, 'extra_data': {'filter_key': 'other'}},
+            ],
+        },
+        {
+            'slug': 'fresh_or_frozen',
+            'name': 'Fresh or Frozen',
+            'description': 'Product storage state',
+            'model_field_path': 'products.product.fresh_or_frozen',
+            'is_extensible': False,
+            'is_reorderable': False,
+            'items': [
+                {'value': 'FRESH', 'label': 'Fresh', 'order': 1},
+                {'value': 'FROZEN', 'label': 'Frozen', 'order': 2},
+            ],
+        },
+        {
+            'slug': 'package_type',
+            'name': 'Package Type',
+            'description': 'Product packaging types',
+            'model_field_path': 'products.product.package_type',
+            'is_extensible': True,
+            'is_reorderable': True,
+            'items': [
+                {'value': 'COMBO_BIN', 'label': 'Combo Bin', 'order': 1},
+                {'value': 'CASES', 'label': 'Cases', 'order': 2},
+                {'value': 'BAGS', 'label': 'Bags', 'order': 3},
+                {'value': 'BULK', 'label': 'Bulk', 'order': 4},
+                {'value': 'VACUUM_SEALED', 'label': 'Vacuum Sealed', 'order': 5},
+                {'value': 'OTHER', 'label': 'Other', 'order': 99},
+            ],
+        },
+        {
+            'slug': 'payment_terms',
+            'name': 'Payment Terms',
+            'description': 'Accounting payment terms',
+            'model_field_path': 'customers.customer.payment_terms',
+            'is_extensible': True,
+            'is_reorderable': True,
+            'items': [
+                {'value': 'NET7', 'label': 'Net 7', 'order': 1},
+                {'value': 'NET10', 'label': 'Net 10', 'order': 2},
+                {'value': 'NET15', 'label': 'Net 15', 'order': 3},
+                {'value': 'NET30', 'label': 'Net 30', 'order': 4, 'is_default': True},
+                {'value': 'NET45', 'label': 'Net 45', 'order': 5},
+                {'value': 'NET60', 'label': 'Net 60', 'order': 6},
+                {'value': 'NET90', 'label': 'Net 90', 'order': 7},
+                {'value': 'COD', 'label': 'Cash on Delivery', 'order': 8},
+                {'value': 'PREPAID', 'label': 'Prepaid', 'order': 9},
+            ],
+        },
+        {
+            'slug': 'weight_unit',
+            'name': 'Weight Unit',
+            'description': 'Unit of measure for weight',
+            'model_field_path': 'products.product.weight_unit',
+            'is_extensible': False,
+            'is_reorderable': False,
+            'items': [
+                {'value': 'LBS', 'label': 'Pounds (lbs)', 'order': 1, 'is_default': True},
+                {'value': 'KG', 'label': 'Kilograms (kg)', 'order': 2},
+                {'value': 'OZ', 'label': 'Ounces (oz)', 'order': 3},
+                {'value': 'G', 'label': 'Grams (g)', 'order': 4},
+            ],
+        },
+        {
+            'slug': 'contact_type',
+            'name': 'Contact Type',
+            'description': 'Types of contacts',
+            'model_field_path': 'contacts.contact.contact_type',
+            'is_extensible': True,
+            'is_reorderable': True,
+            'items': [
+                {'value': 'PRIMARY', 'label': 'Primary Contact', 'order': 1},
+                {'value': 'SALES', 'label': 'Sales', 'order': 2},
+                {'value': 'ACCOUNTING', 'label': 'Accounting', 'order': 3},
+                {'value': 'SHIPPING', 'label': 'Shipping', 'order': 4},
+                {'value': 'RECEIVING', 'label': 'Receiving', 'order': 5},
+                {'value': 'TECHNICAL', 'label': 'Technical', 'order': 6},
+                {'value': 'OTHER', 'label': 'Other', 'order': 99},
+            ],
+        },
+    ]
+
+    for list_def in choice_lists:
+        items = list_def.pop('items')
+        choice_list, _ = SystemChoiceList.objects.update_or_create(
+            slug=list_def['slug'],
+            defaults={
+                'name': list_def['name'],
+                'description': list_def.get('description', ''),
+                'model_field_path': list_def.get('model_field_path', ''),
+                'is_extensible': list_def.get('is_extensible', True),
+                'is_reorderable': list_def.get('is_reorderable', True),
+            },
+        )
+
+        for item_def in items:
+            SystemChoiceItem.objects.update_or_create(
+                choice_list=choice_list,
+                value=item_def['value'],
+                tenant=None,
+                defaults={
+                    'label': item_def['label'],
+                    'order': item_def.get('order', 0),
+                    'extra_data': item_def.get('extra_data', {}),
+                    'is_default': bool(item_def.get('is_default', False)),
+                    'is_active': True,
+                },
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('system', '0012_systemconfiguration'),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_default_choice_lists, migrations.RunPython.noop),
+    ]

--- a/backend/apps/system/views/choice_viewsets.py
+++ b/backend/apps/system/views/choice_viewsets.py
@@ -158,6 +158,11 @@ class SystemChoiceListViewSet(viewsets.ReadOnlyModelViewSet):
                 context={'choice_list': choice_list, 'tenant': tenant}
             )
             serializer.is_valid(raise_exception=True)
+
+            # RLS: ensure session vars are set on the active connection for this write.
+            from apps.tenants.rls import set_current_tenant
+
+            set_current_tenant(str(tenant.id))
             
             item = SystemChoiceItem.objects.create(
                 choice_list=choice_list,
@@ -217,6 +222,12 @@ class SystemChoiceListViewSet(viewsets.ReadOnlyModelViewSet):
         serializer.is_valid(raise_exception=True)
         
         tenant = getattr(request, 'tenant', None)
+
+        if tenant:
+            # RLS: ensure session vars are set on the active connection for this write.
+            from apps.tenants.rls import set_current_tenant
+
+            set_current_tenant(str(tenant.id))
         
         for item_data in serializer.validated_data['items']:
             item_id = item_data['id']
@@ -430,6 +441,11 @@ class TenantChoiceOverrideViewSet(viewsets.ModelViewSet):
 
             raise ValidationError('Tenant context required.')
 
+        # RLS: ensure session vars are set on the active connection for this write.
+        from apps.tenants.rls import set_current_tenant
+
+        set_current_tenant(str(tenant.id))
+
         instance = serializer.save(tenant=tenant, updated_by=self.request.user)
 
         try:
@@ -472,6 +488,12 @@ class TenantChoiceOverrideViewSet(viewsets.ModelViewSet):
             'disabled_system_items': list(instance.disabled_system_items or []),
             'display_config': instance.display_config or {},
         }
+
+        if tenant:
+            # RLS: ensure session vars are set on the active connection for this write.
+            from apps.tenants.rls import set_current_tenant
+
+            set_current_tenant(str(tenant.id))
 
         updated = serializer.save(updated_by=self.request.user)
 

--- a/backend/apps/tenants/middleware.py
+++ b/backend/apps/tenants/middleware.py
@@ -273,20 +273,20 @@ class TenantMiddleware:
         # only persists for the current transaction.
         rls_set = False
         if tenant:
-            try:
-                with connection.cursor() as cursor:
-                    cursor.execute("SET app.current_tenant_id = %s", [str(tenant.id)])
-                    cursor.execute("SET app.current_tenant = %s", [str(tenant.id)])
-                rls_set = True
+            from apps.tenants.rls import set_current_tenant
+
+            result = set_current_tenant(str(tenant.id))
+            rls_set = result.ok
+
+            if result.ok:
                 logger.debug(
                     f"RLS: Set current_tenant_id/current_tenant={tenant.id} for tenant={tenant.slug}"
                 )
-            except Exception as e:
+            else:
                 # Log but don't fail the request if RLS setup fails.
-                # Application-level filtering will still work.
+                # Application-level filtering will still work, but DB-level RLS writes may fail.
                 logger.warning(
-                    f"Failed to set RLS session variables for tenant={tenant.slug}: "
-                    f"{type(e).__name__}: {str(e)}"
+                    f"Failed to set RLS session variables for tenant={tenant.slug}: {result.error}"
                 )
         else:
             # Clear session variables if no tenant is resolved

--- a/backend/apps/tenants/rls.py
+++ b/backend/apps/tenants/rls.py
@@ -1,0 +1,39 @@
+"""Tenant RLS helpers.
+
+ProjectMeats uses PostgreSQL Row-Level Security (RLS) with session variables:
+- app.current_tenant_id
+- app.current_tenant
+
+TenantMiddleware sets these at request start, but write paths should be resilient
+in case middleware couldn't set them (connection issues, early DB access, etc.).
+
+These helpers allow views/services to (re)assert the current tenant on the active
+connection right before a write.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.db import connection
+
+
+@dataclass(frozen=True)
+class RlsSetResult:
+    ok: bool
+    error: str | None = None
+
+
+def set_current_tenant(tenant_id: str) -> RlsSetResult:
+    """Set PostgreSQL session variables used by RLS policies.
+
+    Uses `SET` (not `SET LOCAL`) because Django often runs in autocommit.
+    """
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SET app.current_tenant_id = %s", [tenant_id])
+            cursor.execute("SET app.current_tenant = %s", [tenant_id])
+        return RlsSetResult(ok=True)
+    except Exception as e:  # pragma: no cover
+        return RlsSetResult(ok=False, error=f"{type(e).__name__}: {e}")

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -853,6 +853,24 @@ class TenantFilteredModelViewSet(viewsets.ModelViewSet):
             return qs.filter(tenant=self.request.tenant)
         return qs.none()
 
+    def _ensure_rls_session_vars(self, tenant_id: str) -> None:
+        """Best-effort: (re)set Postgres session vars used by RLS.
+
+        TenantMiddleware normally sets these, but on write paths we re-assert
+        them to avoid "new row violates row-level security policy" 500s if the
+        middleware couldn't set them earlier.
+        """
+
+        from apps.tenants.rls import set_current_tenant
+
+        result = set_current_tenant(tenant_id)
+        if not result.ok:
+            logger.warning(
+                "RLS: failed to set session vars for tenant=%s: %s",
+                tenant_id,
+                result.error,
+            )
+
     def perform_create(self, serializer):
         """Set tenant and created_by on create.
 
@@ -863,12 +881,26 @@ class TenantFilteredModelViewSet(viewsets.ModelViewSet):
         if not tenant:
             raise ValidationError({"tenant": "Tenant context is required (X-Tenant-ID header)."})
 
+        self._ensure_rls_session_vars(str(tenant.id))
+
         save_kwargs = {"tenant": tenant}
 
         if hasattr(serializer.Meta.model, "created_by") and getattr(self.request, "user", None):
             save_kwargs["created_by"] = self.request.user
 
         serializer.save(**save_kwargs)
+
+    def perform_update(self, serializer):
+        tenant = getattr(self.request, "tenant", None)
+        if tenant:
+            self._ensure_rls_session_vars(str(tenant.id))
+        serializer.save()
+
+    def perform_destroy(self, instance):
+        tenant = getattr(self.request, "tenant", None)
+        if tenant:
+            self._ensure_rls_session_vars(str(tenant.id))
+        instance.delete()
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes Admin Workspace Option Lists failures:

- Prevents 500s on tenant list create/update/delete when RLS session vars weren’t set by re-asserting tenant RLS vars on write paths.
- Ensures System Choice Lists aren’t empty by adding an idempotent seed migration.
- Fixes system seed_choice_lists command to match SystemChoiceList schema.

User-visible: system lists show; custom tenant list create button works; tenant overrides writes succeed.