### PR TITLE
AI Assistant: include page context

### DIFF
--- a/frontend/src/components/AIAssistant/AIAgentWidget.tsx
+++ b/frontend/src/components/AIAssistant/AIAgentWidget.tsx
@@ -9,8 +9,12 @@
  * - React to global UX shortcuts (e.g., Cmd/Ctrl+J) via window events
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
+import { useLocation } from 'react-router-dom';
+
+import { useCockpitNavigation } from '@/contexts/CockpitNavigationContext';
+import { buildAIPageContext } from '@/services/aiContext';
 import {
   FileText,
   GitBranch,
@@ -516,6 +520,13 @@ const hasHumanReviewMessage = (msgs: ChatMessage[]) =>
 
 export const AIAgentWidget: React.FC = () => {
   const toast = useToast();
+  const location = useLocation();
+  const cockpitNav = useCockpitNavigation();
+
+  const pageContext = useMemo(
+    () => buildAIPageContext({ pathname: location.pathname, search: location.search }, cockpitNav.path),
+    [location.pathname, location.search, cockpitNav.path]
+  );
 
   const [state, setState] = useState<AgentState>('idle');
   const [expanded, setExpanded] = useState(false);
@@ -550,6 +561,9 @@ export const AIAgentWidget: React.FC = () => {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const sendTextRef = useRef<
+    (text: string, contextOverride?: Record<string, unknown>) => Promise<void>
+  >(async () => {});
 
   const defaultActionMessage = useMemo(
     () => 'I just processed a Purchase Order from Sysco, but the delivery date is unclear. Can you verify?',
@@ -661,7 +675,18 @@ export const AIAgentWidget: React.FC = () => {
       setDetail({});
     };
 
+    const onSend = (event: Event) => {
+      const e = event as CustomEvent<{ message?: string; context?: Record<string, unknown> }>;
+      const msg = (e.detail?.message || '').toString().trim();
+      if (!msg) return;
+
+      setExpanded(true);
+      setMessages((m) => [...m, { id: newId(), role: 'user', content: msg, createdAt: Date.now() }]);
+      void sendTextRef.current(msg, e.detail?.context);
+    };
+
     window.addEventListener('pm:ai-toggle', onToggle as EventListener);
+    window.addEventListener('pm:ai-send', onSend as EventListener);
     window.addEventListener('pm:ai-review-required', onReviewRequired as EventListener);
     window.addEventListener('pm:ai-thinking', onThinking as EventListener);
     window.addEventListener('pm:ai-learning', onThinking as EventListener);
@@ -669,6 +694,7 @@ export const AIAgentWidget: React.FC = () => {
 
     return () => {
       window.removeEventListener('pm:ai-toggle', onToggle as EventListener);
+      window.removeEventListener('pm:ai-send', onSend as EventListener);
       window.removeEventListener('pm:ai-review-required', onReviewRequired as EventListener);
       window.removeEventListener('pm:ai-thinking', onThinking as EventListener);
       window.removeEventListener('pm:ai-learning', onThinking as EventListener);
@@ -983,6 +1009,53 @@ export const AIAgentWidget: React.FC = () => {
     }
   };
 
+  const sendText = useCallback(
+    async (text: string, contextOverride?: Record<string, unknown>) => {
+      if (!text) return;
+
+      setState('thinking');
+      try {
+        const sid = await ensureSession();
+
+        const res = await businessApi.post<{ response: string; session_id: string }>('/ai-assistant/chat/', {
+          message: text,
+          session_id: sid,
+          context: {
+            ui_source: 'AIAgentWidget',
+            ...pageContext,
+            ...(contextOverride || {}),
+          },
+        });
+
+        const responseText = res.data?.response ?? '—';
+        setMessages((m) => [...m, { id: newId(), role: 'assistant', content: responseText, createdAt: Date.now() }]);
+
+        await reloadSessions();
+        await loadSessionMessages(sid);
+        setAttachments([]);
+
+        setState('idle');
+      } catch (err: unknown) {
+        const errObj = err && typeof err === 'object' ? (err as Record<string, unknown>) : null;
+        const response =
+          errObj?.response && typeof errObj.response === 'object' ? (errObj.response as Record<string, unknown>) : null;
+        const data = response?.data && typeof response.data === 'object' ? (response.data as Record<string, unknown>) : null;
+        const serverError =
+          (typeof data?.error === 'string' ? data.error : null) ?? (typeof data?.detail === 'string' ? data.detail : null);
+        const message =
+          typeof serverError === 'string' && serverError.length
+            ? serverError
+            : "Sorry — I couldn't reach the AI service. Please try again.";
+
+        setMessages((m) => [...m, { id: newId(), role: 'assistant', content: message, createdAt: Date.now() }]);
+        setState('action_required');
+      }
+    },
+    [ensureSession, loadSessionMessages, pageContext, reloadSessions, setAttachments, setMessages, setState]
+  );
+
+  sendTextRef.current = sendText;
+
   const handleSend = async () => {
     const text = draft.trim();
     if (!text && attachments.length === 0) return;
@@ -1114,40 +1187,30 @@ export const AIAgentWidget: React.FC = () => {
       return;
     }
 
+    // Attachments are uploaded immediately on selection; clear pills after a send cycle.
+    if (text) {
+      await sendText(text);
+      return;
+    }
+
+    // Attachments-only: just refresh the server-backed history for this session.
     setState('thinking');
     try {
       const sid = await ensureSession();
-
-      // Attachments are uploaded immediately on selection; clear pills after a send cycle.
-
-      if (text) {
-        const res = await businessApi.post<{ response: string; session_id: string }>('/ai-assistant/chat/', {
-          message: text,
-          session_id: sid,
-          context: { ui_source: 'AIAgentWidget' },
-        });
-
-        const responseText = res.data?.response ?? '—';
-        setMessages((m) => [...m, { id: newId(), role: 'assistant', content: responseText, createdAt: Date.now() }]);
-      }
-
       await reloadSessions();
       await loadSessionMessages(sid);
       setAttachments([]);
-
       setState('idle');
-    } catch (err: unknown) {
-      const errObj = err && typeof err === 'object' ? (err as Record<string, unknown>) : null;
-      const response = errObj?.response && typeof errObj.response === 'object' ? (errObj.response as Record<string, unknown>) : null;
-      const data = response?.data && typeof response.data === 'object' ? (response.data as Record<string, unknown>) : null;
-      const serverError = (typeof data?.error === 'string' ? data.error : null) ??
-        (typeof data?.detail === 'string' ? data.detail : null);
-      const message =
-        typeof serverError === 'string' && serverError.length
-          ? serverError
-          : 'Sorry — I couldn\'t reach the AI service. Please try again.';
-
-      setMessages((m) => [...m, { id: newId(), role: 'assistant', content: message, createdAt: Date.now() }]);
+    } catch {
+      setMessages((m) => [
+        ...m,
+        {
+          id: newId(),
+          role: 'assistant',
+          content: 'Sorry — I could not refresh the session right now. Please try again.',
+          createdAt: Date.now(),
+        },
+      ]);
       setState('action_required');
     }
   };

--- a/frontend/src/components/AIAssistant/Omnibox.tsx
+++ b/frontend/src/components/AIAssistant/Omnibox.tsx
@@ -1,6 +1,9 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useMemo, useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
 import Modal from '../Modal/Modal';
+import { useCockpitNavigation } from '@/contexts/CockpitNavigationContext';
+import { buildAIPageContext } from '@/services/aiContext';
 
 interface OmniboxProps {
   isOpen: boolean;
@@ -9,6 +12,14 @@ interface OmniboxProps {
 }
 
 const Omnibox: React.FC<OmniboxProps> = ({ isOpen, onClose, onSubmit }) => {
+  const location = useLocation();
+  const cockpitNav = useCockpitNavigation();
+
+  const pageContext = useMemo(
+    () => buildAIPageContext({ pathname: location.pathname, search: location.search }, cockpitNav.path),
+    [location.pathname, location.search, cockpitNav.path]
+  );
+
   const [command, setCommand] = useState('');
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1);
@@ -63,7 +74,24 @@ const Omnibox: React.FC<OmniboxProps> = ({ isOpen, onClose, onSubmit }) => {
   };
 
   const handleSubmit = (commandToSubmit: string) => {
+    // Always route Omnibox submissions into the global AI widget so it has
+    // consistent auth/tenant behavior and can render streaming responses.
+    window.dispatchEvent(new CustomEvent('pm:ai-toggle'));
+    window.dispatchEvent(
+      new CustomEvent('pm:ai-send', {
+        detail: {
+          message: commandToSubmit,
+          context: {
+            ui_source: 'Omnibox',
+            ...pageContext,
+          },
+        },
+      })
+    );
+
+    // Backward-compatible callback (legacy behavior).
     onSubmit(commandToSubmit);
+
     setCommand('');
     setSuggestions([]);
     setSelectedSuggestionIndex(-1);
@@ -161,7 +189,8 @@ const SuggestionItem = styled.div<{ isSelected: boolean }>`
   gap: 12px;
   padding: 12px 16px;
   cursor: pointer;
-  background: ${(props) => (props.isSelected ? 'rgba(var(--color-primary), 0.10)' : 'white')};
+  background: ${(props) =>
+    props.isSelected ? 'rgb(var(--color-primary) / 0.10)' : 'rgb(var(--color-surface))'};
   border-bottom: 1px solid rgb(var(--color-border));
   transition: background-color 0.2s;
 

--- a/frontend/src/components/ChatInterface/ChatWindow.tsx
+++ b/frontend/src/components/ChatInterface/ChatWindow.tsx
@@ -4,10 +4,13 @@
  * Main chat interface for the AI assistant.
  * Enhanced from PR #63 to integrate file upload into MessageInput and remove separate DocumentUpload component.
  */
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
 import { ChatSession, ChatMessage } from '../../types';
 import { chatApi, chatSessionsApi, documentsApi } from '../../services/aiService';
+import { useCockpitNavigation } from '@/contexts/CockpitNavigationContext';
+import { buildAIPageContext } from '@/services/aiContext';
 import { logger } from '../../utils/logger';
 import MessageList from './MessageList';
 import MessageInput from './MessageInput';
@@ -18,6 +21,14 @@ interface ChatWindowProps {
 }
 
 const ChatWindow: React.FC<ChatWindowProps> = ({ sessionId, onSessionChange }) => {
+  const location = useLocation();
+  const cockpitNav = useCockpitNavigation();
+
+  const pageContext = useMemo(
+    () => buildAIPageContext({ pathname: location.pathname, search: location.search }, cockpitNav.path),
+    [location.pathname, location.search, cockpitNav.path]
+  );
+
   const [session, setSession] = useState<ChatSession | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(false);
@@ -78,7 +89,10 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ sessionId, onSessionChange }) =
       const response = await chatApi.sendMessage({
         message: messageContent,
         session_id: session?.id,
-        context: {},
+        context: {
+          ui_source: 'ChatWindow',
+          ...pageContext,
+        },
       });
 
       // If no session existed, we now have one

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -34,10 +34,9 @@ const Layout: React.FC = () => {
     onToggleAIAgentWidget: () => window.dispatchEvent(new CustomEvent('pm:ai-toggle')),
   });
 
-  const handleOmniboxSubmit = (command: string) => {
-    // For now, just log the command. In a real app, this would be sent to the AI service
-    console.warn('AI Command:', command);
-    // You could also show a notification or redirect to a specific page based on the command
+  const handleOmniboxSubmit = (_command: string) => {
+    // Omnibox now dispatches pm:ai-send directly so the global widget can send
+    // a context-aware message (path + active entity).
   };
 
   return (

--- a/frontend/src/services/aiContext.ts
+++ b/frontend/src/services/aiContext.ts
@@ -1,0 +1,35 @@
+import type { NavigationStep } from '@/contexts/CockpitNavigationContext';
+
+export type AIPageContext = {
+  currentPath: string;
+  activeEntityId: string | null;
+  activeEntityType: string | null;
+  cockpitPath?: Array<{
+    id: string;
+    type: string;
+    label: string;
+    subtitle?: string;
+  }>;
+};
+
+export function buildAIPageContext(
+  location: { pathname: string; search?: string },
+  cockpitPath: NavigationStep[] = []
+): AIPageContext {
+  const currentPath = `${location.pathname}${location.search || ''}`;
+  const active = cockpitPath.length ? cockpitPath[cockpitPath.length - 1] : null;
+
+  return {
+    currentPath,
+    activeEntityId: active?.id ?? null,
+    activeEntityType: active?.type ?? null,
+    cockpitPath: cockpitPath.length
+      ? cockpitPath.map((s) => ({
+          id: String(s.id),
+          type: String(s.type),
+          label: String(s.label),
+          subtitle: typeof s.subtitle === 'string' ? s.subtitle : undefined,
+        }))
+      : undefined,
+  };
+}


### PR DESCRIPTION
Adds a shared AI page-context builder and wires it into Omnibox, AIAgentWidget, and ChatWindow so every AI chat message includes:\n- currentPath\n- activeEntityId\n- activeEntityType\n\nAlso adds a pm:ai-send event so Omnibox can route commands into the global widget.\n\nVerification: frontend npm run type-check