### PR TITLE
Sentry-GitHub-Copilot Loop: webhook stub + AI Sentry bridge

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -11,6 +11,10 @@ This file is the **append-only PR-referenceable execution log**.
 
 ## Active Initiative: V3.0 Final Push (Consolidation + Scale + Polish)
 
+### 2026-03-27 — Sentry-GitHub-Copilot Loop
+- Sentry Passthrough to GitHub — **ACTIVE** (webhook receiver + ownership routing groundwork).
+- AI Assistant Sentry Bridge — **IN-PROGRESS** (tooling to fetch tenant-scoped recent Sentry issues).
+
 **Phase 6.5: AI Document Understanding & Agentic Workflows**
 
 ### 2026-03-19 — Phase 6.5: AI Document Understanding

--- a/.github/SENTRY_ISSUE_OWNERS
+++ b/.github/SENTRY_ISSUE_OWNERS
@@ -1,0 +1,10 @@
+# Sentry Issue Ownership Map
+#
+# Purpose: map code paths to GitHub teams for automated routing/assignment.
+# This is used by the Sentry-GitHub-Copilot Loop initiative.
+#
+# Format:
+# <path-prefix> <github-team>
+
+backend/tenant_apps/workflows/ @ProjectMeats/workflow-engine
+backend/tenant_apps/invoices/ @ProjectMeats/fintech-team

--- a/backend/apps/core/urls.py
+++ b/backend/apps/core/urls.py
@@ -70,6 +70,9 @@ urlpatterns = [
     path("tenant-forms/merge/", workform_views.merge_forms, name="tenant-forms-merge"),
     path("tenant-forms/split/", workform_views.split_form, name="tenant-forms-split"),
     
+    # Webhooks (Sentry-GitHub-Copilot Loop)
+    path('webhooks/sentry/issue-created/', views.sentry_issue_created_webhook, name='sentry-issue-created'),
+
     # Include router URLs
     path("", include(router.urls)),
     path("", include(workforms_router.urls)),

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
 from rest_framework import status, viewsets
@@ -10,6 +12,8 @@ from apps.tenants.models import Tenant, TenantUser
 from apps.core.throttling import AuthRateThrottle
 from apps.core.models import UserFavorite
 from apps.core.serializers import UserFavoriteSerializer
+
+logger = logging.getLogger(__name__)
 
 
 @api_view(["POST"])
@@ -1058,3 +1062,55 @@ class FavoritesViewSet(viewsets.ModelViewSet):
         ).exists()
         
         return Response({'is_favorited': is_favorited})
+
+
+# ==============================================================================
+# Sentry Webhooks (Sentry-GitHub-Copilot Loop)
+# ==============================================================================
+
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def sentry_issue_created_webhook(request):
+    """Stub receiver for Sentry "Issue Created" webhooks.
+
+    This is intentionally permissive (no signature validation yet) and exists
+    to establish the stable endpoint + contract for future automation.
+
+    Expected future flow:
+    - Sentry issue created -> webhook -> route/assign -> create GitHub issue/PR tasks -> Copilot triage
+    """
+    try:
+        resource = request.headers.get('Sentry-Hook-Resource') or request.headers.get('X-Sentry-Hook-Resource')
+        event = request.headers.get('Sentry-Hook-Event') or request.headers.get('X-Sentry-Hook-Event')
+        payload = request.data if isinstance(request.data, dict) else {}
+
+        issue = payload.get('data', {}).get('issue', {}) if isinstance(payload.get('data'), dict) else {}
+        issue_id = issue.get('id')
+        issue_title = issue.get('title')
+        issue_permalink = issue.get('permalink')
+
+        logger.info(
+            '[SentryWebhook] received resource=%s event=%s issue_id=%s title=%s',
+            resource,
+            event,
+            issue_id,
+            issue_title,
+        )
+
+        return Response(
+            {
+                'ok': True,
+                'resource': resource,
+                'event': event,
+                'issue': {
+                    'id': issue_id,
+                    'title': issue_title,
+                    'permalink': issue_permalink,
+                },
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    except Exception as e:
+        logger.warning('[SentryWebhook] failed to process payload: %s', str(e), exc_info=True)
+        return Response({'ok': False}, status=status.HTTP_200_OK)

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -134,6 +134,20 @@ DEFAULT_OPENAI_TOOLS = [
     {
         'type': 'function',
         'function': {
+            'name': 'get_recent_errors',
+            'description': 'Fetch the most recent Sentry issues for the active tenant_id (last 5).',
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'tenant_id': {'type': 'string', 'description': 'Tenant UUID (must match active tenant)'}
+                },
+                'required': ['tenant_id'],
+            },
+        },
+    },
+    {
+        'type': 'function',
+        'function': {
             'name': 'create_record',
             'description': 'Create a tenant-scoped record (limited to safe entity types).',
             'parameters': {
@@ -197,6 +211,7 @@ class ToolExecutor:
             'get_record_detail': self._get_record_detail,
             'get_entity_details': self._get_entity_details,
             'create_task': self._create_task,
+            'get_recent_errors': self._get_recent_errors,
             'create_record': self._create_record,
             'search_entities': self._search_entities,  # Backward-compatible alias
             'get_recent_activity': self._get_recent_activity,
@@ -557,6 +572,72 @@ class ToolExecutor:
             'message': row.message,
             'action_url': row.action_url,
         }
+
+    def _get_recent_errors(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        """Fetch recent Sentry issues tagged with the active tenant_id."""
+        import os
+        import requests
+
+        tenant_id_arg = str(arguments.get('tenant_id') or '').strip()
+        active_tenant_id = str(getattr(tenant, 'id', '') or '')
+
+        if not active_tenant_id:
+            raise ValueError('Tenant context missing')
+        if not tenant_id_arg:
+            raise ValueError('Missing required parameter: tenant_id')
+        if tenant_id_arg != active_tenant_id:
+            raise ValueError('tenant_id must match the active tenant')
+
+        token = os.environ.get('SENTRY_AUTH_TOKEN')
+        org = os.environ.get('SENTRY_ORG_SLUG') or os.environ.get('SENTRY_ORG')
+        base_url = (os.environ.get('SENTRY_BASE_URL') or 'https://sentry.io').rstrip('/')
+
+        if not token:
+            return {'ok': False, 'error': 'SENTRY_AUTH_TOKEN not configured'}
+        if not org:
+            return {'ok': False, 'error': 'SENTRY_ORG_SLUG not configured'}
+
+        url = f"{base_url}/api/0/organizations/{org}/issues/"
+        params = {
+            'query': f"tenant_id:{active_tenant_id}",
+            'limit': 5,
+            'sort': 'date',
+        }
+
+        resp = requests.get(
+            url,
+            headers={'Authorization': f'Bearer {token}', 'Accept': 'application/json'},
+            params=params,
+            timeout=10,
+        )
+
+        if resp.status_code >= 400:
+            return {
+                'ok': False,
+                'status': resp.status_code,
+                'error': 'Sentry API request failed',
+                'detail': (resp.text or '')[:300],
+            }
+
+        issues = resp.json() if resp.content else []
+        out = []
+        for it in (issues or [])[:5]:
+            out.append(
+                {
+                    'id': it.get('id'),
+                    'shortId': it.get('shortId') or it.get('short_id'),
+                    'title': it.get('title'),
+                    'permalink': it.get('permalink'),
+                    'culprit': it.get('culprit'),
+                    'level': it.get('level'),
+                    'status': it.get('status'),
+                    'firstSeen': it.get('firstSeen'),
+                    'lastSeen': it.get('lastSeen'),
+                    'count': it.get('count'),
+                }
+            )
+
+        return {'ok': True, 'tenant_id': active_tenant_id, 'issues': out}
 
     def _search_entities(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
         """Backward-compatible alias for older tool name."""

--- a/backend/tenant_apps/ai_assistant/swarm/router.py
+++ b/backend/tenant_apps/ai_assistant/swarm/router.py
@@ -36,6 +36,7 @@ def build_swarm_system_prompt(*, outlook_connected: bool, outlook_email: str | N
         "\n\nDatabase schema (high level): "
         "Entities include Supplier, Customer, Product (system-wide catalog), Contact, PurchaseOrder, SalesOrder, Invoice, Plant, Carrier. "
         "Most business entities are tenant-scoped via a tenant_id (shared-schema multi-tenancy); Products are system-wide with tenant visibility rules. "
+        "\n\nYou have access to real-time error logs. If a user complains about a failure, check Sentry before asking for clarification. "
         "\n\nAvailable tools (use when it reduces user effort): "
         "- search_entities(query[, entity_types, limit]) to find records via Universal Search. "
         "- get_entity_details(type, id) to load a full record profile payload for a specific entity. "

--- a/backend/tenant_apps/ai_assistant/swarm/tools/registry.py
+++ b/backend/tenant_apps/ai_assistant/swarm/tools/registry.py
@@ -181,6 +181,13 @@ def create_task(title: str, message: str, entity_type: str | None = None, entity
 
 
 @registry.register
+def get_recent_errors(tenant_id: str) -> Dict[str, Any]:
+    """Fetch recent Sentry issues for a tenant (last 5)."""
+
+    return {"status": "available_via_chat", "tenant_id": tenant_id}
+
+
+@registry.register
 def create_record(entity: str, data: Dict[str, Any]) -> Dict[str, Any]:
     """Create a tenant-scoped record.
 


### PR DESCRIPTION
Implements the groundwork for the Sentry-GitHub-Copilot Loop initiative.

- Webhook stub: POST /api/v1/webhooks/sentry/issue-created/ (apps.core) for Sentry Issue Created events
- Ownership map: .github/SENTRY_ISSUE_OWNERS (path → GitHub team)
- AI Assistant: adds tool get_recent_errors(tenant_id) which queries Sentry API (Bearer SENTRY_AUTH_TOKEN) for last 5 issues tagged tenant_id
- Swarm prompt: instructs assistant to check Sentry before asking clarifying questions on failures
- Docs: marks initiative statuses in .github/MASTER_PLAN.md

Notes:
- Tool requires env: SENTRY_AUTH_TOKEN + SENTRY_ORG_SLUG (optional SENTRY_BASE_URL)
