### PR TITLE
Fix: plant available products save

### DIFF
--- a/backend/tenant_apps/plants/views.py
+++ b/backend/tenant_apps/plants/views.py
@@ -132,9 +132,13 @@ class PlantViewSet(viewsets.ModelViewSet):
         from tenant_apps.plants.models import PlantAssociatedProduct
         from apps.system.serializers import SystemProductSerializer
 
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return Response({'error': 'Tenant not found'}, status=status.HTTP_400_BAD_REQUEST)
+
         plant = self.get_object()
         links = PlantAssociatedProduct.objects.filter(
-            tenant=request.tenant,
+            tenant=tenant,
             plant=plant,
         ).select_related('product')
         products = [link.product for link in links]
@@ -153,6 +157,10 @@ class PlantViewSet(viewsets.ModelViewSet):
         from apps.system.models import Product
         from apps.system.serializers import SystemProductSerializer
 
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return Response({'error': 'Tenant not found'}, status=status.HTTP_400_BAD_REQUEST)
+
         plant = self.get_object()
         product_id = request.data.get('product')
         if not product_id:
@@ -165,7 +173,7 @@ class PlantViewSet(viewsets.ModelViewSet):
             return Response({'error': 'Product not found'}, status=status.HTTP_404_NOT_FOUND)
 
         _, created = PlantAssociatedProduct.objects.get_or_create(
-            tenant=request.tenant,
+            tenant=tenant,
             plant=plant,
             product=product,
         )
@@ -181,10 +189,14 @@ class PlantViewSet(viewsets.ModelViewSet):
         """
         from tenant_apps.plants.models import PlantAssociatedProduct
 
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return Response({'error': 'Tenant not found'}, status=status.HTTP_400_BAD_REQUEST)
+
         plant = self.get_object()
         try:
             link = PlantAssociatedProduct.objects.get(
-                tenant=request.tenant,
+                tenant=tenant,
                 plant=plant,
                 product_id=product_id,
             )

--- a/frontend/src/pages/Plants/Products.tsx
+++ b/frontend/src/pages/Plants/Products.tsx
@@ -212,14 +212,27 @@ const PlantProducts: React.FC = () => {
     }
     setAddingProducts(true);
     try {
-      await Promise.all(
-        selectedProductIds.map(productId =>
+      const results = await Promise.allSettled(
+        selectedProductIds.map((productId) =>
           apiClient.post(`/plants/${id}/available-products/`, { product: productId })
         )
       );
-      message.success(`Added ${selectedProductIds.length} product(s) successfully`);
-      setAddModalVisible(false);
-      setSelectedProductIds([]);
+
+      const succeeded = results.filter((r) => r.status === 'fulfilled').length;
+      const failed = results.length - succeeded;
+
+      if (succeeded > 0) {
+        message.success(`Added ${succeeded} product(s) successfully`);
+      }
+      if (failed > 0) {
+        message.warning(`Some products could not be added (${failed} failed).`);
+      }
+
+      if (failed === 0) {
+        setAddModalVisible(false);
+        setSelectedProductIds([]);
+      }
+
       fetchProducts();
     } catch (error) {
       console.error('Error adding products:', error);


### PR DESCRIPTION
Fixes:
- Plant available-products endpoints now fail fast with 400 when tenant context is missing (prevents 500s).
- Plant Products UI uses allSettled so one failing add doesn't abort the whole batch.

Verification:
- python -m compileall -q backend/tenant_apps/plants/views.py
- npm -C frontend run type-check