### PR TITLE
Reports: use tenant-aware service + show warnings

### DIFF
--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -85,6 +85,17 @@ const Reports: React.FC = () => {
   }, [load]);
 
   const kpis = summary?.summary;
+  const warnings = summary?.warnings ?? [];
+
+  const currency = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0,
+      }),
+    []
+  );
 
   const items: TabsProps['items'] = [
     {
@@ -96,12 +107,12 @@ const Reports: React.FC = () => {
             <KpiCard>
               <KpiLabel>Purchase Orders</KpiLabel>
               <KpiValue>{kpis?.purchase_orders.count ?? 0}</KpiValue>
-              <KpiSub>${(kpis?.purchase_orders.total_amount ?? 0).toLocaleString()}</KpiSub>
+              <KpiSub>{currency.format(kpis?.purchase_orders.total_amount ?? 0)}</KpiSub>
             </KpiCard>
             <KpiCard>
               <KpiLabel>Sales Orders</KpiLabel>
               <KpiValue>{kpis?.sales_orders.count ?? 0}</KpiValue>
-              <KpiSub>${(kpis?.sales_orders.total_amount ?? 0).toLocaleString()}</KpiSub>
+              <KpiSub>{currency.format(kpis?.sales_orders.total_amount ?? 0)}</KpiSub>
             </KpiCard>
             <KpiCard>
               <KpiLabel>Inquiries (Win Rate)</KpiLabel>
@@ -201,6 +212,21 @@ const Reports: React.FC = () => {
       </Header>
 
       {error && <Alert type="error" message={error} showIcon style={{ marginBottom: 12 }} />}
+      {!error && warnings.length > 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="Some metrics may be incomplete"
+          description={
+            <ul style={{ margin: 0, paddingLeft: 18 }}>
+              {warnings.map((w, idx) => (
+                <li key={`${w.section}-${idx}`}>{w.message}</li>
+              ))}
+            </ul>
+          }
+        />
+      )}
 
       {loading ? (
         <LoadingBlock>

--- a/frontend/src/services/reportsService.ts
+++ b/frontend/src/services/reportsService.ts
@@ -1,9 +1,11 @@
-import { apiClient } from './apiService';
+import { businessApi } from './businessApi';
 
 export type ReportsDateRange = {
   start: string; // YYYY-MM-DD
   end: string;   // YYYY-MM-DD
 };
+
+export type ReportsWarning = { section: string; message: string };
 
 export type ReportsSummaryResponse = {
   date_range: ReportsDateRange;
@@ -15,6 +17,7 @@ export type ReportsSummaryResponse = {
     workforms: { submissions_total: number; completed: number; in_progress: number; completion_rate: number };
     master_data: { suppliers: number; customers: number; contacts: number };
   };
+  warnings?: ReportsWarning[];
 };
 
 export type PurchaseOrderTrendPoint = {
@@ -43,17 +46,17 @@ export type TopSuppliersResponse = {
 
 export const reportsService = {
   async getSummary(range: ReportsDateRange): Promise<ReportsSummaryResponse> {
-    const resp = await apiClient.get('/reports/summary/', { params: range });
+    const resp = await businessApi.get('/reports/summary/', { params: range });
     return resp.data;
   },
 
   async getPurchaseOrderTrends(range: ReportsDateRange): Promise<PurchaseOrderTrendsResponse> {
-    const resp = await apiClient.get('/reports/trends/purchase-orders/', { params: range });
+    const resp = await businessApi.get('/reports/trends/purchase-orders/', { params: range });
     return resp.data;
   },
 
   async getTopSuppliers(range: ReportsDateRange, limit = 10): Promise<TopSuppliersResponse> {
-    const resp = await apiClient.get('/reports/top/suppliers/', { params: { ...range, limit } });
+    const resp = await businessApi.get('/reports/top/suppliers/', { params: { ...range, limit } });
     return resp.data;
   },
 


### PR DESCRIPTION
Hardens the Reports page client integration.

- Switch reportsService to businessApi (tenant-aware service layer)
- Display backend "warnings" (partial metrics) to explain safe-default data
- Improve KPI currency formatting

Verification:
- frontend: npm -C frontend run type-check
