### PR TITLE
Docs: state audit and remaining P0s

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -150,6 +150,13 @@ This file is the **append-only PR-referenceable execution log**.
 - Fixed AI chat failing with `NameError: lessons_block is not defined` by defining lessons_block in SwarmOrchestrator.run_tool_loop via memory_service (safe fallback when memory fails).
 - PR: #4045.
 
+### 2026-03-27T18:47Z — State Audit (Remaining P0s)
+- Identified remaining gaps from runtime logs and repeated UX reports.
+- Next execution order:
+  1) Fix Workforms AI suggestions route drift (frontend currently calls /api/v1/suggest-nodes/ but backend suggests /api/v1/workflows/suggest-nodes/).
+  2) Universal Forms + Cockpit Search usability hardening (save/create CTA, key-fields-first + expand, searchable FK by name, per-keystroke refresh).
+  3) Workform Editor UX hardening (connectors top+bottom, remove conflicting collapse buttons, drag body, inline title, reorder swaps edges).
+
 ### PR Log (append-only)
 
 - 2026-03-26 — Reports Summary 500 fixed — PR: #3949.

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -14,6 +14,18 @@ This file is the **canonical plan + current truth snapshot**.
 
 We are re-validating and completing the last ~25 prompts with **evidence-based acceptance criteria** and strict shipping discipline.
 
+## State Audit & Remaining P0s (as of 2026-03-27T18:47Z)
+
+### Observed runtime issues
+- Workforms AI Suggestions: frontend calling `POST /api/v1/suggest-nodes/` gets 404; backend `SuggestNodesView` exists but is not routed. Align to `POST /api/v1/workflows/suggest-nodes/`.
+- AI Chat: lessons memory NameError fixed (PR #4045); remaining 400s should be treated as environment config issues (missing OPENAI_API_KEY) with graceful messaging.
+- Charts: Recharts `ResponsiveContainer` warnings (width/height -1) indicate parent container sizing gaps; fix to reduce noise.
+
+### Priority execution strategy
+1) Quick wins: fix suggest-nodes route drift; reduce chart sizing warnings.
+2) Universal Forms + Cockpit Search: make forms truly usable (save/create CTA, key-fields-first + expand-all, single edit toggle, searchable FK by name, per-keystroke refresh where required).
+3) Workform Editor UX: connectors top/bottom, remove conflicting collapse buttons, drag body, inline title edit, reorder arrows swap edges, show key config summary in-node.
+
 **Shipping discipline (MANDATORY):** every batch is shipped via **new branch → PR → merge to `development`**.
 
 ### Execution order (P0→P1)


### PR DESCRIPTION
Adds a 2026-03-27T18:47Z state audit section with observed runtime gaps and an execution strategy for remaining P0 work (suggest-nodes route drift, universal forms/cockpit search usability, workform editor UX hardening).