### PR TITLE
Add key_fields to universal form schema

### DIFF
--- a/backend/apps/system/views/forms_schema.py
+++ b/backend/apps/system/views/forms_schema.py
@@ -99,10 +99,40 @@ class SystemFormSchemaView(APIView):
                 }
             )
 
+        # Key fields: best-effort "most likely needed" subset for create/edit.
+        # This keeps the API additive-only: clients can ignore it.
+        key_field_candidates = [
+            'name',
+            'title',
+            'status',
+            'email',
+            'phone',
+            'contact_person',
+            'full_name',
+            'customer',
+            'supplier',
+            'entity_type',
+            'order_date',
+            'delivery_date',
+            'invoice_date',
+            'valid_until',
+        ]
+
+        # Always include required fields.
+        required_keys = [f['key'] for f in mapped_fields if f.get('required')]
+
+        # Then include common candidates if present.
+        present = {f['key'] for f in mapped_fields}
+        key_fields = []
+        for k in required_keys + key_field_candidates:
+            if k in present and k not in key_fields:
+                key_fields.append(k)
+
         schema = {
             'name': f'Universal Form: {entity_type}',
             'description': 'Auto-generated schema (V3.0 Phase 1).',
             'fields': mapped_fields,
+            'key_fields': key_fields,
         }
 
         return Response(schema, status=status.HTTP_200_OK)

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -51,6 +51,7 @@ type BackendSchema = {
   name?: string;
   description?: string;
   fields?: BackendField[];
+  key_fields?: string[];
 };
 
 const Container = styled.div`
@@ -80,6 +81,14 @@ const normalizeEntityEndpoint = (entityType: string): string => {
     return 'purchase-orders/';
   if (lower === 'inquiries' || lower === 'inquiry') return 'inquiries/';
   if (lower === 'claims' || lower === 'claim') return 'claims/';
+
+  // Common singular → plural API resources
+  if (lower === 'customer') return 'customers/';
+  if (lower === 'supplier') return 'suppliers/';
+  if (lower === 'contact') return 'contacts/';
+  if (lower === 'invoice') return 'invoices/';
+  if (lower === 'product') return 'products/';
+
   return `${lower.replace(/^\/+/, '').replace(/\/+$/, '')}/`;
 };
 
@@ -370,7 +379,11 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     };
 
     const preferred =
-      (keyFields && keyFields.length ? keyFields : defaultKeyFields[normalized]) || [];
+      (keyFields && keyFields.length
+        ? keyFields
+        : schema?.key_fields && schema.key_fields.length
+          ? schema.key_fields
+          : defaultKeyFields[normalized]) || [];
     if (!preferred.length) return raw;
 
     const rank = new Map(preferred.map((k, idx) => [k.toLowerCase(), idx] as const));


### PR DESCRIPTION
Adds server-driven key field metadata for universal forms.

- /api/v1/system/forms/schema/ now includes key_fields (best-effort derived from required fields + common candidates).
- UniversalEntityForm prefers schema.key_fields for ordering when present (still supports explicit keyFields override).
- UniversalEntityForm now maps common singular entity types (customer/supplier/contact/invoice/product) to correct plural API endpoints.

This supports consolidating all create/edit entrypoints onto a single universal form surface.
