### PR TITLE
Replace native browser dialogs with in-app modals

### DIFF
--- a/frontend/src/apps/admin-studio/components/ChoiceListEditor.tsx
+++ b/frontend/src/apps/admin-studio/components/ChoiceListEditor.tsx
@@ -4,6 +4,7 @@ import {
   SystemChoiceList,
 } from '../../../services/configService';
 import { apiClient } from '../../../services/apiService';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 interface ChoiceListEditorProps {
   listSlug?: string;
@@ -129,9 +130,20 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
       // Escape: Close editor or deselect
       else if (e.key === 'Escape') {
         if (onClose) {
-          if (!hasChanges || window.confirm('You have unsaved changes. Discard them?')) {
-            onClose();
-          }
+          void (async () => {
+            const ok =
+              !hasChanges ||
+              (await confirmDialog({
+                title: 'Discard unsaved changes?',
+                content: 'You have unsaved changes. Discard them?',
+                okText: 'Discard',
+                cancelText: 'Keep editing',
+                danger: true,
+              }));
+            if (ok) {
+              onClose();
+            }
+          })();
         }
       }
     };
@@ -140,11 +152,16 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [selectedList, hasChanges, saving, onClose]);
 
-  const handleSelectList = (list: SystemChoiceList) => {
+  const handleSelectList = async (list: SystemChoiceList) => {
     if (hasChanges) {
-      if (!window.confirm('You have unsaved changes. Discard them?')) {
-        return;
-      }
+      const ok = await confirmDialog({
+        title: 'Discard unsaved changes?',
+        content: 'You have unsaved changes. Discard them?',
+        okText: 'Discard',
+        cancelText: 'Keep editing',
+        danger: true,
+      });
+      if (!ok) return;
     }
     loadItems(list.slug);
   };
@@ -174,18 +191,25 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
     setHasChanges(true);
   };
 
-  const handleDeleteItem = (index: number) => {
+  const handleDeleteItem = async (index: number) => {
     const item = items[index];
-    if (item.id && !window.confirm(`Delete "${item.label}"? This cannot be undone.`)) {
-      return;
+    if (item.id) {
+      const ok = await confirmDialog({
+        title: 'Delete choice?',
+        content: `Delete "${item.label}"? This cannot be undone.`,
+        okText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      });
+      if (!ok) return;
     }
-    
+
     const newItems = items.filter((_, i) => i !== index);
     // Recalculate sort orders
     newItems.forEach((item, i) => {
       item.sort_order = i;
     });
-    
+
     setItems(newItems);
     setHasChanges(true);
   };
@@ -369,7 +393,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
           {filteredLists.map((list) => (
             <button
               key={list.id}
-              onClick={() => handleSelectList(list)}
+              onClick={() => void handleSelectList(list)}
               className={`w-full text-left p-3 border-b hover:bg-gray-50 transition-colors ${
                 selectedList?.id === list.id ? 'bg-blue-50 border-l-4 border-l-blue-600' : ''
               }`}
@@ -507,7 +531,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
                       </td>
                       <td className="px-4 py-2 text-center">
                         <button
-                          onClick={() => handleDeleteItem(index)}
+                          onClick={() => void handleDeleteItem(index)}
                           className="text-red-600 hover:text-red-800 text-sm"
                           title="Delete item"
                         >

--- a/frontend/src/apps/admin-studio/components/FormPreview.tsx
+++ b/frontend/src/apps/admin-studio/components/FormPreview.tsx
@@ -5,6 +5,7 @@
  * Helps users visualize their field configurations before saving.
  */
 import React, { useState } from 'react';
+import { showAlert } from '@/utils/uiDialogs';
 
 interface Field {
   id: string;
@@ -29,7 +30,18 @@ const FormPreview: React.FC<FormPreviewProps> = ({ fields, onClose }) => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    alert('Preview mode - form not submitted\n\nData:\n' + JSON.stringify(formData, null, 2));
+    showAlert({
+      title: 'Preview mode',
+      content: (
+        <div>
+          <div style={{ marginBottom: 8 }}>Form not submitted. Data:</div>
+          <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>
+            {JSON.stringify(formData, null, 2)}
+          </pre>
+        </div>
+      ),
+      type: 'info',
+    });
   };
 
   const renderField = (field: Field) => {

--- a/frontend/src/apps/admin-studio/components/SchemaEditor.tsx
+++ b/frontend/src/apps/admin-studio/components/SchemaEditor.tsx
@@ -21,6 +21,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useParams } from 'react-router-dom';
 import styled, { keyframes } from 'styled-components';
 import { adminClient } from '@/services/apiService';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import {
   useReactTable,
   getCoreRowModel,
@@ -942,9 +943,18 @@ const SortableRow: React.FC<{
                 <ActionButton 
                   variant="danger"
                   onClick={() => {
-                    if (window.confirm(`Delete field "${row.original.label}"? This cannot be undone.`)) {
-                      onDelete(row.original.id);
-                    }
+                    void (async () => {
+                      const ok = await confirmDialog({
+                        title: 'Delete field?',
+                        content: `Delete field "${row.original.label}"? This cannot be undone.`,
+                        okText: 'Delete',
+                        cancelText: 'Cancel',
+                        danger: true,
+                      });
+                      if (ok) {
+                        onDelete(row.original.id);
+                      }
+                    })();
                   }}
                   title="Delete"
                 >
@@ -1049,7 +1059,7 @@ const SchemaEditor: React.FC = () => {
       // Delete: Delete selected
       if (e.key === 'Delete' && selectedFields.size > 0) {
         e.preventDefault();
-        handleBulkDelete();
+        void handleBulkDelete();
       }
       // Escape: Clear selection
       if (e.key === 'Escape') {
@@ -1095,15 +1105,23 @@ const SchemaEditor: React.FC = () => {
   };
 
   // Bulk delete selected fields
-  const handleBulkDelete = () => {
+  const handleBulkDelete = async () => {
     if (selectedFields.size === 0) return;
-    if (window.confirm(`Delete ${selectedFields.size} selected field(s)? This cannot be undone.`)) {
-      const newFields = fields.filter(f => !selectedFields.has(f.id));
-      setFields(newFields);
-      setSelectedFields(new Set());
-      saveToHistory(newFields, 'Bulk delete');
-      triggerAutoSave();
-    }
+
+    const ok = await confirmDialog({
+      title: `Delete ${selectedFields.size} selected field(s)?`,
+      content: 'This cannot be undone.',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+    if (!ok) return;
+
+    const newFields = fields.filter(f => !selectedFields.has(f.id));
+    setFields(newFields);
+    setSelectedFields(new Set());
+    saveToHistory(newFields, 'Bulk delete');
+    triggerAutoSave();
   };
 
   // Select all fields
@@ -1194,14 +1212,26 @@ const SchemaEditor: React.FC = () => {
               ...f,
               id: `imported_${Date.now()}_${i}`,
             }));
-            if (window.confirm(`Import ${importedFields.length} fields? This will replace current schema.`)) {
+            void (async () => {
+              const ok = await confirmDialog({
+                title: `Import ${importedFields.length} fields?`,
+                content: 'This will replace current schema.',
+                okText: 'Import',
+                cancelText: 'Cancel',
+              });
+              if (!ok) return;
+
               setFields(importedFields);
               saveToHistory(importedFields, 'Import schema');
               triggerAutoSave();
-            }
+            })();
           }
         } catch (err) {
-          alert('Invalid JSON file. Please check the format.');
+          showAlert({
+            title: 'Invalid JSON',
+            content: 'Invalid JSON file. Please check the format.',
+            type: 'error',
+          });
         }
       };
       reader.readAsText(file);

--- a/frontend/src/apps/admin-studio/components/SchemaEditorSimple.tsx
+++ b/frontend/src/apps/admin-studio/components/SchemaEditorSimple.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import FormPreview from './FormPreview';
 import { adminClient } from '@/services/apiService';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 interface FieldDefinition {
   id: string;
@@ -447,10 +448,17 @@ const SchemaEditor: React.FC<Props> = ({ blueprintId, csrfToken }) => {
     }
   };
 
-  const handleDeleteField = (index: number) => {
-    if (confirm('Delete this field? This action cannot be undone.')) {
-      setFields(fields.filter((_, i) => i !== index));
-    }
+  const handleDeleteField = async (index: number) => {
+    const ok = await confirmDialog({
+      title: 'Delete field?',
+      content: 'This action cannot be undone.',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+    if (!ok) return;
+
+    setFields(fields.filter((_, i) => i !== index));
   };
 
   const handleSaveWithValidation = async () => {
@@ -612,7 +620,7 @@ const SchemaEditor: React.FC<Props> = ({ blueprintId, csrfToken }) => {
                 />
               </Td>
               <Td>
-                <Button variant="danger" onClick={() => handleDeleteField(index)}>
+                <Button variant="danger" onClick={() => void handleDeleteField(index)}>
                   🗑️
                 </Button>
               </Td>

--- a/frontend/src/apps/admin-studio/components/TenantConfigEditor.tsx
+++ b/frontend/src/apps/admin-studio/components/TenantConfigEditor.tsx
@@ -4,6 +4,7 @@ import {
   ConfigCategory,
   ConfigByCategory,
 } from '../../../services/configService';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 interface TenantConfigEditorProps {
   onClose?: () => void;
@@ -113,9 +114,20 @@ export const TenantConfigEditor: React.FC<TenantConfigEditorProps> = ({ onClose 
       // Escape: Close editor
       else if (e.key === 'Escape') {
         if (onClose) {
-          if (!hasChanges || window.confirm('You have unsaved changes. Discard them?')) {
-            onClose();
-          }
+          void (async () => {
+            const ok =
+              !hasChanges ||
+              (await confirmDialog({
+                title: 'Discard unsaved changes?',
+                content: 'You have unsaved changes. Discard them?',
+                okText: 'Discard',
+                cancelText: 'Keep editing',
+                danger: true,
+              }));
+            if (ok) {
+              onClose();
+            }
+          })();
         }
       }
     };
@@ -124,11 +136,16 @@ export const TenantConfigEditor: React.FC<TenantConfigEditorProps> = ({ onClose 
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [hasChanges, saving, onClose]);
 
-  const handleCategoryChange = (category: ConfigCategory) => {
+  const handleCategoryChange = async (category: ConfigCategory) => {
     if (hasChanges) {
-      if (!window.confirm('You have unsaved changes. Discard them?')) {
-        return;
-      }
+      const ok = await confirmDialog({
+        title: 'Discard unsaved changes?',
+        content: 'You have unsaved changes. Discard them?',
+        okText: 'Discard',
+        cancelText: 'Keep editing',
+        danger: true,
+      });
+      if (!ok) return;
     }
     setSelectedCategory(category);
     setSearchQuery('');
@@ -171,9 +188,15 @@ export const TenantConfigEditor: React.FC<TenantConfigEditorProps> = ({ onClose 
   const handleDeleteConfig = async (index: number) => {
     const config = configs[index];
     if (config.id) {
-      if (!window.confirm(`Delete "${config.key}"? This cannot be undone.`)) {
-        return;
-      }
+      const ok = await confirmDialog({
+        title: 'Delete configuration?',
+        content: `Delete "${config.key}"? This cannot be undone.`,
+        okText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      });
+      if (!ok) return;
+
       try {
         await configService.deleteTenantConfig(config.id);
         setSuccessMessage('Config deleted successfully');
@@ -347,7 +370,7 @@ export const TenantConfigEditor: React.FC<TenantConfigEditorProps> = ({ onClose 
             return (
               <button
                 key={category}
-                onClick={() => handleCategoryChange(category)}
+                onClick={() => void handleCategoryChange(category)}
                 className={`w-full text-left p-4 border-b hover:bg-gray-50 transition-colors ${
                   selectedCategory === category ? 'bg-blue-50 border-l-4 border-l-blue-600' : ''
                 }`}
@@ -461,7 +484,7 @@ export const TenantConfigEditor: React.FC<TenantConfigEditorProps> = ({ onClose 
                       </span>
                     </div>
                     <button
-                      onClick={() => handleDeleteConfig(index)}
+                      onClick={() => void handleDeleteConfig(index)}
                       className="mt-5 text-red-600 hover:text-red-800 p-2"
                       title="Delete config"
                     >

--- a/frontend/src/apps/admin-studio/components/VersionHistory.tsx
+++ b/frontend/src/apps/admin-studio/components/VersionHistory.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Clock, GitBranch, Check, X, History, RotateCcw } from 'lucide-react';
 import { adminClient } from '@/services/apiService';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 
 interface Version {
   id: string;
@@ -53,9 +54,14 @@ export const VersionHistory: React.FC<VersionHistoryProps> = ({
   };
 
   const handleRollback = async (versionId: string, versionNumber: number) => {
-    if (!confirm(`Rollback to version ${versionNumber}? This will create a new draft version.`)) {
-      return;
-    }
+    const ok = await confirmDialog({
+      title: `Rollback to version ${versionNumber}?`,
+      content: 'This will create a new draft version.',
+      okText: 'Rollback',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+    if (!ok) return;
 
     try {
       const response = await adminClient.post(
@@ -63,12 +69,20 @@ export const VersionHistory: React.FC<VersionHistoryProps> = ({
         {}
       );
 
-      alert(response.data.message);
+      showAlert({
+        title: 'Rollback complete',
+        content: response.data?.message ?? 'Rollback complete.',
+        type: 'success',
+      });
       onRollback(response.data.new_version_id);
       fetchVersionHistory();
     } catch (error) {
       console.error('Rollback failed:', error);
-      alert('Failed to rollback. See console for details.');
+      showAlert({
+        title: 'Rollback failed',
+        content: 'Failed to rollback. See console for details.',
+        type: 'error',
+      });
     }
   };
 
@@ -85,7 +99,11 @@ export const VersionHistory: React.FC<VersionHistoryProps> = ({
       setComparisonData(response.data);
     } catch (error) {
       console.error('Comparison failed:', error);
-      alert('Failed to compare versions. See console for details.');
+      showAlert({
+        title: 'Comparison failed',
+        content: 'Failed to compare versions. See console for details.',
+        type: 'error',
+      });
     }
   };
 

--- a/frontend/src/apps/admin-studio/pages/Dashboard.tsx
+++ b/frontend/src/apps/admin-studio/pages/Dashboard.tsx
@@ -52,7 +52,7 @@ export const Dashboard: React.FC = () => {
             </Link>
             <button 
               className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 font-medium transition-colors"
-              onClick={() => alert('Create new blueprint functionality to be implemented')}
+              onClick={() => showAlert({ type: 'info', title: 'Coming soon', content: 'Create new blueprint functionality to be implemented' })}
             >
               + Create New Blueprint
             </button>

--- a/frontend/src/apps/admin-studio/pages/Editor.tsx
+++ b/frontend/src/apps/admin-studio/pages/Editor.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import SchemaEditor from '../components/SchemaEditorSimple';
 import { adminClient } from '@/services/apiService';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 // Use UnifiedFlowEditor instead of WorkflowCanvas
 import { UnifiedFlowEditor } from '../../../components/FlowEditor';
 import { VersionHistory } from '../components/VersionHistory';
@@ -67,58 +68,87 @@ const Editor: React.FC<EditorProps> = () => {
   const handlePublish = async () => {
     if (!blueprintId || !csrfToken) return;
 
-    if (confirm('Publish this workflow? It will become available to all tenant users.')) {
-      try {
-        setPublishing(true);
-        await adminClient.post(
-          `/admin/system-config/api/studio/versions/${blueprintId}/publish/`,
-          {},
-          {
-            headers: csrfToken
-              ? {
-                  'X-CSRFToken': csrfToken,
-                  'Content-Type': 'application/json',
-                }
-              : undefined,
-          }
-        );
-        setIsPublished(true);
-        alert('✅ Workflow published successfully!');
-      } catch (error: any) {
-        console.error('Error publishing:', error);
-        alert(`❌ Failed to publish: ${error.message}`);
-      } finally {
-        setPublishing(false);
-      }
+    const ok = await confirmDialog({
+      title: 'Publish this workflow?',
+      content: 'It will become available to all tenant users.',
+      okText: 'Publish',
+      cancelText: 'Cancel',
+    });
+    if (!ok) return;
+
+    try {
+      setPublishing(true);
+      await adminClient.post(
+        `/admin/system-config/api/studio/versions/${blueprintId}/publish/`,
+        {},
+        {
+          headers: csrfToken
+            ? {
+                'X-CSRFToken': csrfToken,
+                'Content-Type': 'application/json',
+              }
+            : undefined,
+        }
+      );
+      setIsPublished(true);
+      showAlert({
+        title: 'Published',
+        content: 'Workflow published successfully.',
+        type: 'success',
+      });
+    } catch (error: any) {
+      console.error('Error publishing:', error);
+      showAlert({
+        title: 'Publish failed',
+        content: error?.message ?? 'Failed to publish workflow.',
+        type: 'error',
+      });
+    } finally {
+      setPublishing(false);
     }
   };
 
   const handleUnpublish = async () => {
     if (!blueprintId || !csrfToken) return;
 
-    if (confirm('Unpublish this workflow? It will be removed from the catalog.')) {
-      try {
-        setPublishing(true);
-        await adminClient.post(
-          `/admin/system-config/api/studio/versions/${blueprintId}/unpublish/`,
-          {},
-          {
-            headers: csrfToken
-              ? {
-                  'X-CSRFToken': csrfToken,
-                  'Content-Type': 'application/json',
-                }
-              : undefined,
-          }
-        );
-        setIsPublished(false);
-        alert('✅ Workflow unpublished successfully!');
-      } catch (error: any) {
-        console.error('Error unpublishing:', error);
-        alert(`❌ Failed to unpublish: ${error.message}`);
-      } finally {
-        setPublishing(false);
-      }
+    const ok = await confirmDialog({
+      title: 'Unpublish this workflow?',
+      content: 'It will be removed from the catalog.',
+      okText: 'Unpublish',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+    if (!ok) return;
+
+    try {
+      setPublishing(true);
+      await adminClient.post(
+        `/admin/system-config/api/studio/versions/${blueprintId}/unpublish/`,
+        {},
+        {
+          headers: csrfToken
+            ? {
+                'X-CSRFToken': csrfToken,
+                'Content-Type': 'application/json',
+              }
+            : undefined,
+        }
+      );
+      setIsPublished(false);
+      showAlert({
+        title: 'Unpublished',
+        content: 'Workflow unpublished successfully.',
+        type: 'success',
+      });
+    } catch (error: any) {
+      console.error('Error unpublishing:', error);
+      showAlert({
+        title: 'Unpublish failed',
+        content: error?.message ?? 'Failed to unpublish workflow.',
+        type: 'error',
+      });
+    } finally {
+      setPublishing(false);
     }
   };
 
@@ -242,7 +272,11 @@ const Editor: React.FC<EditorProps> = () => {
               window.location.href = `/admin/system-config/studio/${versionId}/`;
             }}
             onRollback={(newVersionId) => {
-              alert('Rolled back successfully! Redirecting to new version...');
+              showAlert({
+                title: 'Rolled back',
+                content: 'Rollback succeeded. Redirecting to the new version...',
+                type: 'success',
+              });
               window.location.href = `/admin/system-config/studio/${newVersionId}/`;
             }}
           />

--- a/frontend/src/components/Admin/ChoiceListEditor.tsx
+++ b/frontend/src/components/Admin/ChoiceListEditor.tsx
@@ -42,6 +42,7 @@ import {
   X,
 } from 'lucide-react';
 import { apiClient } from '@/services/apiService';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 interface ChoiceItem {
   id: string;
@@ -303,7 +304,15 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
   };
 
   const handleDeleteItem = async (item: ChoiceItem) => {
-    if (!confirm(`Delete "${item.label}"?`)) return;
+    const confirmed = await confirmDialog({
+      title: 'Delete item?',
+      content: `Delete "${item.label}"?`,
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/system/choice-items/${item.id}/`);

--- a/frontend/src/components/Admin/SystemChoiceManager.tsx
+++ b/frontend/src/components/Admin/SystemChoiceManager.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import { apiClient } from '../../services/apiService';
 import Modal from '../Modal/Modal';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -179,7 +180,15 @@ export const SystemChoiceManager: React.FC<SystemChoiceManagerProps> = ({
    * Delete choice list
    */
   const handleDeleteList = useCallback(async (listId: string) => {
-    if (!confirm('Are you sure you want to delete this choice list?')) return;
+    const confirmed = await confirmDialog({
+      title: 'Delete choice list?',
+      content: 'Are you sure you want to delete this choice list?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/system/choice-lists/${listId}/`);
@@ -224,7 +233,15 @@ export const SystemChoiceManager: React.FC<SystemChoiceManagerProps> = ({
    * Delete item
    */
   const handleDeleteItem = useCallback(async (itemId: string) => {
-    if (!confirm('Are you sure you want to delete this item?')) return;
+    const confirmed = await confirmDialog({
+      title: 'Delete item?',
+      content: 'Are you sure you want to delete this item?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/system/choice-items/${itemId}/`);

--- a/frontend/src/components/Admin/VirtualFieldManager.tsx
+++ b/frontend/src/components/Admin/VirtualFieldManager.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { apiClient } from '../../services/apiService';
 import Modal from '../Modal/Modal';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -153,7 +154,7 @@ export const VirtualFieldManager: React.FC<VirtualFieldManagerProps> = ({
       setEditingField(null);
     } catch (error) {
       console.error('[VirtualFieldManager] Failed to save field:', error);
-      alert('Failed to save field');
+      showAlert({ type: 'error', title: 'Error', content: 'Failed to save field' });
     }
   }, [editingField, tenantId, selectedModel, loadFields]);
 
@@ -161,7 +162,15 @@ export const VirtualFieldManager: React.FC<VirtualFieldManagerProps> = ({
    * Delete field
    */
   const handleDeleteField = useCallback(async (fieldId: string) => {
-    if (!confirm('Are you sure you want to delete this field?')) return;
+    const confirmed = await confirmDialog({
+      title: 'Delete field?',
+      content: 'Are you sure you want to delete this field?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/system/field-schemas/${fieldId}/`);

--- a/frontend/src/components/FlowEditor/ConfigPanel/CreateRecordConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/CreateRecordConfigPanel.tsx
@@ -24,6 +24,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Save, X, AlertCircle } from 'lucide-react';
+import { confirmDialog } from '@/utils/uiDialogs';
 import { Node, Edge } from '@xyflow/react';
 import { FieldMappingPanel, FieldMapping } from './FieldMappingPanel';
 import { InsertVariableButton } from './InsertVariableButton';
@@ -147,13 +148,22 @@ export const CreateRecordConfigPanel: React.FC<CreateRecordConfigPanelProps> = (
   };
 
   const handleClose = () => {
-    if (hasUnsavedChanges) {
-      if (window.confirm('You have unsaved changes. Are you sure you want to close?')) {
+    void (async () => {
+      if (hasUnsavedChanges) {
+        const confirmed = await confirmDialog({
+          title: 'Discard changes?',
+          content: 'You have unsaved changes. Are you sure you want to close?',
+          okText: 'Discard',
+          cancelText: 'Keep editing',
+          danger: true,
+        });
+        if (confirmed) {
+          onClose();
+        }
+      } else {
         onClose();
       }
-    } else {
-      onClose();
-    }
+    })();
   };
 
   return (

--- a/frontend/src/components/FlowEditor/ConfigPanel/FieldMappingPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FieldMappingPanel.tsx
@@ -16,6 +16,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { showAlert } from '@/utils/uiDialogs';
 import { 
   Link, Unlink, ArrowRight, AlertCircle, CheckCircle, 
   ChevronDown, ChevronUp, Zap
@@ -599,7 +600,11 @@ export const FieldMappingPanel: React.FC<FieldMappingPanelProps> = ({
             onClick={() => {
               const count = autoSuggestMappings();
               if (count === 0) {
-                alert('No good matches found. Try mapping fields manually.');
+                showAlert({
+                  type: 'info',
+                  title: 'No matches',
+                  content: 'No good matches found. Try mapping fields manually.',
+                });
               }
             }}
             style={{ display: 'flex', alignItems: 'center', gap: '6px' }}

--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanel.tsx
@@ -18,6 +18,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
+import { confirmDialog } from '@/utils/uiDialogs';
 import * as Sentry from '@sentry/react';
 import { X, HelpCircle, Play, Save, AlertCircle, Plus, Trash2, Edit2, Check, GripVertical, Download } from 'lucide-react';
 import { Node, Edge } from '@xyflow/react';
@@ -672,14 +673,23 @@ export const NodeConfigPanel: React.FC<NodeConfigPanelProps> = ({
   };
 
   const handleClose = () => {
-    if (hasUnsavedChanges) {
-      if (window.confirm('You have unsaved changes. Close anyway?')) {
-        setHasUnsavedChanges(false);
+    void (async () => {
+      if (hasUnsavedChanges) {
+        const confirmed = await confirmDialog({
+          title: 'Discard changes?',
+          content: 'You have unsaved changes. Close anyway?',
+          okText: 'Discard',
+          cancelText: 'Keep editing',
+          danger: true,
+        });
+        if (confirmed) {
+          setHasUnsavedChanges(false);
+          onClose();
+        }
+      } else {
         onClose();
       }
-    } else {
-      onClose();
-    }
+    })();
   };
 
   // ============================================================================

--- a/frontend/src/components/FlowEditor/ConfigPanel/StepManagerPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/StepManagerPanel.tsx
@@ -30,6 +30,7 @@ import {
 } from 'lucide-react';
 import { Node, Edge } from '@xyflow/react';
 import { calculateStepOrder } from '../utils/stepOrderingUtils';
+import { confirmDialog } from '@/utils/uiDialogs';
 import {
   EmptyState,
   EmptyIcon,
@@ -347,13 +348,19 @@ export const StepManagerPanel: React.FC<StepManagerPanelProps> = ({
 
   // Handle delete with confirmation
   const handleDelete = useCallback((stepId: string, stepLabel: string) => {
-    const confirmed = window.confirm(
-      `Are you sure you want to delete "${stepLabel}"?\n\nThis will remove the step and all its connections.`
-    );
-    
-    if (confirmed) {
-      onDeleteNode(stepId);
-    }
+    void (async () => {
+      const confirmed = await confirmDialog({
+        title: 'Delete step?',
+        content: `Are you sure you want to delete "${stepLabel}"?\n\nThis will remove the step and all its connections.`,
+        okText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      });
+
+      if (confirmed) {
+        onDeleteNode(stepId);
+      }
+    })();
   }, [onDeleteNode]);
 
   return (

--- a/frontend/src/components/FlowEditor/ConfigPanel/SubFlowLibraryDialog.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/SubFlowLibraryDialog.tsx
@@ -10,6 +10,7 @@
 
 import React, { useState, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
+import { confirmDialog, promptDialog, showAlert } from '@/utils/uiDialogs';
 import { Search, X, Download, Upload, Trash2, Copy, FileText, Tag } from 'lucide-react';
 import { PanelFooter, PrimaryButton, SecondaryButton } from './shared/StyledComponents';
 import {
@@ -299,21 +300,37 @@ export const SubFlowLibraryDialog: React.FC<SubFlowLibraryDialogProps> = ({
     onClose();
   }, [onSelectTemplate, onClose]);
 
-  const handleDelete = useCallback((templateId: string, event: React.MouseEvent) => {
+  const handleDelete = useCallback(async (templateId: string, event: React.MouseEvent) => {
     event.stopPropagation();
-    if (confirm('Are you sure you want to delete this template?')) {
-      deleteTemplate(templateId);
-      setTemplates(getAllTemplates());
-    }
+
+    const confirmed = await confirmDialog({
+      title: 'Delete template?',
+      content: 'Are you sure you want to delete this template?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
+
+    deleteTemplate(templateId);
+    setTemplates(getAllTemplates());
   }, []);
 
-  const handleDuplicate = useCallback((templateId: string, templateName: string, event: React.MouseEvent) => {
+  const handleDuplicate = useCallback(async (templateId: string, templateName: string, event: React.MouseEvent) => {
     event.stopPropagation();
-    const newName = prompt('Enter name for duplicate:', `${templateName} (Copy)`);
-    if (newName) {
-      duplicateTemplate(templateId, newName);
-      setTemplates(getAllTemplates());
-    }
+
+    const newName = await promptDialog({
+      title: 'Duplicate template',
+      defaultValue: `${templateName} (Copy)`,
+      placeholder: 'New template name',
+      okText: 'Duplicate',
+    });
+
+    if (!newName?.trim()) return;
+
+    duplicateTemplate(templateId, newName.trim());
+    setTemplates(getAllTemplates());
   }, []);
 
   const handleExport = useCallback((template: SubFlowTemplate, event: React.MouseEvent) => {
@@ -342,7 +359,11 @@ export const SubFlowLibraryDialog: React.FC<SubFlowLibraryDialogProps> = ({
         saveTemplate(template);
         setTemplates(getAllTemplates());
       } catch (error) {
-        alert('Failed to import template: ' + (error as Error).message);
+        showAlert({
+          type: 'error',
+          title: 'Import failed',
+          content: 'Failed to import template: ' + (error as Error).message,
+        });
       }
     };
     input.click();

--- a/frontend/src/components/FlowEditor/ConfigPanel/ValidationRuleBuilder.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/ValidationRuleBuilder.tsx
@@ -14,6 +14,7 @@
  */
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { showAlert } from '@/utils/uiDialogs';
 import { Plus, Trash2, Edit2, AlertCircle } from 'lucide-react';
 import {
   FormField,
@@ -442,7 +443,11 @@ export const ValidationRuleBuilder: React.FC<ValidationRuleBuilderProps> = ({
     
     // Validate required value
     if (ruleDefinition.requiresValue && !formData.value) {
-      alert('Please provide a value for this rule');
+      showAlert({
+        type: 'warning',
+        title: 'Validation',
+        content: 'Please provide a value for this rule',
+      });
       return;
     }
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/VisualFormBuilderPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VisualFormBuilderPanel.tsx
@@ -16,6 +16,7 @@
 
 import React, { useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
+import { confirmDialog } from '@/utils/uiDialogs';
 import { 
   Plus, 
   Trash2, 
@@ -606,9 +607,19 @@ export const VisualFormBuilderPanel: React.FC<VisualFormBuilderPanelProps> = ({
   }, [fields, onChange]);
   
   const handleDeleteField = useCallback((fieldId: string) => {
-    if (confirm('Delete this field?')) {
-      onChange(fields.filter(f => f.id !== fieldId));
-    }
+    void (async () => {
+      const confirmed = await confirmDialog({
+        title: 'Delete field?',
+        content: 'Delete this field?',
+        okText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      });
+
+      if (confirmed) {
+        onChange(fields.filter(f => f.id !== fieldId));
+      }
+    })();
   }, [fields, onChange]);
   
   return (

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -33,6 +33,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import { debounce } from 'lodash';
+import { showAlert } from '@/utils/uiDialogs';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { adminClient } from '../../services/apiService';
 import toast, { Toaster } from 'react-hot-toast'; // Phase 8.1
@@ -5980,7 +5981,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     logger.debug(`[Phase 6] Migration complete: ${nodesToMigrate.length} nodes migrated`);
     
     // Show success message
-    alert(`Successfully migrated ${nodesToMigrate.length} deprecated node(s) to modern format!\n\nPlease review the migrated nodes and save your workflow.`);
+    showAlert({
+      type: 'success',
+      title: 'Migration complete',
+      content: `Successfully migrated ${nodesToMigrate.length} deprecated node(s) to modern format!\n\nPlease review the migrated nodes and save your workflow.`,
+    });
   }, [nodes, setNodes]);
 
   // ============================================================================

--- a/frontend/src/components/FormSubmission/RichTextField.tsx
+++ b/frontend/src/components/FormSubmission/RichTextField.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useRef, useCallback } from 'react';
 import styled from 'styled-components';
+import { promptDialog } from '@/utils/uiDialogs';
 
 const RichTextContainer = styled.div<{ $hasError?: boolean }>`
   border: 1px solid ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
@@ -191,10 +192,17 @@ export const RichTextField: React.FC<RichTextFieldProps> = ({
   }, [execCommand]);
 
   const insertLink = useCallback(() => {
-    const url = prompt('Enter URL:');
-    if (url) {
-      execCommand('createLink', url);
-    }
+    void (async () => {
+      const url = await promptDialog({
+        title: 'Insert link',
+        placeholder: 'https://',
+        okText: 'Insert',
+      });
+
+      if (url?.trim()) {
+        execCommand('createLink', url.trim());
+      }
+    })();
   }, [execCommand]);
 
   const getCharCount = () => {

--- a/frontend/src/components/Inquiry/CloneInquiryModal.tsx
+++ b/frontend/src/components/Inquiry/CloneInquiryModal.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
+import { showAlert } from '@/utils/uiDialogs';
 import { Inquiry } from '../../types';
 
 // ============================================================================
@@ -301,7 +302,11 @@ export const CloneInquiryModal: React.FC<CloneInquiryModalProps> = ({
       onClose();
     } catch (error) {
       console.error('Failed to clone inquiry:', error);
-      alert('Failed to clone inquiry');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to clone inquiry',
+      });
     } finally {
       setCloning(false);
     }

--- a/frontend/src/components/Inquiry/InquiryTemplateModal.tsx
+++ b/frontend/src/components/Inquiry/InquiryTemplateModal.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { Select as AntSelect } from 'antd';
+import { showAlert } from '@/utils/uiDialogs';
 import { businessApi } from '../../services/businessApi';
 import { InquiryTemplate, InquiryEntityType } from '../../types';
 import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
@@ -416,7 +417,11 @@ export const InquiryTemplateModal: React.FC<InquiryTemplateModalProps> = ({
   
   const handleSave = async () => {
     if (!name.trim()) {
-      alert('Template name is required');
+      showAlert({
+        type: 'warning',
+        title: 'Validation',
+        content: 'Template name is required',
+      });
       return;
     }
     
@@ -450,7 +455,11 @@ export const InquiryTemplateModal: React.FC<InquiryTemplateModalProps> = ({
       onClose();
     } catch (error) {
       console.error('Failed to save template:', error);
-      alert('Failed to save template');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to save template',
+      });
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/Integrations/IntegrationsSection.tsx
+++ b/frontend/src/components/Integrations/IntegrationsSection.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import styled from 'styled-components';
 import { apiClient } from '../../services/apiService'; // FIX: Use authenticated client
 import { toast } from 'react-hot-toast';
+import { confirmDialog } from '@/utils/uiDialogs';
 import { Trash2, RefreshCw } from 'lucide-react';
 import { EmailConnection } from './EmailConnection';
 import { IngestionMonitor } from './IngestionMonitor';
@@ -62,9 +63,13 @@ export const IntegrationsSection: React.FC = () => {
   }, [loadConnections]);
 
   const handleDisconnect = async (provider: string) => {
-    const confirmed = window.confirm(
-      `Are you sure you want to disconnect ${provider}?`
-    );
+    const confirmed = await confirmDialog({
+      title: 'Disconnect integration?',
+      content: `Are you sure you want to disconnect ${provider}?`,
+      okText: 'Disconnect',
+      cancelText: 'Cancel',
+      danger: true,
+    });
     if (!confirmed) return;
 
     setIsDisconnecting(provider);

--- a/frontend/src/components/Widgets/EmailIntegrationWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIntegrationWidget.tsx
@@ -11,6 +11,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Mail, CheckCircle, AlertTriangle, XCircle, Plus, Trash2, RefreshCw } from 'lucide-react';
 import { apiClient } from '../../services/apiService';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -351,21 +352,35 @@ export const EmailIntegrationWidget: React.FC<EmailIntegrationWidgetProps> = ({ 
       }
     } catch (err: any) {
       console.error('Failed to initiate OAuth connection:', err);
-      alert(err.response?.data?.error || 'Failed to initiate connection. Please try again.');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: err.response?.data?.error || 'Failed to initiate connection. Please try again.',
+      });
     }
   };
 
   const handleDisconnect = async (accountId: number) => {
-    if (!confirm('Are you sure you want to disconnect this email account?')) {
-      return;
-    }
+    const confirmed = await confirmDialog({
+      title: 'Disconnect email account?',
+      content: 'Are you sure you want to disconnect this email account?',
+      okText: 'Disconnect',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/workflows/email-accounts/${accountId}/`);
       setAccounts(accounts.filter(acc => acc.id !== accountId));
     } catch (err: any) {
       console.error('Failed to disconnect account:', err);
-      alert(err.response?.data?.message || 'Failed to disconnect account');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: err.response?.data?.message || 'Failed to disconnect account',
+      });
     }
   };
 

--- a/frontend/src/components/form-builder/FieldConfigModal.tsx
+++ b/frontend/src/components/form-builder/FieldConfigModal.tsx
@@ -10,6 +10,7 @@
 
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { showAlert } from '@/utils/uiDialogs';
 import { X, Save, Sparkles, TrendingUp } from 'lucide-react';
 import { FormField, FieldType, ValidationType, AutoPopulateSuggestion } from './types';
 import { useFormBuilderStore } from './store';
@@ -407,7 +408,7 @@ export const FieldConfigModal: React.FC = () => {
   const handleSave = () => {
     if (!activeStepId) return;
     if (!fieldData.label.trim()) {
-      alert('Field label is required');
+      showAlert({ type: 'warning', title: 'Validation', content: 'Field label is required' });
       return;
     }
     

--- a/frontend/src/components/form-builder/FormBuilder.tsx
+++ b/frontend/src/components/form-builder/FormBuilder.tsx
@@ -10,6 +10,7 @@
 
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
+import { confirmDialog } from '@/utils/uiDialogs';
 import { X, Save, Eye, Settings as SettingsIcon, Layers } from 'lucide-react';
 import { useFormBuilderStore } from './store';
 import { StepCard } from './StepCard';
@@ -318,11 +319,19 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
   
   // Handle close with unsaved changes
   const handleClose = () => {
-    if (isDirty) {
-      const confirmed = window.confirm('You have unsaved changes. Are you sure you want to close?');
-      if (!confirmed) return;
-    }
-    onClose();
+    void (async () => {
+      if (isDirty) {
+        const confirmed = await confirmDialog({
+          title: 'Discard changes?',
+          content: 'You have unsaved changes. Are you sure you want to close?',
+          okText: 'Discard',
+          cancelText: 'Keep editing',
+          danger: true,
+        });
+        if (!confirmed) return;
+      }
+      onClose();
+    })();
   };
   
   // Render tab content

--- a/frontend/src/components/form-builder/RuleBuilderModal.tsx
+++ b/frontend/src/components/form-builder/RuleBuilderModal.tsx
@@ -10,6 +10,7 @@
 
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { showAlert } from '@/utils/uiDialogs';
 import { X, Save, Plus, Trash2 } from 'lucide-react';
 import { FormRule, RuleCondition, RuleAction, RuleOperator, RuleActionType } from './types';
 import { useFormBuilderStore } from './store';
@@ -238,7 +239,7 @@ export const RuleBuilderModal: React.FC = () => {
   
   const handleSave = () => {
     if (!activeStepId || !ruleData.name.trim()) {
-      alert('Rule name is required');
+      showAlert({ type: 'warning', title: 'Validation', content: 'Rule name is required' });
       return;
     }
     saveRule(activeStepId, ruleData);

--- a/frontend/src/components/form-builder/StepCard.tsx
+++ b/frontend/src/components/form-builder/StepCard.tsx
@@ -10,6 +10,7 @@
 
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { confirmDialog } from '@/utils/uiDialogs';
 import { ChevronDown, ChevronRight, GripVertical, Plus, Edit2, Trash2, Settings, Wand2 } from 'lucide-react';
 import { FormStep } from './types';
 import { useFormBuilderStore } from './store';
@@ -245,18 +246,34 @@ export const StepCard: React.FC<StepCardProps> = ({ step }) => {
   };
   
   const handleRemoveStep = () => {
-    const confirmed = window.confirm(`Delete "${step.name}"? This cannot be undone.`);
-    if (confirmed) {
-      removeStep(step.id);
-    }
+    void (async () => {
+      const confirmed = await confirmDialog({
+        title: 'Delete step?',
+        content: `Delete "${step.name}"? This cannot be undone.`,
+        okText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      });
+      if (confirmed) {
+        removeStep(step.id);
+      }
+    })();
   };
   
   const handleRemoveField = (fieldId: string) => {
-    const field = step.fields.find(f => f.id === fieldId);
-    const confirmed = window.confirm(`Delete field "${field?.label}"?`);
-    if (confirmed) {
-      removeField(step.id, fieldId);
-    }
+    void (async () => {
+      const field = step.fields.find(f => f.id === fieldId);
+      const confirmed = await confirmDialog({
+        title: 'Delete field?',
+        content: `Delete field "${field?.label}"?`,
+        okText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      });
+      if (confirmed) {
+        removeField(step.id, fieldId);
+      }
+    })();
   };
   
   return (

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -5,6 +5,7 @@
  * Handles loading, caching, and updating user's quick actions.
  */
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { showAlert } from '@/utils/uiDialogs';
 import {
   quickActionsService,
   formSubmissionService,
@@ -173,7 +174,11 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
       const errorMsg = err?.response?.data?.error || err?.message || 'Failed to start form';
       setError(errorMsg);
       // Alert the user since the modal won't open
-      alert(`Error: ${errorMsg}`);
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: errorMsg,
+      });
     }
   }, [startFormSubmission]);
 

--- a/frontend/src/pages/Accounting/Claims.tsx
+++ b/frontend/src/pages/Accounting/Claims.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { showAlert } from '@/utils/uiDialogs';
 import { ActivityFeed, EntityFormSurface } from '../../components/Shared';
 import { apiClient } from '../../services/apiService';
 import { formatCurrency } from '../../shared/utils';
@@ -510,7 +511,11 @@ export const Claims: React.FC = () => {
       setSelectedClaim(response.data);
     } catch (err: any) {
       console.error('Failed to update claim status:', err);
-      alert('Failed to update claim status');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to update claim status',
+      });
     }
   };
 

--- a/frontend/src/pages/AccountsReceivables.tsx
+++ b/frontend/src/pages/AccountsReceivables.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import { apiService, Invoice } from '../services/apiService';
 
 // Styled Components
@@ -377,7 +378,11 @@ const AccountsReceivables: React.FC = () => {
         } : 'No response data'
       });
       // Display user-friendly error to the UI
-      alert(`Failed to save invoice: ${err.message || 'Please try again later'}`);
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Failed to save invoice: ${err.message || 'Please try again later'}`,
+      });
     }
   };
 
@@ -394,21 +399,37 @@ const AccountsReceivables: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
-    if (window.confirm('Are you sure you want to delete this invoice?')) {
-      try {
-        await apiService.deleteInvoice(id);
-        alert('Invoice deleted successfully!');
-        await loadReceivables(); // Re-fetch to update the list
-      } catch (error: unknown) {
-        // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
-        console.error('Error deleting accounts receivable:', error);
-        const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
-        const errorMessage = err?.response?.data?.detail 
-          || err?.response?.data?.message 
-          || err?.message 
-          || 'Failed to delete accounts receivable';
-        alert(`Error: ${errorMessage}`);
-      }
+    const confirmed = await confirmDialog({
+      title: 'Delete invoice?',
+      content: 'Are you sure you want to delete this invoice?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
+
+    try {
+      await apiService.deleteInvoice(id);
+      showAlert({
+        type: 'success',
+        title: 'Deleted',
+        content: 'Invoice deleted successfully.',
+      });
+      await loadReceivables(); // Re-fetch to update the list
+    } catch (error: unknown) {
+      // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
+      console.error('Error deleting accounts receivable:', error);
+      const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
+      const errorMessage = err?.response?.data?.detail
+        || err?.response?.data?.message
+        || err?.message
+        || 'Failed to delete accounts receivable';
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Error: ${errorMessage}`,
+      });
     }
   };
 

--- a/frontend/src/pages/Admin/Configurations/index.tsx
+++ b/frontend/src/pages/Admin/Configurations/index.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/Button';
 import { useToast } from '@/hooks/useToast';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 import { captureSentryException } from '@/utils/sentry';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 interface Configuration {
   id: string;
@@ -317,9 +318,15 @@ const ConfigurationsPage: React.FC = () => {
       return;
     }
 
-    if (!window.confirm(`Delete configuration "${config.display_name}"?`)) {
-      return;
-    }
+    const confirmed = await confirmDialog({
+      title: 'Delete configuration?',
+      content: `Delete configuration "${config.display_name}"?`,
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/configurations/${config.id}/`);

--- a/frontend/src/pages/Admin/OptionLists/OptionListModal.tsx
+++ b/frontend/src/pages/Admin/OptionLists/OptionListModal.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { X, Plus, Save, Trash2, ChevronUp, ChevronDown, Lock, Globe, Building } from 'lucide-react';
 import Modal from '@/components/Modal/Modal';
 import { apiClient } from '@/services/apiService';
+import { confirmDialog } from '@/utils/uiDialogs';
 import { useToast } from '@/hooks/useToast';
 
 // ============================================================================
@@ -426,9 +427,15 @@ export const OptionListModal: React.FC<OptionListModalProps> = ({
   const handleDeleteItem = async (id: string) => {
     if (!isExtensible) return;
 
-    if (!window.confirm('Are you sure you want to delete this item?')) {
-      return;
-    }
+    const confirmed = await confirmDialog({
+      title: 'Delete item?',
+      content: 'Are you sure you want to delete this item?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
 
     // If it's a new item (not saved yet), just remove from local state
     if (id.startsWith('temp-')) {
@@ -526,13 +533,22 @@ export const OptionListModal: React.FC<OptionListModalProps> = ({
   };
 
   const handleClose = () => {
-    if (hasChanges) {
-      if (window.confirm('You have unsaved changes. Discard them?')) {
+    void (async () => {
+      if (hasChanges) {
+        const confirmed = await confirmDialog({
+          title: 'Discard changes?',
+          content: 'You have unsaved changes. Discard them?',
+          okText: 'Discard',
+          cancelText: 'Keep editing',
+          danger: true,
+        });
+        if (confirmed) {
+          onClose();
+        }
+      } else {
         onClose();
       }
-    } else {
-      onClose();
-    }
+    })();
   };
 
   return (

--- a/frontend/src/pages/Cockpit/CallLog.tsx
+++ b/frontend/src/pages/Cockpit/CallLog.tsx
@@ -19,6 +19,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Calendar, Badge, Segmented } from 'antd';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 import dayjs, { Dayjs } from 'dayjs';
 import { ActivityFeed } from '../../components/Shared/ActivityFeed';
@@ -743,7 +744,11 @@ export const CallLog: React.FC = () => {
       ));
     } catch (err: any) {
       console.error('Failed to complete call:', err);
-      alert('Failed to mark call as completed');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to mark call as completed',
+      });
     }
   };
 
@@ -773,17 +778,27 @@ export const CallLog: React.FC = () => {
 
   const handleDeleteCall = async (callId: number, e: React.MouseEvent) => {
     e.stopPropagation();
-    
-    if (!window.confirm('Are you sure you want to delete this scheduled call?')) {
-      return;
-    }
-    
+
+    const confirmed = await confirmDialog({
+      title: 'Delete scheduled call?',
+      content: 'Are you sure you want to delete this scheduled call?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
+
     try {
       await businessApi.delete(`/workspace/scheduled-calls/${callId}/`);
       await fetchScheduledCalls();
     } catch (err: any) {
       console.error('Failed to delete call:', err);
-      alert('Failed to delete call. Please try again.');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to delete call. Please try again.',
+      });
     }
   };
 
@@ -905,7 +920,11 @@ export const CallLog: React.FC = () => {
       setDraggedCall(null);
     } catch (err: any) {
       console.error('Failed to reschedule call:', err);
-      alert('Failed to reschedule call. Please try again.');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to reschedule call. Please try again.',
+      });
       setDraggedCall(null);
     }
   };

--- a/frontend/src/pages/Contacts.tsx
+++ b/frontend/src/pages/Contacts.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import { apiService, Contact } from '../services/apiService';
 import { apiClient } from '../services/apiService';
 import { PhoneInput } from '../components/ui/PhoneInput';
@@ -408,7 +409,7 @@ const Contacts: React.FC = () => {
     e.preventDefault();
 
     if (formData.email?.trim() && !isValidEmail(formData.email.trim())) {
-      alert('Please enter a valid email address');
+      showAlert({ type: 'warning', title: 'Validation', content: 'Please enter a valid email address' });
       return;
     }
 
@@ -446,7 +447,11 @@ const Contacts: React.FC = () => {
         } : 'No response data'
       });
       // Display user-friendly error to the UI
-      alert(`Failed to save contact: ${err.message || 'Please try again later'}`);
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Failed to save contact: ${err.message || 'Please try again later'}`,
+      });
     }
   };
 
@@ -473,21 +478,37 @@ const Contacts: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
-    if (window.confirm('Are you sure you want to delete this contact?')) {
-      try {
-        await apiService.deleteContact(id);
-        alert('Contact deleted successfully!');
-        await loadContacts(); // Re-fetch to update the list
-      } catch (error: unknown) {
-        // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
-        console.error('Error deleting contact:', error);
-        const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
-        const errorMessage = err?.response?.data?.detail 
-          || err?.response?.data?.message 
-          || err?.message 
-          || 'Failed to delete contact';
-        alert(`Error: ${errorMessage}`);
-      }
+    const confirmed = await confirmDialog({
+      title: 'Delete contact?',
+      content: 'Are you sure you want to delete this contact?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
+
+    try {
+      await apiService.deleteContact(id);
+      showAlert({
+        type: 'success',
+        title: 'Deleted',
+        content: 'Contact deleted successfully.',
+      });
+      await loadContacts(); // Re-fetch to update the list
+    } catch (error: unknown) {
+      // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
+      console.error('Error deleting contact:', error);
+      const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
+      const errorMessage = err?.response?.data?.detail
+        || err?.response?.data?.message
+        || err?.message
+        || 'Failed to delete contact';
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Error: ${errorMessage}`,
+      });
     }
   };
 

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -8,6 +8,7 @@ import { apiService, Customer, apiClient } from '../services/apiService';
 import { CountrySelect, PhoneInput, Select, StateSelect } from '../components/ui';
 import { MultiSelect } from '../components/Shared';
 import { INDUSTRY_CHOICES, PROTEIN_TYPE_CHOICES } from '../utils/constants/choices';
+import { confirmDialog, showAlert } from '../utils/uiDialogs';
 
 interface CustomerLocation {
   id: number;
@@ -243,12 +244,20 @@ const Customers: React.FC = () => {
     if (!selectedCustomerId) return;
 
     if (!locationForm.name.trim()) {
-      alert('Location name is required');
+      showAlert({
+        type: 'warning',
+        title: 'Validation',
+        content: 'Location name is required',
+      });
       return;
     }
 
     if (locationForm.email?.trim() && !isValidEmail(locationForm.email.trim())) {
-      alert('Please enter a valid email address for the location');
+      showAlert({
+        type: 'warning',
+        title: 'Validation',
+        content: 'Please enter a valid email address for the location',
+      });
       return;
     }
 
@@ -270,7 +279,11 @@ const Customers: React.FC = () => {
       await loadCustomerLocations(selectedCustomerId);
     } catch (error) {
       console.error('[Customers] Failed to create location:', error);
-      alert('Failed to create location');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to create location',
+      });
     }
   };
 
@@ -291,7 +304,11 @@ const Customers: React.FC = () => {
     e.preventDefault();
 
     if (formData.email?.trim() && !isValidEmail(formData.email.trim())) {
-      alert('Please enter a valid email address');
+      showAlert({
+        type: 'warning',
+        title: 'Validation',
+        content: 'Please enter a valid email address',
+      });
       return;
     }
 
@@ -323,7 +340,11 @@ const Customers: React.FC = () => {
         } : 'No response data'
       });
       // Display user-friendly error to the UI
-      alert(`Failed to save customer: ${err.message || 'Please try again later'}`);
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Failed to save customer: ${err.message || 'Please try again later'}`,
+      });
     }
   };
 
@@ -348,21 +369,37 @@ const Customers: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
-    if (window.confirm('Are you sure you want to delete this customer?')) {
-      try {
-        await apiService.deleteCustomer(id);
-        alert('Customer deleted successfully!');
-        await fetchCustomers(); // Re-fetch to update the list
-      } catch (error: unknown) {
-        // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
-        console.error('Error deleting customer:', error);
-        const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
-        const errorMessage = err?.response?.data?.detail 
-          || err?.response?.data?.message 
-          || err?.message 
-          || 'Failed to delete customer';
-        alert(`Error: ${errorMessage}`);
-      }
+    const confirmed = await confirmDialog({
+      title: 'Delete customer?',
+      content: 'Are you sure you want to delete this customer?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
+
+    try {
+      await apiService.deleteCustomer(id);
+      showAlert({
+        type: 'success',
+        title: 'Deleted',
+        content: 'Customer deleted successfully.',
+      });
+      await fetchCustomers(); // Re-fetch to update the list
+    } catch (error: unknown) {
+      // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
+      console.error('Error deleting customer:', error);
+      const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
+      const errorMessage = err?.response?.data?.detail
+        || err?.response?.data?.message
+        || err?.message
+        || 'Failed to delete customer';
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Error: ${errorMessage}`,
+      });
     }
   };
 

--- a/frontend/src/pages/Inquiries.tsx
+++ b/frontend/src/pages/Inquiries.tsx
@@ -14,6 +14,7 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { showAlert } from '@/utils/uiDialogs';
 import { apiClient } from '../services/apiService';
 import { InquiryListItem, InquiryStatus, InquiryTemplateListItem } from '../types';
 import { InquiryDetailModal, CloneInquiryModal, InquiryCreateModal } from '../components/Inquiry';
@@ -486,7 +487,11 @@ const Inquiries: React.FC = () => {
       fetchInquiries();
     } catch (err) {
       console.error('Failed to create inquiry from template:', err);
-      alert('Failed to create inquiry from template');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to create inquiry from template',
+      });
     }
   };
 

--- a/frontend/src/pages/InquiryTemplates.tsx
+++ b/frontend/src/pages/InquiryTemplates.tsx
@@ -5,6 +5,7 @@
  */
 import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import { apiClient } from '../services/apiService';
 import { InquiryTemplate, InquiryEntityType } from '../types';
 import { InquiryTemplateModal } from '../components/Inquiry';
@@ -290,16 +291,22 @@ const InquiryTemplates: React.FC = () => {
   };
   
   const handleDeleteClick = async (template: InquiryTemplate) => {
-    if (!window.confirm(`Delete template "${template.name}"? This cannot be undone.`)) {
-      return;
-    }
-    
+    const confirmed = await confirmDialog({
+      title: 'Delete template?',
+      content: `Delete template "${template.name}"? This cannot be undone.`,
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
+
     try {
       await apiClient.delete(`/api/v1/inquiry-templates/${template.id}/`);
       setTemplates(prev => prev.filter(t => t.id !== template.id));
     } catch (error) {
       console.error('Failed to delete template:', error);
-      alert('Failed to delete template');
+      showAlert({ type: 'error', title: 'Error', content: 'Failed to delete template' });
     }
   };
   
@@ -313,7 +320,7 @@ const InquiryTemplates: React.FC = () => {
       ));
     } catch (error) {
       console.error('Failed to update template:', error);
-      alert('Failed to update template');
+      showAlert({ type: 'error', title: 'Error', content: 'Failed to update template' });
     }
   };
   

--- a/frontend/src/pages/MySubmissions/index.tsx
+++ b/frontend/src/pages/MySubmissions/index.tsx
@@ -5,6 +5,7 @@
  */
 import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import { formSubmissionService, FormSubmissionListItem } from '../../services/quickActionsService';
 import { useQuickActions } from '../../contexts/QuickActionsContext';
 
@@ -301,7 +302,13 @@ const MySubmissions: React.FC = () => {
   }, [openFormModal]);
 
   const handleCancel = useCallback(async (submissionId: string) => {
-    const confirmed = window.confirm('Are you sure you want to cancel this submission?');
+    const confirmed = await confirmDialog({
+      title: 'Cancel submission?',
+      content: 'Are you sure you want to cancel this submission?',
+      okText: 'Cancel submission',
+      cancelText: 'Keep',
+      danger: true,
+    });
     if (!confirmed) return;
 
     try {
@@ -309,12 +316,22 @@ const MySubmissions: React.FC = () => {
       loadSubmissions();
     } catch (err: any) {
       console.error('Failed to cancel submission:', err);
-      alert(err.message || 'Failed to cancel submission');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: err.message || 'Failed to cancel submission',
+      });
     }
   }, [loadSubmissions]);
 
   const handleDelete = useCallback(async (submissionId: string) => {
-    const confirmed = window.confirm('Are you sure you want to delete this submission? This cannot be undone.');
+    const confirmed = await confirmDialog({
+      title: 'Delete submission?',
+      content: 'Are you sure you want to delete this submission? This cannot be undone.',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
     if (!confirmed) return;
 
     try {
@@ -322,7 +339,11 @@ const MySubmissions: React.FC = () => {
       loadSubmissions();
     } catch (err: any) {
       console.error('Failed to delete submission:', err);
-      alert(err.message || 'Failed to delete submission');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: err.message || 'Failed to delete submission',
+      });
     }
   }, [loadSubmissions]);
 

--- a/frontend/src/pages/MyTasks/MyTasks.tsx
+++ b/frontend/src/pages/MyTasks/MyTasks.tsx
@@ -9,6 +9,7 @@
  */
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
+import { showAlert } from '@/utils/uiDialogs';
 import { useNotifications, ActionItem } from '../../contexts/NotificationsContext';
 import { DelegateTaskModal, DelegationData, User } from '../../components/Delegation';
 import { DelegationHistory } from '../../components/Delegation';
@@ -621,7 +622,11 @@ export const MyTasks: React.FC = () => {
       window.location.href = `/workflows/run/${execution.id}`;
     } catch (err) {
       console.error('Failed to resume workflow:', err);
-      alert('Failed to resume workflow. Please try again.');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to resume workflow. Please try again.',
+      });
     } finally {
       setResumingId(null);
     }

--- a/frontend/src/pages/PurchaseOrders.tsx
+++ b/frontend/src/pages/PurchaseOrders.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import { apiService, PurchaseOrder, Supplier } from '../services/apiService';
 import { LocationSelector } from '../components/Shared';
 import PurchaseOrderWorkflow from '../components/Workflow/PurchaseOrderWorkflow';
@@ -535,7 +536,11 @@ const PurchaseOrders: React.FC = () => {
         } : 'No response data'
       });
       // Display user-friendly error to the UI
-      alert(`Failed to save purchase order: ${err.message || 'Please try again later'}`);
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Failed to save purchase order: ${err.message || 'Please try again later'}`,
+      });
     }
   };
 
@@ -557,21 +562,37 @@ const PurchaseOrders: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
-    if (window.confirm('Are you sure you want to delete this purchase order?')) {
-      try {
-        await apiService.deletePurchaseOrder(id);
-        alert('Purchase order deleted successfully!');
-        await loadPurchaseOrders(); // Re-fetch to update the list
-      } catch (error: unknown) {
-        // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
-        console.error('Error deleting purchase order:', error);
-        const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
-        const errorMessage = err?.response?.data?.detail 
-          || err?.response?.data?.message 
-          || err?.message 
-          || 'Failed to delete purchase order';
-        alert(`Error: ${errorMessage}`);
-      }
+    const confirmed = await confirmDialog({
+      title: 'Delete purchase order?',
+      content: 'Are you sure you want to delete this purchase order?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
+
+    try {
+      await apiService.deletePurchaseOrder(id);
+      showAlert({
+        type: 'success',
+        title: 'Deleted',
+        content: 'Purchase order deleted successfully.',
+      });
+      await loadPurchaseOrders(); // Re-fetch to update the list
+    } catch (error: unknown) {
+      // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
+      console.error('Error deleting purchase order:', error);
+      const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
+      const errorMessage = err?.response?.data?.detail
+        || err?.response?.data?.message
+        || err?.message
+        || 'Failed to delete purchase order';
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Error: ${errorMessage}`,
+      });
     }
   };
 

--- a/frontend/src/pages/Settings/IntegrationSettings.tsx
+++ b/frontend/src/pages/Settings/IntegrationSettings.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { AlertCircle, CheckCircle, Mail, ExternalLink } from 'lucide-react';
+import { confirmDialog } from '@/utils/uiDialogs';
 import { apiClient as axios } from '../../services/apiService';
 
 interface Connection {
@@ -69,9 +70,15 @@ export const IntegrationSettings: React.FC = () => {
   };
 
   const handleDisconnect = async (provider: string) => {
-    if (!confirm(`Are you sure you want to disconnect this email account?`)) {
-      return;
-    }
+    const confirmed = await confirmDialog({
+      title: 'Disconnect email account?',
+      content: 'Are you sure you want to disconnect this email account?',
+      okText: 'Disconnect',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
 
     setDisconnecting(provider);
     setError(null);

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { isValidEmail } from '../shared/utils';
 import { logger } from '@/utils/logger';
+import { confirmDialog, showAlert } from '../utils/uiDialogs';
 
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { CountrySelect, PhoneInput, Select, StateSelect } from '../components/ui';
@@ -254,12 +255,20 @@ const Suppliers: React.FC = () => {
     if (!selectedSupplierId) return;
 
     if (!plantForm.name.trim() || !plantForm.code.trim()) {
-      alert('Plant name and code are required');
+      showAlert({
+        type: 'warning',
+        title: 'Validation',
+        content: 'Plant name and code are required',
+      });
       return;
     }
 
     if (plantForm.email?.trim() && !isValidEmail(plantForm.email.trim())) {
-      alert('Please enter a valid email address for the plant');
+      showAlert({
+        type: 'warning',
+        title: 'Validation',
+        content: 'Please enter a valid email address for the plant',
+      });
       return;
     }
 
@@ -278,7 +287,11 @@ const Suppliers: React.FC = () => {
       await loadSupplierPlants(selectedSupplierId);
     } catch (error: unknown) {
       logger.error('[Suppliers] Failed to create plant:', error);
-      alert('Failed to create plant');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to create plant',
+      });
     }
   };
 
@@ -333,7 +346,11 @@ const Suppliers: React.FC = () => {
     e.preventDefault();
 
     if (formData.email?.trim() && !isValidEmail(formData.email.trim())) {
-      alert('Please enter a valid email address');
+      showAlert({
+        type: 'warning',
+        title: 'Validation',
+        content: 'Please enter a valid email address',
+      });
       return;
     }
 
@@ -352,7 +369,11 @@ const Suppliers: React.FC = () => {
         await syncSupplierAvailableProducts(supplierId, availableProductIds);
       } catch (error) {
         logger.error('[Suppliers] Supplier saved but product sync failed:', error);
-        alert('Supplier saved, but products could not be updated. Please try again from the supplier Products page.');
+        showAlert({
+          type: 'warning',
+          title: 'Saved with warnings',
+          content: 'Supplier saved, but products could not be updated. Please try again from the supplier Products page.',
+        });
       }
 
       setShowEditForm(false);
@@ -369,7 +390,11 @@ const Suppliers: React.FC = () => {
         action: editingSupplier ? 'update' : 'create',
       });
 
-      alert(errorMessage);
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: errorMessage,
+      });
     }
   };
 
@@ -397,22 +422,38 @@ const Suppliers: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
-    if (window.confirm('Are you sure you want to delete this supplier?')) {
-      try {
-        await apiService.deleteSupplier(id);
-        alert('Supplier deleted successfully!');
-        await fetchSuppliers(); // Re-fetch to update the list
-      } catch (error: unknown) {
-        // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
-        // This ensures we handle errors safely while maintaining type checking
-        logger.error('Error deleting supplier:', error);
-        const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
-        const errorMessage = err?.response?.data?.detail 
-          || err?.response?.data?.message 
-          || err?.message 
-          || 'Failed to delete supplier';
-        alert(`Error: ${errorMessage}`);
-      }
+    const confirmed = await confirmDialog({
+      title: 'Delete supplier?',
+      content: 'Are you sure you want to delete this supplier?',
+      okText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
+
+    if (!confirmed) return;
+
+    try {
+      await apiService.deleteSupplier(id);
+      showAlert({
+        type: 'success',
+        title: 'Deleted',
+        content: 'Supplier deleted successfully.',
+      });
+      await fetchSuppliers(); // Re-fetch to update the list
+    } catch (error: unknown) {
+      // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
+      // This ensures we handle errors safely while maintaining type checking
+      logger.error('Error deleting supplier:', error);
+      const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
+      const errorMessage = err?.response?.data?.detail
+        || err?.response?.data?.message
+        || err?.message
+        || 'Failed to delete supplier';
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: `Error: ${errorMessage}`,
+      });
     }
   };
 

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useState } from 'react';
 import { logger } from '@/utils/logger';
+import { showAlert } from '@/utils/uiDialogs';
 
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
@@ -701,7 +702,11 @@ const FormsFlowsCatalog: React.FC = () => {
       navigate(`/workforms/in-progress/${submissionId}`);
     } catch (error) {
       logger.error('[Catalog] Quick Run failed:', error);
-      alert('Failed to start workflow. Please try again.');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to start workflow. Please try again.',
+      });
     } finally {
       setIsQuickRunning(null);
     }

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -17,6 +17,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { showAlert } from '@/utils/uiDialogs';
 import { 
   CheckCircle, XCircle, Calendar, Search, Download, 
   Eye, Filter, RefreshCw, FileText, ChevronRight, ChevronDown,
@@ -640,7 +641,11 @@ const FormsFlowsHistory: React.FC = () => {
   // Export to CSV - Planned for Wave F (Features) - see REMAINING_WORK_OUTLINE.md
   const handleExport = () => {
     // Feature F3.5: Export to Excel/PDF - scheduled for implementation
-    alert('Export functionality coming soon!');
+    showAlert({
+      type: 'info',
+      title: 'Coming soon',
+      content: 'Export functionality coming soon!',
+    });
   };
   
   const totalPages = Math.ceil(totalCount / pageSize);

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -17,6 +17,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import { Play, Clock, Filter, RefreshCw, FileText, X } from 'lucide-react';
 import { businessApi } from '../../services/businessApi';
 import { useQuickActions } from '../../contexts/QuickActionsContext';
@@ -502,7 +503,11 @@ const FormsFlowsInProgress: React.FC = () => {
       setSelectedSubmission(null);
     } catch (error) {
       console.error('Failed to cancel workflow:', error);
-      alert('Failed to cancel workflow. Please try again.');
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to cancel workflow. Please try again.',
+      });
     } finally {
       setCancelingId(null);
     }

--- a/frontend/src/pages/Workflows/WorkflowList.tsx
+++ b/frontend/src/pages/Workflows/WorkflowList.tsx
@@ -7,6 +7,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { showAlert } from '@/utils/uiDialogs';
 import { adminClient } from '../../services/apiService';
 import styled from 'styled-components';
 import { PageContainer } from '../../components/ui/PageContainer';
@@ -134,10 +135,11 @@ export const WorkflowList: React.FC = () => {
     },
     onError: (error: any) => {
       console.error('Failed to start workflow:', error);
-      alert(
-        error.response?.data?.error || 
-        'Failed to start workflow. Please try again.'
-      );
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: error.response?.data?.error || 'Failed to start workflow. Please try again.',
+      });
       setStartingWorkflow(null);
     },
   });

--- a/frontend/src/utils/uiDialogs.tsx
+++ b/frontend/src/utils/uiDialogs.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Input, Modal } from 'antd';
+
+type AlertType = 'info' | 'success' | 'warning' | 'error';
+
+export function showAlert(options: {
+  title: React.ReactNode;
+  content: React.ReactNode;
+  type?: AlertType;
+}): void {
+  const { type = 'info', title, content } = options;
+
+  const fn =
+    type === 'success'
+      ? Modal.success
+      : type === 'warning'
+        ? Modal.warning
+        : type === 'error'
+          ? Modal.error
+          : Modal.info;
+
+  fn({
+    title,
+    content,
+    centered: true,
+  });
+}
+
+export function confirmDialog(options: {
+  title: React.ReactNode;
+  content: React.ReactNode;
+  okText?: string;
+  cancelText?: string;
+  danger?: boolean;
+}): Promise<boolean> {
+  const { title, content, okText, cancelText, danger } = options;
+
+  return new Promise((resolve) => {
+    Modal.confirm({
+      title,
+      content,
+      centered: true,
+      okText: okText ?? 'Confirm',
+      cancelText: cancelText ?? 'Cancel',
+      okButtonProps: danger ? { danger: true } : undefined,
+      onOk: () => resolve(true),
+      onCancel: () => resolve(false),
+    });
+  });
+}
+
+export function promptDialog(options: {
+  title: React.ReactNode;
+  defaultValue?: string;
+  placeholder?: string;
+  okText?: string;
+  cancelText?: string;
+}): Promise<string | null> {
+  const { title, defaultValue, placeholder, okText, cancelText } = options;
+
+  return new Promise((resolve) => {
+    let value = defaultValue ?? '';
+
+    Modal.confirm({
+      title,
+      centered: true,
+      okText: okText ?? 'OK',
+      cancelText: cancelText ?? 'Cancel',
+      content: (
+        <Input
+          autoFocus
+          defaultValue={value}
+          placeholder={placeholder}
+          onChange={(e) => {
+            value = e.target.value;
+          }}
+        />
+      ),
+      onOk: () => resolve(value),
+      onCancel: () => resolve(null),
+    });
+  });
+}


### PR DESCRIPTION
Replaces native confirm/alert/prompt with AntD-based uiDialogs for consistent, non-blocking in-app modals.

Key points:
- Adds frontend/src/utils/uiDialogs.tsx (showAlert, confirmDialog, promptDialog)
- Removes remaining browser popups in admin-studio (Editor, VersionHistory, Schema editors, Choice/Tenant config editors)
- Completes sweep across other touched pages/components that previously used native dialogs

Verification:
- cd frontend && npm run build