### PR TITLE
Sentry: stabilize orchestration handshake

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -16,9 +16,10 @@ This file is the **append-only PR-referenceable execution log**.
 - AI Assistant Sentry Bridge — **STABILIZED** (tenant-scoped `get_recent_errors` tool + admin diagnostics endpoint; uses GitHub Environment secret injection for `SENTRY_AUTH_TOKEN` and defaults org slug to `meats-central` if unset).
   - PR: #4007
   - Follow-up PR: #4008
-- Environment-based Sentry Orchestration (Seer) — **VERIFIED & ACTIVE**
+- Environment-based Sentry Orchestration (Seer) — **STABILIZED**
   - SDK hardening: sendDefaultPii enabled (frontend+backend); backend in_app_include set for CODEOWNERS mapping — PR: #4009.
-  - Runtime wiring: frontend supports DSN fallback (window.ENV.SENTRY_DSN → REACT_APP_SENTRY_DSN), deploy passes SENTRY_DSN into env-config.js and REACT_APP_SENTRY_DSN, plus Admin→Configurations includes a "Sentry Test" button.
+  - Runtime wiring + secret mapping: `SENTRY_DSN` (runtime env) → `/usr/share/nginx/html/env-config.js` → `window.ENV.SENTRY_DSN` (fallback: build-time `REACT_APP_SENTRY_DSN`), and deploy sets `REACT_APP_SENTRY_DSN` on `docker run`.
+  - Verification: Admin→Configurations "Sentry Test" emits `Error(\"Sentry Orchestration Handshake Verified\")`.
   - AI SRE prompt: explicitly calls get_recent_errors(tenant_id) before asking for clarification.
   - PR: #4010
 

--- a/frontend/src/pages/Admin/Configurations/index.tsx
+++ b/frontend/src/pages/Admin/Configurations/index.tsx
@@ -187,10 +187,9 @@ const ConfigurationsPage: React.FC = () => {
 
   const handleSentryTest = () => {
     const timestamp = new Date().toISOString();
-    const err = new Error(`Sentry Orchestration Verified - ${timestamp}`);
 
     try {
-      throw err;
+      throw new Error('Sentry Orchestration Handshake Verified');
     } catch (caught) {
       captureSentryException(caught as Error, {
         component: 'Admin/Configurations',


### PR DESCRIPTION
Stabilizes the Sentry orchestration verification UX and documents the DSN secret mapping.

Notes:
- Backend Sentry hardening (SENTRY_DSN via os.environ, send_default_pii=True, in_app_include=["backend","tenant_apps"]) is already present.
- Frontend init already prefers window.ENV.SENTRY_DSN with fallback to build-time REACT_APP_SENTRY_DSN and has sendDefaultPii:true.
- frontend/docker-entrypoint.sh already defaults REACT_APP_SENTRY_DSN to "" safely.

Changes in this PR:
- Admin→Configurations "Sentry Test" now throws exactly: Error("Sentry Orchestration Handshake Verified")
- .github/MASTER_PLAN.md: mark Environment-based Sentry Orchestration as STABILIZED and document mapping SENTRY_DSN → env-config.js → window.ENV.SENTRY_DSN (fallback REACT_APP_SENTRY_DSN)

Verification:
- frontend: npm run type-check
