### PR TITLE
fix: AI document upload error hardening

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -65,6 +65,7 @@ This file is the **append-only PR-referenceable execution log**.
 ### 2026-03-27 — Phase 9.5: AI Document Stability
 - AI Assistant documents: updated `AIDocument.file.upload_to` to include tenant UUID + unique prefix to prevent naming collisions.
 - Upload hardening follow-up: switched to a flat tenant+UUID filename (avoids deep mkdir permission issues on mounted media volumes) and assert RLS session vars right before saving.
+- Error hardening follow-up: database exceptions now map to actionable 400s (e.g., missing migrations/table) instead of misleading RLS messages or 500s.
 - Added diagnostic command to reproduce uploads and capture tracebacks without needing the frontend:
   - `python manage.py test_document_upload --tenant-id 0f024884-b9ef-4e50-8fc0-89b2eb7c8c69`
   - Safe default: temp `MEDIA_ROOT` (no persistent artifacts)

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -450,8 +450,11 @@ class AIDocumentViewSet(viewsets.ModelViewSet):
                 file_size=getattr(self.request.FILES.get('file'), 'size', 0) or 0,
             )
         except Exception as e:
-            from django.db.utils import DatabaseError
+            from django.db.utils import DatabaseError, ProgrammingError
             from rest_framework.exceptions import ValidationError
+
+            if isinstance(e, ValidationError):
+                raise
 
             if isinstance(e, OSError):
                 logger.error('AIDocument upload: storage error: %s', str(e), exc_info=True)
@@ -459,13 +462,25 @@ class AIDocumentViewSet(viewsets.ModelViewSet):
                     'Upload failed: storage is not writable. Please contact an administrator.'
                 )
 
-            if isinstance(e, DatabaseError):
-                logger.error('AIDocument upload: database error: %s', str(e), exc_info=True)
-                raise ValidationError(
-                    'Upload failed: tenant context could not be asserted for RLS. Please reload and retry.'
-                )
+            if isinstance(e, (DatabaseError, ProgrammingError)):
+                msg = str(e)
+                lower = msg.lower()
+                logger.error('AIDocument upload: database error: %s', msg, exc_info=True)
 
-            raise
+                if 'does not exist' in lower and 'ai_assistant_documents' in lower:
+                    raise ValidationError(
+                        'Upload failed: documents table is not ready (migrations not applied). Please contact an administrator.'
+                    )
+
+                if 'row-level security' in lower or 'rls' in lower:
+                    raise ValidationError(
+                        'Upload failed: tenant context could not be asserted for RLS. Please reload and retry.'
+                    )
+
+                raise ValidationError('Upload failed: database error. Please retry in a moment.')
+
+            logger.error('AIDocument upload: unexpected error: %s', str(e), exc_info=True)
+            raise ValidationError('Upload failed: unexpected error. Please retry.')
 
         # If the upload was tied to a session, also create a DOCUMENT message so UIs can show it inline.
         if instance.session_id:


### PR DESCRIPTION
Hardens AIDocument upload error mapping so DB/storage/unexpected issues return actionable 400s (no misleading RLS messages, no 500s). Adds doc note in .github/MASTER_PLAN.md.\n\nVerification:\n- python manage.py check\n- python manage.py test_document_upload --tenant-id 0f024884-b9ef-4e50-8fc0-89b2eb7c8c69