### PR TITLE
fix: workform initial canvas buttons clickable

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -125,6 +125,9 @@ This file is the **append-only PR-referenceable execution log**.
 - Option Lists: "Master Products" entry now appears under the System Choice Lists tab; Tenant Overrides now use the same Card/Table layout as other admin screens.
 - Workflow Lists: tenant list create asserts RLS session vars before validation/save to prevent RLS-related write failures.
 
+### 2026-03-27 — Workform Editor: Initial Canvas Buttons Clickable
+- Fixed empty-canvas CTA buttons (Add Manual Trigger / Use Template / Browse Triggers) not being clickable due to ReactFlow pane overlay capturing pointer events.
+
 ### 2026-03-27 — Purchase Orders: Location Fields Auth Fix
 - LocationSelector now uses the standard JWT-aware apiClient (instead of raw axios + legacy Token auth), preventing spurious “Authentication required” errors on the New PO form.
 - Pick-up / Delivery locations are treated as optional (omitted from payload when unset).

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1046,6 +1046,9 @@ const NodeDesc = styled.div`
 `;
 
 const EmptyState = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 50;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1054,6 +1057,14 @@ const EmptyState = styled.div`
   color: rgb(var(--color-text-tertiary));
   padding: 40px;
   text-align: center;
+
+  /* ReactFlow's pane can sit above generic children; keep the overlay visible,
+     but only make the content clickable (so canvas can still be panned). */
+  pointer-events: none;
+
+  & > * {
+    pointer-events: auto;
+  }
 `;
 
 const EmptyIcon = styled.div`


### PR DESCRIPTION
Fixes Workform Editor empty-canvas CTA buttons (Add Manual Trigger / Use Template / Browse Triggers) not being clickable by rendering the empty state as an absolute overlay above the ReactFlow pane with pointer-events enabled for content.\n\nVerification:\n- npm -C frontend run type-check