### PR TITLE
fix: PO location fields auth

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -125,6 +125,10 @@ This file is the **append-only PR-referenceable execution log**.
 - Option Lists: "Master Products" entry now appears under the System Choice Lists tab; Tenant Overrides now use the same Card/Table layout as other admin screens.
 - Workflow Lists: tenant list create asserts RLS session vars before validation/save to prevent RLS-related write failures.
 
+### 2026-03-27 — Purchase Orders: Location Fields Auth Fix
+- LocationSelector now uses the standard JWT-aware apiClient (instead of raw axios + legacy Token auth), preventing spurious “Authentication required” errors on the New PO form.
+- Pick-up / Delivery locations are treated as optional (omitted from payload when unset).
+
 ### 2026-03-27 — Cockpit Favorites: Backend Persistence (Tenant-Safe)
 - SmartSearch + FavoritesWidget now use the backend favorites API (optimistic toggles; no localStorage dependence).
 - Favorites are tenant-scoped to prevent cross-tenant entity_id collisions; includes RLS policy on `core_userfavorite`.

--- a/frontend/src/components/Shared/LocationSelector.tsx
+++ b/frontend/src/components/Shared/LocationSelector.tsx
@@ -16,8 +16,7 @@ import styled from 'styled-components';
 import { Theme } from '../../config/theme';
 import { useTheme } from '../../contexts/ThemeContext';
 import { Location } from '../../types/index';
-import axios from 'axios';
-import { config } from '../../config/runtime';
+import { apiClient } from '../../services/apiService';
 
 export interface LocationSelectorProps {
   value: string | null;
@@ -56,33 +55,16 @@ export const LocationSelector: React.FC<LocationSelectorProps> = ({
       setLoading(true);
       setFetchError(null);
 
-      const token = localStorage.getItem('authToken');
-      const tenantId = localStorage.getItem('tenantId');
-
-      if (!token) {
-        setFetchError('Authentication required');
-        setLoading(false);
-        return;
-      }
-
-      // Build API URL with optional type filter
-      let url = `${config.API_BASE_URL}/locations/`;
-      if (type) {
-        url += `?type=${type}`;
-      }
-
-      const response = await axios.get<Location[]>(url, {
-        headers: {
-          Authorization: `Token ${token}`,
-          ...(tenantId && { 'X-Tenant-ID': tenantId }),
-        },
+      const response = await apiClient.get('/locations/', {
+        params: type ? { type } : undefined,
         timeout: 10000,
       });
 
       // Handle both paginated and non-paginated responses
-      const data = Array.isArray(response.data) 
-        ? response.data 
-        : (response.data as any).results || [];
+      const raw = response.data as unknown;
+      const data = Array.isArray(raw)
+        ? (raw as Location[])
+        : ((raw as any)?.results || []) as Location[];
 
       setLocations(data);
     } catch (err: any) {
@@ -91,13 +73,8 @@ export const LocationSelector: React.FC<LocationSelectorProps> = ({
         setFetchError('Access denied - insufficient permissions');
         console.error('[LocationSelector] RLS policy rejected request:', err);
       } else if (err.response?.status === 401) {
-        setFetchError('Session expired - please log in again');
-        console.error('[LocationSelector] Token expired:', err);
-        // Optionally trigger logout
-        localStorage.removeItem('authToken');
-        setTimeout(() => {
-          window.location.href = '/login';
-        }, 2000);
+        setFetchError('Authentication required');
+        console.error('[LocationSelector] Not authenticated:', err);
       } else if (err.code === 'ECONNABORTED') {
         setFetchError('Request timeout - please try again');
       } else {

--- a/frontend/src/pages/PurchaseOrders.tsx
+++ b/frontend/src/pages/PurchaseOrders.tsx
@@ -492,6 +492,10 @@ const PurchaseOrders: React.FC = () => {
         total_amount: parseFloat(formData.total_amount),
         supplier: parseInt(formData.supplier),
       };
+
+      // Location fields are optional; omit when unset to avoid backend validation surprises.
+      if (!purchaseOrderData.pick_up_location) purchaseOrderData.pick_up_location = undefined;
+      if (!purchaseOrderData.delivery_location) purchaseOrderData.delivery_location = undefined;
       
       // Remove order_number if empty - let backend auto-generate
       if (!purchaseOrderData.order_number || purchaseOrderData.order_number.trim() === '') {


### PR DESCRIPTION
Fixes New Purchase Order form location dropdowns incorrectly showing 'Authentication required' by migrating LocationSelector off raw axios + legacy Token auth to standard JWT-aware apiClient (includes tenant header). Also treats pick-up/delivery locations as optional by omitting them from payload when blank.\n\nVerification:\n- npm -C frontend run type-check\n- python manage.py check