### PR TITLE
Fix: plants available-products GET returns 405

### DIFF
--- a/backend/tenant_apps/plants/views.py
+++ b/backend/tenant_apps/plants/views.py
@@ -141,7 +141,7 @@ class PlantViewSet(viewsets.ModelViewSet):
         serializer = SystemProductSerializer(products, many=True)
         return Response(serializer.data)
 
-    @action(detail=True, methods=['post'], url_path='available-products')
+    @available_products.mapping.post
     def add_available_product(self, request, pk=None):
         """
         Add a system product to plant's available products.


### PR DESCRIPTION
Fixes a backend routing conflict that caused GET /api/v1/plants/{id}/available-products/ to return 405.

Change:
- Use DRF action mapping (available_products + available_products.mapping.post) instead of two @action decorators with the same url_path.

Verification:
- python -m compileall backend/tenant_apps/plants/views.py