### PR TITLE
Hotfix: SmartSearch build failure

### DIFF
--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -626,7 +626,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
       });
       setResults({});
       setResultCounts({});
-    } finally {"}}]}
+    } finally {
       setIsSearching(false);
     }
   }, []);


### PR DESCRIPTION
Fixes Vite build failure (unterminated string) by removing an accidental stray fragment after a finally block in frontend/src/components/Cockpit/SmartSearch.tsx.