### PR TITLE
docs: recovery execution plan (last 25 prompts)

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -11,6 +11,15 @@ This file is the **append-only PR-referenceable execution log**.
 
 ## Active Initiative: V3.0 Final Push (Consolidation + Scale + Polish)
 
+### 2026-03-27T17:03Z — Recovery Execution Plan (Last ~25 prompts)
+- Merging a comprehensive recovery plan into `MASTER_PLAN.md` (canonical snapshot) and executing remaining work **only via**: branch → PR → merge to `development`.
+- P0 execution order:
+  1) Cockpit Favorites (backend persistence + optimistic UX, tenant-safe, RLS-backed)
+  2) Email Ingestion Monitor “Sync Now” decrypt error surfacing (stable codes + reconnect CTA)
+  3) AI Document Upload stability (no 500s; verify via `test_document_upload`)
+
+## Active Initiative: V3.0 Final Push (Consolidation + Scale + Polish)
+
 ### 2026-03-27 — Workform Editor: Node Opacity Fix
 - Fixed "all nodes semi-transparent" regression caused by debug session decorations being left active when the Dry Run Debugger panel was hidden.
 - Debugger panel now stops/resets debug session when closed and unmounts the debugger UI when not visible.

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -10,6 +10,26 @@ This file is the **canonical plan + current truth snapshot**.
 
 ---
 
+## Recovery Execution Plan (as of 2026-03-27T17:03Z)
+
+We are re-validating and completing the last ~25 prompts with **evidence-based acceptance criteria** and strict shipping discipline.
+
+**Shipping discipline (MANDATORY):** every batch is shipped via **new branch → PR → merge to `development`**.
+
+### Execution order (P0→P1)
+1. **Docs plan** (this section + PR log entry) — merge first.
+2. **Cockpit Favorites (industry-grade):** replace localStorage favorites with backend favorites API + optimistic UX, tenant-safe, RLS-backed.
+3. **Email Ingestion Monitor “Sync Now”:** ensure decrypt errors surface as stable structured codes and the UI shows a reconnect CTA (no raw string).
+4. **AI Document Upload:** reproduce via `test_document_upload` command and eliminate remaining 500s.
+5. **Verify prior batches:** Universal Forms, Cockpit Search relevance/entity coverage, Workform Editor UX.
+
+### Acceptance criteria (high signal)
+- Favorites persist across reload and do not collide across tenants.
+- Sync Now never emits raw decrypt error strings; always shows reconnect guidance.
+- PDF upload returns 201/400 only (no 500) with actionable error payloads.
+
+---
+
 ## Reality Snapshot (as of 2026-03-26)
 
 ### What is actively in progress


### PR DESCRIPTION
Adds a timestamped Recovery Execution Plan to MASTER_PLAN.md (canonical) and .github/MASTER_PLAN.md (PR log) to drive completion/verification of remaining last-25-prompt items.