### PR TITLE
Fix: consolidate remaining form entrypoints

### DIFF
--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -28,7 +28,8 @@ import { Tabs, Spin, Button, Dropdown, message, type MenuProps } from 'antd';
 import { NotesAndCallsDrawer } from './NotesAndCallsDrawer';
 import { businessApi } from '../../services/businessApi';
 import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
-import UniversalEntityForm from '../Shared/UniversalEntityForm';
+// UniversalEntityForm usage consolidated via EntityFormSurface
+
 import { EntityFormSurface } from '../Shared';
 import { InquiryCreateModal } from '../Inquiry';
 import { EntityProfileHeader } from './EntityProfileHeader';
@@ -1451,12 +1452,13 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
         )}
 
         {isInlineCreateSalesOrderOpen && activeEntity && String(activeEntity.type).toLowerCase() === 'customer' && (
-          <UniversalEntityForm
+          <EntityFormSurface
             entityType="sales-orders"
+            mode="create"
             isOpen={true}
             onClose={closeInlineSubview}
             onSuccess={() => closeInlineSubview()}
-            initialValues={{ customer: String(activeEntity.id) } as any}
+            context={{ customerId: String(activeEntity.id) }}
           />
         )}
 

--- a/frontend/src/components/Inquiry/InquiryCreateModal.tsx
+++ b/frontend/src/components/Inquiry/InquiryCreateModal.tsx
@@ -36,6 +36,9 @@ export interface InquiryCreateModalProps {
   onSuccess: (created?: unknown) => void;
   initialEntityType?: EntityType;
   initialEntityId?: string | number;
+
+  /** Optional: link the inquiry to a scheduled call (e.g., created from ScheduleCallModal). */
+  sourceCallId?: string | number;
 }
 
 const Overlay = styled.div<{ $open: boolean }>`
@@ -319,6 +322,7 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
   onSuccess,
   initialEntityType,
   initialEntityId,
+  sourceCallId,
 }) => {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -450,7 +454,8 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
 
       const payload: Record<string, unknown> = {
         entity_type: entityType,
-        source_type: 'other',
+        source_type: sourceCallId ? 'scheduled_call' : 'other',
+        ...(sourceCallId ? { source_call: Number(sourceCallId) } : {}),
         valid_until: validUntil || undefined,
         notes: notes.trim() || undefined,
         products,

--- a/frontend/src/components/Shared/EntityFormSurface.tsx
+++ b/frontend/src/components/Shared/EntityFormSurface.tsx
@@ -82,6 +82,7 @@ export const EntityFormSurface: React.FC<EntityFormSurfaceProps> = ({
         onSuccess={(created) => onSuccess?.(created)}
         initialEntityType={initialEntityType}
         initialEntityId={initialEntityId}
+        sourceCallId={context?.sourceCallId}
       />
     );
   }

--- a/frontend/src/components/Shared/ScheduleCallModal.tsx
+++ b/frontend/src/components/Shared/ScheduleCallModal.tsx
@@ -27,7 +27,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { businessApi } from '../../services/businessApi';
-import UniversalEntityForm from './UniversalEntityForm';
+import { EntityFormSurface } from './EntityFormSurface';
 import { CallTimer } from '../Calls';
 
 // ============================================================================
@@ -669,19 +669,20 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
 
       {/* Inquiry Modal */}
       {showInquiryModal && initialData?.id && (
-        <UniversalEntityForm
+        <EntityFormSurface
           entityType="inquiries"
+          mode="create"
           isOpen={showInquiryModal}
           onClose={() => setShowInquiryModal(false)}
           onSuccess={() => {
             setShowInquiryModal(false);
           }}
-          initialValues={{
-            source_type: 'scheduled_call',
-            source_call: String(initialData.id),
-            entity_type: entityType,
-            ...(String(entityType).toLowerCase() === 'supplier' ? { supplier: entityId } : { customer: entityId }),
-          } as any}
+          context={{
+            sourceCallId: initialData.id,
+            ...(String(entityType).toLowerCase() === 'supplier'
+              ? { supplierId: entityId }
+              : { customerId: entityId }),
+          }}
         />
       )}
     </Overlay>


### PR DESCRIPTION
Consolidates remaining direct UniversalEntityForm usages by routing them through EntityFormSurface, and preserves inquiry-from-call linking via InquiryCreateModal sourceCallId.

Verification:
- npm -C frontend run type-check
- npm -C frontend run lint:colors