### PR TITLE
Entity tables: row click opens drilldown

### DIFF
--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -772,7 +772,24 @@ const Customers: React.FC = () => {
             <TableBody>
               {visibleCustomers.map((customer) => (
                 <React.Fragment key={customer.id}>
-                <TableRow $theme={theme} key={customer.id}>
+                <TableRow
+                  $theme={theme}
+                  key={customer.id}
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={selectedCustomerId === customer.id}
+                  style={{ cursor: 'pointer' }}
+                  onClick={(e) => {
+                    const target = e.target as HTMLElement | null;
+                    if (target?.closest('button, a, input, textarea, select, [role="button"]')) return;
+                    void toggleCustomerDrilldown(customer);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key !== 'Enter' && e.key !== ' ') return;
+                    e.preventDefault();
+                    void toggleCustomerDrilldown(customer);
+                  }}
+                >
                   <TableCell $theme={theme}>
                     <CompanyButton
                       $theme={theme}

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -782,7 +782,24 @@ const Suppliers: React.FC = () => {
             <TableBody>
               {visibleSuppliers.map((supplier) => (
                 <React.Fragment key={supplier.id}>
-                <TableRow key={supplier.id} $theme={theme}>
+                <TableRow
+                  key={supplier.id}
+                  $theme={theme}
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={selectedSupplierId === supplier.id}
+                  style={{ cursor: 'pointer' }}
+                  onClick={(e) => {
+                    const target = e.target as HTMLElement | null;
+                    if (target?.closest('button, a, input, textarea, select, [role="button"]')) return;
+                    void toggleSupplierDrilldown(supplier);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key !== 'Enter' && e.key !== ' ') return;
+                    e.preventDefault();
+                    void toggleSupplierDrilldown(supplier);
+                  }}
+                >
                   <TableCell $theme={theme}>
                     <CompanyButton
                       $theme={theme}


### PR DESCRIPTION
## What
- Make Customers + Suppliers list rows clickable so selecting any row cell opens the same drilldown/details panel as clicking the Company Name.
- Ignore clicks on interactive controls (company button, edit/delete buttons, etc.) so actions still work normally.

## Why
Users expect clicking anywhere on the entity row to open the details view, not only the company name.

## Verification
- Ran: cd frontend && npm run build