### PR TITLE
AI Assistant: UniversalSearch tools + VectorMemory decommission

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -46,7 +46,7 @@ This file is the **append-only PR-referenceable execution log**.
 - Promoted `apps.core.services.universal_search.UniversalSearchService` as the unified search standard for AI tools + SME grounding context.
 - AI context payloads now include canonical `current_entity_type` + `current_entity_id` keys (kept legacy camelCase keys for compatibility).
 - Added tool schemas + executor implementations: `search_records`, `get_record_detail`, `create_task` (in-app task notification).
-- PR: (pending)
+- PR: #4004.
 
 **Phase 8.0: Autonomous Multi-Agent Swarm & Continuous RLHF**
 

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -41,6 +41,13 @@ This file is the **append-only PR-referenceable execution log**.
 - Theme hardening: define `--color-surface`/`--color-background` tokens for `[data-theme="high-contrast"]`; add BaseNode background fallback.
 - PR: #4003.
 
+### 2026-03-27 — Decommission VectorMemory (UniversalSearchService Standard)
+- Removed VectorMemory API endpoints (`/ai-assistant/memory/search/`, `/ai-assistant/memory/upsert/`) and pgvector-based retrieval from the AI assistant surface.
+- Promoted `apps.core.services.universal_search.UniversalSearchService` as the unified search standard for AI tools + SME grounding context.
+- AI context payloads now include canonical `current_entity_type` + `current_entity_id` keys (kept legacy camelCase keys for compatibility).
+- Added tool schemas + executor implementations: `search_records`, `get_record_detail`, `create_task` (in-app task notification).
+- PR: (pending)
+
 **Phase 8.0: Autonomous Multi-Agent Swarm & Continuous RLHF**
 
 ### 2026-03-20 — Phase 8.0: Autonomous Multi-Agent Swarm & Continuous RLHF

--- a/backend/apps/core/services/universal_search.py
+++ b/backend/apps/core/services/universal_search.py
@@ -265,7 +265,50 @@ class UniversalSearchService:
         except Exception as e:
             logger.error(f"Search error for {entity_type}: {e}")
             return []
-    
+
+    def get_record_detail(self, entity_type: str, entity_id: str | int) -> Optional[Dict[str, Any]]:
+        """Fetch a single record detail payload for a given entity type.
+
+        This is intentionally lightweight and uses the same entity config and tenant
+        filtering rules as universal search.
+        """
+        config = SEARCHABLE_ENTITIES.get(entity_type)
+        if not config:
+            return None
+
+        Model = self._get_model(entity_type)
+        if not Model:
+            return None
+
+        try:
+            base_qs = Model.objects.all()
+            if hasattr(Model, 'tenant'):
+                base_qs = base_qs.filter(tenant=self.tenant)
+
+            if entity_type == 'product':
+                from apps.system.services.product_visibility import visible_products_qs
+
+                base_qs = visible_products_qs(tenant=self.tenant, qs=base_qs)
+
+            obj = base_qs.filter(id=entity_id).first()
+            if not obj:
+                return None
+
+            display_value = self._get_display_value(obj, config)
+            subtitle = self._get_subtitle(obj, config)
+
+            return {
+                'id': obj.id,
+                'type': entity_type,
+                'title': display_value,
+                'subtitle': subtitle,
+                'route': config['route'].format(id=obj.id),
+            }
+
+        except Exception as e:
+            logger.error(f"Record detail error for {entity_type}/{entity_id}: {e}")
+            return None
+
     def _get_display_value(self, obj, config: Dict) -> str:
         """Get the display value for an object."""
         display_field = config['display_field']

--- a/backend/tenant_apps/ai_assistant/serializers.py
+++ b/backend/tenant_apps/ai_assistant/serializers.py
@@ -5,33 +5,6 @@ from rest_framework import serializers
 from .models import AIDocument, AIFeedbackLog, AIConfiguration, ChatMessage, ChatSession
 
 
-class VectorMemorySearchRequestSerializer(serializers.Serializer):
-    embedding = serializers.ListField(child=serializers.FloatField(), allow_empty=False)
-    top_k = serializers.IntegerField(required=False, default=5, min_value=1, max_value=50)
-
-    def validate_embedding(self, value):
-        if len(value) != 1536:
-            raise serializers.ValidationError('embedding must be a 1536-length float array')
-        return value
-
-
-class VectorMemoryUpsertRequestSerializer(serializers.Serializer):
-    embedding = serializers.ListField(child=serializers.FloatField(), allow_empty=False)
-    source_type = serializers.CharField(required=False, default='context', max_length=64)
-    document_id = serializers.UUIDField(required=False, allow_null=True)
-    content = serializers.CharField(required=False, allow_blank=True, default='')
-    metadata = serializers.JSONField(required=False, default=dict)
-
-    def validate_embedding(self, value):
-        if len(value) != 1536:
-            raise serializers.ValidationError('embedding must be a 1536-length float array')
-        return value
-
-    def validate_metadata(self, value):
-        if not isinstance(value, dict):
-            raise serializers.ValidationError('metadata must be an object')
-        return value
-
 
 class PendingReviewResolveRequestSerializer(serializers.Serializer):
     user_corrected_data = serializers.JSONField(required=False, allow_null=True)
@@ -193,14 +166,6 @@ class AIConfigurationSerializer(serializers.ModelSerializer):
         model = AIConfiguration
         fields = ["id", "name", "provider", "model_name", "is_default"]
 
-
-class VectorMemorySearchResultSerializer(serializers.Serializer):
-    id = serializers.UUIDField()
-    source_type = serializers.CharField()
-    document_id = serializers.UUIDField(allow_null=True, required=False)
-    distance = serializers.FloatField()
-    content_preview = serializers.CharField()
-    metadata = serializers.JSONField()
 
 
 class SwarmInvokeRequestSerializer(serializers.Serializer):

--- a/backend/tenant_apps/ai_assistant/swarm/agents/meat_sme.py
+++ b/backend/tenant_apps/ai_assistant/swarm/agents/meat_sme.py
@@ -1,6 +1,9 @@
 """Meat Subject Matter Expert (SME) agent.
 
-Phase 8.2: Tenant-isolated Vector RAG pipeline.
+VectorMemory has been decommissioned.
+
+We now use UniversalSearchService (keyword + operator search) to retrieve
+lightweight tenant context to ground responses.
 
 CRITICAL RULE:
 - Retrieval MUST be tenant-scoped.
@@ -9,24 +12,21 @@ CRITICAL RULE:
 from __future__ import annotations
 
 import logging
-from typing import Any, List
+from typing import List
 
 from django.conf import settings
-from pgvector.django import CosineDistance
-
-from tenant_apps.ai_assistant.models import VectorMemory
 
 logger = logging.getLogger(__name__)
 
 
 SYSTEM_PROMPT = (
-    "You are the ProjectMeats Subject Matter Expert. Use the provided tenant history and industry context to answer the query accurately. "
+    "You are the ProjectMeats Subject Matter Expert. Use the provided tenant context to answer the query accurately. "
     "Do not hallucinate outside the provided context."
 )
 
 
 class MeatSMEAgent:
-    """Domain expert agent backed by strict tenant-scoped vector retrieval."""
+    """Domain expert agent backed by tenant-scoped Universal Search retrieval."""
 
     def analyze(self, query: str, tenant_id: str) -> str:
         if not tenant_id:
@@ -42,48 +42,46 @@ class MeatSMEAgent:
         except Exception as e:
             raise RuntimeError('OpenAI client not available on server') from e
 
+        from apps.tenants.models import Tenant
+        from apps.core.services.universal_search import UniversalSearchService
+
+        tenant = Tenant.objects.filter(id=tenant_id).first()
+        if not tenant:
+            raise ValueError('Tenant not found')
+
+        # Retrieve lightweight context via UniversalSearchService.
+        service = UniversalSearchService(tenant=tenant)
+        search_payload = service.search(query, limit_per_type=3)
+        results = (search_payload or {}).get('results') or []
+
+        context_blocks: List[str] = []
+        for r in results[:12]:
+            title = str(r.get('title') or '')
+            subtitle = str(r.get('subtitle') or '') if r.get('subtitle') else ''
+            route = str(r.get('route') or '')
+            etype = str(r.get('type') or '')
+            rid = str(r.get('id') or '')
+            bits = [f"{etype}:{rid}", title]
+            if subtitle:
+                bits.append(f"({subtitle})")
+            if route:
+                bits.append(f"route={route}")
+            context_blocks.append(" ".join(bits).strip())
+
+        context_text = "\n".join(context_blocks) if context_blocks else "(no universal search context found)"
+
         openai = OpenAI(
             api_key=settings.OPENAI_API_KEY,
             organization=getattr(settings, 'OPENAI_ORG_ID', None) or None,
         )
 
-        # Step 1: Embed the query
-        embedding_resp = openai.embeddings.create(
-            model="text-embedding-3-small",
-            input=query,
-        )
-        query_embedding: List[float] = embedding_resp.data[0].embedding  # 1536 dims
-
-        # Step 2: Retrieve tenant-scoped memory ordered by cosine distance
-        memories = list(
-            VectorMemory.objects.filter(tenant_id=tenant_id)
-            .annotate(distance=CosineDistance('embedding', query_embedding))
-            .order_by('distance')[:5]
-        )
-
-        context_blocks: List[str] = []
-        for m in memories:
-            meta = m.metadata or {}
-            header_bits = [str(m.source_type or 'context')]
-            if m.document_id:
-                header_bits.append(str(m.document_id))
-            header = " ".join(header_bits)
-            snippet = (m.content or '').strip()
-            if not snippet:
-                continue
-            # Keep context compact but useful
-            context_blocks.append(f"[{header}]\n{snippet}\nMetadata: {meta}")
-
-        context_text = "\n\n".join(context_blocks) if context_blocks else "(no tenant vector memory matches found)"
-
-        # Step 3: Answer with gpt-4o using ONLY the provided context
         user_payload = (
-            "Tenant history + industry context (authoritative):\n"
+            "Tenant context (authoritative):\n"
             f"{context_text}\n\n"
             "User query:\n"
             f"{query}\n\n"
-            "Instructions: Answer using ONLY the tenant history + context above. "
-            "If the context is insufficient, say what is missing and what to ingest into VectorMemory."
+            "Instructions: Answer using ONLY the tenant context above. "
+            "If the context is insufficient, say what is missing."
         )
 
         completion = openai.chat.completions.create(

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -67,6 +67,58 @@ DEFAULT_OPENAI_TOOLS = [
     {
         'type': 'function',
         'function': {
+            'name': 'search_records',
+            'description': 'Search tenant records using Universal Search (unified search standard).',
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'query': {'type': 'string', 'description': 'Free-text search query (operators supported, e.g. supplier:ABC)'},
+                    'entity_types': {
+                        'type': 'array',
+                        'items': {'type': 'string'},
+                        'description': 'Optional entity types to include (supplier, customer, purchase_order, product, ...)',
+                    },
+                    'limit': {'type': 'integer', 'description': 'Limit per entity type (default 5)'},
+                },
+                'required': ['query'],
+            },
+        },
+    },
+    {
+        'type': 'function',
+        'function': {
+            'name': 'get_record_detail',
+            'description': 'Fetch a single record detail payload (tenant-scoped).',
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'entity_type': {'type': 'string', 'description': 'Entity type (supplier, customer, purchase_order, ...)'},
+                    'entity_id': {'type': 'string', 'description': 'Primary key value (uuid/int accepted as string)'},
+                },
+                'required': ['entity_type', 'entity_id'],
+            },
+        },
+    },
+    {
+        'type': 'function',
+        'function': {
+            'name': 'create_task',
+            'description': 'Create a task for the current user (implemented as an in-app notification).',
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'title': {'type': 'string', 'description': 'Short task title'},
+                    'message': {'type': 'string', 'description': 'Task description/message'},
+                    'entity_type': {'type': 'string', 'description': 'Optional related entity type'},
+                    'entity_id': {'type': 'string', 'description': 'Optional related entity id'},
+                },
+                'required': ['title', 'message'],
+            },
+        },
+    },
+    {
+        'type': 'function',
+        'function': {
             'name': 'create_record',
             'description': 'Create a tenant-scoped record (limited to safe entity types).',
             'parameters': {
@@ -126,8 +178,11 @@ class ToolExecutor:
             'check_unread_emails': self._check_unread_emails,
             'draft_outlook_email': self._draft_outlook_email,
             'search_cockpit_records': self._search_cockpit_records,
+            'search_records': self._search_records,
+            'get_record_detail': self._get_record_detail,
+            'create_task': self._create_task,
             'create_record': self._create_record,
-            'search_entities': self._search_entities,
+            'search_entities': self._search_entities,  # Backward-compatible alias
             'get_recent_activity': self._get_recent_activity,
         }
 
@@ -246,7 +301,7 @@ class ToolExecutor:
         if not entity_type or not search_term:
             raise ValueError('Missing required parameters: entity_type, search_term')
 
-        return self._search_entities(
+        return self._search_records(
             {'query': search_term, 'entity_types': [entity_type], 'limit': 10},
             tenant,
             user,
@@ -370,15 +425,15 @@ class ToolExecutor:
 
         raise ValueError(f"Unsupported entity for create_record: {entity}")
 
-    def _search_entities(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
-        """Search common entities with strict tenant filtering."""
+    def _search_records(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        """Search tenant records using UniversalSearchService."""
         query = (arguments.get('query') or '').strip()
         if not query:
             raise ValueError('Missing required parameters: query')
 
         entity_types = arguments.get('entity_types')
         if not isinstance(entity_types, list) or not entity_types:
-            entity_types = ['customer', 'supplier', 'contact', 'purchase_order', 'sales_order']
+            entity_types = None
 
         limit = arguments.get('limit')
         try:
@@ -387,105 +442,86 @@ class ToolExecutor:
             limit_int = 5
         limit_int = max(1, min(25, limit_int))
 
-        results: Dict[str, Any] = {
-            'query': query,
-            'results': [],
-            'counts': {},
+        from apps.core.services.universal_search import UniversalSearchService
+
+        service = UniversalSearchService(tenant=tenant)
+        return service.search(query, limit_per_type=limit_int, entity_types=entity_types)
+
+    def _get_record_detail(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        entity_type = (arguments.get('entity_type') or '').strip().lower()
+        entity_id = (arguments.get('entity_id') or '').strip()
+        if not entity_type or not entity_id:
+            raise ValueError('Missing required parameters: entity_type, entity_id')
+
+        from apps.core.services.universal_search import UniversalSearchService
+
+        service = UniversalSearchService(tenant=tenant)
+        detail = service.get_record_detail(entity_type, entity_id)
+        if not detail:
+            return {'found': False, 'entity_type': entity_type, 'entity_id': entity_id}
+        return {'found': True, 'record': detail}
+
+    def _create_task(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        """Create a task for the current user (implemented as an in-app notification)."""
+        if not user or not getattr(user, 'is_authenticated', False):
+            raise ValueError('Authenticated user is required to create tasks')
+
+        title = (arguments.get('title') or '').strip()
+        message = (arguments.get('message') or '').strip()
+        if not title or not message:
+            raise ValueError('Missing required parameters: title, message')
+
+        entity_type = (arguments.get('entity_type') or '').strip().lower() or None
+        entity_id = (arguments.get('entity_id') or '').strip() or None
+
+        action_url = ''
+        metadata: Dict[str, Any] = {}
+
+        if entity_type and entity_id:
+            try:
+                from apps.core.services.universal_search import UniversalSearchService
+
+                svc = UniversalSearchService(tenant=tenant)
+                detail = svc.get_record_detail(entity_type, entity_id)
+                if detail and detail.get('route'):
+                    action_url = str(detail.get('route') or '')
+            except Exception:
+                pass
+
+        entity_uuid = None
+        if entity_id:
+            try:
+                from uuid import UUID
+
+                entity_uuid = UUID(str(entity_id))
+            except Exception:
+                metadata['entity_id'] = str(entity_id)
+
+        from tenant_apps.workflows.models import NotificationType, NotificationPriority, UserNotification
+
+        row = UserNotification.objects.create(
+            user=user,
+            tenant=tenant,
+            notification_type=NotificationType.TASK_ASSIGNED,
+            title=title,
+            message=message,
+            priority=NotificationPriority.NORMAL,
+            entity_type=entity_type or '',
+            entity_id=entity_uuid,
+            action_url=action_url,
+            metadata=metadata,
+        )
+
+        return {
+            'id': str(row.id),
+            'title': row.title,
+            'message': row.message,
+            'action_url': row.action_url,
         }
 
-        for et in [str(x).strip().lower() for x in entity_types if str(x).strip()]:
-            if et == 'customer':
-                from tenant_apps.customers.models import Customer
-
-                qs = Customer.objects.filter(tenant=tenant, name__icontains=query).order_by('name')
-                results['counts'][et] = qs.count()
-                results['results'].append(
-                    {
-                        'entity_type': et,
-                        'items': [
-                            {'id': str(c.id), 'title': c.name, 'route': f'/cockpit?type=customer&id={c.id}'}
-                            for c in qs[:limit_int]
-                        ],
-                    }
-                )
-                continue
-
-            if et == 'supplier':
-                from tenant_apps.suppliers.models import Supplier
-
-                qs = Supplier.objects.filter(tenant=tenant, name__icontains=query).order_by('name')
-                results['counts'][et] = qs.count()
-                results['results'].append(
-                    {
-                        'entity_type': et,
-                        'items': [
-                            {'id': str(s.id), 'title': s.name, 'route': f'/cockpit?type=supplier&id={s.id}'}
-                            for s in qs[:limit_int]
-                        ],
-                    }
-                )
-                continue
-
-            if et == 'contact':
-                from tenant_apps.contacts.models import Contact
-
-                qs = Contact.objects.filter(tenant=tenant, last_name__icontains=query).order_by('last_name')
-                results['counts'][et] = qs.count()
-                results['results'].append(
-                    {
-                        'entity_type': et,
-                        'items': [
-                            {'id': str(c.id), 'title': str(c), 'route': f'/contacts/{c.id}'}
-                            for c in qs[:limit_int]
-                        ],
-                    }
-                )
-                continue
-
-            if et in {'purchase_order', 'purchaseorder', 'po'}:
-                from tenant_apps.purchase_orders.models import PurchaseOrder
-
-                qs = PurchaseOrder.objects.filter(tenant=tenant, order_number__icontains=query).order_by('-created_on')
-                results['counts'][et] = qs.count()
-                results['results'].append(
-                    {
-                        'entity_type': 'purchase_order',
-                        'items': [
-                            {
-                                'id': str(po.id),
-                                'title': getattr(po, 'order_number', '') or f'PO {po.id}',
-                                'route': f'/cockpit?type=purchase_order&id={po.id}',
-                            }
-                            for po in qs[:limit_int]
-                        ],
-                    }
-                )
-                continue
-
-            if et in {'sales_order', 'salesorder', 'so'}:
-                from tenant_apps.sales_orders.models import SalesOrder
-
-                qs = SalesOrder.objects.filter(tenant=tenant, our_sales_order_num__icontains=query).order_by('-created_on')
-                results['counts'][et] = qs.count()
-                results['results'].append(
-                    {
-                        'entity_type': 'sales_order',
-                        'items': [
-                            {
-                                'id': str(so.id),
-                                'title': getattr(so, 'our_sales_order_num', '') or f'SO {so.id}',
-                                'route': f'/cockpit?type=sales_order&id={so.id}',
-                            }
-                            for so in qs[:limit_int]
-                        ],
-                    }
-                )
-                continue
-
-            results['counts'][et] = 0
-            results['results'].append({'entity_type': et, 'items': [], 'note': 'unsupported entity type'})
-
-        return results
+    def _search_entities(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        """Backward-compatible alias for older tool name."""
+        return self._search_records(arguments, tenant, user)
 
     def _get_recent_activity(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
         from tenant_apps.cockpit.models import ActivityLog

--- a/backend/tenant_apps/ai_assistant/swarm/tools/registry.py
+++ b/backend/tenant_apps/ai_assistant/swarm/tools/registry.py
@@ -144,15 +144,33 @@ def update_claim_status(claim_id: str, status: str) -> Dict[str, Any]:
 
 
 @registry.register
-def search_vector_memory(embedding: List[float], top_k: int = 5) -> Dict[str, Any]:
-    """Search tenant VectorMemory by embedding.
+def search_records(query: str, entity_types: List[str] | None = None, limit: int = 5) -> Dict[str, Any]:
+    """Search tenant records using Universal Search.
 
-    NOTE: This is schema-only for agent discovery. Actual execution is
-    performed via the staff-only API endpoint:
-    POST /api/v1/ai-assistant/memory/search/ (expects 1536-dim embedding).
+    Executed via the Swarm tool loop in /api/v1/ai-assistant/chat/.
     """
 
-    return {"status": "use_api_endpoint", "top_k": top_k}
+    return {"status": "available_via_chat", "query": query, "limit": limit}
+
+
+@registry.register
+def get_record_detail(entity_type: str, entity_id: str) -> Dict[str, Any]:
+    """Fetch a single record detail payload.
+
+    Executed via the Swarm tool loop in /api/v1/ai-assistant/chat/.
+    """
+
+    return {"status": "available_via_chat", "entity_type": entity_type, "entity_id": entity_id}
+
+
+@registry.register
+def create_task(title: str, message: str, entity_type: str | None = None, entity_id: str | None = None) -> Dict[str, Any]:
+    """Create a user-visible task (implemented as an in-app notification).
+
+    Executed via the Swarm tool loop in /api/v1/ai-assistant/chat/.
+    """
+
+    return {"status": "available_via_chat", "title": title}
 
 
 @registry.register

--- a/backend/tenant_apps/ai_assistant/urls.py
+++ b/backend/tenant_apps/ai_assistant/urls.py
@@ -21,8 +21,6 @@ from .views import (
     PendingReviewView,
     SwarmInvokeAPIView,
     ToolsOpenAPIView,
-    VectorMemorySearchAPIView,
-    VectorMemoryUpsertAPIView,
 )
 
 app_name = 'ai_assistant'
@@ -50,6 +48,5 @@ urlpatterns = [
     # Supporting endpoints
     path('review/<uuid:feedback_id>/resolve/', PendingReviewResolveAPIView.as_view(), name='ai-review-resolve'),
     path('swarm/invoke/', SwarmInvokeAPIView.as_view(), name='ai-swarm-invoke'),
-    path('memory/search/', VectorMemorySearchAPIView.as_view(), name='ai-memory-search'),
-    path('memory/upsert/', VectorMemoryUpsertAPIView.as_view(), name='ai-memory-upsert'),
+
 ]

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -13,7 +13,6 @@ from django.db.models import Avg
 from django.db.models.functions import TruncDate
 from django.utils import timezone
 from openai import OpenAI
-from pgvector.django import CosineDistance
 from rest_framework import filters, mixins, permissions, status, viewsets
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.decorators import action
@@ -22,7 +21,7 @@ from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle, User
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .models import AIDocument, AIFeedbackLog, AIConfiguration, ChatMessage, ChatSession, MessageTypeChoices, VectorMemory
+from .models import AIDocument, AIFeedbackLog, AIConfiguration, ChatMessage, ChatSession, MessageTypeChoices
 from .serializers import (
     AIDocumentSerializer,
     AIFeedbackLogSerializer,
@@ -38,8 +37,6 @@ from .serializers import (
     PendingReviewItemSerializer,
     PendingReviewResolveRequestSerializer,
     SwarmInvokeRequestSerializer,
-    VectorMemorySearchRequestSerializer,
-    VectorMemoryUpsertRequestSerializer,
 )
 
 logger = logging.getLogger(__name__)
@@ -488,12 +485,16 @@ class SwarmToolsOpenAPIView(APIView):
         except Exception:
             logger.warning('tools/openapi: failed to load outlook connection status', exc_info=True)
 
+        email_tools = {'check_unread_emails', 'draft_outlook_email'}
+
         if outlook['connected']:
             tools = DEFAULT_OPENAI_TOOLS
         else:
+            # Always allow safe internal tools; only hide Outlook tools when not connected.
             tools = [
-                t for t in DEFAULT_OPENAI_TOOLS
-                if t.get('function', {}).get('name') == 'search_cockpit_records'
+                t
+                for t in DEFAULT_OPENAI_TOOLS
+                if t.get('function', {}).get('name') not in email_tools
             ]
 
         payload = {
@@ -554,106 +555,6 @@ class SwarmInvokeAPIView(APIView):
         )
 
 
-class VectorMemorySearchAPIView(APIView):
-    """Staff-only vector similarity search over tenant VectorMemory.
-
-    Read-only: this endpoint performs a nearest-neighbor query and returns
-    matching records with their distance score.
-    """
-
-    permission_classes = [IsAdminUser]
-
-    def post(self, request):
-        serializer = VectorMemorySearchRequestSerializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        tenant = getattr(request, 'tenant', None)
-        tenant_id = str(getattr(tenant, 'id', '') or '')
-        if not tenant_id:
-            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
-
-        embedding = serializer.validated_data['embedding']
-        top_k = serializer.validated_data['top_k']
-
-        qs = (
-            VectorMemory.objects.filter(tenant_id=tenant_id)
-            .annotate(distance=CosineDistance('embedding', embedding))
-            .order_by('distance')
-        )
-        results = []
-        for row in qs[:top_k]:
-            content = row.content or ''
-            results.append(
-                {
-                    'id': row.id,
-                    'source_type': row.source_type,
-                    'document_id': row.document_id,
-                    'distance': float(getattr(row, 'distance', 0.0) or 0.0),
-                    'content_preview': content[:500],
-                    'metadata': row.metadata or {},
-                }
-            )
-
-        return Response({'results': results}, status=status.HTTP_200_OK)
-
-
-class VectorMemoryUpsertAPIView(APIView):
-    """Staff-only ingestion endpoint for VectorMemory.
-
-    Caller must supply a 1536-dim embedding (no OpenAI dependency here).
-    If document_id is provided, best-effort upsert keyed by (tenant, source_type, document_id).
-    """
-
-    permission_classes = [IsAdminUser]
-
-    def post(self, request):
-        serializer = VectorMemoryUpsertRequestSerializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        tenant = getattr(request, 'tenant', None)
-        tenant_id = str(getattr(tenant, 'id', '') or '')
-        if not tenant_id:
-            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
-
-        embedding = serializer.validated_data['embedding']
-        source_type = serializer.validated_data['source_type']
-        document_id = serializer.validated_data.get('document_id')
-        content = serializer.validated_data.get('content', '')
-        metadata = serializer.validated_data.get('metadata', {})
-
-        if document_id:
-            obj, created = VectorMemory.objects.update_or_create(
-                tenant_id=tenant_id,
-                source_type=source_type,
-                document_id=document_id,
-                defaults={
-                    'content': content,
-                    'metadata': metadata,
-                    'embedding': embedding,
-                },
-            )
-        else:
-            obj = VectorMemory.objects.create(
-                tenant_id=tenant_id,
-                source_type=source_type,
-                document_id=None,
-                content=content,
-                metadata=metadata,
-                embedding=embedding,
-            )
-            created = True
-
-        return Response(
-            {
-                'id': str(obj.id),
-                'created': created,
-                'source_type': obj.source_type,
-                'document_id': str(obj.document_id) if obj.document_id else None,
-            },
-            status=status.HTTP_200_OK,
-        )
 
 
 class PendingReviewAPIView(APIView):
@@ -818,12 +719,15 @@ class ToolsOpenAPIView(APIView):
         except Exception:
             outlook_connected = False
 
+        email_tools = {'check_unread_emails', 'draft_outlook_email'}
+
         if outlook_connected:
             tools = DEFAULT_OPENAI_TOOLS
         else:
             tools = [
-                t for t in DEFAULT_OPENAI_TOOLS
-                if t.get('function', {}).get('name') == 'search_cockpit_records'
+                t
+                for t in DEFAULT_OPENAI_TOOLS
+                if t.get('function', {}).get('name') not in email_tools
             ]
 
         return Response({'tools': tools}, status=status.HTTP_200_OK)

--- a/frontend/src/services/aiContext.ts
+++ b/frontend/src/services/aiContext.ts
@@ -2,8 +2,15 @@ import type { NavigationStep } from '@/contexts/CockpitNavigationContext';
 
 export type AIPageContext = {
   currentPath: string;
+
+  // Legacy keys (camelCase)
   activeEntityId: string | null;
   activeEntityType: string | null;
+
+  // Canonical keys (snake_case) expected by the backend
+  current_entity_id: string | null;
+  current_entity_type: string | null;
+
   cockpitPath?: Array<{
     id: string;
     type: string;
@@ -21,8 +28,15 @@ export function buildAIPageContext(
 
   return {
     currentPath,
+
+    // Legacy keys (camelCase)
     activeEntityId: active?.id ?? null,
     activeEntityType: active?.type ?? null,
+
+    // Canonical keys (snake_case)
+    current_entity_id: active?.id ?? null,
+    current_entity_type: active?.type ?? null,
+
     cockpitPath: cockpitPath.length
       ? cockpitPath.map((s) => ({
           id: String(s.id),


### PR DESCRIPTION
Decommissions VectorMemory and promotes UniversalSearchService as the unified search standard for the AI assistant.

Changes:
- Remove VectorMemory endpoints (/ai-assistant/memory/search, /ai-assistant/memory/upsert) and pgvector-based retrieval from AI assistant
- Add LLM tools: search_records, get_record_detail, create_task (task is an in-app notification)
- Tool discovery endpoints now hide ONLY Outlook tools when not connected (safe tools still advertised)
- AI context payload includes canonical current_entity_type/current_entity_id (keeps legacy camelCase keys)

Verification:
- npm --prefix frontend run type-check
- python -m compileall backend
