### PR TITLE
Fix Admin Invitations 500 when email fails

### DIFF
--- a/backend/apps/tenants/invitation_serializers.py
+++ b/backend/apps/tenants/invitation_serializers.py
@@ -10,6 +10,11 @@ from apps.tenants.models import Tenant, TenantUser, TenantInvitation
 class TenantInvitationCreateSerializer(serializers.ModelSerializer):
     """Serializer for creating tenant invitations."""
 
+    id = serializers.UUIDField(read_only=True)
+    token = serializers.CharField(read_only=True)
+    status = serializers.CharField(read_only=True)
+    created_at = serializers.DateTimeField(read_only=True)
+
     def _get_is_reusable(self) -> bool:
         """Parse the is_reusable flag from initial_data safely.
 
@@ -56,7 +61,18 @@ class TenantInvitationCreateSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = TenantInvitation
-        fields = ['email', 'role', 'message', 'expires_at', 'is_reusable', 'max_uses']
+        fields = [
+            'id',
+            'token',
+            'status',
+            'created_at',
+            'email',
+            'role',
+            'message',
+            'expires_at',
+            'is_reusable',
+            'max_uses',
+        ]
         extra_kwargs = {
             'expires_at': {'required': False},
             'message': {'required': False},
@@ -125,14 +141,14 @@ class TenantInvitationListSerializer(serializers.ModelSerializer):
     class Meta:
         model = TenantInvitation
         fields = [
-            'id', 'email', 'role', 'status', 'message',
+            'id', 'token', 'email', 'role', 'status', 'message',
             'created_at', 'expires_at', 'accepted_at',
             'tenant_name', 'invited_by_username',
             'is_expired_status', 'is_valid_status',
             'is_reusable', 'max_uses', 'usage_count'
         ]
         read_only_fields = (
-            'id', 'email', 'role', 'status', 'message',
+            'id', 'token', 'email', 'role', 'status', 'message',
             'created_at', 'expires_at', 'accepted_at',
             'tenant_name', 'invited_by_username',
             'is_expired_status', 'is_valid_status',

--- a/backend/apps/tenants/signals.py
+++ b/backend/apps/tenants/signals.py
@@ -10,6 +10,8 @@ from django.dispatch import receiver
 from django.core.mail import send_mail
 from django.core.cache import cache
 from django.conf import settings
+from django.db import transaction
+
 from .models import TenantInvitation, TenantUser, Tenant
 
 logger = logging.getLogger(__name__)
@@ -56,22 +58,25 @@ def send_invitation_email(sender, instance, created, **kwargs):
             f"The Meats Central Team"
         )
         
-        try:
-            logger.info(f"📤 Sending invitation email to {instance.email} via SendGrid Web API...")
-            result = send_mail(
-                subject=subject,
-                message=message,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[instance.email],
-                fail_silently=False,
-            )
-            logger.info(f"✅ Email sent successfully! (result={result})")
-        except Exception as e:
-            logger.exception(f"❌ Failed to send email to {instance.email}")
-            logger.error(f"Error type: {type(e).__name__}")
-            logger.error(f"Error message: {str(e)}")
-            # Re-raise to ensure error is visible
-            raise
+        def _send_invitation_email() -> None:
+            try:
+                logger.info(f"📤 Sending invitation email to {instance.email}...")
+                result = send_mail(
+                    subject=subject,
+                    message=message,
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    recipient_list=[instance.email],
+                    fail_silently=False,
+                )
+                logger.info(f"✅ Email sent successfully! (result={result})")
+            except Exception:
+                # Never fail invitation creation due to email configuration issues.
+                # The UI can still display/copy the invitation link (token).
+                logger.exception(f"❌ Failed to send invitation email to {instance.email}")
+
+        # Ensure invitation creation isn't rolled back if email fails.
+        # If we're inside a transaction, send after commit; otherwise runs immediately.
+        transaction.on_commit(_send_invitation_email)
 
 
 @receiver(post_save, sender=TenantUser, dispatch_uid="ensure_privileged_roles_have_staff_access")

--- a/backend/apps/tenants/tests.py
+++ b/backend/apps/tenants/tests.py
@@ -5,6 +5,8 @@ from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.test import APITestCase
 from rest_framework import status
+from unittest.mock import patch
+
 from .models import Tenant, TenantUser, TenantDomain
 import uuid
 import io
@@ -263,6 +265,42 @@ class TenantAPITests(APITestCase):
         self.assertEqual(theme['primary_color_dark'], '#33FF57')
         self.assertEqual(theme['name'], self.tenant.name)
         self.assertIsNone(theme['logo_url'])  # No logo uploaded yet
+
+
+class InvitationEmailFailureDoesNot500(APITestCase):
+    def setUp(self):
+        unique_id = str(uuid.uuid4())[:8]
+        self.user = User.objects.create_user(
+            username=f"invite_admin_{unique_id}",
+            email=f"invite_admin_{unique_id}@example.com",
+            password="testpass123",
+        )
+        self.client.force_authenticate(user=self.user)
+
+        self.tenant = Tenant.objects.create(
+            name=f"Invite Tenant {unique_id}",
+            slug=f"invite-tenant-{unique_id}",
+            contact_email=f"admin_{unique_id}@testcompany.com",
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role="owner")
+
+    @patch('apps.tenants.signals.send_mail', side_effect=Exception('SMTP down'))
+    def test_invitation_create_succeeds_when_email_send_fails(self, _send_mail):
+        url = reverse('tenants:tenant-invitation-list')
+        payload = {
+            'email': 'newuser@example.com',
+            'role': 'user',
+            'message': 'Welcome!',
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(url, payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('token', response.data)
+        self.assertTrue(response.data['token'])
+        self.assertTrue(_send_mail.called)
 
 
 class DomainModelTests(TestCase):


### PR DESCRIPTION
Fixes Admin → Users & Invitations invite flow returning 500 when SMTP/SendGrid is misconfigured.

Changes:
- Invitation email send is now best-effort (on_commit + swallow errors), so invitation creation never fails due to email config.
- Include invitation token in create + list responses so admins can copy/share the link if email fails.
- Add regression test covering email-send failure.

Notes:
- Local DB tests are currently blocked in this workspace by missing pgvector extension required by existing migrations; code is compile-checked.