### PR TITLE
Harden Quick Actions: use shared apiClient

### DIFF
--- a/frontend/src/services/quickActionsService.test.ts
+++ b/frontend/src/services/quickActionsService.test.ts
@@ -11,22 +11,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 
-// We need to mock axios before importing the service
+const mockApiClient = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('./apiService', () => ({
+  apiClient: mockApiClient,
+}));
+
+// axios is still used for CancelToken + isCancel
 vi.mock('axios', () => {
-  const mockAxiosInstance = {
-    get: vi.fn(),
-    post: vi.fn(),
-    put: vi.fn(),
-    delete: vi.fn(),
-    interceptors: {
-      request: { use: vi.fn() },
-      response: { use: vi.fn() },
-    },
-  };
-  
   return {
     default: {
-      create: vi.fn(() => mockAxiosInstance),
       CancelToken: {
         source: vi.fn(() => ({
           token: 'mock-cancel-token',
@@ -38,7 +37,6 @@ vi.mock('axios', () => {
   };
 });
 
-// Import after mocking
 import {
   quickActionsService,
   formSubmissionService,
@@ -47,20 +45,10 @@ import {
   isRequestCancelled,
 } from './quickActionsService';
 
-// Get reference to mocked instance
-const getMockAxios = () => {
-  const axiosCreate = axios.create as ReturnType<typeof vi.fn>;
-  return axiosCreate.mock.results[0]?.value || axiosCreate();
-};
-
 describe('QuickActionsService', () => {
-  let mockAxios: ReturnType<typeof getMockAxios>;
-
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
-    localStorage.setItem('authToken', 'test-token');
-    mockAxios = getMockAxios();
   });
 
   describe('quickActionsService', () => {
@@ -73,22 +61,22 @@ describe('QuickActionsService', () => {
             ],
           },
         };
-        mockAxios.get.mockResolvedValue(mockResponse);
+        mockApiClient.get.mockResolvedValue(mockResponse);
 
         const result = await quickActionsService.getQuickActions();
 
-        expect(mockAxios.get).toHaveBeenCalledWith('/workflows/quick-actions/', {});
+        expect(mockApiClient.get).toHaveBeenCalledWith('/workflows/quick-actions/', {});
         expect(result.items).toHaveLength(1);
         expect(result.items[0].label).toBe('New Supplier');
       });
 
       it('should support cancel key for request cancellation', async () => {
         const mockResponse = { data: { items: [] } };
-        mockAxios.get.mockResolvedValue(mockResponse);
+        mockApiClient.get.mockResolvedValue(mockResponse);
 
         await quickActionsService.getQuickActions('fetch-actions');
 
-        expect(mockAxios.get).toHaveBeenCalledWith(
+        expect(mockApiClient.get).toHaveBeenCalledWith(
           '/workflows/quick-actions/',
           expect.objectContaining({ cancelToken: expect.anything() })
         );
@@ -101,11 +89,11 @@ describe('QuickActionsService', () => {
           { id: 'qa_1', type: 'form' as const, form_id: 'f1', label: 'Updated', icon: 'truck', order: 0 },
         ];
         const mockResponse = { data: { success: true, items } };
-        mockAxios.put.mockResolvedValue(mockResponse);
+        mockApiClient.put.mockResolvedValue(mockResponse);
 
         const result = await quickActionsService.updateQuickActions(items);
 
-        expect(mockAxios.put).toHaveBeenCalledWith('/workflows/quick-actions/', { items });
+        expect(mockApiClient.put).toHaveBeenCalledWith('/workflows/quick-actions/', { items });
         expect(result.success).toBe(true);
       });
     });
@@ -115,17 +103,17 @@ describe('QuickActionsService', () => {
         const mockForms = [
           { id: 'f1', name: 'Supplier Form', description: 'Add supplier', icon: 'truck', status: 'active' },
         ];
-        mockAxios.get.mockResolvedValue({ data: mockForms });
+        mockApiClient.get.mockResolvedValue({ data: mockForms });
 
         const result = await quickActionsService.getAvailableForms();
 
-        expect(mockAxios.get).toHaveBeenCalledWith('/workflows/available-forms/', {});
+        expect(mockApiClient.get).toHaveBeenCalledWith('/workflows/available-forms/', {});
         expect(result).toEqual(mockForms);
       });
 
       it('should handle paginated response', async () => {
         const mockForms = [{ id: 'f1', name: 'Form 1' }];
-        mockAxios.get.mockResolvedValue({ data: { results: mockForms } });
+        mockApiClient.get.mockResolvedValue({ data: { results: mockForms } });
 
         const result = await quickActionsService.getAvailableForms();
 
@@ -138,20 +126,20 @@ describe('QuickActionsService', () => {
     describe('list', () => {
       it('should list form submissions', async () => {
         const mockSubmissions = [{ id: 'sub_1', form_name: 'Test Form', status: 'draft' }];
-        mockAxios.get.mockResolvedValue({ data: mockSubmissions });
+        mockApiClient.get.mockResolvedValue({ data: mockSubmissions });
 
         const result = await formSubmissionService.list();
 
-        expect(mockAxios.get).toHaveBeenCalledWith('/workflows/form-submissions/', { params: undefined });
+        expect(mockApiClient.get).toHaveBeenCalledWith('/workflows/form-submissions/', { params: undefined });
         expect(result).toEqual(mockSubmissions);
       });
 
       it('should filter by status', async () => {
-        mockAxios.get.mockResolvedValue({ data: [] });
+        mockApiClient.get.mockResolvedValue({ data: [] });
 
         await formSubmissionService.list({ status: 'completed' });
 
-        expect(mockAxios.get).toHaveBeenCalledWith(
+        expect(mockApiClient.get).toHaveBeenCalledWith(
           '/workflows/form-submissions/',
           { params: { status: 'completed' } }
         );
@@ -161,11 +149,11 @@ describe('QuickActionsService', () => {
     describe('create', () => {
       it('should create a form submission', async () => {
         const mockSubmission = { id: 'sub_1', form: 'f1', status: 'draft' };
-        mockAxios.post.mockResolvedValue({ data: mockSubmission });
+        mockApiClient.post.mockResolvedValue({ data: mockSubmission });
 
         const result = await formSubmissionService.create('f1');
 
-        expect(mockAxios.post).toHaveBeenCalledWith('/workflows/form-submissions/', { form: 'f1' });
+        expect(mockApiClient.post).toHaveBeenCalledWith('/workflows/form-submissions/', { form: 'f1' });
         expect(result.id).toBe('sub_1');
       });
     });
@@ -173,11 +161,11 @@ describe('QuickActionsService', () => {
     describe('get', () => {
       it('should get submission details', async () => {
         const mockSubmission = { id: 'sub_1', form_name: 'Test', status: 'in_progress' };
-        mockAxios.get.mockResolvedValue({ data: mockSubmission });
+        mockApiClient.get.mockResolvedValue({ data: mockSubmission });
 
         const result = await formSubmissionService.get('sub_1');
 
-        expect(mockAxios.get).toHaveBeenCalledWith('/workflows/form-submissions/sub_1/', {});
+        expect(mockApiClient.get).toHaveBeenCalledWith('/workflows/form-submissions/sub_1/', {});
         expect(result).toEqual(mockSubmission);
       });
     });
@@ -185,13 +173,13 @@ describe('QuickActionsService', () => {
     describe('autoSave', () => {
       it('should auto-save a field value', async () => {
         const mockResponse = { data: { success: true, saved_at: '2026-02-01T00:00:00Z' } };
-        mockAxios.post.mockResolvedValue(mockResponse);
+        mockApiClient.post.mockResolvedValue(mockResponse);
 
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
         const result = await formSubmissionService.autoSave('sub_1', 'step_1', 'name', 'Test Value');
 
-        expect(mockAxios.post).toHaveBeenCalledWith(
+        expect(mockApiClient.post).toHaveBeenCalledWith(
           '/workflows/form-submissions/sub_1/auto_save/',
           { step_id: 'step_1', field_key: 'name', value: 'Test Value' },
           expect.objectContaining({ cancelToken: expect.anything() })
@@ -205,11 +193,11 @@ describe('QuickActionsService', () => {
     describe('completeStep', () => {
       it('should complete a step', async () => {
         const mockResponse = { data: { success: true, step_status: 'completed', next_step_id: 'step_2' } };
-        mockAxios.post.mockResolvedValue(mockResponse);
+        mockApiClient.post.mockResolvedValue(mockResponse);
 
         const result = await formSubmissionService.completeStep('sub_1', 'step_1');
 
-        expect(mockAxios.post).toHaveBeenCalledWith(
+        expect(mockApiClient.post).toHaveBeenCalledWith(
           '/workflows/form-submissions/sub_1/complete-step/',
           { step_id: 'step_1' }
         );
@@ -221,11 +209,11 @@ describe('QuickActionsService', () => {
     describe('submit', () => {
       it('should submit the form', async () => {
         const mockResponse = { data: { success: true, status: 'completed', completed_at: '2026-02-01' } };
-        mockAxios.post.mockResolvedValue(mockResponse);
+        mockApiClient.post.mockResolvedValue(mockResponse);
 
         const result = await formSubmissionService.submit('sub_1');
 
-        expect(mockAxios.post).toHaveBeenCalledWith(
+        expect(mockApiClient.post).toHaveBeenCalledWith(
           '/workflows/form-submissions/sub_1/submit/',
           { force: undefined }
         );
@@ -233,11 +221,11 @@ describe('QuickActionsService', () => {
       });
 
       it('should support force submit', async () => {
-        mockAxios.post.mockResolvedValue({ data: { success: true } });
+        mockApiClient.post.mockResolvedValue({ data: { success: true } });
 
         await formSubmissionService.submit('sub_1', true);
 
-        expect(mockAxios.post).toHaveBeenCalledWith(
+        expect(mockApiClient.post).toHaveBeenCalledWith(
           '/workflows/form-submissions/sub_1/submit/',
           { force: true }
         );
@@ -246,34 +234,34 @@ describe('QuickActionsService', () => {
 
     describe('cancel', () => {
       it('should cancel a submission', async () => {
-        mockAxios.post.mockResolvedValue({ data: { success: true, status: 'cancelled' } });
+        mockApiClient.post.mockResolvedValue({ data: { success: true, status: 'cancelled' } });
 
         const result = await formSubmissionService.cancel('sub_1');
 
-        expect(mockAxios.post).toHaveBeenCalledWith('/workflows/form-submissions/sub_1/cancel/');
+        expect(mockApiClient.post).toHaveBeenCalledWith('/workflows/form-submissions/sub_1/cancel/');
         expect(result.status).toBe('cancelled');
       });
     });
 
     describe('delete', () => {
       it('should delete a submission', async () => {
-        mockAxios.delete.mockResolvedValue({});
+        mockApiClient.delete.mockResolvedValue({});
 
         await formSubmissionService.delete('sub_1');
 
-        expect(mockAxios.delete).toHaveBeenCalledWith('/workflows/form-submissions/sub_1/');
+        expect(mockApiClient.delete).toHaveBeenCalledWith('/workflows/form-submissions/sub_1/');
       });
     });
 
     describe('uploadFile', () => {
       it('should upload a file', async () => {
         const mockResponse = { data: { id: 'file_1', name: 'test.pdf', url: '/files/test.pdf', size: 1024 } };
-        mockAxios.post.mockResolvedValue(mockResponse);
+        mockApiClient.post.mockResolvedValue(mockResponse);
 
         const file = new File(['test'], 'test.pdf', { type: 'application/pdf' });
         const result = await formSubmissionService.uploadFile('sub_1', 'document', file);
 
-        expect(mockAxios.post).toHaveBeenCalledWith(
+        expect(mockApiClient.post).toHaveBeenCalledWith(
           '/workflows/form-submissions/sub_1/upload/',
           expect.any(FormData),
           { headers: { 'Content-Type': 'multipart/form-data' } }
@@ -284,11 +272,11 @@ describe('QuickActionsService', () => {
 
     describe('deleteFile', () => {
       it('should delete a file', async () => {
-        mockAxios.delete.mockResolvedValue({});
+        mockApiClient.delete.mockResolvedValue({});
 
         await formSubmissionService.deleteFile('sub_1', 'file_1');
 
-        expect(mockAxios.delete).toHaveBeenCalledWith('/workflows/form-submissions/sub_1/files/file_1/');
+        expect(mockApiClient.delete).toHaveBeenCalledWith('/workflows/form-submissions/sub_1/files/file_1/');
       });
     });
   });
@@ -307,20 +295,20 @@ describe('QuickActionsService', () => {
             has_more: true,
           },
         };
-        mockAxios.get.mockResolvedValue(mockResponse);
+        mockApiClient.get.mockResolvedValue(mockResponse);
 
         const result = await entityOptionsService.getOptions('supplier');
 
-        expect(mockAxios.get).toHaveBeenCalledWith('/workflows/entity-options/supplier/', { params: {} });
+        expect(mockApiClient.get).toHaveBeenCalledWith('/workflows/entity-options/supplier/', { params: {} });
         expect(result.options).toHaveLength(1);
       });
 
       it('should support search and limit params', async () => {
-        mockAxios.get.mockResolvedValue({ data: { options: [] } });
+        mockApiClient.get.mockResolvedValue({ data: { options: [] } });
 
         await entityOptionsService.getOptions('supplier', 'test', 10);
 
-        expect(mockAxios.get).toHaveBeenCalledWith(
+        expect(mockApiClient.get).toHaveBeenCalledWith(
           '/workflows/entity-options/supplier/',
           { params: { q: 'test', limit: '10' } }
         );
@@ -329,11 +317,11 @@ describe('QuickActionsService', () => {
 
     describe('searchOptions', () => {
       it('should search options with query', async () => {
-        mockAxios.get.mockResolvedValue({ data: { options: [] } });
+        mockApiClient.get.mockResolvedValue({ data: { options: [] } });
 
         await entityOptionsService.searchOptions('customer', 'acme');
 
-        expect(mockAxios.get).toHaveBeenCalledWith(
+        expect(mockApiClient.get).toHaveBeenCalledWith(
           '/workflows/entity-options/customer/',
           { params: { q: 'acme' } }
         );
@@ -349,11 +337,11 @@ describe('QuickActionsService', () => {
             fields: [{ key: 'name', label: 'Name', type: 'text', required: true }],
           },
         };
-        mockAxios.get.mockResolvedValue(mockResponse);
+        mockApiClient.get.mockResolvedValue(mockResponse);
 
         const result = await entityOptionsService.getQuickCreateFields('supplier');
 
-        expect(mockAxios.get).toHaveBeenCalledWith('/workflows/quick-create/supplier/');
+        expect(mockApiClient.get).toHaveBeenCalledWith('/workflows/quick-create/supplier/');
         expect(result.fields).toHaveLength(1);
       });
     });
@@ -363,11 +351,11 @@ describe('QuickActionsService', () => {
         const mockResponse = {
           data: { success: true, id: '123', value: '123', label: 'New Supplier', entity_type: 'supplier' },
         };
-        mockAxios.post.mockResolvedValue(mockResponse);
+        mockApiClient.post.mockResolvedValue(mockResponse);
 
         const result = await entityOptionsService.quickCreate('supplier', { name: 'New Supplier' });
 
-        expect(mockAxios.post).toHaveBeenCalledWith('/workflows/quick-create/supplier/', { name: 'New Supplier' });
+        expect(mockApiClient.post).toHaveBeenCalledWith('/workflows/quick-create/supplier/', { name: 'New Supplier' });
         expect(result.label).toBe('New Supplier');
       });
     });

--- a/frontend/src/services/quickActionsService.ts
+++ b/frontend/src/services/quickActionsService.ts
@@ -5,33 +5,7 @@
  * Supports request cancellation via AbortController.
  */
 import axios, { CancelTokenSource } from 'axios';
-import { config } from '../config/runtime';
-
-const API_BASE_URL = config.API_BASE_URL;
-
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  timeout: 30000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-  xsrfCookieName: 'csrftoken',
-  xsrfHeaderName: 'X-CSRFToken',
-});
-
-// Request interceptor for authentication
-apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('authToken');
-  if (token) {
-    config.headers.Authorization = `Token ${token}`;
-  }
-  const tenantId = localStorage.getItem('tenantId');
-  if (tenantId) {
-    config.headers['X-Tenant-ID'] = tenantId;
-  }
-  return config;
-});
+import { apiClient } from './apiService';
 
 // Cancel token manager for request cancellation
 class CancelTokenManager {


### PR DESCRIPTION
Fixes flaky quick-create / quick-actions by removing a separate Token-based axios client.\n\n- quickActionsService now uses the shared apiClient (JWT refresh + X-Tenant-ID)\n- Updated quickActionsService tests to mock apiClient\n\nVerification:\n- npm -C frontend run type-check\n- npm -C frontend run test:ci -- src/services/quickActionsService.test.ts