### PR TITLE
Fix: product associations persist

### DIFF
--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -279,12 +279,12 @@ const Customers: React.FC = () => {
       if (editingCustomer) {
         await apiService.updateCustomer(editingCustomer.id, {
           ...formData,
-          products: formData.products.map((v) => Number(v)),
+          products: formData.products,
         });
       } else {
         await apiService.createCustomer({
           ...formData,
-          products: formData.products.map((v) => Number(v)),
+          products: formData.products,
         });
       }
       setShowEditForm(false);

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -74,8 +74,10 @@ const Suppliers: React.FC = () => {
     country: '',
     departments_array: [] as string[], // Phase 4: ArrayField integration
     preferred_protein_types: [] as string[], // NEW: Protein filtering
-    products: [] as number[], // Product IDs for M2M
   });
+
+  const [availableProductIds, setAvailableProductIds] = useState<string[]>([]);
+  const [initialAvailableProductIds, setInitialAvailableProductIds] = useState<string[]>([]);
 
   // Auto-open form if ?action=create in URL
   useEffect(() => {
@@ -278,31 +280,74 @@ const Suppliers: React.FC = () => {
     void loadPlantContacts(selectedPlantId);
   }, [selectedPlantId]);
 
+  const loadSupplierAvailableProductIds = async (supplierId: number) => {
+    try {
+      const response = await apiClient.get(`/suppliers/${supplierId}/products/`);
+      const items = Array.isArray(response.data) ? response.data : [];
+      const activeIds = items
+        .filter((it) => it && it.is_active !== false)
+        .map((it) => String(it.product))
+        .filter(Boolean);
+      setAvailableProductIds(activeIds);
+      setInitialAvailableProductIds(activeIds);
+    } catch (error) {
+      logger.error('[Suppliers] Failed to load supplier available products:', error);
+      setAvailableProductIds([]);
+      setInitialAvailableProductIds([]);
+    }
+  };
+
+  const syncSupplierAvailableProducts = async (supplierId: number, desiredProductIds: string[]) => {
+    const desired = new Set(desiredProductIds.map(String));
+    const initial = new Set(initialAvailableProductIds.map(String));
+
+    const toAdd = [...desired].filter((id) => !initial.has(id));
+    const toRemove = [...initial].filter((id) => !desired.has(id));
+
+    if (!toAdd.length && !toRemove.length) return;
+
+    await Promise.all([
+      ...toAdd.map((productId) => apiClient.post(`/suppliers/${supplierId}/available-products/`, { product: productId })),
+      ...toRemove.map((productId) => apiClient.delete(`/suppliers/${supplierId}/available-products/${productId}/`)),
+    ]);
+
+    setInitialAvailableProductIds(desiredProductIds);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
+      let supplierId: number;
+
       if (editingSupplier) {
-        await apiService.updateSupplier(editingSupplier.id, formData);
+        const updated = await apiService.updateSupplier(editingSupplier.id, formData);
+        supplierId = updated.id;
       } else {
-        await apiService.createSupplier(formData);
+        const created = await apiService.createSupplier(formData);
+        supplierId = created.id;
       }
+
+      try {
+        await syncSupplierAvailableProducts(supplierId, availableProductIds);
+      } catch (error) {
+        logger.error('[Suppliers] Supplier saved but product sync failed:', error);
+        alert('Supplier saved, but products could not be updated. Please try again from the supplier Products page.');
+      }
+
       setShowEditForm(false);
       setEditingSupplier(null);
       resetForm();
       fetchSuppliers();
     } catch (error: unknown) {
-      // Extract error message
       const err = error as Error;
       const errorMessage = err.message || 'An unexpected error occurred. Please try again.';
-      
-      // Log detailed error information for debugging
+
       logger.error('[Suppliers] Error saving supplier:', {
         message: errorMessage,
         error: err,
         action: editingSupplier ? 'update' : 'create',
       });
-      
-      // Display user-friendly error to the UI
+
       alert(errorMessage);
     }
   };
@@ -321,9 +366,12 @@ const Suppliers: React.FC = () => {
       country: supplier.country || '',
       departments_array: supplier.departments_array || [], // Phase 4: Populate array
       preferred_protein_types: supplier.preferred_protein_types || [], // NEW: Populate protein types
-      products: supplier.products || [], // Populate product IDs
     });
+
+    setAvailableProductIds([]);
+    setInitialAvailableProductIds([]);
     setShowEditForm(true);
+    void loadSupplierAvailableProductIds(supplier.id);
   };
 
   const handleDelete = async (id: number) => {
@@ -359,8 +407,9 @@ const Suppliers: React.FC = () => {
       country: '',
       departments_array: [], // Phase 4: Reset array
       preferred_protein_types: [], // NEW: Reset protein types
-      products: [], // Reset products
     });
+    setAvailableProductIds([]);
+    setInitialAvailableProductIds([]);
   };
 
   const handleCancel = () => {
@@ -525,14 +574,14 @@ const Suppliers: React.FC = () => {
 
                 <FormGroup $fullWidth>
                   <MultiSelect
-                    value={formData.products.map(String)}
-                    onChange={(values) => setFormData({ ...formData, products: values.map(Number) })}
-                    options={Array.isArray(products) ? products.map(p => ({ 
-                      value: String(p.id), 
-                      label: `${p.product_code} - ${p.effective_name || p.product_name || p.name || 'Unknown'}` 
+                    value={availableProductIds}
+                    onChange={(values) => setAvailableProductIds(values.map(String))}
+                    options={Array.isArray(products) ? products.map(p => ({
+                      value: String(p.id),
+                      label: `${p.product_code} - ${p.effective_name || p.product_name || p.name || 'Unknown'}`
                     })) : []}
-                    label="Products"
-                    placeholder="Select products to associate (hold Ctrl/Cmd for multiple)"
+                    label="Available Products"
+                    placeholder="Select products this supplier can provide"
                   />
                 </FormGroup>
               </FormGrid>

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -431,7 +431,6 @@ export interface Supplier {
   country?: string;
   departments_array?: string[]; // Phase 4: ArrayField
   preferred_protein_types?: string[]; // NEW: Protein filtering
-  products?: number[]; // Product IDs for M2M relationship
   created_at: string;
   updated_at: string;
 }
@@ -449,7 +448,7 @@ export interface Customer {
   country?: string;
   industry_array?: string[]; // Phase 4: ArrayField
   preferred_protein_types?: string[]; // Phase 4: ArrayField
-  products?: number[]; // Product IDs for M2M relationship
+  products?: string[]; // system.Product UUIDs
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Fixes:
- Customers: stop coercing system.Product UUIDs to Number() so product associations persist.
- Suppliers: make the 'Available Products' multi-select actually sync to SupplierAvailableItem via /suppliers/{id}/available-products/.

Verification:
- npm -C frontend run type-check
- npm -C frontend run lint:colors