### PR TITLE
Fix cockpit search favorites icon click

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -141,6 +141,11 @@ This file is the **append-only PR-referenceable execution log**.
 - Fixed Reports Summary API incorrectly marking purchase_orders/sales_orders/workforms as “metrics unavailable” due to Django `aggregate()` alias collisions (e.g. `total_amount=Sum('total_amount')` shadowing the field name used by `Avg('total_amount')`, raising FieldError).
 - PR: #4043.
 
+### 2026-03-27 — Cockpit Search: Favorites Icon Clickable
+- Fixed the SmartSearch results “favorite” (star) icon doing nothing. Root cause: nested <button> inside <button> (invalid HTML) prevented click events.
+- Result cards now render as accessible div-buttons with keyboard activation; favorite toggle surfaces errors.
+- PR: #4044.
+
 ### PR Log (append-only)
 
 - 2026-03-26 — Reports Summary 500 fixed — PR: #3949.

--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -203,7 +203,7 @@ const ResultGrid = styled.div`
   gap: 8px;
 `;
 
-const ResultCard = styled.button`
+const ResultCard = styled.div.attrs({ role: 'button', tabIndex: 0 })`
   display: flex;
   align-items: center;
   gap: 12px;
@@ -219,6 +219,11 @@ const ResultCard = styled.button`
     background: rgb(var(--color-background-tertiary));
     border-color: rgb(var(--color-primary));
     transform: translateX(4px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(var(--color-primary), 0.6);
+    outline-offset: 2px;
   }
 `;
 
@@ -861,11 +866,18 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
     const id = Number(entityId);
     if (!type || !Number.isFinite(id)) return;
 
-    toggleFavoriteMutation.mutate({
-      entity_type: type,
-      entity_id: id,
-      entity_title: entityTitle || '',
-    });
+    toggleFavoriteMutation.mutate(
+      {
+        entity_type: type,
+        entity_id: id,
+        entity_title: entityTitle || '',
+      },
+      {
+        onError: () => {
+          message.error('Failed to update favorite. Please try again.');
+        },
+      }
+    );
   }, [toggleFavoriteMutation]);
 
   /**
@@ -885,6 +897,15 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
   }, [controlledQuery, navigation, onQueryChange, onClose]);
 
   const activeStep = navigation.path[navigation.path.length - 1];
+
+  const handleCardKeyDown = useCallback((e: React.KeyboardEvent, onActivate: () => void) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      onActivate();
+    }
+  }, []);
+
 
   const handleNavigateToEntity = useCallback((nextType: string, nextId: string, label: string) => {
     navigation.addStep({
@@ -1073,6 +1094,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
               <ResultCard
                 key={entity.id}
                 onClick={() => handleSelectEntity(entity)}
+                onKeyDown={(e) => handleCardKeyDown(e, () => handleSelectEntity(entity))}
               >
                 <ResultIcon $tone={getEntityTone(entity.type)}>
                   {getEntityIcon(entity.type)}
@@ -1090,6 +1112,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
                 </ResultContent>
 
                 <FavoriteButton
+                  type="button"
                   $isFavorite={isFavorited(String(entity.type).toLowerCase(), Number(entity.id))}
                   onClick={(e) => toggleFavorite(entity.type, entity.id, entity.name, e)}
                   title={
@@ -1146,6 +1169,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
             <ResultCard
               key={item.id}
               onClick={() => chunk.type === 'actions' ? handleQuickAction(item) : handleSelectEntity(item)}
+              onKeyDown={(e) => handleCardKeyDown(e, () => chunk.type === 'actions' ? handleQuickAction(item) : handleSelectEntity(item))}
               style={chunk.type === 'actions' ? { cursor: 'pointer', borderStyle: 'dashed' } : {}}
             >
               <ResultIcon $tone={getEntityTone(item.type)}>
@@ -1161,6 +1185,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
 
               {chunk.type !== 'actions' && (
                 <FavoriteButton
+                  type="button"
                   $isFavorite={isFavorited(String(item.type).toLowerCase(), Number(item.id))}
                   onClick={(e) => toggleFavorite(item.type, item.id, item.name, e)}
                   title={


### PR DESCRIPTION
Fixes SmartSearch favorites icon doing nothing.

Root cause: result rows were rendered as <button> cards that contained a nested <button> (favorite icon). Nested buttons are invalid HTML and can prevent click events from firing.

Changes:
- Render result cards as accessible div buttons (role=button, tabIndex=0) to avoid nested interactive elements.
- Add Enter/Space keyboard activation.
- Surface favorite toggle errors via antd message.

Verification:
- npm -C frontend run type-check
- npm -C frontend run lint