### PR TITLE
Fix Recharts ResponsiveContainer sizing warnings

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -161,6 +161,10 @@ This file is the **append-only PR-referenceable execution log**.
 - Fixed 404s for Workforms AI Suggestions by routing `SuggestNodesView` under `/api/v1/workflows/suggest-nodes/` and updating the frontend to call `/workflows/suggest-nodes/`.
 - PR: #4047.
 
+### 2026-03-27 — Charts: ResponsiveContainer Sizing Warning Reduced
+- Added explicit width/height and min dimensions for `ResponsiveContainer` in AI Learning Metrics widget to reduce `width(-1)/height(-1)` console warnings.
+- PR: #4048.
+
 ### PR Log (append-only)
 
 - 2026-03-26 — Reports Summary 500 fixed — PR: #3949.

--- a/frontend/src/components/Cockpit/AILearningMetricsWidget.tsx
+++ b/frontend/src/components/Cockpit/AILearningMetricsWidget.tsx
@@ -86,8 +86,8 @@ export const AILearningMetricsWidget: React.FC<AILearningMetricsWidgetProps> = (
         <Text type="secondary" style={{ fontSize: 12 }}>
           Confidence trend (last 30 days)
         </Text>
-        <div style={{ width: '100%', height: 120, marginTop: 8 }}>
-          <ResponsiveContainer>
+        <div style={{ width: '100%', height: 120, minHeight: 120, minWidth: 0, marginTop: 8 }}>
+          <ResponsiveContainer width="100%" height="100%">
             <LineChart data={m.confidenceTrend || defaultTrend}>
               <XAxis dataKey="day" hide />
               <YAxis domain={[0, 1]} hide />


### PR DESCRIPTION
Reduces noisy chart warnings (width/height -1) by giving ResponsiveContainer explicit width/height and min dimensions in AILearningMetricsWidget.

Verification:
- npm -C frontend run type-check
- npm -C frontend run lint