### PR TITLE
Cockpit: + New call purpose + inquiry modal

### DIFF
--- a/frontend/src/cockpit/views/CustomerDetailView.tsx
+++ b/frontend/src/cockpit/views/CustomerDetailView.tsx
@@ -2,6 +2,8 @@ import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { InquiryCreateModal } from '@/components/Inquiry';
+import { ScheduleCallModal } from '@/components/Shared';
+import { InquiryCallModal } from '@/components/Calls/InquiryCallModal';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Building2, Mail, MapPin, Phone, Plus, Sparkles, StickyNote } from 'lucide-react';
@@ -456,6 +458,9 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
   const [activeTab, setActiveTab] = useState<DetailTab>('products');
   const [isNewMenuOpen, setIsNewMenuOpen] = useState(false);
   const [isInquiryCreateOpen, setIsInquiryCreateOpen] = useState(false);
+  const [showScheduleCallModal, setShowScheduleCallModal] = useState(false);
+  const [defaultCallPurpose, setDefaultCallPurpose] = useState<string | undefined>(undefined);
+  const [showInquiryCallModal, setShowInquiryCallModal] = useState(false);
 
   const entityQuery = useQuery({
     queryKey: ['cockpit-entity', canonicalType, entityId],
@@ -555,11 +560,29 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
     };
   }, [canonicalType, counts]);
 
+  const startNewCall = (purpose: string) => {
+    setIsNewMenuOpen(false);
+
+    if (purpose === 'inquiry') {
+      setShowInquiryCallModal(true);
+      return;
+    }
+
+    setDefaultCallPurpose(purpose);
+    setShowScheduleCallModal(true);
+  };
+
   const handleNewAction = (action: 'product' | 'order' | 'call' | 'inquiry') => {
     setIsNewMenuOpen(false);
 
     if (action === 'inquiry') {
       setIsInquiryCreateOpen(true);
+      return;
+    }
+
+    if (action === 'call') {
+      // Default to follow-up if user used keyboard/quick action.
+      startNewCall('follow_up');
       return;
     }
 
@@ -600,6 +623,30 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
         }}
         initialEntityType={canonicalType ?? undefined}
         initialEntityId={entityId}
+      />
+
+      <ScheduleCallModal
+        isOpen={showScheduleCallModal}
+        onClose={() => setShowScheduleCallModal(false)}
+        onSuccess={() => {
+          void countsQuery.refetch();
+          void tabItemsQuery.refetch();
+        }}
+        defaultCallPurpose={defaultCallPurpose}
+        defaultEntityType={canonicalType ?? undefined}
+        defaultEntityId={Number.isFinite(Number(entityId)) ? entityId : undefined}
+      />
+
+      <InquiryCallModal
+        isOpen={showInquiryCallModal}
+        onClose={() => setShowInquiryCallModal(false)}
+        onSuccess={() => {
+          void countsQuery.refetch();
+          void tabItemsQuery.refetch();
+          setShowInquiryCallModal(false);
+        }}
+        initialEntityType={canonicalType ?? undefined}
+        initialEntityId={Number.isFinite(Number(entityId)) ? entityId : undefined}
       />
       <StickyHeader>
         <HeaderInner>
@@ -748,8 +795,23 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
                     <MenuItem type="button" onClick={() => handleNewAction('order')} role="menuitem">
                       New Order <span>↵</span>
                     </MenuItem>
-                    <MenuItem type="button" onClick={() => handleNewAction('call')} role="menuitem">
-                      New Call Log <span>↵</span>
+                    <MenuItem type="button" onClick={() => startNewCall('follow_up')} role="menuitem">
+                      New Call (Follow-up) <span>↵</span>
+                    </MenuItem>
+                    <MenuItem type="button" onClick={() => startNewCall('inquiry')} role="menuitem">
+                      New Call (Inquiry) <span>↵</span>
+                    </MenuItem>
+                    <MenuItem type="button" onClick={() => startNewCall('complaint')} role="menuitem">
+                      New Call (Complaint) <span>↵</span>
+                    </MenuItem>
+                    <MenuItem type="button" onClick={() => startNewCall('order')} role="menuitem">
+                      New Call (Order) <span>↵</span>
+                    </MenuItem>
+                    <MenuItem type="button" onClick={() => startNewCall('support')} role="menuitem">
+                      New Call (Support) <span>↵</span>
+                    </MenuItem>
+                    <MenuItem type="button" onClick={() => startNewCall('other')} role="menuitem">
+                      New Call (Other) <span>↵</span>
                     </MenuItem>
                     <MenuItem type="button" onClick={() => handleNewAction('inquiry')} role="menuitem">
                       New Inquiry <span>↵</span>

--- a/frontend/src/components/Calls/InquiryCallModal.tsx
+++ b/frontend/src/components/Calls/InquiryCallModal.tsx
@@ -37,6 +37,9 @@ interface InquiryCallModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: () => void;
+  /** Optional preselection when launched from an entity surface (e.g. Cockpit customer detail). */
+  initialEntityType?: EntityType;
+  initialEntityId?: string | number;
 }
 
 const Overlay = styled.div<{ $open: boolean }>`
@@ -331,7 +334,13 @@ const newLine = (): LineItem => ({
   notes: '',
 });
 
-export const InquiryCallModal: React.FC<InquiryCallModalProps> = ({ isOpen, onClose, onSuccess }) => {
+export const InquiryCallModal: React.FC<InquiryCallModalProps> = ({
+  isOpen,
+  onClose,
+  onSuccess,
+  initialEntityType,
+  initialEntityId,
+}) => {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -371,6 +380,14 @@ export const InquiryCallModal: React.FC<InquiryCallModalProps> = ({ isOpen, onCl
   useEffect(() => {
     if (!isOpen) return;
 
+    // Apply entity defaults when opened.
+    if (initialEntityType) {
+      setEntityType(initialEntityType);
+    }
+    if (initialEntityId !== undefined && initialEntityId !== null && String(initialEntityId).trim() !== '') {
+      setEntityId(String(initialEntityId));
+    }
+
     // Load weight unit choices (best-effort)
     void (async () => {
       try {
@@ -380,7 +397,7 @@ export const InquiryCallModal: React.FC<InquiryCallModalProps> = ({ isOpen, onCl
         setUomOptions([]);
       }
     })();
-  }, [isOpen]);
+  }, [initialEntityId, initialEntityType, isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/frontend/src/components/Shared/ScheduleCallModal.tsx
+++ b/frontend/src/components/Shared/ScheduleCallModal.tsx
@@ -62,6 +62,12 @@ interface ScheduleCallModalProps {
    * Only applied in create mode.
    */
   defaultCallPurpose?: string;
+  /**
+   * Used by entry points that already know the target entity (e.g. Cockpit entity detail).
+   * Only applied in create mode.
+   */
+  defaultEntityType?: EntityType;
+  defaultEntityId?: string | number;
 }
 
 // Restrict to only Supplier and Customer per requirements
@@ -322,6 +328,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
   onSuccess,
   initialData,
   defaultCallPurpose,
+  defaultEntityType,
+  defaultEntityId,
 }) => {
   const isEditMode = !!initialData?.id;
   
@@ -365,8 +373,14 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
     } else if (isOpen) {
       resetForm();
       setCallPurpose(defaultCallPurpose || 'follow_up');
+      if (defaultEntityType) {
+        setEntityType(defaultEntityType);
+      }
+      if (defaultEntityId !== undefined && defaultEntityId !== null && String(defaultEntityId).trim() !== '') {
+        setEntityId(String(defaultEntityId));
+      }
     }
-  }, [initialData, isOpen, defaultCallPurpose]);
+  }, [initialData, isOpen, defaultCallPurpose, defaultEntityId, defaultEntityType]);
 
   // Fetch entity options when entity type changes
   useEffect(() => {


### PR DESCRIPTION
Implements the requested Cockpit call creation UX.

- Cockpit CustomerDetailView “+ New” menu now supports creating calls by purpose.
  - Follow-up/complaint/order/support/other → ScheduleCallModal
  - Inquiry → InquiryCallModal (rich multi-product inquiry form)
- ScheduleCallModal now supports defaultEntityType/defaultEntityId for context prefill.
- InquiryCallModal now supports initialEntityType/initialEntityId for context prefill.

This makes inquiry calls use the “nice smart inquiry form” and removes the dead-end “Coming soon” call action.
