### PR TITLE
Fix workforms AI suggestions endpoint routing

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -157,6 +157,10 @@ This file is the **append-only PR-referenceable execution log**.
   2) Universal Forms + Cockpit Search usability hardening (save/create CTA, key-fields-first + expand, searchable FK by name, per-keystroke refresh).
   3) Workform Editor UX hardening (connectors top+bottom, remove conflicting collapse buttons, drag body, inline title, reorder swaps edges).
 
+### 2026-03-27 — Workforms: AI Suggestions Endpoint Routed
+- Fixed 404s for Workforms AI Suggestions by routing `SuggestNodesView` under `/api/v1/workflows/suggest-nodes/` and updating the frontend to call `/workflows/suggest-nodes/`.
+- PR: #4047.
+
 ### PR Log (append-only)
 
 - 2026-03-26 — Reports Summary 500 fixed — PR: #3949.

--- a/backend/tenant_apps/workflows/urls.py
+++ b/backend/tenant_apps/workflows/urls.py
@@ -34,7 +34,9 @@ from .views import (
     UserNotificationViewSet, UserNotificationPreferencesView,
     ActionItemsAPIView, ActionItemCountsAPIView,
     # Phase 4.2: Permission System
-    WorkFormPermissionsAPIView
+    WorkFormPermissionsAPIView,
+    # AI suggestions
+    SuggestNodesView,
 )
 
 # Debug helper (temporary)
@@ -136,6 +138,9 @@ urlpatterns = [
     # Debug endpoint (temporary - for diagnosing superuser permissions issue)
     path('debug-permissions/', DebugPermissionsView.as_view(), name='debug-permissions'),
     
+    # AI workflow suggestions
+    path('suggest-nodes/', SuggestNodesView.as_view(), name='suggest-nodes'),
+
     # Phase 5: Workflow Trigger API endpoints
     path('workflows/<uuid:workflow_id>/webhooks/', WorkflowWebhookAPIView.as_view(), name='workflow-webhooks'),
     path('workflows/<uuid:workflow_id>/trigger/', ManualTriggerAPIView.as_view(), name='workflow-manual-trigger'),

--- a/frontend/src/services/workformsApi.ts
+++ b/frontend/src/services/workformsApi.ts
@@ -460,7 +460,7 @@ export interface SuggestNodesResponse {
 }
 
 export const suggestNodes = async (payload: any): Promise<SuggestNodesResponse> => {
-  const response = await apiClient.post('/suggest-nodes/', payload);
+  const response = await apiClient.post('/workflows/suggest-nodes/', payload);
   return response.data;
 };
 


### PR DESCRIPTION
Fixes 404s for Workforms AI Suggestions.

- Backend: route SuggestNodesView at /api/v1/workflows/suggest-nodes/.
- Frontend: workformsApi.suggestNodes now calls /workflows/suggest-nodes/ (apiClient is already rooted at /api/v1).

Verification:
- python manage.py check
- npm -C frontend run type-check