### PR TITLE
AI assistant: Sentry recent errors + env injection

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -14,7 +14,7 @@ This file is the **append-only PR-referenceable execution log**.
 ### 2026-03-27 — Sentry-GitHub-Copilot Loop
 - Sentry Passthrough to GitHub — **ACTIVE** (webhook receiver + ownership routing groundwork).
 - AI Assistant Sentry Bridge — **COMPLETE** (tenant-scoped `get_recent_errors` tool + admin diagnostics endpoint; requires GitHub Environment secret injection for `SENTRY_AUTH_TOKEN` + `SENTRY_ORG_SLUG`).
-  - PR: (fill after merge)
+  - PR: #4007
 
 **Phase 6.5: AI Document Understanding & Agentic Workflows**
 

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -13,7 +13,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 ### 2026-03-27 — Sentry-GitHub-Copilot Loop
 - Sentry Passthrough to GitHub — **ACTIVE** (webhook receiver + ownership routing groundwork).
-- AI Assistant Sentry Bridge — **IN-PROGRESS** (tooling to fetch tenant-scoped recent Sentry issues).
+- AI Assistant Sentry Bridge — **COMPLETE** (tenant-scoped `get_recent_errors` tool + admin diagnostics endpoint; requires GitHub Environment secret injection for `SENTRY_AUTH_TOKEN` + `SENTRY_ORG_SLUG`).
+  - PR: (fill after merge)
 
 **Phase 6.5: AI Document Understanding & Agentic Workflows**
 

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -99,6 +99,15 @@ on:
       SENTRY_ENABLED:
         required: false
         description: "Enable/disable Sentry error tracking (from job environment)"
+      SENTRY_AUTH_TOKEN:
+        required: false
+        description: "Sentry auth token for Sentry API access (AI assistant tooling)"
+      SENTRY_ORG_SLUG:
+        required: false
+        description: "Sentry organization slug (AI assistant tooling)"
+      SENTRY_BASE_URL:
+        required: false
+        description: "Sentry base URL (optional; self-hosted Sentry)"
       OPENAI_API_KEY:
         required: false
         description: "OpenAI API key (optional; Phase 8 AI features)"
@@ -933,6 +942,9 @@ jobs:
           	DEFAULT_FROM_EMAIL=no-reply@meatscentral.com
           	SENTRY_DSN=${{ secrets.SENTRY_DSN }}
           	SENTRY_ENABLED=${{ secrets.SENTRY_ENABLED }}
+          	SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          	SENTRY_ORG_SLUG=${{ secrets.SENTRY_ORG_SLUG }}
+          	SENTRY_BASE_URL=${{ secrets.SENTRY_BASE_URL }}
           	OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
           	OPENAI_ORG_ID=${{ secrets.OPENAI_ORG_ID }}
           	OPENAI_MODEL=${{ secrets.OPENAI_MODEL }}

--- a/backend/projectmeats/settings/base.py
+++ b/backend/projectmeats/settings/base.py
@@ -568,6 +568,11 @@ SENTRY_ENABLED = os.environ.get("SENTRY_ENABLED", "").lower() in ("true", "1", "
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
 SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "development")
 
+# Used by the AI assistant "get_recent_errors" tool (Phase 7: Sentry-GitHub-Copilot loop)
+SENTRY_AUTH_TOKEN = os.environ.get("SENTRY_AUTH_TOKEN")
+SENTRY_ORG_SLUG = os.environ.get("SENTRY_ORG_SLUG")
+SENTRY_BASE_URL = os.environ.get("SENTRY_BASE_URL", "https://sentry.io")
+
 if SENTRY_ENABLED and SENTRY_DSN:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration

--- a/backend/tenant_apps/ai_assistant/services/sentry_issues.py
+++ b/backend/tenant_apps/ai_assistant/services/sentry_issues.py
@@ -1,0 +1,100 @@
+"""Sentry integration helpers for the AI assistant.
+
+This module intentionally contains *no* tenant resolution logic.
+Callers must provide the active tenant_id and enforce that it matches
+request.tenant / app.current_tenant.
+
+We keep this logic here so both:
+- Swarm tool execution (internal)
+- Optional admin-only diagnostics endpoints
+share a single implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def fetch_recent_sentry_issues_for_tenant(
+    *,
+    tenant_id: str,
+    token: str | None,
+    org_slug: str | None,
+    base_url: str = "https://sentry.io",
+    limit: int = 5,
+    timeout_seconds: int = 10,
+) -> Dict[str, Any]:
+    """Fetch recent Sentry issues tagged with the given tenant_id.
+
+    Returns a stable JSON-ish payload:
+      { ok: bool, error?: str, issues?: [...] }
+
+    Caller is responsible for verifying `tenant_id` is the active tenant.
+    """
+
+    tenant_id = (tenant_id or "").strip()
+    if not tenant_id:
+        raise ValueError("tenant_id is required")
+
+    if not token:
+        return {"ok": False, "error": "SENTRY_AUTH_TOKEN not configured"}
+    if not org_slug:
+        return {"ok": False, "error": "SENTRY_ORG_SLUG not configured"}
+
+    try:
+        import requests
+    except Exception as exc:  # pragma: no cover
+        return {"ok": False, "error": f"requests not available: {exc}"}
+
+    base_url = (base_url or "https://sentry.io").rstrip("/")
+    url = f"{base_url}/api/0/organizations/{org_slug}/issues/"
+
+    try:
+        limit_int = int(limit)
+    except Exception:
+        limit_int = 5
+    limit_int = max(1, min(20, limit_int))
+
+    params = {
+        "query": f"tenant_id:{tenant_id}",
+        "limit": limit_int,
+        "sort": "date",
+    }
+
+    try:
+        resp = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+            params=params,
+            timeout=timeout_seconds,
+        )
+    except Exception as exc:
+        return {"ok": False, "error": "Sentry API request failed", "detail": str(exc)[:300]}
+
+    if resp.status_code >= 400:
+        return {
+            "ok": False,
+            "status": resp.status_code,
+            "error": "Sentry API request failed",
+            "detail": (resp.text or "")[:300],
+        }
+
+    issues: List[Dict[str, Any]] = resp.json() if resp.content else []
+    out: List[Dict[str, Any]] = []
+    for it in (issues or [])[:limit_int]:
+        out.append(
+            {
+                "id": it.get("id"),
+                "shortId": it.get("shortId") or it.get("short_id"),
+                "title": it.get("title"),
+                "permalink": it.get("permalink"),
+                "culprit": it.get("culprit"),
+                "level": it.get("level"),
+                "status": it.get("status"),
+                "firstSeen": it.get("firstSeen"),
+                "lastSeen": it.get("lastSeen"),
+                "count": it.get("count"),
+            }
+        )
+
+    return {"ok": True, "tenant_id": tenant_id, "issues": out}

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -576,7 +576,6 @@ class ToolExecutor:
     def _get_recent_errors(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
         """Fetch recent Sentry issues tagged with the active tenant_id."""
         import os
-        import requests
 
         tenant_id_arg = str(arguments.get('tenant_id') or '').strip()
         active_tenant_id = str(getattr(tenant, 'id', '') or '')
@@ -588,56 +587,20 @@ class ToolExecutor:
         if tenant_id_arg != active_tenant_id:
             raise ValueError('tenant_id must match the active tenant')
 
+        from tenant_apps.ai_assistant.services.sentry_issues import fetch_recent_sentry_issues_for_tenant
+
         token = os.environ.get('SENTRY_AUTH_TOKEN')
         org = os.environ.get('SENTRY_ORG_SLUG') or os.environ.get('SENTRY_ORG')
-        base_url = (os.environ.get('SENTRY_BASE_URL') or 'https://sentry.io').rstrip('/')
+        base_url = os.environ.get('SENTRY_BASE_URL') or 'https://sentry.io'
 
-        if not token:
-            return {'ok': False, 'error': 'SENTRY_AUTH_TOKEN not configured'}
-        if not org:
-            return {'ok': False, 'error': 'SENTRY_ORG_SLUG not configured'}
-
-        url = f"{base_url}/api/0/organizations/{org}/issues/"
-        params = {
-            'query': f"tenant_id:{active_tenant_id}",
-            'limit': 5,
-            'sort': 'date',
-        }
-
-        resp = requests.get(
-            url,
-            headers={'Authorization': f'Bearer {token}', 'Accept': 'application/json'},
-            params=params,
-            timeout=10,
+        return fetch_recent_sentry_issues_for_tenant(
+            tenant_id=active_tenant_id,
+            token=token,
+            org_slug=org,
+            base_url=base_url,
+            limit=5,
+            timeout_seconds=10,
         )
-
-        if resp.status_code >= 400:
-            return {
-                'ok': False,
-                'status': resp.status_code,
-                'error': 'Sentry API request failed',
-                'detail': (resp.text or '')[:300],
-            }
-
-        issues = resp.json() if resp.content else []
-        out = []
-        for it in (issues or [])[:5]:
-            out.append(
-                {
-                    'id': it.get('id'),
-                    'shortId': it.get('shortId') or it.get('short_id'),
-                    'title': it.get('title'),
-                    'permalink': it.get('permalink'),
-                    'culprit': it.get('culprit'),
-                    'level': it.get('level'),
-                    'status': it.get('status'),
-                    'firstSeen': it.get('firstSeen'),
-                    'lastSeen': it.get('lastSeen'),
-                    'count': it.get('count'),
-                }
-            )
-
-        return {'ok': True, 'tenant_id': active_tenant_id, 'issues': out}
 
     def _search_entities(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
         """Backward-compatible alias for older tool name."""

--- a/backend/tenant_apps/ai_assistant/urls.py
+++ b/backend/tenant_apps/ai_assistant/urls.py
@@ -21,6 +21,7 @@ from .views import (
     PendingReviewView,
     SwarmInvokeAPIView,
     ToolsOpenAPIView,
+    RecentErrorsAPIView,
 )
 
 app_name = 'ai_assistant'
@@ -44,6 +45,7 @@ urlpatterns = [
     path('metrics/', AILearningMetricsAPIView.as_view(), name='ai-metrics'),
     path('review/pending/', PendingReviewView.as_view(), name='pending-review'),
     path('tools/openapi/', ToolsOpenAPIView.as_view(), name='tools-openapi'),
+    path('errors/recent/', RecentErrorsAPIView.as_view(), name='ai-recent-errors'),
 
     # Supporting endpoints
     path('review/<uuid:feedback_id>/resolve/', PendingReviewResolveAPIView.as_view(), name='ai-review-resolve'),

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -685,6 +685,51 @@ class AIFeedbackViewSet(mixins.CreateModelMixin, mixins.ListModelMixin, mixins.R
         return Response(payload, status=status.HTTP_201_CREATED if created else status.HTTP_200_OK)
 
 
+class RecentErrorsAPIView(APIView):
+    """Admin-only diagnostics endpoint for tenant-scoped Sentry issues.
+
+    This mirrors the Swarm tool behavior (get_recent_errors) and is useful for
+    debugging the Sentry bridge without involving an LLM call.
+
+    Safety:
+    - Enforces active tenant context.
+    - If a tenant_id is provided, it must match the active tenant.
+    """
+
+    permission_classes = [IsAdminUser]
+
+    def get(self, request):
+        import os
+
+        tenant = getattr(request, 'tenant', None)
+        active_tenant_id = str(getattr(tenant, 'id', '') or '')
+        if not active_tenant_id:
+            return Response({'ok': False, 'error': 'Tenant context missing', 'issues': []}, status=status.HTTP_200_OK)
+
+        tenant_id_arg = str(request.query_params.get('tenant_id') or '').strip()
+        if tenant_id_arg and tenant_id_arg != active_tenant_id:
+            return Response(
+                {'ok': False, 'error': 'tenant_id must match the active tenant', 'issues': []},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        from tenant_apps.ai_assistant.services.sentry_issues import fetch_recent_sentry_issues_for_tenant
+
+        token = os.environ.get('SENTRY_AUTH_TOKEN')
+        org = os.environ.get('SENTRY_ORG_SLUG') or os.environ.get('SENTRY_ORG')
+        base_url = os.environ.get('SENTRY_BASE_URL') or 'https://sentry.io'
+
+        payload = fetch_recent_sentry_issues_for_tenant(
+            tenant_id=active_tenant_id,
+            token=token,
+            org_slug=org,
+            base_url=base_url,
+            limit=5,
+            timeout_seconds=10,
+        )
+        return Response(payload, status=status.HTTP_200_OK)
+
+
 class ToolsOpenAPIView(APIView):
     """Compatibility endpoint for the frontend widget.
 

--- a/manifests/env.manifest.json
+++ b/manifests/env.manifest.json
@@ -360,6 +360,29 @@
           "production-backend": "production"
         }
       },
+      "SENTRY_AUTH_TOKEN": {
+        "description": "Sentry auth token for the Sentry API (used by AI assistant tooling)",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "security": "NEVER commit to repository. Store only in GitHub Secrets.",
+        "note": "Required for the AI assistant get_recent_errors tool to fetch recent issues tagged with tenant_id."
+      },
+      "SENTRY_ORG_SLUG": {
+        "description": "Sentry organization slug (used to build Sentry API URLs)",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "note": "Required for the AI assistant get_recent_errors tool."
+      },
+      "SENTRY_BASE_URL": {
+        "description": "Base URL for Sentry API (optional)",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "default": "https://sentry.io",
+        "note": "Only override for self-hosted Sentry."
+      },
       "MICROSOFT_CLIENT_ID": {
         "description": "Microsoft Azure OAuth client ID",
         "scope": "environment",
@@ -410,6 +433,7 @@
       "REACT_APP_ENVIRONMENT", "REACT_APP_AI_ASSISTANT_ENABLED",
       "REDIS_URL", "OPENAI_API_KEY", "OPENAI_ORG_ID", "OPENAI_MODEL",
       "SENTRY_DSN", "SENTRY_ENABLED", "SENTRY_ENVIRONMENT",
+      "SENTRY_AUTH_TOKEN", "SENTRY_ORG_SLUG", "SENTRY_BASE_URL",
       "MICROSOFT_CLIENT_ID", "MICROSOFT_CLIENT_SECRET", "MICROSOFT_TENANT_ID", "MICROSOFT_REDIRECT_URI"
     ]
   },


### PR DESCRIPTION
Adds Sentry API auth env vars and a shared Sentry issue fetch helper used by the AI assistant get_recent_errors tool.\n\nChanges:\n- backend: centralize Sentry issue fetching (tenant-scoped), add admin-only diagnostics endpoint /api/v1/ai-assistant/errors/recent/\n- settings: declare SENTRY_AUTH_TOKEN / SENTRY_ORG_SLUG / SENTRY_BASE_URL\n- workflows: inject Sentry auth vars into backend.env via reusable-deploy.yml\n- manifests: document the new optional env vars\n\nNotes:\n- Safe if secrets are unset (tool returns ok:false w/ error).\n- Tenant safety: tenant_id arg must match active tenant; endpoint requires IsAdminUser.