### PR TITLE
Allow dragging from node body

### DIFF
--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -604,7 +604,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
 
       {/* Body (collapsible) */}
       {isExpanded && (
-        <NodeBody className="nodrag">
+        <NodeBody>
           <NodeContent>
             {children || (
               <>


### PR DESCRIPTION
Nodes were only draggable by the header because BaseNode marked the entire body as nodrag. This allows dragging from the body too, while keeping interactive controls (inputs/buttons) protected via nodrag classes.\n\nValidated: frontend npm run type-check.