### PR TITLE
Fix AI chat lessons block NameError

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -146,6 +146,10 @@ This file is the **append-only PR-referenceable execution log**.
 - Result cards now render as accessible div-buttons with keyboard activation; favorite toggle surfaces errors.
 - PR: #4044.
 
+### 2026-03-27 — AI Chat: Lessons Block NameError
+- Fixed AI chat failing with `NameError: lessons_block is not defined` by defining lessons_block in SwarmOrchestrator.run_tool_loop via memory_service (safe fallback when memory fails).
+- PR: #4045.
+
 ### PR Log (append-only)
 
 - 2026-03-26 — Reports Summary 500 fixed — PR: #3949.

--- a/backend/tenant_apps/ai_assistant/swarm/router.py
+++ b/backend/tenant_apps/ai_assistant/swarm/router.py
@@ -209,6 +209,15 @@ class SwarmOrchestrator:
         if not openai_api_key:
             raise ValueError('OpenAI not configured (missing OPENAI_API_KEY)')
 
+        lessons_block = ''
+        try:
+            from tenant_apps.ai_assistant.services.memory_service import format_lessons_block, get_relevant_lessons
+
+            lessons = get_relevant_lessons(tenant=tenant, query=user_message, limit=8)
+            lessons_block = format_lessons_block(lessons)
+        except Exception as e:
+            logger.warning('[SwarmOrchestrator] Lessons lookup failed; continuing without lessons: %s', str(e))
+
         # Phase 8.2: intent classification → delegate deep meat/logistics questions to MeatSME RAG.
         # Reliability mandate: if RAG fails for any reason, fall back to the standard tool loop.
         if self._requires_meat_sme(user_message):


### PR DESCRIPTION
Fixes AI chat failing with NameError lessons_block not defined.

Root cause: SwarmOrchestrator.run_tool_loop referenced lessons_block when building the system prompt but did not define it.

Change: define lessons_block via memory_service (get_relevant_lessons and format_lessons_block) with safe fallback.

Verification: python manage.py check.