### PR TITLE
Docs: refresh master plan evidence + PR log

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -49,6 +49,23 @@ This file is the **append-only PR-referenceable execution log**.
 - 2026-03-26 — Reports Summary 500 fixed — PR: #3949.
 - 2026-03-26 — Tenant Option Lists (Tenant Lists) create 500 hardened — PR: #3950.
 - 2026-03-26 — Email Ingestion “Sync Now” correctness + pagination + error surfacing — PR: #3951.
+- 2026-03-26 — Docs: canonicalize Master Plan — PR: #3952.
+- 2026-03-26 — Docs: master plan gap audit — PR: #3953.
+- 2026-03-26 — Unify Inquiry create form across Cockpit — PR: #3956.
+- 2026-03-26 — Add EntityFormSurface consolidation layer — PR: #3957.
+- 2026-03-26 — Harden UniversalEntityForm submit + key-field ordering — PR: #3958.
+- 2026-03-26 — Add key_fields to universal form schema — PR: #3959.
+- 2026-03-26 — Cockpit: fix +New entity create modal — PR: #3960.
+- 2026-03-26 — Cockpit: + New call purpose + inquiry modal — PR: #3961.
+- 2026-03-26 — Docs: demote non-canonical roadmaps — PR: #3962.
+- 2026-03-26 — FlowEditor: auto-map Apply shows Apply Changes — PR: #3963.
+- 2026-03-26 — FlowEditor: Form Process node not transparent — PR: #3964.
+- 2026-03-26 — Backend: prevent RLS-related 500s — PR: #3965.
+- 2026-03-26 — Cockpit: confirm + navigate after create — PR: #3966.
+- 2026-03-26 — Email sync: find new order emails reliably — PR: #3967.
+- 2026-03-26 — Admin Billing: payment method portal + plan select — PR: #3968.
+- 2026-03-26 — Forms: migrate SalesOrders/Claims to EntityFormSurface — PR: #3969.
+- 2026-03-26 — Fix Admin Invitations 500 when email fails — PR: #3970.
 
 - 2026-03-24 — Fixed global Ant Design theme corruption (Sanitized background tokens causing pure black component rendering) — PR: #3925.
 - 2026-03-24 — Admin Workspace: Organization Profile save hardened (avoid multipart PATCH 502s) — PR: #3924.

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -14,12 +14,19 @@ This file is the **canonical plan + current truth snapshot**.
 
 ### What is actively in progress
 - **Type-check hardening:** `pr-golden-sweep-typecheck` (tracked in SQL session todos)
-- **Docs:** Master Plan consolidation + gap audit (this work)
 
 ### Recently shipped fixes (evidence)
 - Reports Summary 500 fixed — PR #3949
-- Tenant Option Lists (Tenant Lists) create 500 hardened — PR #3950
+- Tenant Lists create 500 fixed/hardened — PR #3950
 - Email Ingestion “Sync Now” correctness + pagination + error surfacing — PR #3951
+- Docs: canonicalize Master Plan + gap audit + demote non-canonical roadmaps — PR #3952, #3953, #3962
+- Forms consolidation: unify inquiry create + add EntityFormSurface + harden UniversalEntityForm + expose key_fields + migrate SalesOrders/Claims — PR #3956, #3957, #3958, #3959, #3969
+- Cockpit create UX: +New entity modal fix + +New call purpose/inquiry modal + confirm+navigate after create — PR #3960, #3961, #3966
+- FlowEditor: auto-map Apply shows Apply Changes + Form Process node not transparent — PR #3963, #3964
+- Backend: prevent RLS-related 500s — PR #3965
+- Email sync: find new order emails reliably — PR #3967
+- Admin Billing: payment method portal + plan select — PR #3968
+- Admin Invitations: avoid 500 when email fails — PR #3970
 
 ### Current blockers / external dependencies
 - Some features require environment secrets/infra to activate fully (e.g., OpenAI key, OAuth credentials). Code must degrade gracefully when secrets are missing.


### PR DESCRIPTION
Refreshes the canonical master plan snapshot and the append-only PR log to reflect the latest shipped batches (through #3970).\n\n- Updates MASTER_PLAN.md ‘Recently shipped fixes’ evidence list\n- Extends .github/MASTER_PLAN.md PR Log with recent merged PRs\n