### PR TITLE
Sentry: Seer hardening + release tracking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,10 @@
 /backend/apps/ @Meats-Central/backend-team
 /backend/config/ @Meats-Central/backend-team
 
+# Critical tenant-app ownership (path-specific overrides)
+/backend/tenant_apps/workflows/ @Meats-Central/workflow-engine
+/backend/tenant_apps/invoices/ @Meats-Central/fintech-team
+
 # Frontend React/TypeScript code  
 /frontend/ @Meats-Central/frontend-team
 /frontend/src/ @Meats-Central/frontend-team

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -16,8 +16,8 @@ This file is the **append-only PR-referenceable execution log**.
 - AI Assistant Sentry Bridge — **STABILIZED** (tenant-scoped `get_recent_errors` tool + admin diagnostics endpoint; uses GitHub Environment secret injection for `SENTRY_AUTH_TOKEN` and defaults org slug to `meats-central` if unset).
   - PR: #4007
   - Follow-up PR: #4008
-- Sentry as Active Orchestrator (Seer) — **STABILIZING** (sendDefaultPii enabled; in_app_include/inAppInclude set for CODEOWNERS mapping; CI creates releases via getsentry/action-release for Suspect Commits).
-  - PR: (fill after merge)
+- Sentry as Active Orchestrator (Seer) — **STABILIZING** (sendDefaultPii enabled; in_app_include set for CODEOWNERS mapping; CI creates releases via getsentry/action-release for Suspect Commits).
+  - PR: #4009
 
 **Phase 6.5: AI Document Understanding & Agentic Workflows**
 

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -16,6 +16,8 @@ This file is the **append-only PR-referenceable execution log**.
 - AI Assistant Sentry Bridge — **STABILIZED** (tenant-scoped `get_recent_errors` tool + admin diagnostics endpoint; uses GitHub Environment secret injection for `SENTRY_AUTH_TOKEN` and defaults org slug to `meats-central` if unset).
   - PR: #4007
   - Follow-up PR: #4008
+- Sentry as Active Orchestrator (Seer) — **STABILIZING** (sendDefaultPii enabled; in_app_include/inAppInclude set for CODEOWNERS mapping; CI creates releases via getsentry/action-release for Suspect Commits).
+  - PR: (fill after merge)
 
 **Phase 6.5: AI Document Understanding & Agentic Workflows**
 

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -145,3 +145,113 @@ jobs:
       backend_environment: 'production-backend'
       frontend_environment: 'production-frontend'
       api_base_url: 'https://meatscentral.com'
+
+  # ==========================================
+  # Sentry Release Tracking (Seer "Suspect Commits")
+  # ==========================================
+  # Non-blocking: if Sentry secrets aren't configured, this job skips.
+
+  sentry-release-dev:
+    name: "Sentry Release: Development"
+    if: |
+      needs.check-latest.outputs.should_deploy == 'true' &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/development') ||
+      (github.event_name == 'workflow_dispatch' && inputs.environment == 'development'))
+    needs: [deploy-dev]
+    runs-on: ubuntu-latest
+    environment: dev-backend
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create Sentry release (guarded)
+        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && (secrets.SENTRY_PROJECT_SLUG != '' || secrets.SENTRY_PROJECT != '') }}
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG_SLUG || 'meats-central' }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_SLUG || secrets.SENTRY_PROJECT }}
+        with:
+          environment: development
+          version: ${{ github.sha }}
+          projects: ${{ secrets.SENTRY_PROJECT_SLUG || secrets.SENTRY_PROJECT }}
+          set_commits: auto
+          ignore_missing: true
+          ignore_empty: true
+
+      - name: Skip notice
+        if: ${{ !(secrets.SENTRY_AUTH_TOKEN != '' && (secrets.SENTRY_PROJECT_SLUG != '' || secrets.SENTRY_PROJECT != '')) }}
+        run: echo "Sentry release skipped (missing SENTRY_AUTH_TOKEN and/or SENTRY_PROJECT_SLUG)"
+
+  sentry-release-uat:
+    name: "Sentry Release: UAT"
+    if: |
+      needs.check-latest.outputs.should_deploy == 'true' &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/uat') ||
+      (github.event_name == 'workflow_dispatch' && inputs.environment == 'uat'))
+    needs: [deploy-uat]
+    runs-on: ubuntu-latest
+    environment: uat-backend
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create Sentry release (guarded)
+        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && (secrets.SENTRY_PROJECT_SLUG != '' || secrets.SENTRY_PROJECT != '') }}
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG_SLUG || 'meats-central' }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_SLUG || secrets.SENTRY_PROJECT }}
+        with:
+          environment: uat
+          version: ${{ github.sha }}
+          projects: ${{ secrets.SENTRY_PROJECT_SLUG || secrets.SENTRY_PROJECT }}
+          set_commits: auto
+          ignore_missing: true
+          ignore_empty: true
+
+      - name: Skip notice
+        if: ${{ !(secrets.SENTRY_AUTH_TOKEN != '' && (secrets.SENTRY_PROJECT_SLUG != '' || secrets.SENTRY_PROJECT != '')) }}
+        run: echo "Sentry release skipped (missing SENTRY_AUTH_TOKEN and/or SENTRY_PROJECT_SLUG)"
+
+  sentry-release-prod:
+    name: "Sentry Release: Production"
+    if: |
+      needs.check-latest.outputs.should_deploy == 'true' &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.environment == 'production'))
+    needs: [deploy-prod]
+    runs-on: ubuntu-latest
+    environment: production-backend
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create Sentry release (guarded)
+        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && (secrets.SENTRY_PROJECT_SLUG != '' || secrets.SENTRY_PROJECT != '') }}
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG_SLUG || 'meats-central' }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_SLUG || secrets.SENTRY_PROJECT }}
+        with:
+          environment: production
+          version: ${{ github.sha }}
+          projects: ${{ secrets.SENTRY_PROJECT_SLUG || secrets.SENTRY_PROJECT }}
+          set_commits: auto
+          ignore_missing: true
+          ignore_empty: true
+
+      - name: Skip notice
+        if: ${{ !(secrets.SENTRY_AUTH_TOKEN != '' && (secrets.SENTRY_PROJECT_SLUG != '' || secrets.SENTRY_PROJECT != '')) }}
+        run: echo "Sentry release skipped (missing SENTRY_AUTH_TOKEN and/or SENTRY_PROJECT_SLUG)"

--- a/backend/projectmeats/settings/base.py
+++ b/backend/projectmeats/settings/base.py
@@ -609,7 +609,9 @@ if SENTRY_ENABLED and SENTRY_DSN:
         release=os.environ.get("GIT_COMMIT_SHA", "unknown"),  # Set by CI/CD
         
         # Additional Options
-        send_default_pii=False,  # Don't send PII by default (GDPR compliance)
+        # Required for Seer (user-impact analysis) + richer debugging context.
+        send_default_pii=True,
+        in_app_include=["backend", "tenant_apps"],
         attach_stacktrace=True,   # Always include stacktraces
         max_breadcrumbs=50,       # Keep more breadcrumbs for context
     )

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -112,11 +112,31 @@ export const initSentry = (config?: SentryConfig): void => {
         return null;
       }
       
+      // Mark repo frames as "in-app" so stack traces are easier to route via CODEOWNERS.
+      // Note: Sentry JS SDK v10 types don't expose inAppInclude; we tag frames directly.
+      try {
+        const exceptions = event.exception?.values || [];
+        for (const ex of exceptions) {
+          const frames = ex.stacktrace?.frames || [];
+          for (const frame of frames) {
+            const filename = (frame as any).filename;
+            if (typeof filename === 'string') {
+              if (filename.includes('/backend/') || filename.includes('/tenant_apps/')) {
+                (frame as any).in_app = true;
+              }
+            }
+          }
+        }
+      } catch {
+        // best-effort
+      }
+
       return event;
     },
     
     // Privacy
-    sendDefaultPii: false, // Don't send PII by default (GDPR)
+    // Required for Seer (user-impact analysis) + richer debugging context.
+    sendDefaultPii: true,
     
     // Context
     initialScope: {

--- a/manifests/env.manifest.json
+++ b/manifests/env.manifest.json
@@ -375,6 +375,13 @@
         "applies_to": ["backend environments"],
         "note": "Required for the AI assistant get_recent_errors tool."
       },
+      "SENTRY_PROJECT_SLUG": {
+        "description": "Sentry project slug (used by CI to create Releases for Seer Suspect Commits)",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "note": "Optional, but required to enable getsentry/action-release in .github/workflows/main-pipeline.yml."
+      },
       "SENTRY_BASE_URL": {
         "description": "Base URL for Sentry API (optional)",
         "scope": "environment",
@@ -433,7 +440,7 @@
       "REACT_APP_ENVIRONMENT", "REACT_APP_AI_ASSISTANT_ENABLED",
       "REDIS_URL", "OPENAI_API_KEY", "OPENAI_ORG_ID", "OPENAI_MODEL",
       "SENTRY_DSN", "SENTRY_ENABLED", "SENTRY_ENVIRONMENT",
-      "SENTRY_AUTH_TOKEN", "SENTRY_ORG_SLUG", "SENTRY_BASE_URL",
+      "SENTRY_AUTH_TOKEN", "SENTRY_ORG_SLUG", "SENTRY_PROJECT_SLUG", "SENTRY_BASE_URL",
       "MICROSOFT_CLIENT_ID", "MICROSOFT_CLIENT_SECRET", "MICROSOFT_TENANT_ID", "MICROSOFT_REDIRECT_URI"
     ]
   },


### PR DESCRIPTION
Implements Seer-required Sentry SDK hardening + CI release tracking.\n\nBackend\n- settings/base.py: send_default_pii=true; in_app_include=['backend','tenant_apps']\n\nFrontend\n- utils/sentry.ts: sendDefaultPii=true\n- SDK v10 BrowserOptions doesn't expose inAppInclude, so we mark frames as in_app in beforeSend when filename contains /backend/ or /tenant_apps/ (best-effort).\n\nCODEOWNERS\n- workflow-engine owns backend/tenant_apps/workflows\n- fintech-team owns backend/tenant_apps/invoices\n\nCI\n- main-pipeline.yml: add guarded getsentry/action-release jobs per environment (skips if SENTRY_AUTH_TOKEN or SENTRY_PROJECT_SLUG missing; continue-on-error=true so deploys never fail).\n\nManifest/Docs\n- manifests/env.manifest.json: add SENTRY_PROJECT_SLUG\n- .github/MASTER_PLAN.md: note Seer orchestration is stabilizing\n