### PR TITLE
Add EntityFormSurface consolidation layer

### DIFF
--- a/frontend/src/components/Shared/EntityFormSurface.tsx
+++ b/frontend/src/components/Shared/EntityFormSurface.tsx
@@ -1,0 +1,109 @@
+/**
+ * EntityFormSurface
+ *
+ * Single entry point for record create/edit forms.
+ *
+ * - Default renderer: UniversalEntityForm (schema-driven)
+ * - Enhanced renderer(s): entity-specific modules (e.g., InquiryCreateModal)
+ *
+ * This is the consolidation layer that lets the same form be embedded
+ * in a modal today, and later embedded inline/panels/workforms without
+ * duplicating per-entry-point logic.
+ */
+
+import React, { useMemo } from 'react';
+
+import UniversalEntityForm from './UniversalEntityForm';
+import { InquiryCreateModal } from '../Inquiry';
+
+export type EntityFormMode = 'create' | 'edit';
+
+export type EntityFormContext = {
+  customerId?: string | number;
+  supplierId?: string | number;
+  contactId?: string | number;
+  sourceCallId?: string | number;
+};
+
+export interface EntityFormSurfaceProps {
+  entityType: string;
+  mode: EntityFormMode;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess?: (result: unknown) => void;
+
+  /** For edit mode */
+  entityId?: string | number;
+
+  /** Seed values for universal schema-driven form */
+  initialValues?: Record<string, unknown>;
+
+  /** Context entity for cascade-prefill across Cockpit etc. */
+  context?: EntityFormContext;
+}
+
+const normalizeEntityType = (raw: string): string => {
+  const t = String(raw || '')
+    .trim()
+    .toLowerCase();
+
+  if (t === 'inquiry' || t === 'inquiries') return 'inquiry';
+  if (t === 'customer' || t === 'customers') return 'customer';
+  if (t === 'supplier' || t === 'suppliers') return 'supplier';
+
+  return t;
+};
+
+export const EntityFormSurface: React.FC<EntityFormSurfaceProps> = ({
+  entityType,
+  mode,
+  isOpen,
+  onClose,
+  onSuccess,
+  entityId,
+  initialValues,
+  context,
+}) => {
+  const normalized = useMemo(() => normalizeEntityType(entityType), [entityType]);
+
+  // Enhanced form: Inquiry (create).
+  if (normalized === 'inquiry' && mode === 'create') {
+    const initialEntityType = context?.customerId
+      ? 'customer'
+      : context?.supplierId
+        ? 'supplier'
+        : undefined;
+    const initialEntityId = context?.customerId ?? context?.supplierId;
+
+    return (
+      <InquiryCreateModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onSuccess={(created) => onSuccess?.(created)}
+        initialEntityType={initialEntityType}
+        initialEntityId={initialEntityId}
+      />
+    );
+  }
+
+  // Default: Universal schema-driven form.
+  const derivedInitialValues: Record<string, unknown> = {
+    ...(initialValues || {}),
+    ...(context?.customerId != null ? { customer: String(context.customerId) } : {}),
+    ...(context?.supplierId != null ? { supplier: String(context.supplierId) } : {}),
+    ...(context?.contactId != null ? { contact: String(context.contactId) } : {}),
+  };
+
+  return (
+    <UniversalEntityForm
+      entityType={entityType}
+      entityId={mode === 'edit' ? entityId : undefined}
+      isOpen={isOpen}
+      onClose={onClose}
+      onSuccess={(result) => onSuccess?.(result)}
+      initialValues={derivedInitialValues}
+    />
+  );
+};
+
+export default EntityFormSurface;

--- a/frontend/src/components/Shared/index.ts
+++ b/frontend/src/components/Shared/index.ts
@@ -1,6 +1,6 @@
 /**
  * Shared Components - Phase 4 Frontend Integration
- * 
+ *
  * Export all shared UI components for easy importing
  */
 
@@ -11,6 +11,7 @@ export { RecordPaymentModal } from './RecordPaymentModal';
 export { PaymentHistoryList } from './PaymentHistoryList';
 export { ScheduleCallModal } from './ScheduleCallModal';
 export { UniversalEntityForm } from './UniversalEntityForm';
+export { EntityFormSurface } from './EntityFormSurface';
 export { CreateInvoiceModal } from './CreateInvoiceModal';
 export { SearchableSelect } from './SearchableSelect';
 export type { LocationSelectorProps } from './LocationSelector';


### PR DESCRIPTION
Adds EntityFormSurface: a single consolidation layer for record create/edit forms.

- Default renderer: schema-driven UniversalEntityForm
- Enhanced renderer hook: Inquiry (routes to InquiryCreateModal)

This provides a stable surface so Cockpit/entity pages/workforms can all render the same entity form without duplicating logic.
