### PR TITLE
Fix Sync Now when Outlook token can’t decrypt

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -14,6 +14,7 @@ This file is the **append-only PR-referenceable execution log**.
 ### 2026-03-27 — Emergency Fix - OAuth Decryption
 - Verified Microsoft OAuth encryption salt remains `projectmeats_oauth_encryption_v1` (no drift).
 - Added management command: `python manage.py diagnose_oauth_encryption --tenant-id <uuid>` to distinguish `InvalidToken` (key mismatch) vs missing data.
+- Email Sync Now: backend now detects `InvalidToken` and returns `code=decryption_failed` with a stable reconnect hint (UI can show a deterministic CTA).
 - AI Swarm: Microsoft Graph tools now catch token decryption failures and return structured payload:
   `{ "status": "error", "error_code": "DECRYPTION_FAILED", "message": "Your Outlook connection needs to be refreshed for security reasons." }`
 

--- a/backend/apps/integrations/views.py
+++ b/backend/apps/integrations/views.py
@@ -362,6 +362,26 @@ def sync_emails(request):
             except Exception:
                 detail = None
 
+            # Normalize error codes so the frontend can provide a deterministic CTA.
+            error_code = str((stats or {}).get('error_code') or '').strip().lower()
+            if not error_code and isinstance(detail, str) and detail.startswith('DECRYPTION_FAILED'):
+                error_code = 'decryption_failed'
+
+            if error_code == 'decryption_failed':
+                return Response(
+                    {
+                        "ok": False,
+                        "message": "Email sync requires reconnect",
+                        "error": "Your Outlook connection needs to be refreshed for security reasons.",
+                        "code": "decryption_failed",
+                        "hint": "Reconnect Outlook in Settings → Email Integrations, then retry Sync Now.",
+                        "tenant_id": tenant_id,
+                        "provider_email": provider.connected_email,
+                        "stats": stats,
+                    },
+                    status=status.HTTP_200_OK,
+                )
+
             return Response(
                 {
                     "ok": False,

--- a/backend/tenant_apps/integrations/services/email_ingestion.py
+++ b/backend/tenant_apps/integrations/services/email_ingestion.py
@@ -142,6 +142,8 @@ class EmailIngestionService:
         try:
             access_token = provider.get_decrypted_token('access')
         except Exception as e:
+            from cryptography.fernet import InvalidToken
+
             logger.error(
                 'Failed to decrypt access token tenant=%s provider_id=%s: %s',
                 tenant.id,
@@ -150,7 +152,17 @@ class EmailIngestionService:
                 exc_info=True,
             )
             self.stats['errors'] += 1
-            self.stats.setdefault('errors_detail', []).append('Failed to decrypt Microsoft access token. Check OAUTH_ENCRYPTION_KEY / reconnect Outlook.')
+
+            if isinstance(e, InvalidToken):
+                # Common after OAUTH_ENCRYPTION_KEY rotation/mismatch.
+                self.stats['error_code'] = 'decryption_failed'
+                self.stats.setdefault('errors_detail', []).append(
+                    'DECRYPTION_FAILED: Your Outlook connection needs to be refreshed for security reasons.'
+                )
+            else:
+                self.stats.setdefault('errors_detail', []).append(
+                    'Failed to decrypt Microsoft access token. Check OAUTH_ENCRYPTION_KEY / reconnect Outlook.'
+                )
             return
 
         if not access_token:

--- a/frontend/src/components/Integrations/IngestionMonitor.tsx
+++ b/frontend/src/components/Integrations/IngestionMonitor.tsx
@@ -94,6 +94,13 @@ export const IngestionMonitor: React.FC = () => {
 
       // Soft-fail path: backend can return 200 with ok:false when Outlook/Graph is unhealthy.
       if (ok === false) {
+        const code = String(response.data?.code || '');
+        if (code === 'decryption_failed') {
+          message.error('Outlook needs to be reconnected. Go to Settings → Email Integrations (/settings/email-integrations) and reconnect, then retry Sync Now.');
+          await fetchEmailLogs();
+          return;
+        }
+
         const err = response.data?.error || 'Email sync failed.';
         message.error(hint ? `${err} ${hint}` : err);
         await fetchEmailLogs();

--- a/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
@@ -273,6 +273,13 @@ export const EmailIngestionMonitorWidget: React.FC<EmailIngestionMonitorWidgetPr
       const stats = response.data?.stats;
 
       if (ok === false) {
+        const code = String(response.data?.code || '');
+        if (code === 'decryption_failed') {
+          message.error('Outlook needs to be reconnected. Open /settings/email-integrations and reconnect, then retry Sync.');
+          await fetchEmailLogs();
+          return;
+        }
+
         const err = response.data?.error || 'Email sync failed.';
         message.error(hint ? `${err} ${hint}` : err);
         await fetchEmailLogs();


### PR DESCRIPTION
## What\nEmail Ingestion Sync Now could fail with an access token decrypt error and show a generic message.\n\n## Fix\n- Backend: detect cryptography.fernet.InvalidToken during token decrypt and set stats.error_code=decryption_failed\n- API: return stable code=decryption_failed + reconnect hint\n- Frontend: Sync Now handlers show reconnect guidance when code=decryption_failed\n\n## Notes\nDoes not expose tokens; only returns a deterministic reconnect CTA.