### PR TITLE
Backend: prevent RLS-related 500s

### DIFF
--- a/backend/apps/core/report_views.py
+++ b/backend/apps/core/report_views.py
@@ -72,6 +72,14 @@ class ReportsSummaryAPIView(APIView):
         if not tenant:
             return Response({"error": "Tenant context required"}, status=400)
 
+        # Ensure RLS session vars exist for any tenant-scoped models queried below.
+        try:
+            from apps.tenants.rls import set_current_tenant
+
+            set_current_tenant(str(tenant.id))
+        except Exception:
+            logger.exception("Reports: failed to set RLS session vars")
+
         dr = _get_date_range(request)
         now = timezone.now()
 
@@ -241,6 +249,13 @@ class PurchaseOrderTrendsAPIView(APIView):
         if not tenant:
             return Response({"error": "Tenant context required"}, status=400)
 
+        try:
+            from apps.tenants.rls import set_current_tenant
+
+            set_current_tenant(str(tenant.id))
+        except Exception:
+            logger.exception("Reports: failed to set RLS session vars")
+
         dr = _get_date_range(request)
 
         from tenant_apps.purchase_orders.models import PurchaseOrder
@@ -280,6 +295,13 @@ class TopSuppliersAPIView(APIView):
         tenant = getattr(request, "tenant", None)
         if not tenant:
             return Response({"error": "Tenant context required"}, status=400)
+
+        try:
+            from apps.tenants.rls import set_current_tenant
+
+            set_current_tenant(str(tenant.id))
+        except Exception:
+            logger.exception("Reports: failed to set RLS session vars")
 
         dr = _get_date_range(request)
         try:

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -842,9 +842,21 @@ class FormRuleDetailAPIView(APIView):
 
 
 class TenantFilteredModelViewSet(viewsets.ModelViewSet):
-    """Base ViewSet that filters by tenant."""
+    """Base ViewSet that filters by tenant.
+
+    Note: With PostgreSQL RLS enabled, many tenant-scoped tables rely on the
+    `app.current_tenant` session var. Middleware normally sets it, but we also
+    set it here (best-effort) to avoid 500s during serializer validation or
+    read paths when the session var isn't present.
+    """
 
     permission_classes = [IsAuthenticated]
+
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+        tenant = getattr(request, "tenant", None)
+        if tenant:
+            self._ensure_rls_session_vars(str(tenant.id))
 
     def get_queryset(self):
         """Filter queryset by current tenant."""


### PR DESCRIPTION
Fix intermittent 500s on tenant-scoped endpoints when PostgreSQL RLS is enabled but
`app.current_tenant` is not set early enough.

Changes:
- TenantFilteredModelViewSet now sets RLS session vars in `initial()` (best-effort) so
  serializer validation + read paths don't explode.
- Reports endpoints set RLS session vars before running tenant-scoped aggregates.

This should stabilize:
- POST /api/v1/workflows/lists/ (custom tenant lists)
- GET /api/v1/reports/summary/ and related report endpoints

Verification:
- python -m compileall backend
