### PR TITLE
fix: stable Sync Now decryption errors

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -160,6 +160,7 @@ This file is the **append-only PR-referenceable execution log**.
 - 2026-03-27 — Fix: cockpit favorites + inquiry create — PR: #3993.
 - 2026-03-27 — Fix: product associations persist — PR: #3994.
 - 2026-03-27 — Fix: Email Sync Now avoids timeouts — PR: #3995.
+- 2026-03-27 — Fix: Email Sync Now decryption failures always return stable `code=decryption_failed` (UI shows reconnect CTA) — PR: #TBD.
 - 2026-03-27 — Hotfix: restore development deployments (main-pipeline workflow file issue) — PR: #4011.
 - 2026-03-27 — Fix: plant available products save — PR: #3996.
 - 2026-03-27 — UI: facelift customer + supplier pages — PR: #3997.

--- a/backend/apps/integrations/views.py
+++ b/backend/apps/integrations/views.py
@@ -410,13 +410,44 @@ def sync_emails(request):
 
     except Exception as e:
         logger.error('Failed to sync emails for tenant %s: %s', tenant_id, str(e), exc_info=True)
+
+        # If this is an auth token decryption failure, always return a stable reconnect CTA.
+        # This protects the UX even if downstream code paths change.
+        try:
+            from cryptography.fernet import InvalidToken
+
+            is_decrypt = isinstance(e, InvalidToken) or any(
+                token in str(e).lower()
+                for token in [
+                    'decrypt',
+                    'invalidtoken',
+                    'oauth_encryption_key',
+                ]
+            )
+        except Exception:
+            is_decrypt = 'decrypt' in str(e).lower()
+
+        if is_decrypt:
+            return Response(
+                {
+                    "ok": False,
+                    "message": "Email sync requires reconnect",
+                    "error": "Your Outlook connection needs to be refreshed for security reasons.",
+                    "code": "decryption_failed",
+                    "hint": "Reconnect Outlook in Settings → Email Integrations, then retry Sync Now.",
+                    "tenant_id": tenant_id,
+                    "provider_email": provider.connected_email,
+                },
+                status=status.HTTP_200_OK,
+            )
+
         # This is a user-triggered action. Prefer a 200 + structured failure payload so the UI
         # can display actionable guidance instead of treating it as a hard outage.
         return Response(
             {
                 "ok": False,
                 "message": "Email sync failed",
-                "error": f"Failed to sync emails: {str(e)}",
+                "error": "Email sync failed. Outlook connection may be expired or misconfigured.",
                 "code": "sync_exception",
                 "hint": "If this persists, reconnect Outlook in Settings → Integrations and retry.",
                 "tenant_id": tenant_id,

--- a/frontend/src/components/Integrations/IngestionMonitor.tsx
+++ b/frontend/src/components/Integrations/IngestionMonitor.tsx
@@ -133,6 +133,21 @@ export const IngestionMonitor: React.FC = () => {
       await fetchEmailLogs();
     } catch (error: any) {
       console.error('Failed to trigger sync:', error);
+
+      const code = String(error?.response?.data?.code || '').toLowerCase();
+      const detail = String(error?.response?.data?.error || error?.message || '').toLowerCase();
+
+      if (
+        code === 'decryption_failed' ||
+        detail.includes('decrypt') ||
+        detail.includes('invalidtoken') ||
+        detail.includes('oauth_encryption_key')
+      ) {
+        message.error('Outlook needs to be reconnected. Go to Settings → Email Integrations (/settings/email-integrations) and reconnect, then retry Sync Now.');
+        await fetchEmailLogs();
+        return;
+      }
+
       message.error(error?.response?.data?.error || 'Failed to start email sync');
     } finally {
       setSyncing(false);

--- a/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIngestionMonitorWidget.tsx
@@ -312,6 +312,21 @@ export const EmailIngestionMonitorWidget: React.FC<EmailIngestionMonitorWidgetPr
       await fetchEmailLogs();
     } catch (error: any) {
       console.error('Failed to trigger sync:', error);
+
+      const code = String(error?.response?.data?.code || '').toLowerCase();
+      const detail = String(error?.response?.data?.error || error?.message || '').toLowerCase();
+
+      if (
+        code === 'decryption_failed' ||
+        detail.includes('decrypt') ||
+        detail.includes('invalidtoken') ||
+        detail.includes('oauth_encryption_key')
+      ) {
+        message.error('Outlook needs to be reconnected. Open /settings/email-integrations and reconnect, then retry Sync.');
+        await fetchEmailLogs();
+        return;
+      }
+
       message.error(error?.response?.data?.error || 'Failed to start email sync');
     } finally {
       setSyncing(false);


### PR DESCRIPTION
Ensures email ingestion 'Sync Now' never surfaces raw token decrypt errors. Backend sync endpoint maps decrypt-like exceptions to stable code=decryption_failed, and frontend catch paths also map decrypt-like error text to reconnect CTA.\n\nVerification:\n- python manage.py check\n- npm -C frontend run type-check