### PR TITLE
FlowEditor: Form Process node not transparent

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/FormProcessContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessContainerNode.tsx
@@ -14,13 +14,17 @@ type Props = {
 const Container = styled.div<{ $selected: boolean }>`
   min-width: 220px;
   padding: 10px 12px;
-  background: rgb(var(--color-background));
-  border: 1px solid rgb(var(--color-primary));
+  background: rgb(var(--color-surface));
+  border: 1px solid rgb(var(--color-border));
   border-radius: 8px;
   color: rgb(var(--color-text-primary));
   box-shadow:
     0 0 0 1px rgb(var(--color-primary) / 0.12),
     ${(p) => (p.$selected ? '0 0 0 3px rgb(var(--color-primary) / 0.25)' : 'none')};
+
+  &:hover {
+    border-color: rgb(var(--color-primary));
+  }
 `;
 
 const TitleRow = styled.div`

--- a/frontend/src/components/FlowEditor/utils/containerStyling.ts
+++ b/frontend/src/components/FlowEditor/utils/containerStyling.ts
@@ -45,7 +45,9 @@ export function getContainerTheme(
 
   // Collapsed state - lighter visual weight
   if (!isExpanded) {
-    theme.background = 'rgba(var(--color-surface), 0.95)';
+    // NOTE: theme RGB tokens are stored as "r g b" and must be wrapped with rgb(... / alpha)
+    // (not rgba(var(--token), a)).
+    theme.background = 'rgb(var(--color-surface) / 0.95)';
     theme.shadow = '0 1px 4px rgba(0, 0, 0, 0.08)';
     theme.headerBackground = 'rgba(102, 126, 234, 0.05)';
   }


### PR DESCRIPTION
Fixes the Form Process node appearing visually transparent by:
- Rendering the non-purple FormProcessContainerNode with surface background + proper border token.
- Fixing container theme collapsed background alpha syntax to match our RGB CSS token convention.

Verification:
- frontend: npm run type-check
