### PR TITLE
FlowEditor: vertical reordering + selection fix

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -115,6 +115,7 @@ This file is the **append-only PR-referenceable execution log**.
 - 2026-03-27 — FlowEditor: wire AI Suggestions panel (toggle + backend suggest-nodes + local fallback) — PR: #3998.
 - 2026-03-27 — FlowEditor: unify Form Step normalization (explicit legacy→canonical map in nodeNormalization) — PR: #4013.
 - 2026-03-27 — FlowEditor: canonicalize AI node suggestions to match NODE_TYPE_REGISTRY IDs (so suggested nodes always add successfully) — PR: #4014.
+- 2026-03-27 — FlowEditor: vertical reordering (Move Up/Down) + restore standard selection (remove click-to-edit onNodeClick override) — PR: #4016.
 
 - 2026-03-24 — Fixed global Ant Design theme corruption (Sanitized background tokens causing pure black component rendering) — PR: #3925.
 - 2026-03-24 — Admin Workspace: Organization Profile save hardened (avoid multipart PATCH 502s) — PR: #3924.

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -112,7 +112,6 @@ import {
   FormNode,
   FormProcessNode,
   FormProcessContainerNode,
-  FormProcessAddButtonNode,
   FormStepNode,
   FormStepSingleNode,
   FormReferenceNode,
@@ -1750,7 +1749,6 @@ const staticNodeTypes: Record<string, AnyNodeComponent> = {
   formProcessContainer: FormProcessContainerNode,
 
   // Render-time "+" button node for Form Process containers
-  formProcessAddButton: FormProcessAddButtonNode,
 
   smartWorkForm: SmartWorkFormNode,
 
@@ -6113,22 +6111,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     }
   }, [selectedNode]);
   
-  // Handler for direct node clicks (opens config panel) - debounced to prevent double-triggers
-  const handleNodeClick = useCallback((event: React.MouseEvent, node: Node) => {
-    event.stopPropagation();
-    event.preventDefault();
-    
-    logger.debug('[handleNodeClick] Node clicked, opening config:', {
-      nodeType: node.type,
-      nodeId: node.id,
-      timestamp: new Date().toISOString()
-    });
-    
-    // Short timeout to prevent double-triggers and allow event to fully propagate
-    setTimeout(() => {
-      handleNodeEdit(node.id);
-    }, 50);
-  }, [handleNodeEdit]);
   
   // Batch 3: Handler to delete node from Delete button
   const handleNodeDeleteImpl = useCallback(async (nodeId: string) => {
@@ -6830,6 +6812,65 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     [setNodes]
   );
   
+  const handleMoveNode = useCallback(
+    (nodeId: string, direction: -1 | 1) => {
+      if (readOnly) return;
+
+      setHasUnsavedChanges(true);
+
+      setNodes((prev) => {
+        const current = prev.find((n) => n.id === nodeId);
+        if (!current) return prev;
+
+        const currentY = current.position?.y ?? 0;
+        const parentKey = current.parentId ?? null;
+
+        const siblings = prev.filter((n) => {
+          if (n.id === nodeId) return false;
+          if (String(n.id).startsWith('__virtual:')) return false;
+          return (n.parentId ?? null) === parentKey;
+        });
+
+        const candidates = siblings.filter((n) => {
+          const dy = n.position?.y ?? 0;
+          return direction === -1 ? dy < currentY : dy > currentY;
+        });
+
+        if (candidates.length === 0) return prev;
+
+        const target =
+          direction === -1
+            ? candidates.reduce((best, n) => ((n.position?.y ?? 0) > (best.position?.y ?? 0) ? n : best))
+            : candidates.reduce((best, n) => ((n.position?.y ?? 0) < (best.position?.y ?? 0) ? n : best));
+
+        const targetY = target.position?.y ?? 0;
+
+        return prev.map((n) => {
+          if (n.id === current.id) {
+            return {
+              ...n,
+              position: {
+                ...(n.position || { x: 0, y: 0 }),
+                y: targetY,
+              },
+            } as Node;
+          }
+          if (n.id === target.id) {
+            return {
+              ...n,
+              position: {
+                ...(n.position || { x: 0, y: 0 }),
+                y: currentY,
+              },
+            } as Node;
+          }
+          return n;
+        });
+      });
+    },
+    [readOnly, setHasUnsavedChanges, setNodes]
+  );
+
   // Batch 3: Inject edit/delete handlers into node data
   // Batch 4: Also inject title change handler
   const nodesWithHandlers = useMemo(() => {
@@ -6901,6 +6942,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           onTitleChange,
           onInsertAfter,
           onAddStepInsideForm,
+          onMoveUp: () => handleMoveNode(node.id, -1),
+          onMoveDown: () => handleMoveNode(node.id, 1),
           isLastInWorkflow: lastNodeIdSet.has(node.id),
         },
       };
@@ -6970,50 +7013,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     return derived;
   }, [edges, nodesWithHandlers]);
 
-  // Render-time "+" button beneath the last form step inside each expanded FormProcess container.
-  // This node is virtual (not persisted) and triggers creation of the next Form step.
-  const nodesForCanvas = useMemo(() => {
-    const isPageNodeType = (type?: string) =>
-      type === 'form' || type === 'formStepSingle' || type === 'formStep' || type === 'formReference';
-
-    const virtualNodes: Node[] = [];
-
-    nodesWithHandlers.forEach((n) => {
-      const containerType = ((n.data as any)?.nodeType as string | undefined) || n.type;
-      if (!isFormProcessContainerType(containerType)) return;
-      if ((n.data as any)?.isExpanded === false) return;
-
-      const pages = nodesWithHandlers
-        .filter((c) => c.parentId === n.id && isPageNodeType(c.type) && !c.hidden)
-        .sort((a, b) => (a.position?.y || 0) - (b.position?.y || 0));
-
-      const last = pages[pages.length - 1];
-      const anchorY = last ? last.position.y + LAYOUT_CONSTANTS.STEP_H : LAYOUT_CONSTANTS.STEP_Y;
-
-      const x = LAYOUT_CONSTANTS.START_X + (LAYOUT_CONSTANTS.STEP_W / 2 - LAYOUT_CONSTANTS.ADD_BUTTON_D / 2);
-      const y = anchorY + LAYOUT_CONSTANTS.ADD_BUTTON_MARGIN_Y;
-
-      virtualNodes.push({
-        id: `__virtual:add:${n.id}`,
-        type: 'formProcessAddButton',
-        parentId: n.id,
-        extent: 'parent',
-        position: { x, y },
-        draggable: false,
-        selectable: false,
-        connectable: false,
-        focusable: false,
-        deletable: false,
-        style: { width: LAYOUT_CONSTANTS.ADD_BUTTON_D, height: LAYOUT_CONSTANTS.ADD_BUTTON_D },
-        data: {
-          containerId: n.id,
-          onAddStepInsideForm: (n.data as any)?.onAddStepInsideForm,
-        },
-      });
-    });
-
-    return virtualNodes.length ? [...nodesWithHandlers, ...virtualNodes] : nodesWithHandlers;
-  }, [nodesWithHandlers]);
+  // Add-from-palette only: no in-canvas "+" nodes.
+  const nodesForCanvas = useMemo(() => nodesWithHandlers, [nodesWithHandlers]);
 
   return (
     <FormBuilderProvider onNodeDataUpdate={handleNodeDataUpdate}>
@@ -7550,7 +7551,6 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         onDragOver={onDragOver}
         onNodeDragStart={onNodeDragStart}
         onNodeDragStop={onNodeDragStop}
-        onNodeClick={handleNodeClick}
         onNodeContextMenu={handleNodeContextMenu}
         onPaneClick={handleCloseMenu}
         onPaneMouseMove={(event) => {

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -12,7 +12,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Handle, Position, NodeToolbar, useStore } from '@xyflow/react';
-import { Edit2, Trash2, ChevronDown, ChevronUp, Lock, Unlock, Plus } from 'lucide-react';
+import { Edit2, Trash2, ChevronDown, ChevronUp, Lock, Unlock, ArrowUp, ArrowDown } from 'lucide-react';
 import { NodeTypeDefinition } from '../nodeTypes';
 import type { NodeBadgeStatus } from '../components/NodeBadge';
 import { NodeIcon, NodeIconType } from '../components/NodeIcons';
@@ -36,6 +36,10 @@ export interface BaseNodeData extends Record<string, unknown> {
   onInsertAfter?: () => void;
   /** Add a step/page inside the nearest Form container (Book) */
   onAddStepInsideForm?: () => void;
+  /** Move this node up among siblings (same parentId) */
+  onMoveUp?: () => void;
+  /** Move this node down among siblings (same parentId) */
+  onMoveDown?: () => void;
   /** Whether this node is considered a "sink" in its scope (root or container sub-flow) */
   isLastInWorkflow?: boolean;
   // Phase 9.4: Breakpoints
@@ -501,16 +505,27 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
             transition: 'opacity 0.15s ease, transform 0.15s ease',
           }}
         >
-          {(data.onAddStepInsideForm || data.onInsertAfter) && (
-            <ToolbarBtn
-              onClick={(e) => {
-                e.stopPropagation();
-                (data.onAddStepInsideForm || data.onInsertAfter)?.();
-              }}
-              title={data.onAddStepInsideForm ? 'Add step inside Form' : 'Add next node'}
-            >
-              <Plus size={16} />
-            </ToolbarBtn>
+          {(data.onMoveUp || data.onMoveDown) && (
+            <>
+              <ToolbarBtn
+                onClick={(e) => {
+                  e.stopPropagation();
+                  data.onMoveUp?.();
+                }}
+                title="Move up"
+              >
+                <ArrowUp size={16} />
+              </ToolbarBtn>
+              <ToolbarBtn
+                onClick={(e) => {
+                  e.stopPropagation();
+                  data.onMoveDown?.();
+                }}
+                title="Move down"
+              >
+                <ArrowDown size={16} />
+              </ToolbarBtn>
+            </>
           )}
           {data.onEdit && (
             <ToolbarBtn

--- a/frontend/src/components/FlowEditor/nodes/FormProcessContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessContainerNode.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { Handle, NodeToolbar, Position, useNodes } from '@xyflow/react';
-import { Plus, Pencil } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import styled from 'styled-components';
 
 import type { ContainerNodeData } from './FormProcessNode';
@@ -92,16 +92,6 @@ export const FormProcessContainerNode = React.memo<Props>(({ id, data, selected 
     <>
       <NodeToolbar isVisible position={Position.Top}>
         <div style={{ display: 'flex', gap: 8 }}>
-          <ToolbarButton
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              (data as any)?.onAddStepInsideForm?.();
-            }}
-            title="Add a form step"
-          >
-            <Plus size={14} /> Step
-          </ToolbarButton>
           <ToolbarButton
             type="button"
             onClick={(e) => {

--- a/frontend/src/components/FlowEditor/nodes/index.ts
+++ b/frontend/src/components/FlowEditor/nodes/index.ts
@@ -31,8 +31,6 @@ export { FormProcessNode } from './FormProcessNode';
 export type { ContainerNodeData } from './FormProcessNode';
 
 export { FormProcessContainerNode } from './FormProcessContainerNode';
-export { FormProcessAddButtonNode } from './FormProcessAddButtonNode';
-export type { FormProcessAddButtonData } from './FormProcessAddButtonNode';
 
 export { TriggerNode } from './TriggerNode';
 export type { TriggerNodeData } from './TriggerNode';


### PR DESCRIPTION
Implements vertical sibling reordering and restores standard selection/moving behavior in the FlowEditor.

Changes:
- Remove ReactFlow onNodeClick override (no click-to-edit); selection/moving behaves normally
- Add Move Up/Down controls to BaseNode toolbar and implement sibling Y-position swap logic in UnifiedFlowEditor
- Enforce Add-from-Palette-only by removing in-node "+" add-step controls for Form Process containers and removing virtual in-canvas add-step button nodes

Verification:
- frontend: npm run type-check
- frontend: npx vitest run src/services/aiNodeSuggestionService.test.ts