### PR TITLE
Harden Email Sync decrypt failure handling

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -14,7 +14,7 @@ This file is the **append-only PR-referenceable execution log**.
 ### 2026-03-27 — Emergency Fix - OAuth Decryption
 - Verified Microsoft OAuth encryption salt remains `projectmeats_oauth_encryption_v1` (no drift).
 - Added management command: `python manage.py diagnose_oauth_encryption --tenant-id <uuid>` to distinguish `InvalidToken` (key mismatch) vs missing data.
-- Email Sync Now: backend now detects `InvalidToken` and returns `code=decryption_failed` with a stable reconnect hint (UI can show a deterministic CTA).
+- Email Sync Now: backend now detects decrypt failures and returns `code=decryption_failed` with a stable reconnect hint (UI can show a deterministic CTA).
 - AI Swarm: Microsoft Graph tools now catch token decryption failures and return structured payload:
   `{ "status": "error", "error_code": "DECRYPTION_FAILED", "message": "Your Outlook connection needs to be refreshed for security reasons." }`
 

--- a/backend/apps/integrations/views.py
+++ b/backend/apps/integrations/views.py
@@ -364,8 +364,9 @@ def sync_emails(request):
 
             # Normalize error codes so the frontend can provide a deterministic CTA.
             error_code = str((stats or {}).get('error_code') or '').strip().lower()
-            if not error_code and isinstance(detail, str) and detail.startswith('DECRYPTION_FAILED'):
-                error_code = 'decryption_failed'
+            if not error_code and isinstance(detail, str):
+                if detail.startswith('DECRYPTION_FAILED') or 'Failed to decrypt Microsoft access token' in detail:
+                    error_code = 'decryption_failed'
 
             if error_code == 'decryption_failed':
                 return Response(

--- a/backend/tenant_apps/integrations/services/email_ingestion.py
+++ b/backend/tenant_apps/integrations/services/email_ingestion.py
@@ -142,8 +142,9 @@ class EmailIngestionService:
         try:
             access_token = provider.get_decrypted_token('access')
         except Exception as e:
-            from cryptography.fernet import InvalidToken
-
+            # Treat ANY decrypt failure as requiring a reconnect.
+            # In practice we see InvalidToken (key mismatch) but other exceptions can occur
+            # depending on config/state; the user action is the same.
             logger.error(
                 'Failed to decrypt access token tenant=%s provider_id=%s: %s',
                 tenant.id,
@@ -152,17 +153,10 @@ class EmailIngestionService:
                 exc_info=True,
             )
             self.stats['errors'] += 1
-
-            if isinstance(e, InvalidToken):
-                # Common after OAUTH_ENCRYPTION_KEY rotation/mismatch.
-                self.stats['error_code'] = 'decryption_failed'
-                self.stats.setdefault('errors_detail', []).append(
-                    'DECRYPTION_FAILED: Your Outlook connection needs to be refreshed for security reasons.'
-                )
-            else:
-                self.stats.setdefault('errors_detail', []).append(
-                    'Failed to decrypt Microsoft access token. Check OAUTH_ENCRYPTION_KEY / reconnect Outlook.'
-                )
+            self.stats['error_code'] = 'decryption_failed'
+            self.stats.setdefault('errors_detail', []).append(
+                'DECRYPTION_FAILED: Your Outlook connection needs to be refreshed for security reasons.'
+            )
             return
 
         if not access_token:


### PR DESCRIPTION
## Problem\nEmail Ingestion Monitor still shows generic decrypt error because not all decrypt exceptions were classified as decryption_failed.\n\n## Fix\n- Treat any get_decrypted_token() exception as decryption_failed (user action is always reconnect)\n- Sync endpoint maps legacy 'Failed to decrypt Microsoft access token' string to decryption_failed as a safety net\n\nResult: frontend always receives code=decryption_failed and shows the reconnect CTA.