### PR TITLE
Enforce 5-digit ZIP inputs

### DIFF
--- a/frontend/src/components/FormSubmission/QuickCreateModal.tsx
+++ b/frontend/src/components/FormSubmission/QuickCreateModal.tsx
@@ -397,10 +397,20 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
 
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
-    
-    fields.forEach(field => {
-      if (field.required && !formData[field.key]) {
+
+    fields.forEach((field) => {
+      const raw = formData[field.key];
+
+      if (field.required && !raw) {
         newErrors[field.key] = `${field.label} is required`;
+        return;
+      }
+
+      if (field.key === 'zip_code' && raw) {
+        const zip = String(raw).trim();
+        if (!/^\d{5}$/.test(zip)) {
+          newErrors[field.key] = 'ZIP code must be 5 digits';
+        }
       }
     });
 
@@ -556,7 +566,17 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
                         id={`quick-create-${field.key}`}
                         type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : field.type === 'date' ? 'date' : 'text'}
                         value={formData[field.key] || ''}
-                        onChange={(e) => handleInputChange(field.key, e.target.value)}
+                        onChange={(e) => {
+                          const raw = e.target.value;
+                          if (field.key === 'zip_code') {
+                            handleInputChange(field.key, raw.replace(/\D/g, '').slice(0, 5));
+                            return;
+                          }
+                          handleInputChange(field.key, raw);
+                        }}
+                        maxLength={field.key === 'zip_code' ? 5 : undefined}
+                        inputMode={field.key === 'zip_code' ? 'numeric' : undefined}
+                        pattern={field.key === 'zip_code' ? '^\\d{5}$' : undefined}
                         className={errors[field.key] ? 'error' : ''}
                         disabled={isSubmitting}
                         autoFocus={fields.indexOf(field) === 0}
@@ -671,7 +691,17 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
                         id={`quick-create-${field.key}`}
                         type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : field.type === 'date' ? 'date' : 'text'}
                         value={formData[field.key] || ''}
-                        onChange={(e) => handleInputChange(field.key, e.target.value)}
+                        onChange={(e) => {
+                          const raw = e.target.value;
+                          if (field.key === 'zip_code') {
+                            handleInputChange(field.key, raw.replace(/\D/g, '').slice(0, 5));
+                            return;
+                          }
+                          handleInputChange(field.key, raw);
+                        }}
+                        maxLength={field.key === 'zip_code' ? 5 : undefined}
+                        inputMode={field.key === 'zip_code' ? 'numeric' : undefined}
+                        pattern={field.key === 'zip_code' ? '^\\d{5}$' : undefined}
                         className={errors[field.key] ? 'error' : ''}
                         disabled={isSubmitting}
                         autoFocus={fields.indexOf(field) === 0}

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -512,6 +512,16 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           .filter((f) => emailKeySet.has(f.key))
           .map((f) => [f.key, f.label || f.key] as const)
       );
+      const zipKeySet = new Set(
+        (scalarFields || [])
+          .filter((f) => String(f.key || '').toLowerCase().includes('zip_code'))
+          .map((f) => f.key)
+      );
+      const zipLabelByKey = new Map(
+        (scalarFields || [])
+          .filter((f) => zipKeySet.has(f.key))
+          .map((f) => [f.key, f.label || f.key] as const)
+      );
 
       Object.entries(payload).forEach(([k, v]) => {
         if (v === '') {
@@ -522,6 +532,10 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           const trimmed = v.trim();
           if (!trimmed) {
             delete payload[k];
+            return;
+          }
+          if (zipKeySet.has(k)) {
+            payload[k] = trimmed.replace(/\D/g, '').slice(0, 5);
             return;
           }
           if (numberKeys.has(k)) {
@@ -539,6 +553,16 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
         if (typeof v === 'string' && v.trim() && !isValidEmail(v.trim())) {
           const label = emailLabelByKey.get(k) || k;
           message.error(`Please enter a valid email for ${label}`);
+          return;
+        }
+      }
+
+      // Validate ZIP code(s) before submit.
+      for (const k of zipKeySet) {
+        const v = payload[k];
+        if (typeof v === 'string' && v.trim() && !/^\d{5}$/.test(v.trim())) {
+          const label = zipLabelByKey.get(k) || k;
+          message.error(`${label} must be exactly 5 digits`);
           return;
         }
       }

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -677,7 +677,15 @@ const Customers: React.FC = () => {
                     $theme={theme}
                     type="text"
                     value={locationForm.zip_code}
-                    onChange={(e) => setLocationForm((p) => ({ ...p, zip_code: e.target.value }))}
+                    onChange={(e) => {
+                      const value = e.target.value.replace(/\D/g, '').slice(0, 5);
+                      setLocationForm((p) => ({ ...p, zip_code: value }));
+                    }}
+                    maxLength={5}
+                    inputMode="numeric"
+                    pattern="^\d{5}$"
+                    placeholder="12345"
+                    aria-label="ZIP Code"
                   />
                 </FormGroup>
 

--- a/frontend/src/pages/Customers/Locations.tsx
+++ b/frontend/src/pages/Customers/Locations.tsx
@@ -573,8 +573,13 @@ const CustomerLocations: React.FC = () => {
             />
           </Form.Item>
 
-          <Form.Item name="zip_code" label={<Label>ZIP Code</Label>}>
-            <Input placeholder="ZIP Code" />
+          <Form.Item
+            name="zip_code"
+            label={<Label>ZIP Code</Label>}
+            rules={[{ pattern: /^\d{5}$/, message: 'ZIP Code must be exactly 5 digits' }]}
+            getValueFromEvent={(e) => String(e?.target?.value ?? '').replace(/\D/g, '').slice(0, 5)}
+          >
+            <Input placeholder="12345" maxLength={5} inputMode="numeric" />
           </Form.Item>
 
           <Form.Item name="country" label={<Label>Country</Label>}>

--- a/frontend/src/pages/Suppliers/Plants.tsx
+++ b/frontend/src/pages/Suppliers/Plants.tsx
@@ -593,8 +593,13 @@ const Plants: React.FC = () => {
             />
           </Form.Item>
 
-          <Form.Item name="zip_code" label={<Label>ZIP Code</Label>}>
-            <Input placeholder="ZIP Code" />
+          <Form.Item
+            name="zip_code"
+            label={<Label>ZIP Code</Label>}
+            rules={[{ pattern: /^\d{5}$/, message: 'ZIP Code must be exactly 5 digits' }]}
+            getValueFromEvent={(e) => String(e?.target?.value ?? '').replace(/\D/g, '').slice(0, 5)}
+          >
+            <Input placeholder="12345" maxLength={5} inputMode="numeric" />
           </Form.Item>
 
           <Form.Item name="country" label={<Label>Country</Label>}>


### PR DESCRIPTION
Enforces 5-digit ZIP code input validation across entity forms and quick-create flows.

- Sanitizes zip_code input to digits only and max length 5 (including QuickCreateModal inline + modal)
- Blocks submit when ZIP is not exactly 5 digits (when provided)
- Keeps existing AntD rules on Locations/Plants pages

Frontend build: ✅