### PR TITLE
Fix: cockpit favorites + inquiry create

### DIFF
--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -501,7 +501,10 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
     const savedFavorites = localStorage.getItem('cockpit_favorites');
     if (savedFavorites) {
       try {
-        setFavorites(new Set(JSON.parse(savedFavorites)));
+        const raw = JSON.parse(savedFavorites) as unknown;
+        const ids = Array.isArray(raw) ? (raw as unknown[]) : [];
+        const normalized = ids.map((v) => String(v));
+        setFavorites(new Set(normalized));
       } catch (error) {
         console.error('[SmartSearch] Failed to load favorites:', error);
       }
@@ -513,6 +516,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
    */
   const saveFavorites = useCallback((newFavorites: Set<string>) => {
     localStorage.setItem('cockpit_favorites', JSON.stringify(Array.from(newFavorites)));
+    window.dispatchEvent(new Event('cockpit_favorites_updated'));
   }, []);
 
   /**
@@ -807,15 +811,20 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
   /**
    * Toggle favorite
    */
-  const toggleFavorite = useCallback((entityId: string, e: React.MouseEvent) => {
+  const toggleFavorite = useCallback((entityType: string, entityId: string, e: React.MouseEvent) => {
     e.stopPropagation();
 
-    setFavorites(prev => {
+    const key = `${String(entityType).toLowerCase()}:${String(entityId)}`;
+    const legacyKey = String(entityId);
+
+    setFavorites((prev) => {
       const newFavorites = new Set(prev);
-      if (newFavorites.has(entityId)) {
-        newFavorites.delete(entityId);
+      const isFav = newFavorites.has(key) || newFavorites.has(legacyKey);
+      if (isFav) {
+        newFavorites.delete(key);
+        newFavorites.delete(legacyKey);
       } else {
-        newFavorites.add(entityId);
+        newFavorites.add(key);
       }
       saveFavorites(newFavorites);
       return newFavorites;
@@ -1044,9 +1053,17 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
                 </ResultContent>
 
                 <FavoriteButton
-                  $isFavorite={favorites.has(entity.id)}
-                  onClick={(e) => toggleFavorite(entity.id, e)}
-                  title={favorites.has(entity.id) ? 'Remove from favorites' : 'Add to favorites'}
+                  $isFavorite={
+                    favorites.has(`${String(entity.type).toLowerCase()}:${entity.id}`) ||
+                    favorites.has(String(entity.id))
+                  }
+                  onClick={(e) => toggleFavorite(entity.type, entity.id, e)}
+                  title={
+                    favorites.has(`${String(entity.type).toLowerCase()}:${entity.id}`) ||
+                    favorites.has(String(entity.id))
+                      ? 'Remove from favorites'
+                      : 'Add to favorites'
+                  }
                 >
                   <Star size={16} />
                 </FavoriteButton>
@@ -1106,9 +1123,17 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
 
               {chunk.type !== 'actions' && (
                 <FavoriteButton
-                  $isFavorite={favorites.has(item.id)}
-                  onClick={(e) => toggleFavorite(item.id, e)}
-                  title={favorites.has(item.id) ? 'Remove from favorites' : 'Add to favorites'}
+                  $isFavorite={
+                    favorites.has(`${String(item.type).toLowerCase()}:${item.id}`) ||
+                    favorites.has(String(item.id))
+                  }
+                  onClick={(e) => toggleFavorite(item.type, item.id, e)}
+                  title={
+                    favorites.has(`${String(item.type).toLowerCase()}:${item.id}`) ||
+                    favorites.has(String(item.id))
+                      ? 'Remove from favorites'
+                      : 'Add to favorites'
+                  }
                 >
                   <Star size={16} />
                 </FavoriteButton>

--- a/frontend/src/components/Inquiry/InquiryCreateModal.tsx
+++ b/frontend/src/components/Inquiry/InquiryCreateModal.tsx
@@ -469,8 +469,19 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
       onSuccess(resp.data);
       onClose();
     } catch (err: any) {
-      const apiMsg = err?.response?.data?.detail || err?.response?.data?.error || err?.message;
-      setError(typeof apiMsg === 'string' ? apiMsg : 'Failed to create inquiry. Please try again.');
+      const data = err?.response?.data;
+      const apiMsg =
+        (typeof data?.detail === 'string' && data.detail) ||
+        (typeof data?.error === 'string' && data.error) ||
+        (data && typeof data === 'object'
+          ? (() => {
+              const first = Object.entries(data).find(([, v]) => Array.isArray(v) || typeof v === 'string');
+              if (!first) return null;
+              return Array.isArray(first[1]) ? String(first[1][0] ?? 'Invalid value') : String(first[1]);
+            })()
+          : null) ||
+        err?.message;
+      setError(typeof apiMsg === 'string' && apiMsg ? apiMsg : 'Failed to create inquiry. Please try again.');
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/components/Widgets/FavoritesWidget.tsx
+++ b/frontend/src/components/Widgets/FavoritesWidget.tsx
@@ -188,6 +188,15 @@ export const FavoritesWidget: React.FC<FavoritesWidgetProps> = ({
   const [favorites, setFavorites] = useState<FavoriteEntity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
+  const parseKey = (raw: string): { type: string | null; id: string } => {
+    const s = String(raw);
+    if (s.includes(':')) {
+      const [t, ...rest] = s.split(':');
+      return { type: (t || '').trim() || null, id: rest.join(':') };
+    }
+    return { type: null, id: s };
+  };
+
   /**
    * Load favorites from localStorage and hydrate with API data
    */
@@ -213,23 +222,55 @@ export const FavoritesWidget: React.FC<FavoritesWidgetProps> = ({
       // Fetch entity details for each favorite
       // In a real implementation, this would be a batch API call
       const favoriteEntities: FavoriteEntity[] = [];
+      const migratedKeys: string[] = [];
 
-      for (const id of favoriteIds.slice(0, maxItems)) {
-        try {
-          // This is a simplified example - you'd need to determine entity type
-          // and call the appropriate API endpoint
-          const response = await apiClient.get(`/entities/${id}/`);
-          favoriteEntities.push({
-            id: response.data.id,
-            type: response.data.type,
-            name: response.data.name || response.data.title,
-            subtitle: response.data.subtitle || response.data.status,
-            color: getEntityColor(response.data.type),
-          });
-        } catch (error) {
-          console.warn(`[FavoritesWidget] Failed to load favorite ${id}:`, error);
-          // Skip this favorite if it fails to load
+      for (const rawKey of favoriteIds.slice(0, maxItems)) {
+        const parsed = parseKey(rawKey);
+        const candidates = parsed.type
+          ? [{ type: parsed.type, id: parsed.id }]
+          : [
+              { type: 'customer', id: parsed.id },
+              { type: 'supplier', id: parsed.id },
+              { type: 'contact', id: parsed.id },
+              { type: 'invoice', id: parsed.id },
+              { type: 'purchase_order', id: parsed.id },
+              { type: 'sales_order', id: parsed.id },
+            ];
+
+        let loaded = false;
+        for (const c of candidates) {
+          try {
+            const response = await apiClient.get(`/system/entities/${c.type}/${c.id}/`);
+            const compositeId = `${c.type}:${String(response.data.id ?? c.id)}`;
+            favoriteEntities.push({
+              id: compositeId,
+              type: String(response.data.type ?? c.type),
+              name: response.data.title || response.data.name || 'Unnamed',
+              subtitle: response.data.subtitle || response.data.status || '',
+              color: getEntityColor(String(response.data.type ?? c.type)),
+            });
+            migratedKeys.push(compositeId);
+            loaded = true;
+            break;
+          } catch {
+            // try next candidate
+          }
         }
+
+        if (!loaded) {
+          migratedKeys.push(String(rawKey));
+          console.warn(`[FavoritesWidget] Failed to load favorite ${rawKey}`);
+        }
+      }
+
+      // Best-effort migrate legacy favorites (raw IDs) to composite keys.
+      try {
+        const next = JSON.stringify(migratedKeys);
+        if (next !== savedFavorites) {
+          localStorage.setItem('cockpit_favorites', next);
+        }
+      } catch {
+        // ignore
       }
 
       setFavorites(favoriteEntities);
@@ -251,8 +292,14 @@ export const FavoritesWidget: React.FC<FavoritesWidgetProps> = ({
       }
     };
 
+    const handleLocalUpdate = () => loadFavorites();
+
     window.addEventListener('storage', handleStorageChange);
-    return () => window.removeEventListener('storage', handleStorageChange);
+    window.addEventListener('cockpit_favorites_updated', handleLocalUpdate);
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener('cockpit_favorites_updated', handleLocalUpdate);
+    };
   }, [loadFavorites]);
 
   /**


### PR DESCRIPTION
Fixes:
- Cockpit favorites now persist and display correctly (FavoritesWidget uses real /system/entities typed endpoint and updates in-tab).
- Favorites stored as composite keys type:id (best-effort migration from legacy raw IDs).
- Cockpit New Inquiry modal surfaces DRF field errors instead of generic failure.

Verification:
- npm -C frontend run type-check
- npm -C frontend run lint:colors