### PR TITLE
Docs: demote non-canonical roadmaps

### DIFF
--- a/PHASE_VERIFICATION_COMPLETE.md
+++ b/PHASE_VERIFICATION_COMPLETE.md
@@ -1,10 +1,14 @@
 # Master Execution Plan 2026 - Phase Verification Complete ✅
 
+> **Reference-only / historical snapshot** (Feb 2026). This document may contain completion claims that are no longer accurate.
+>
+> **Canonical source of truth:** `MASTER_PLAN.md` (repo root)
+
 ## Executive Summary
 
 **Date**: February 26, 2026  
-**Status**: **ALL PHASES COMPLETE** (Phases 1-4 fully operational)  
-**Outcome**: Zero code changes needed - all requested features already implemented in production codebase
+**Status**: Historical verification snapshot (see `MASTER_PLAN.md` for current truth)  
+**Outcome**: Captures what was verified at the time; subsequent work may have changed scope/status.
 
 ## Phase-by-Phase Verification
 

--- a/UI_ROADMAP.md
+++ b/UI_ROADMAP.md
@@ -1,6 +1,8 @@
-# UI Roadmap
+# UI Roadmap (Reference)
 
-**Status**: Living document
+**Authority:** This is **not** the canonical status tracker. For current truth and backlog, see `MASTER_PLAN.md`.
+
+**Status**: Reference / historical notes (update only when it adds value beyond the Master Plan)
 
 ## Vanguard UI Templates (Shipped)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,8 @@
-# ProjectMeats Development Roadmap
+# ProjectMeats Development Roadmap (Reference)
 
-**Status**: 🔄 LIVING DOCUMENT  
+**Authority:** This is **not** the canonical status tracker. For current truth and backlog, see `MASTER_PLAN.md`.
+
+**Status**: Reference / historical context  
 **Category**: Reference  
 **Last Updated**: 2026-02-01
 


### PR DESCRIPTION
Docs hygiene pass to reduce contradictory "100% complete" claims.

- UI_ROADMAP.md: mark as reference-only + point to repo-root MASTER_PLAN.md.
- docs/ROADMAP.md: mark as reference-only + point to MASTER_PLAN.md.
- PHASE_VERIFICATION_COMPLETE.md: mark as historical snapshot (Feb 2026), canonical truth is MASTER_PLAN.md.

No functional code changes.
