### PR TITLE
Fix Workform Editor nodes appearing semi-transparent

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -11,6 +11,10 @@ This file is the **append-only PR-referenceable execution log**.
 
 ## Active Initiative: V3.0 Final Push (Consolidation + Scale + Polish)
 
+### 2026-03-27 — Workform Editor: Node Opacity Fix
+- Fixed "all nodes semi-transparent" regression caused by debug session decorations being left active when the Dry Run Debugger panel was hidden.
+- Debugger panel now stops/resets debug session when closed and unmounts the debugger UI when not visible.
+
 ### 2026-03-27 — Emergency Fix - OAuth Decryption
 - Verified Microsoft OAuth encryption salt remains `projectmeats_oauth_encryption_v1` (no drift).
 - Added management command: `python manage.py diagnose_oauth_encryption --tenant-id <uuid>` to distinguish `InvalidToken` (key mismatch) vs missing data.

--- a/frontend/src/components/FlowEditor/panels/DryRunDebuggerPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/DryRunDebuggerPanel.tsx
@@ -7,12 +7,13 @@
  * discoverable and usable without disturbing the canvas layout.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { X, Bug } from 'lucide-react';
 import type { Node } from '@xyflow/react';
 
 import { DryRunDebugger } from '../components/DryRunDebugger';
+import { useFlowEditor } from '../context';
 
 export interface DryRunDebuggerPanelProps {
   isVisible: boolean;
@@ -83,6 +84,15 @@ export const DryRunDebuggerPanel: React.FC<DryRunDebuggerPanelProps> = ({
   selectedNode,
   onClose,
 }) => {
+  const { stopDebugSession, resetDebugSession } = useFlowEditor();
+
+  useEffect(() => {
+    if (isVisible) return;
+    // If the panel is hidden, ensure we are not leaving debug decorations enabled.
+    stopDebugSession();
+    resetDebugSession();
+  }, [isVisible, resetDebugSession, stopDebugSession]);
+
   return (
     <PanelOverlay $isVisible={isVisible} aria-hidden={!isVisible}>
       <PanelHeader>
@@ -96,7 +106,7 @@ export const DryRunDebuggerPanel: React.FC<DryRunDebuggerPanelProps> = ({
       </PanelHeader>
 
       <PanelBody>
-        <DryRunDebugger selectedNode={selectedNode} onClose={onClose} />
+        {isVisible ? <DryRunDebugger selectedNode={selectedNode} onClose={onClose} /> : null}
       </PanelBody>
     </PanelOverlay>
   );


### PR DESCRIPTION
## Problem\nIn the Workform Editor, all nodes except triggers appeared semi-transparent.\n\n## Root cause\nDebugAwareReactFlow decorates non-active nodes with opacity when debug session is active. The DryRunDebuggerPanel kept DryRunDebugger mounted even when hidden, leaving debug session active and dimming the canvas.\n\n## Fix\n- DryRunDebuggerPanel stops + resets debug session when hidden\n- DryRunDebugger unmounted when panel not visible\n\nResult: nodes are fully opaque unless the debugger is explicitly open.