### PR TITLE
Fix Universal Forms + Cockpit Search

### DIFF
--- a/backend/apps/core/services/universal_search.py
+++ b/backend/apps/core/services/universal_search.py
@@ -120,6 +120,50 @@ SEARCHABLE_ENTITIES = {
         'route': '/carriers/{id}',
         'operators': ['carrier:'],
     },
+    'inquiry': {
+        'app': 'inquiries',
+        'model': 'Inquiry',
+        'search_fields': ['inquiry_number', 'notes', 'contact_name', 'contact_company', 'contact_email', 'contact_phone'],
+        'display_field': 'inquiry_number',
+        'icon': 'FileText',
+        'color': '#ef4444',  # red
+        'route': '/inquiries/{id}',
+        'operators': ['inquiry:', 'inq:'],
+        'related_display': ['customer__name', 'supplier__name'],
+    },
+    'claim': {
+        'app': 'invoices',
+        'model': 'Claim',
+        'search_fields': ['claim_number', 'reason', 'description'],
+        'display_field': 'claim_number',
+        'icon': 'AlertTriangle',
+        'color': '#f97316',  # orange
+        'route': '/accounting/claims/{id}',
+        'operators': ['claim:', 'clm:'],
+        'related_display': ['invoice__invoice_number', 'supplier__name', 'customer__name'],
+    },
+    'call': {
+        'app': 'cockpit',
+        'model': 'ScheduledCall',
+        'search_fields': ['title', 'description'],
+        'display_field': 'title',
+        'icon': 'PhoneCall',
+        'color': '#06b6d4',  # cyan
+        'route': '/cockpit',
+        'operators': ['call:'],
+        'related_display': 'scheduled_for',
+    },
+    'tenant_user': {
+        'app': 'tenants',
+        'model': 'TenantUser',
+        'search_fields': ['user__username', 'user__email', 'user__first_name', 'user__last_name', 'role'],
+        'display_field': 'user__username',
+        'icon': 'User',
+        'color': '#64748b',  # slate
+        'route': '/admin/users',
+        'operators': ['user:', 'u:', 'tenant-user:'],
+        'related_display': 'role',
+    },
 }
 
 
@@ -167,31 +211,55 @@ class UniversalSearchService:
         return self._model_cache[entity_type]
     
     def _parse_query(self, query: str) -> Tuple[str, Optional[str]]:
-        """
-        Parse query for operators and return (search_text, entity_type).
-        
+        """Parse query for operators and return (search_text, entity_type).
+
         Examples:
             "beef supplier:ABC" -> ("beef ABC", "supplier")
             "po:1234" -> ("1234", "purchase_order")
             "@john" -> ("john", "contact")
-            "beef products" -> ("beef products", None)
+            "purchase" -> ("", "purchase_order")
         """
         query = query.strip()
-        
-        # Check for operators
+        lower = query.lower()
+
+        # If the query is basically an entity name, treat it like a type filter.
+        type_aliases = {
+            'purchase': 'purchase_order',
+            'purchase order': 'purchase_order',
+            'purchase orders': 'purchase_order',
+            'po': 'purchase_order',
+            'sales': 'sales_order',
+            'sales order': 'sales_order',
+            'sales orders': 'sales_order',
+            'so': 'sales_order',
+            'invoice': 'invoice',
+            'invoices': 'invoice',
+            'inquiry': 'inquiry',
+            'inquiries': 'inquiry',
+            'claim': 'claim',
+            'claims': 'claim',
+            'call': 'call',
+            'calls': 'call',
+            'user': 'tenant_user',
+            'users': 'tenant_user',
+            'tenant user': 'tenant_user',
+            'tenant users': 'tenant_user',
+        }
+
+        if lower in type_aliases:
+            return '', type_aliases[lower]
+
+        # Check for explicit operators
         for entity_type, config in SEARCHABLE_ENTITIES.items():
             for operator in config.get('operators', []):
-                # Check if query contains operator
                 pattern = rf'{re.escape(operator)}(\S+)'
                 match = re.search(pattern, query, re.IGNORECASE)
                 if match:
-                    # Extract the value after operator
                     operator_value = match.group(1)
-                    # Remove operator from query and add value
                     remaining = re.sub(pattern, '', query, flags=re.IGNORECASE).strip()
                     search_text = f"{remaining} {operator_value}".strip()
                     return search_text, entity_type
-        
+
         return query, None
     
     def _build_query_filter(self, search_text: str, search_fields: List[str]) -> Q:
@@ -241,7 +309,17 @@ class UniversalSearchService:
 
                 base_qs = visible_products_qs(tenant=self.tenant, qs=base_qs)
 
-            queryset = base_qs.filter(query_filter)[:limit]
+            if search_text:
+                queryset = base_qs.filter(query_filter)
+            else:
+                # If the user is effectively filtering by entity type (e.g. query="purchase"),
+                # show the most recent records for that type.
+                ordering = '-created_at'
+                if not any(f.name == 'created_at' for f in Model._meta.fields):
+                    ordering = '-id'
+                queryset = base_qs.order_by(ordering)
+
+            queryset = queryset[:limit]
             
             # Format results
             results = []
@@ -312,13 +390,22 @@ class UniversalSearchService:
     def _get_display_value(self, obj, config: Dict) -> str:
         """Get the display value for an object."""
         display_field = config['display_field']
-        
+
         # Handle computed fields
         if display_field == 'full_name':
             first = getattr(obj, 'first_name', '')
             last = getattr(obj, 'last_name', '')
             return f"{first} {last}".strip() or str(obj)
-        
+
+        # Support nested fields like 'user__username'
+        if '__' in display_field:
+            value = obj
+            for part in display_field.split('__'):
+                value = getattr(value, part, None)
+                if value is None:
+                    break
+            return str(value) if value is not None else str(obj)
+
         return getattr(obj, display_field, str(obj))
     
     def _get_subtitle(self, obj, config: Dict) -> Optional[str]:
@@ -326,16 +413,26 @@ class UniversalSearchService:
         related_field = config.get('related_display')
         if not related_field:
             return None
-        
-        # Handle nested fields like 'supplier__name'
-        parts = related_field.split('__')
-        value = obj
-        for part in parts:
-            value = getattr(value, part, None)
-            if value is None:
-                break
-        
-        return str(value) if value else None
+
+        # Allow a list of candidate subtitles and use the first non-empty.
+        candidates = related_field if isinstance(related_field, list) else [related_field]
+
+        for field_path in candidates:
+            if not field_path:
+                continue
+
+            # Handle nested fields like 'supplier__name'
+            parts = str(field_path).split('__')
+            value = obj
+            for part in parts:
+                value = getattr(value, part, None)
+                if value is None:
+                    break
+
+            if value:
+                return str(value)
+
+        return None
     
     def search(
         self,

--- a/backend/apps/system/views/entity_viewset.py
+++ b/backend/apps/system/views/entity_viewset.py
@@ -39,6 +39,11 @@ class EntityViewSet(viewsets.ViewSet):
         'purchase_order': ('purchase_orders', 'PurchaseOrder'),
         'sales_order': ('sales_orders', 'SalesOrder'),
         'invoice': ('invoices', 'Invoice'),
+        # Additional Cockpit-searchable entities
+        'inquiry': ('inquiries', 'Inquiry'),
+        'claim': ('invoices', 'Claim'),
+        'call': ('cockpit', 'ScheduledCall'),
+        'tenant_user': ('tenants', 'TenantUser'),
     }
     
     @action(detail=True, methods=['get'], url_path='relationships')

--- a/frontend/src/components/Cockpit/EntityProfileHeader.tsx
+++ b/frontend/src/components/Cockpit/EntityProfileHeader.tsx
@@ -330,6 +330,8 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
 }) => {
   const [data, setData] = useState<EntityDetailResponse | null>(null);
   const [loading, setLoading] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [showAllFields, setShowAllFields] = useState(false);
   const [editingArrayField, setEditingArrayField] = useState<string | null>(null);
   const [arrayDraft, setArrayDraft] = useState<string[]>([]);
 
@@ -354,6 +356,8 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
   const canEdit = Boolean(data?.can_edit);
 
   useEffect(() => {
+    setIsEditMode(false);
+    setShowAllFields(false);
     setEditingArrayField(null);
     setArrayDraft([]);
   }, [entityType, entityId]);
@@ -494,8 +498,8 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
       return a.localeCompare(b);
     });
 
-    return sorted.slice(0, 6);
-  }, [data, entityType, variant]);
+    return showAllFields ? sorted : sorted.slice(0, 6);
+  }, [data, entityType, showAllFields, variant]);
 
   return (
     <Container>
@@ -507,6 +511,31 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
             <span style={{ marginLeft: 8 }}>ID: {entityId}</span>
           </Subtitle>
         </TitleBlock>
+
+        <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+          {variant === 'compact' && (
+            <LinkButton type="button" onClick={() => setShowAllFields((v) => !v)}>
+              {showAllFields ? 'Show fewer fields' : 'Show all fields'}
+            </LinkButton>
+          )}
+          {canEdit && (
+            <LinkButton
+              type="button"
+              onClick={() =>
+                setIsEditMode((v) => {
+                  const next = !v;
+                  if (!next) {
+                    setEditingArrayField(null);
+                    setArrayDraft([]);
+                  }
+                  return next;
+                })
+              }
+            >
+              {isEditMode ? 'Done' : 'Edit'}
+            </LinkButton>
+          )}
+        </div>
       </TitleRow>
 
       {loading ? (
@@ -536,7 +565,7 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
               const lowerKey = String(key).toLowerCase();
               const isMultiValue = Array.isArray(value) || lowerKey.includes('products');
               const isEditingMulti = editingArrayField === key;
-              const isEditableText = canEdit && !isMultiValue && typeof value === 'string' && scalar.length <= 200;
+              const isEditableText = canEdit && isEditMode && !isMultiValue && typeof value === 'string' && scalar.length <= 200;
 
               const renderMultiValue = () => {
                 const values = Array.isArray(value) ? normalizeArrayStrings(value) : [];
@@ -592,7 +621,7 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
                       <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>—</span>
                     )}
 
-                    {canEdit && (
+                    {canEdit && isEditMode && (
                       <LinkButton
                         type="button"
                         onClick={() => {
@@ -617,11 +646,15 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
                       renderMultiValue()
                     ) : isEditableText ? (
                       <Text
-                        editable={{
-                          onChange: (next) => debouncedPatch(key, next),
-                          tooltip: 'Click to edit',
-                          triggerType: ['icon', 'text'],
-                        }}
+                        editable={
+                          isEditMode
+                            ? {
+                                onChange: (next) => debouncedPatch(key, next),
+                                tooltip: 'Click to edit',
+                                triggerType: ['icon', 'text'],
+                              }
+                            : false
+                        }
                       >
                         {scalar || <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>—</span>}
                       </Text>
@@ -648,7 +681,7 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
             const activeIds = new Set(activeProducts.map((p) => p.id));
             const activeIsSameAsPreferred = preferredIds.size === activeIds.size && Array.from(preferredIds).every((id) => activeIds.has(id));
 
-            const canEditProducts = canEdit && (isCustomer || isSupplier);
+            const canEditProducts = canEdit && isEditMode && (isCustomer || isSupplier);
 
             const showPreferred = canEditProducts || preferredProducts.length > 0;
             const showActive = isSupplier

--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -322,13 +322,28 @@ const EmptyMessage = styled.div`
 
 const getEntityIcon = (type: SearchEntity['type'], size = 20) => {
   switch (type) {
-    case 'customer': return <Users size={size} />;
-    case 'supplier': return <Building2 size={size} />;
-    case 'contact': return <Users size={size} />;
-    case 'product': return <Package size={size} />;
-    case 'order': return <FileText size={size} />;
-    case 'inquiry': return <FileText size={size} />;
-    default: return <FileText size={size} />;
+    case 'customer':
+      return <Users size={size} />;
+    case 'supplier':
+      return <Building2 size={size} />;
+    case 'contact':
+      return <Users size={size} />;
+    case 'product':
+      return <Package size={size} />;
+    case 'purchase_order':
+    case 'sales_order':
+    case 'invoice':
+      return <FileText size={size} />;
+    case 'inquiry':
+      return <FileText size={size} />;
+    case 'claim':
+      return <FileText size={size} />;
+    case 'call':
+      return <Clock size={size} />;
+    case 'tenant_user':
+      return <Users size={size} />;
+    default:
+      return <FileText size={size} />;
   }
 };
 
@@ -343,10 +358,18 @@ const getEntityTone = (type: SearchEntity['type']) => {
       return 'var(--color-info)';
     case 'product':
       return 'var(--color-warning)';
-    case 'order':
+    case 'purchase_order':
+    case 'sales_order':
+    case 'invoice':
       return 'var(--color-warning)';
     case 'inquiry':
       return 'var(--color-error)';
+    case 'claim':
+      return 'var(--color-error)';
+    case 'call':
+      return 'var(--color-info)';
+    case 'tenant_user':
+      return 'var(--color-primary)';
     default:
       return 'var(--color-primary)';
   }
@@ -588,7 +611,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
 
   const debouncedSearch = useMemo(() => debounce((q: string) => {
     searchEntities(q);
-  }, 300), [searchEntities]);
+  }, 120), [searchEntities]);
 
   useEffect(() => {
     debouncedSearch(query);

--- a/frontend/src/components/FormSubmission/SearchableSelect.tsx
+++ b/frontend/src/components/FormSubmission/SearchableSelect.tsx
@@ -8,7 +8,7 @@
  * - Loading states and "no results" handling
  * - Keyboard navigation support
  */
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useId, useState, useEffect, useRef, useCallback } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { entityOptionsService } from '../../services/quickActionsService';
 
@@ -28,6 +28,12 @@ interface SearchableSelectProps {
   initialOptions?: Option[];
   threshold?: number; // Number of options before switching to search mode
   filterParams?: Record<string, any>;
+
+  /** Force API-backed search mode even for small option sets. */
+  forceSearch?: boolean;
+
+  /** Debounce delay for server-side search, in ms. Set to 0 for per-keystroke. */
+  debounceMs?: number;
 }
 
 const spin = keyframes`
@@ -206,14 +212,18 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
   initialOptions = [],
   threshold = 50,
   filterParams,
+  forceSearch = false,
+  debounceMs = 150,
 }) => {
+  const instanceId = useId();
+
   const [isOpen, setIsOpen] = useState(false);
   const [options, setOptions] = useState<Option[]>(initialOptions);
   const [searchQuery, setSearchQuery] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const [isSearchMode, setIsSearchMode] = useState(false);
+  const [isSearchMode, setIsSearchMode] = useState(forceSearch);
   
   const containerRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -221,10 +231,15 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
 
   // Determine if we should use search mode
   useEffect(() => {
+    if (forceSearch) {
+      setIsSearchMode(true);
+      return;
+    }
+
     if (initialOptions.length >= threshold || totalCount >= threshold) {
       setIsSearchMode(true);
     }
-  }, [initialOptions.length, totalCount, threshold]);
+  }, [forceSearch, initialOptions.length, totalCount, threshold]);
 
   // Load initial options if not provided
   useEffect(() => {
@@ -258,12 +273,13 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
   const loadOptions = async (query: string = '') => {
     setIsLoading(true);
     try {
-      const cancelKey = `search-${entityType}-${Date.now()}`;
+      // Stable cancel key so in-flight requests are cancelled when the user types.
+      const cancelKey = `entity-options:${instanceId}:${entityType}`;
       const response = await entityOptionsService.searchOptions(entityType, query, cancelKey, filterParams);
       setOptions(response.options);
       setTotalCount(response.total_count);
-      
-      if (response.total_count >= threshold) {
+
+      if (forceSearch || response.total_count >= threshold) {
         setIsSearchMode(true);
       }
     } catch (err) {
@@ -277,16 +293,16 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
     const query = e.target.value;
     setSearchQuery(query);
     setHighlightedIndex(-1);
-    
+
     // Debounce search
     if (searchTimeoutRef.current) {
       clearTimeout(searchTimeoutRef.current);
     }
-    
+
     searchTimeoutRef.current = setTimeout(() => {
-      loadOptions(query);
-    }, 300);
-  }, [entityType, filterParams]);
+      void loadOptions(query);
+    }, Math.max(0, debounceMs));
+  }, [debounceMs, loadOptions]);
 
   const handleToggle = () => {
     if (disabled) return;

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -13,13 +13,13 @@
  * - Foreign keys should use SearchableSelect to avoid massive dropdowns
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Modal, Spin, message, Select, Skeleton } from 'antd';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Button, Modal, Spin, message, Select, Skeleton } from 'antd';
 import styled from 'styled-components';
 import { businessApi } from '../../services/businessApi';
 import { apiClient } from '../../services/apiService';
 import DynamicFormEngine from '../../features/system/DynamicFormEngine';
-import { SearchableSelect } from './SearchableSelect';
+import EntityOptionsSelect from '../FormSubmission/SearchableSelect';
 
 export interface UniversalEntityFormProps {
   entityType: string;
@@ -100,9 +100,29 @@ const normalizeEntityEndpoint = (entityType: string): string => {
   return `${lower.replace(/^\/+/, '').replace(/\/+$/, '')}/`;
 };
 
+const relatedEntityToEntityOptionsType = (relatedEntity: string | null | undefined, fieldKey: string): string | null => {
+  const related = String(relatedEntity || '').toLowerCase();
+  const key = String(fieldKey || '').toLowerCase();
+
+  if (!related && !key) return null;
+
+  if (related.includes('customers.') || key === 'customer') return 'customer';
+  if (related.includes('suppliers.') || key === 'supplier') return 'supplier';
+  if (related.includes('contacts.') || key === 'contact') return 'contact';
+  if (related.includes('purchase_orders.') || key === 'purchase_order') return 'purchase_order';
+  if (related.includes('sales_orders.') || key === 'sales_order') return 'sales_order';
+  if (related.includes('inquiries.') || key === 'inquiry') return 'inquiry';
+  if (related.includes('invoices.') || key === 'invoice') return 'invoice';
+  if (key.includes('product') || related.includes('system.product')) return 'product';
+
+  return null;
+};
+
 const shouldSkipField = (key: string): boolean => {
   const k = String(key || '').toLowerCase();
   return [
+    'id',
+    'uuid',
     'tenant',
     'custom_data',
     'created_at',
@@ -153,6 +173,9 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     Record<string, Array<{ value: string; label: string }>>
   >({});
   const [loadingProducts, setLoadingProducts] = useState<Record<string, boolean>>({});
+  const [showAllFields, setShowAllFields] = useState(false);
+
+  const productSearchSeqRef = useRef<Record<string, number>>({});
 
   const schemaEntityKey = useMemo(() => normalizeEntityKey(entityType), [entityType]);
   const endpoint = useMemo(() => normalizeEntityEndpoint(entityType), [entityType]);
@@ -217,6 +240,8 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
 
   useEffect(() => {
     if (!isOpen) return;
+
+    setShowAllFields(false);
 
     let mounted = true;
 
@@ -319,26 +344,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     };
   }, [isOpen, schema?.fields]);
 
-  const fkFields = useMemo(() => {
-    return (schema?.fields ?? []).filter(
-      (f) => !shouldSkipField(f.key) && Boolean(f.related_entity)
-    );
-  }, [schema?.fields]);
-
-  const scalarFields = useMemo(() => {
-    const raw = (schema?.fields ?? [])
-      .filter((f) => !shouldSkipField(f.key))
-      .filter((f) => !f.related_entity)
-      .map((f) => ({
-        key: f.key,
-        label: f.label || f.key,
-        type: f.choices?.length ? 'select' : String(f.type ?? 'text'),
-        required: Boolean(f.required),
-        options: f.choices?.map((c) => String(c.value)) || undefined,
-        placeholder: f.placeholder || undefined,
-        help_text: f.help_text,
-      }));
-
+  const preferredKeys = useMemo(() => {
     const normalized = schemaEntityKey.toLowerCase();
     const defaultKeyFields: Record<string, string[]> = {
       customer: [
@@ -381,27 +387,61 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
         'valid_until',
       ],
       sales_order: ['customer', 'order_date', 'delivery_date', 'status', 'notes'],
-      purchase_order: ['supplier', 'order_date', 'delivery_date', 'status', 'notes'],
+      purchase_order: ['supplier', 'product', 'order_date', 'delivery_date', 'status', 'notes'],
       invoice: ['customer', 'invoice_date', 'status', 'notes'],
       product: ['name', 'product_code', 'protein_type', 'packaging_type', 'weight_unit'],
     };
 
-    const preferred =
+    return (
       (keyFields && keyFields.length
         ? keyFields
         : schema?.key_fields && schema.key_fields.length
           ? schema.key_fields
-          : defaultKeyFields[normalized]) || [];
-    if (!preferred.length) return raw;
+          : defaultKeyFields[normalized]) ||
+      []
+    );
+  }, [keyFields, schema?.key_fields, schemaEntityKey]);
 
-    const rank = new Map(preferred.map((k, idx) => [k.toLowerCase(), idx] as const));
+  const preferredKeySet = useMemo(() => {
+    return new Set(preferredKeys.map((k) => String(k).toLowerCase()));
+  }, [preferredKeys]);
+
+  const fkFields = useMemo(() => {
+    return (schema?.fields ?? []).filter((f) => !shouldSkipField(f.key) && Boolean(f.related_entity));
+  }, [schema?.fields]);
+
+  const keyFkFields = useMemo(() => {
+    return fkFields.filter((f) => preferredKeySet.has(String(f.key).toLowerCase()));
+  }, [fkFields, preferredKeySet]);
+
+  const otherFkFields = useMemo(() => {
+    return fkFields.filter((f) => !preferredKeySet.has(String(f.key).toLowerCase()));
+  }, [fkFields, preferredKeySet]);
+
+  const scalarFields = useMemo(() => {
+    const raw = (schema?.fields ?? [])
+      .filter((f) => !shouldSkipField(f.key))
+      .filter((f) => !f.related_entity)
+      .map((f) => ({
+        key: f.key,
+        label: f.label || f.key,
+        type: f.choices?.length ? 'select' : String(f.type ?? 'text'),
+        required: Boolean(f.required),
+        options: f.choices?.map((c) => String(c.value)) || undefined,
+        placeholder: f.placeholder || undefined,
+        help_text: f.help_text,
+      }));
+
+    if (!preferredKeys.length) return raw;
+
+    const rank = new Map(preferredKeys.map((k, idx) => [String(k).toLowerCase(), idx] as const));
     return [...raw].sort((a, b) => {
       const ra = rank.has(a.key.toLowerCase()) ? (rank.get(a.key.toLowerCase()) as number) : 9999;
       const rb = rank.has(b.key.toLowerCase()) ? (rank.get(b.key.toLowerCase()) as number) : 9999;
       if (ra !== rb) return ra - rb;
       return a.label.localeCompare(b.label);
     });
-  }, [keyFields, schema?.fields, schemaEntityKey]);
+  }, [preferredKeys, schema?.fields]);
 
   type DynamicSchema = {
     step_index: number;
@@ -521,13 +561,20 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     [endpoint, entityId, fkFields, fkValues, initialValues, onClose, onSuccess]
   );
 
-  const fetchProducts = useMemo(
-    () => async (fieldKey: string, q: string) => {
+  const fetchProducts = useCallback(
+    async (fieldKey: string, q: string) => {
+      const nextSeq = (productSearchSeqRef.current[fieldKey] ?? 0) + 1;
+      productSearchSeqRef.current[fieldKey] = nextSeq;
+
       setLoadingProducts((prev) => ({ ...prev, [fieldKey]: true }));
       try {
         const resp = await businessApi.get('/system/products/', {
-          params: { search: q || undefined, page_size: 50, is_active: true },
+          params: { search: q || undefined, page_size: 50, limit: 50, is_active: true },
         });
+
+        // Ignore out-of-order responses.
+        if (productSearchSeqRef.current[fieldKey] !== nextSeq) return;
+
         const payload = resp.data as unknown;
         const payloadObj =
           typeof payload === 'object' && payload ? (payload as Record<string, unknown>) : null;
@@ -550,21 +597,35 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           const label = `${code ? `${code} - ` : ''}${name}`.trim() || String(id ?? '');
           return { value: String(id ?? ''), label };
         });
-        setProductOptions((prev) => ({
-          ...prev,
-          [fieldKey]: (() => {
-            const map = new Map((prev[fieldKey] || []).map((o) => [o.value, o] as const));
-            opts.forEach((o) => map.set(o.value, o));
-            return Array.from(map.values());
-          })(),
-        }));
+
+        // Replace options for the current search (so results actually refresh on every keystroke),
+        // but keep the currently-selected value so it doesn't disappear.
+        const selectedValue = String((fkValues[fieldKey] as string | number | undefined) ?? '');
+
+        setProductOptions((prev) => {
+          const selected = selectedValue
+            ? (prev[fieldKey] || []).find((o) => String(o.value) === selectedValue)
+            : undefined;
+
+          const merged = [...opts];
+          if (selected && !merged.some((o) => String(o.value) === String(selected.value))) {
+            merged.unshift(selected);
+          }
+
+          return {
+            ...prev,
+            [fieldKey]: merged,
+          };
+        });
       } catch (err) {
         console.error('[UniversalEntityForm] Failed to search products:', err);
       } finally {
-        setLoadingProducts((prev) => ({ ...prev, [fieldKey]: false }));
+        if (productSearchSeqRef.current[fieldKey] === nextSeq) {
+          setLoadingProducts((prev) => ({ ...prev, [fieldKey]: false }));
+        }
       }
     },
-    []
+    [fkValues]
   );
 
   return (
@@ -592,16 +653,16 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           </div>
         ) : (
           <>
-            {fkFields.length > 0 && (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 16 }}>
-                {fkFields.map((f) => {
+            {(keyFkFields.length > 0 || otherFkFields.length > 0) && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 10 }}>
+                {[...keyFkFields, ...(showAllFields ? otherFkFields : [])].map((f) => {
                   const related = String(f.related_entity || '').toLowerCase();
                   const isProduct =
                     related.includes('system.product') ||
                     String(f.key).toLowerCase().includes('product');
 
                   if (isProduct) {
-                    const value = fkValues[f.key] as string | number | undefined;
+                    const value = String((fkValues[f.key] as string | number | undefined) ?? '');
                     return (
                       <div key={f.key}>
                         <div
@@ -617,13 +678,46 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
                         <Select
                           showSearch
                           filterOption={false}
+                          onDropdownVisibleChange={(open) => {
+                            if (open && (productOptions[f.key] || []).length === 0) {
+                              void fetchProducts(f.key, '');
+                            }
+                          }}
                           onSearch={(q) => void fetchProducts(f.key, q)}
                           options={productOptions[f.key] || []}
-                          value={value}
-                          onChange={(next) => setFkValues((prev) => ({ ...prev, [f.key]: next }))}
+                          value={value || undefined}
+                          onChange={(next) => setFkValues((prev) => ({ ...prev, [f.key]: String(next) }))}
                           notFoundContent={loadingProducts[f.key] ? <Spin size="small" /> : null}
                           style={{ width: '100%' }}
                           placeholder="Search products…"
+                        />
+                      </div>
+                    );
+                  }
+
+                  const mapped = relatedEntityToEntityOptionsType(f.related_entity, f.key);
+                  const value = String((fkValues[f.key] as string | number | undefined) ?? '');
+
+                  if (mapped && mapped !== 'product') {
+                    return (
+                      <div key={f.key}>
+                        <div
+                          style={{
+                            fontSize: 12,
+                            fontWeight: 600,
+                            color: 'rgb(var(--color-text-secondary))',
+                            marginBottom: 6,
+                          }}
+                        >
+                          {f.label || f.key}
+                        </div>
+                        <EntityOptionsSelect
+                          entityType={mapped}
+                          value={value}
+                          onChange={(next) => setFkValues((prev) => ({ ...prev, [f.key]: next }))}
+                          placeholder={`Search ${f.label || f.key}…`}
+                          forceSearch
+                          debounceMs={0}
                         />
                       </div>
                     );
@@ -642,11 +736,16 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
                       >
                         {f.label || f.key}
                       </div>
-                      <SearchableSelect
-                        value={(fkValues[f.key] as string | number | undefined) ?? ''}
-                        options={options}
-                        onChange={(next) => setFkValues((prev) => ({ ...prev, [f.key]: next }))}
+                      <Select
+                        showSearch
+                        options={options.map((o) => ({ value: String(o.id), label: o.name }))}
+                        value={value || undefined}
+                        onChange={(next) => setFkValues((prev) => ({ ...prev, [f.key]: String(next) }))}
+                        style={{ width: '100%' }}
                         placeholder={`Select ${f.label || f.key}`}
+                        filterOption={(input, option) =>
+                          String(option?.label || '').toLowerCase().includes(String(input || '').toLowerCase())
+                        }
                       />
                     </div>
                   );
@@ -654,10 +753,27 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
               </div>
             )}
 
+            {(otherFkFields.length > 0 || scalarFields.some((f) => !preferredKeySet.has(String(f.key).toLowerCase()))) && (
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 14 }}>
+                <Button
+                  type="link"
+                  onClick={() => setShowAllFields((v) => !v)}
+                  style={{ padding: 0, height: 'auto' }}
+                >
+                  {showAllFields ? 'Show fewer fields' : 'Show all fields'}
+                </Button>
+              </div>
+            )}
+
             <DynamicFormEngine
               schema={dynamicSchema as any}
               initialValues={initialValues || {}}
               isSubmitting={submitting}
+              submitLabel={entityId ? 'Save' : 'Create'}
+              keyFieldKeys={preferredKeys}
+              showAllFields={showAllFields}
+              onShowAllFieldsChange={setShowAllFields}
+              showAllFieldsToggle={false}
               onSubmit={(data) => {
                 void submit(data);
               }}

--- a/frontend/src/features/system/DynamicFormEngine.tsx
+++ b/frontend/src/features/system/DynamicFormEngine.tsx
@@ -6,7 +6,7 @@
  * 
  * Wave 4 - Task 4.12: Integrated with ConfigResolver for dynamic settings.
  */
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -40,6 +40,19 @@ interface DynamicFormEngineProps {
   onSubmit: (data: Record<string, any>) => void;
   onCancel?: () => void;
   isSubmitting?: boolean;
+
+  /** Prefer showing these keys first, and collapse the rest behind an expand toggle. */
+  keyFieldKeys?: string[];
+
+  /** Controlled show-all-fields state (used when a parent needs to expand multiple sections). */
+  showAllFields?: boolean;
+  onShowAllFieldsChange?: (next: boolean) => void;
+
+  /** When false, hides the expand/collapse toggle UI (still respects showAllFields). */
+  showAllFieldsToggle?: boolean;
+
+  /** Override submit button label (e.g. "Create" vs "Save"). */
+  submitLabel?: string;
 }
 
 const FormContainer = styled.form`
@@ -222,8 +235,17 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
   onSubmit,
   onCancel,
   isSubmitting = false,
+  keyFieldKeys,
+  showAllFields,
+  onShowAllFieldsChange,
+  showAllFieldsToggle = true,
+  submitLabel,
 }) => {
   const validationSchema = buildValidationSchema(schema.fields);
+
+  const [internalShowAllFields, setInternalShowAllFields] = useState(false);
+  const effectiveShowAllFields = showAllFields ?? internalShowAllFields;
+  const setEffectiveShowAllFields = onShowAllFieldsChange ?? setInternalShowAllFields;
   
   // Form-level config from ConfigResolver (Wave 4 - Task 4.12)
   const [formConfig, setFormConfig] = useState({
@@ -291,13 +313,28 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     mode: formConfig.validateOnChange ? 'onChange' : 'onSubmit',
   });
   
+  const keySet = useMemo(() => {
+    const keys = (keyFieldKeys || []).map((k) => String(k).toLowerCase());
+    return new Set(keys);
+  }, [keyFieldKeys]);
+
+  const hasKeySplit = Boolean(keyFieldKeys && keyFieldKeys.length);
+
+  const keyFields = useMemo(() => {
+    if (!hasKeySplit) return schema.fields;
+    return schema.fields.filter((f) => keySet.has(String(f.key).toLowerCase()));
+  }, [hasKeySplit, keySet, schema.fields]);
+
+  const otherFields = useMemo(() => {
+    if (!hasKeySplit) return [] as FieldDefinition[];
+    return schema.fields.filter((f) => !keySet.has(String(f.key).toLowerCase()));
+  }, [hasKeySplit, keySet, schema.fields]);
+
   // Get options for a select field (static or dynamic)
   const getFieldOptions = (field: FieldDefinition): { value: string; label: string }[] => {
     // Use provided options first
     if (field.options?.length) {
-      return field.options.map(opt => 
-        typeof opt === 'string' ? { value: opt, label: opt } : opt
-      );
+      return field.options.map((opt) => (typeof opt === 'string' ? { value: opt, label: opt } : opt));
     }
     // Fall back to dynamically loaded options
     return dynamicOptions[field.key] || [];
@@ -414,30 +451,56 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     }
   };
 
+  const resolvedSubmitLabel =
+    (typeof submitLabel === 'string' && submitLabel.trim()) ||
+    (typeof formConfig.submitButtonText === 'string' && formConfig.submitButtonText.trim()) ||
+    'Save';
+
+  const onInvalid = (errs: Record<string, any>) => {
+    if (!hasKeySplit) return;
+    const errorKeys = Object.keys(errs || {});
+    const hasHiddenError = errorKeys.some((k) => !keySet.has(String(k).toLowerCase()));
+    if (hasHiddenError) {
+      setEffectiveShowAllFields(true);
+    }
+  };
+
   return (
-    <FormContainer onSubmit={handleSubmit(onSubmit)}>
+    <FormContainer onSubmit={handleSubmit(onSubmit, onInvalid)}>
       <FormHeader>
         <FormTitle>{schema.name}</FormTitle>
-        {schema.description && (
-          <FormDescription>{schema.description}</FormDescription>
-        )}
+        {schema.description && <FormDescription>{schema.description}</FormDescription>}
       </FormHeader>
 
-      {schema.fields.map((field) => renderField(field))}
+      {(hasKeySplit ? keyFields : schema.fields).map((field) => renderField(field))}
 
-      <FormActions>
-        {onCancel && (
+      {hasKeySplit && otherFields.length > 0 && showAllFieldsToggle && (
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
           <Button
             type="button"
             variant="outline"
-            onClick={onCancel}
+            onClick={() => setEffectiveShowAllFields(!effectiveShowAllFields)}
             disabled={isSubmitting}
           >
+            {effectiveShowAllFields ? 'Hide remaining fields' : 'Show all fields'}
+          </Button>
+        </div>
+      )}
+
+      {hasKeySplit && otherFields.length > 0 && (
+        <div style={{ display: effectiveShowAllFields ? 'block' : 'none' }}>
+          {otherFields.map((field) => renderField(field))}
+        </div>
+      )}
+
+      <FormActions>
+        {onCancel && (
+          <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
             Cancel
           </Button>
         )}
         <Button type="submit" variant="primary" disabled={isSubmitting}>
-          {isSubmitting ? 'Submitting...' : formConfig.submitButtonText}
+          {isSubmitting ? 'Submitting...' : resolvedSubmitLabel}
         </Button>
       </FormActions>
     </FormContainer>


### PR DESCRIPTION
Fixes universal form field behavior and cockpit search relevance:\n\n- Universal forms: key-fields-first w/ expand, Save/Create label, hide ID/UUID\n- Purchase Order Product lookup refreshes results on every keystroke (race-safe)\n- Lookup fields use API-backed search selects w/ cancellation\n- Cockpit search includes inquiries/calls/claims/tenant users; type-only queries like "purchase" return recent Purchase Orders\n- Cockpit record header: single Edit toggle + Show all fields toggle\n\nVerification:\n- frontend: npm run type-check\n- backend: python manage.py check