### PR TITLE
Forms: migrate SalesOrders/Claims to EntityFormSurface

### DIFF
--- a/frontend/src/pages/Accounting/Claims.tsx
+++ b/frontend/src/pages/Accounting/Claims.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { ActivityFeed, UniversalEntityForm } from '../../components/Shared';
+import { ActivityFeed, EntityFormSurface } from '../../components/Shared';
 import { apiClient } from '../../services/apiService';
 import { formatCurrency } from '../../shared/utils';
 import { formatDateLocal, formatToLocal } from '../../utils/formatters';
@@ -753,8 +753,9 @@ export const Claims: React.FC = () => {
         )}
       </ContentContainer>
 
-      <UniversalEntityForm
+      <EntityFormSurface
         entityType="claims"
+        mode="create"
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onSuccess={() => fetchClaims()}

--- a/frontend/src/pages/SalesOrders/SalesOrders.tsx
+++ b/frontend/src/pages/SalesOrders/SalesOrders.tsx
@@ -15,7 +15,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { ActivityFeed, UniversalEntityForm } from '../../components/Shared';
+import { ActivityFeed, EntityFormSurface } from '../../components/Shared';
 import { apiClient } from '../../services/apiService';
 import { formatCurrency } from '../../shared/utils';
 import { formatDateLocal, formatToLocal } from '../../utils/formatters';
@@ -715,8 +715,9 @@ export const SalesOrdersPage: React.FC = () => {
         )}
       </ContentContainer>
 
-      <UniversalEntityForm
+      <EntityFormSurface
         entityType="sales-orders"
+        mode="create"
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onSuccess={() => fetchOrders()}


### PR DESCRIPTION
Migrate remaining create-entrypoints to the consolidated EntityFormSurface.

- Sales Orders page: replace direct UniversalEntityForm usage with EntityFormSurface.
- Claims page: replace direct UniversalEntityForm usage with EntityFormSurface.

No behavior change expected (EntityFormSurface delegates to UniversalEntityForm for these entity types),
but this reduces duplication and keeps create/edit surfaces consistent.

Verification:
- frontend: npm run type-check
