### PR TITLE
AI assistant: schema-aware prompt + get_entity_details tool

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -41,12 +41,14 @@ This file is the **append-only PR-referenceable execution log**.
 - Theme hardening: define `--color-surface`/`--color-background` tokens for `[data-theme="high-contrast"]`; add BaseNode background fallback.
 - PR: #4003.
 
-### 2026-03-27 — Decommission VectorMemory (UniversalSearchService Standard)
+### 2026-03-27 — Decommission VectorMemory (UniversalSearchService Standard) — COMPLETE
 - Removed VectorMemory API endpoints (`/ai-assistant/memory/search/`, `/ai-assistant/memory/upsert/`) and pgvector-based retrieval from the AI assistant surface.
 - Promoted `apps.core.services.universal_search.UniversalSearchService` as the unified search standard for AI tools + SME grounding context.
-- AI context payloads now include canonical `current_entity_type` + `current_entity_id` keys (kept legacy camelCase keys for compatibility).
-- Added tool schemas + executor implementations: `search_records`, `get_record_detail`, `create_task` (in-app task notification).
-- PR: #4004.
+- Added tool schemas + executor implementations: `search_records`, `get_record_detail`, `create_task` (in-app task notification) — PR: #4004.
+
+### 2026-03-27 — Omnibox Context Bridge — IN-PROGRESS
+- Ensure Omnibox/AI widget payloads consistently include `currentPath` + active entity context (`current_entity_type`, `current_entity_id`) across all message entrypoints.
+- PR: #4004 (initial wiring shipped; verify + extend as needed)
 
 **Phase 8.0: Autonomous Multi-Agent Swarm & Continuous RLHF**
 

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -49,6 +49,7 @@ This file is the **append-only PR-referenceable execution log**.
 ### 2026-03-27 — Omnibox Context Bridge — IN-PROGRESS
 - Ensure Omnibox/AI widget payloads consistently include `currentPath` + active entity context (`current_entity_type`, `current_entity_id`) across all message entrypoints.
 - PR: #4004 (initial wiring shipped; verify + extend as needed)
+- PR: #4005 (schema-aware prompt + get_entity_details tool)
 
 **Phase 8.0: Autonomous Multi-Agent Swarm & Continuous RLHF**
 

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -88,7 +88,7 @@ DEFAULT_OPENAI_TOOLS = [
         'type': 'function',
         'function': {
             'name': 'get_record_detail',
-            'description': 'Fetch a single record detail payload (tenant-scoped).',
+            'description': 'Fetch a lightweight record detail payload (tenant-scoped).',
             'parameters': {
                 'type': 'object',
                 'properties': {
@@ -96,6 +96,21 @@ DEFAULT_OPENAI_TOOLS = [
                     'entity_id': {'type': 'string', 'description': 'Primary key value (uuid/int accepted as string)'},
                 },
                 'required': ['entity_type', 'entity_id'],
+            },
+        },
+    },
+    {
+        'type': 'function',
+        'function': {
+            'name': 'get_entity_details',
+            'description': 'Fetch full entity details payload (maps to system EntityViewSet.retrieve).',
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'type': {'type': 'string', 'description': 'Entity type (supplier, customer, product, purchase_order, ...)'} ,
+                    'id': {'type': 'string', 'description': 'Entity primary key value'}
+                },
+                'required': ['type', 'id'],
             },
         },
     },
@@ -180,6 +195,7 @@ class ToolExecutor:
             'search_cockpit_records': self._search_cockpit_records,
             'search_records': self._search_records,
             'get_record_detail': self._get_record_detail,
+            'get_entity_details': self._get_entity_details,
             'create_task': self._create_task,
             'create_record': self._create_record,
             'search_entities': self._search_entities,  # Backward-compatible alias
@@ -460,6 +476,29 @@ class ToolExecutor:
         if not detail:
             return {'found': False, 'entity_type': entity_type, 'entity_id': entity_id}
         return {'found': True, 'record': detail}
+
+    def _get_entity_details(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        """Return the same payload as GET /api/v1/system/entities/{type}/{id}/."""
+        entity_type = (arguments.get('type') or '').strip().lower()
+        entity_id = (arguments.get('id') or '').strip()
+        if not entity_type or not entity_id:
+            raise ValueError('Missing required parameters: type, id')
+
+        # Call the same serializer logic as EntityViewSet.retrieve without making HTTP requests.
+        from apps.system.views.entity_viewset import EntityViewSet
+
+        class _ToolRequest:
+            def __init__(self, tenant, user):
+                self.tenant = tenant
+                self.user = user
+                self.query_params = {}
+
+        req = _ToolRequest(tenant=tenant, user=user)
+        view = EntityViewSet()
+
+        entity, resolved_type, _Model = view._get_entity_or_404(req, type=entity_type, pk=entity_id)
+        can_edit = bool(getattr(user, 'is_staff', False) or getattr(user, 'is_superuser', False))
+        return view._serialize_entity_detail(entity, resolved_type, can_edit=can_edit)
 
     def _create_task(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
         """Create a task for the current user (implemented as an in-app notification)."""

--- a/backend/tenant_apps/ai_assistant/swarm/router.py
+++ b/backend/tenant_apps/ai_assistant/swarm/router.py
@@ -33,6 +33,13 @@ def build_swarm_system_prompt(*, outlook_connected: bool, outlook_email: str | N
         "You are the ProjectMeats Autonomous Swarm Orchestrator. "
         "You are an expert in wholesale meat logistics, purchase orders, cold storage, and supplier management. "
         "Be highly analytical, concise, and proactive. "
+        "\n\nDatabase schema (high level): "
+        "Entities include Supplier, Customer, Product (system-wide catalog), Contact, PurchaseOrder, SalesOrder, Invoice, Plant, Carrier. "
+        "Most business entities are tenant-scoped via a tenant_id (shared-schema multi-tenancy); Products are system-wide with tenant visibility rules. "
+        "\n\nAvailable tools (use when it reduces user effort): "
+        "- search_entities(query[, entity_types, limit]) to find records via Universal Search. "
+        "- get_entity_details(type, id) to load a full record profile payload for a specific entity. "
+        "- create_task(title, message[, entity_type, entity_id]) to create an in-app task notification for the current user. "
     )
 
     if outlook_connected:

--- a/backend/tenant_apps/ai_assistant/swarm/tools/registry.py
+++ b/backend/tenant_apps/ai_assistant/swarm/tools/registry.py
@@ -155,12 +155,19 @@ def search_records(query: str, entity_types: List[str] | None = None, limit: int
 
 @registry.register
 def get_record_detail(entity_type: str, entity_id: str) -> Dict[str, Any]:
-    """Fetch a single record detail payload.
+    """Fetch a lightweight record detail payload.
 
     Executed via the Swarm tool loop in /api/v1/ai-assistant/chat/.
     """
 
     return {"status": "available_via_chat", "entity_type": entity_type, "entity_id": entity_id}
+
+
+@registry.register
+def get_entity_details(type: str, id: str) -> Dict[str, Any]:
+    """Fetch full entity details payload (maps to EntityViewSet.retrieve)."""
+
+    return {"status": "available_via_chat", "type": type, "id": id}
 
 
 @registry.register


### PR DESCRIPTION
Adds schema-aware system prompt guidance and a new entity detail tool for the AI assistant.

- Swarm system prompt: adds high-level schema overview (Supplier/Customer/Product/PurchaseOrder/etc) + tool guidance
- Tool: get_entity_details(type,id) implemented via EntityViewSet.retrieve serialization logic (no HTTP)
- Tool registry exposes get_entity_details
- Docs: mark VectorMemory Decommissioning COMPLETE; Omnibox Context Bridge IN-PROGRESS

Verification:
- npm --prefix frontend run type-check
- python -m compileall backend
