### PR TITLE
Fix AI document upload (PDF drag/drop) 500

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -51,6 +51,7 @@ This file is the **append-only PR-referenceable execution log**.
 
 ### 2026-03-27 — Phase 9.5: AI Document Stability
 - AI Assistant documents: updated `AIDocument.file.upload_to` to include tenant UUID + unique prefix to prevent naming collisions.
+- Upload hardening follow-up: switched to a flat tenant+UUID filename (avoids deep mkdir permission issues on mounted media volumes) and assert RLS session vars right before saving.
 - Added diagnostic command to reproduce uploads and capture tracebacks without needing the frontend:
   - `python manage.py test_document_upload --tenant-id 0f024884-b9ef-4e50-8fc0-89b2eb7c8c69`
   - Safe default: temp `MEDIA_ROOT` (no persistent artifacts)

--- a/backend/tenant_apps/ai_assistant/models.py
+++ b/backend/tenant_apps/ai_assistant/models.py
@@ -305,11 +305,10 @@ def aidocument_upload_to(instance: "AIDocument", filename: str) -> str:
     now = timezone.now()
     unique = uuid.uuid4().hex
 
-    return (
-        f"ai_assistant/documents/{tenant_part}/"
-        f"{now:%Y/%m/%d}/"
-        f"{unique}_{safe_name}"
-    )
+    # Keep a flat-ish structure to avoid permission issues on hosts where the
+    # mounted media volume is writable but does not allow creating deep directory trees.
+    # Still includes tenant + UUID to prevent naming collisions.
+    return f"ai_assistant/documents/{tenant_part}_{unique}_{safe_name}"
 
 
 class AIDocument(TenantAwareModel):

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -431,13 +431,41 @@ class AIDocumentViewSet(viewsets.ModelViewSet):
 
             raise ValidationError('Tenant context required.')
 
-        instance = serializer.save(
-            tenant=tenant,
-            owner=self.request.user,
-            original_filename=getattr(self.request.FILES.get('file'), 'name', ''),
-            content_type=getattr(self.request.FILES.get('file'), 'content_type', '') or '',
-            file_size=getattr(self.request.FILES.get('file'), 'size', 0) or 0,
-        )
+        tenant_id = str(getattr(tenant, 'id', '') or '')
+        if tenant_id:
+            # Defense-in-depth: assert RLS vars right before the write.
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SET app.current_tenant_id = %s", [tenant_id])
+                    cursor.execute("SET app.current_tenant = %s", [tenant_id])
+            except Exception:
+                logger.warning('AIDocument upload: failed to assert RLS session vars', exc_info=True)
+
+        try:
+            instance = serializer.save(
+                tenant=tenant,
+                owner=self.request.user,
+                original_filename=getattr(self.request.FILES.get('file'), 'name', ''),
+                content_type=getattr(self.request.FILES.get('file'), 'content_type', '') or '',
+                file_size=getattr(self.request.FILES.get('file'), 'size', 0) or 0,
+            )
+        except Exception as e:
+            from django.db.utils import DatabaseError
+            from rest_framework.exceptions import ValidationError
+
+            if isinstance(e, OSError):
+                logger.error('AIDocument upload: storage error: %s', str(e), exc_info=True)
+                raise ValidationError(
+                    'Upload failed: storage is not writable. Please contact an administrator.'
+                )
+
+            if isinstance(e, DatabaseError):
+                logger.error('AIDocument upload: database error: %s', str(e), exc_info=True)
+                raise ValidationError(
+                    'Upload failed: tenant context could not be asserted for RLS. Please reload and retry.'
+                )
+
+            raise
 
         # If the upload was tied to a session, also create a DOCUMENT message so UIs can show it inline.
         if instance.session_id:


### PR DESCRIPTION
## Problem\nAIAgentWidget attachment upload (POST /api/v1/ai-assistant/ai-documents/) returns 500 on dev when dropping PDFs.\n\n## Fix\n- Flatten upload_to path to avoid deep directory creation on mounted media volumes (common UID 1000 perms issue)\n- Assert app.current_tenant/app.current_tenant_id immediately before saving the AIDocument (RLS-safe)\n- Convert storage/RLS write failures into friendly 400 ValidationErrors\n\n## Notes\nDoes not change schema; affects new uploads only.