### PR TITLE
Fix Outlook Sync Now 503 UX

### DIFF
--- a/backend/apps/integrations/tests.py
+++ b/backend/apps/integrations/tests.py
@@ -1,3 +1,70 @@
-from django.test import TestCase
+from datetime import timedelta
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+from unittest.mock import patch
+
+from apps.tenants.models import Tenant, TenantUser
+from apps.integrations.models import ExternalAuthProvider
+
+
+class EmailSyncTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='testuser', password='testpass123')
+        self.tenant = Tenant.objects.create(
+            name='Test Tenant',
+            slug='test-tenant',
+            contact_email='test@example.com',
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner')
+
+        ExternalAuthProvider.objects.create(
+            tenant=self.tenant,
+            provider_type='microsoft',
+            is_active=True,
+            connected_email='test@tenant.com',
+            token_expiry=timezone.now() + timedelta(days=1),
+        )
+
+        self.client.force_authenticate(user=self.user)
+
+    @patch('tenant_apps.integrations.services.email_ingestion.EmailIngestionService.poll_tenant_by_id')
+    def test_sync_emails_soft_fails_on_exception(self, poll_tenant_by_id):
+        poll_tenant_by_id.side_effect = RuntimeError('boom')
+
+        resp = self.client.post(
+            '/api/v1/integrations/email/sync/',
+            {},
+            format='json',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data.get('ok'), False)
+        self.assertEqual(resp.data.get('code'), 'sync_exception')
+        self.assertIn('boom', resp.data.get('error', ''))
+
+    @patch('tenant_apps.integrations.services.email_ingestion.EmailIngestionService.poll_tenant_by_id')
+    def test_sync_emails_soft_fails_when_graph_returns_zero_scanned_with_errors(self, poll_tenant_by_id):
+        poll_tenant_by_id.return_value = {
+            'errors': 1,
+            'emails_scanned': 0,
+            'errors_detail': ['Token invalid/expired'],
+            'emails_matched': 0,
+            'emails_fetched': 0,
+            'emails_saved': 0,
+            'emails_skipped': 0,
+        }
+
+        resp = self.client.post(
+            '/api/v1/integrations/email/sync/',
+            {},
+            format='json',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data.get('ok'), False)
+        self.assertEqual(resp.data.get('code'), 'sync_failed')
+        self.assertEqual(resp.data.get('error'), 'Token invalid/expired')

--- a/backend/apps/integrations/views.py
+++ b/backend/apps/integrations/views.py
@@ -351,6 +351,8 @@ def sync_emails(request):
             )
 
         # If Graph/token/decrypt failed, do NOT report "no new emails".
+        # IMPORTANT: This is still an application-level failure, but not a server availability failure.
+        # Returning 503 here makes the UI look "broken" even though we have actionable diagnostics.
         if isinstance(stats, dict) and stats.get('errors', 0) and stats.get('emails_scanned', 0) == 0:
             detail = None
             try:
@@ -360,17 +362,21 @@ def sync_emails(request):
 
             return Response(
                 {
+                    "ok": False,
+                    "message": "Email sync completed with errors",
                     "error": detail or "Email sync failed. Outlook connection may be expired or misconfigured.",
                     "code": "sync_failed",
+                    "hint": "Try reconnecting Outlook in Settings → Integrations, then retry Sync Now.",
                     "tenant_id": tenant_id,
                     "provider_email": provider.connected_email,
                     "stats": stats,
                 },
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status=status.HTTP_200_OK,
             )
 
         return Response(
             {
+                "ok": True,
                 "message": "Email sync completed",
                 "tenant_id": tenant_id,
                 "provider_email": provider.connected_email,
@@ -381,13 +387,19 @@ def sync_emails(request):
 
     except Exception as e:
         logger.error('Failed to sync emails for tenant %s: %s', tenant_id, str(e), exc_info=True)
+        # This is a user-triggered action. Prefer a 200 + structured failure payload so the UI
+        # can display actionable guidance instead of treating it as a hard outage.
         return Response(
             {
+                "ok": False,
+                "message": "Email sync failed",
                 "error": f"Failed to sync emails: {str(e)}",
                 "code": "sync_exception",
+                "hint": "If this persists, reconnect Outlook in Settings → Integrations and retry.",
                 "tenant_id": tenant_id,
+                "provider_email": provider.connected_email,
             },
-            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            status=status.HTTP_200_OK,
         )
 
 

--- a/frontend/src/components/Integrations/IngestionMonitor.tsx
+++ b/frontend/src/components/Integrations/IngestionMonitor.tsx
@@ -88,7 +88,17 @@ export const IngestionMonitor: React.FC = () => {
         await new Promise((resolve) => setTimeout(resolve, 1500 - elapsedTime));
       }
 
+      const ok = response.data?.ok;
+      const hint = response.data?.hint;
       const stats = response.data?.stats;
+
+      // Soft-fail path: backend can return 200 with ok:false when Outlook/Graph is unhealthy.
+      if (ok === false) {
+        const err = response.data?.error || 'Email sync failed.';
+        message.error(hint ? `${err} ${hint}` : err);
+        await fetchEmailLogs();
+        return;
+      }
 
       if (stats) {
         const scanned = stats.emails_scanned ?? 0;
@@ -113,7 +123,7 @@ export const IngestionMonitor: React.FC = () => {
         message.success('Email sync completed.');
       }
 
-      fetchEmailLogs();
+      await fetchEmailLogs();
     } catch (error: any) {
       console.error('Failed to trigger sync:', error);
       message.error(error?.response?.data?.error || 'Failed to start email sync');
@@ -191,7 +201,7 @@ export const IngestionMonitor: React.FC = () => {
                   ].filter(Boolean)}
                 >
                   <List.Item.Meta
-                    avatar={<MailOutlined style={{ fontSize: '24px', color: '#1890ff' }} />}
+                    avatar={<MailOutlined style={{ fontSize: '24px', color: 'rgb(var(--color-primary))' }} />}
                     title={
                       <Space direction="vertical" size={0}>
                         <Text strong>{email.subject}</Text>
@@ -224,7 +234,14 @@ export const IngestionMonitor: React.FC = () => {
         </Spin>
 
         {/* Status Legend */}
-        <div style={{ padding: '12px', background: '#f5f5f5', borderRadius: '4px' }}>
+        <div
+          style={{
+            padding: '12px',
+            background: 'rgb(var(--color-surface))',
+            border: '1px solid rgb(var(--color-border))',
+            borderRadius: 'var(--radius-sm)',
+          }}
+        >
           <Text type="secondary" strong>Status Legend:</Text>
           <div style={{ marginTop: '8px' }}>
             <Space wrap>

--- a/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
@@ -268,7 +268,16 @@ export const EmailIngestionMonitorWidget: React.FC<EmailIngestionMonitorWidgetPr
         await new Promise((resolve) => setTimeout(resolve, 1500 - elapsedTime));
       }
 
+      const ok = response.data?.ok;
+      const hint = response.data?.hint;
       const stats = response.data?.stats;
+
+      if (ok === false) {
+        const err = response.data?.error || 'Email sync failed.';
+        message.error(hint ? `${err} ${hint}` : err);
+        await fetchEmailLogs();
+        return;
+      }
 
       if (stats) {
         const scanned = stats.emails_scanned ?? 0;
@@ -293,7 +302,7 @@ export const EmailIngestionMonitorWidget: React.FC<EmailIngestionMonitorWidgetPr
         message.success('Email sync completed.');
       }
 
-      fetchEmailLogs();
+      await fetchEmailLogs();
     } catch (error: any) {
       console.error('Failed to trigger sync:', error);
       message.error(error?.response?.data?.error || 'Failed to start email sync');


### PR DESCRIPTION
Fixes the Outlook/Ingestion Monitor “Sync Now” button failing with HTTP 503.

Changes
- Backend: POST /api/v1/integrations/email/sync/ returns HTTP 200 with { ok: false, error, hint, ... } for common operational failures so the UI can show actionable guidance.
- Frontend: Settings IngestionMonitor + Cockpit widget display error + reconnect hint when ok:false.
- Tests: integrations regression tests for soft-fail behavior.

Verification
- npm -C frontend run type-check
- DJANGO_SETTINGS_MODULE=projectmeats.settings.test python manage.py test apps.integrations
