### PR TITLE
Plant code optional (auto-generate)

### DIFF
--- a/backend/tenant_apps/plants/serializers.py
+++ b/backend/tenant_apps/plants/serializers.py
@@ -1,3 +1,5 @@
+import uuid
+
 from rest_framework import serializers
 
 from apps.system.models import Product as SystemProduct
@@ -19,6 +21,8 @@ class MasterProductMinimalSerializer(serializers.ModelSerializer):
 
 
 class PlantSerializer(serializers.ModelSerializer):
+    code = serializers.CharField(required=False, allow_blank=True)
+
     created_by_name = serializers.CharField(
         source="created_by.username", read_only=True
     )
@@ -84,6 +88,31 @@ class PlantSerializer(serializers.ModelSerializer):
             "created_by_name",
         ]
 
+    def _generate_code(self, name: str | None) -> str:
+        base = (name or 'Plant').strip().upper()
+        base = ''.join(ch for ch in base if ch.isalnum())
+        prefix = (base[:3] or 'PLT').ljust(3, 'T')
+
+        for _ in range(20):
+            candidate = f"{prefix}-{uuid.uuid4().hex[:8].upper()}"
+            if not Plant.objects.filter(code=candidate).exists():
+                return candidate
+
+        return f"PLT-{uuid.uuid4().hex[:12].upper()}"
+
     def create(self, validated_data):
         validated_data["created_by"] = self.context["request"].user
+
+        code = validated_data.get('code')
+        if not code or not str(code).strip():
+            validated_data['code'] = self._generate_code(validated_data.get('name'))
+
         return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        if 'code' in validated_data:
+            code = validated_data.get('code')
+            if not code or not str(code).strip():
+                validated_data['code'] = self._generate_code(validated_data.get('name') or instance.name)
+
+        return super().update(instance, validated_data)

--- a/backend/tenant_apps/plants/tests.py
+++ b/backend/tenant_apps/plants/tests.py
@@ -6,7 +6,10 @@ Uses shared-schema multi-tenancy with tenant ForeignKey isolation.
 import uuid
 from django.test import TestCase
 from django.contrib.auth.models import User
+from rest_framework.test import APIRequestFactory
+
 from tenant_apps.plants.models import Plant
+from tenant_apps.plants.serializers import PlantSerializer
 from tenant_apps.suppliers.models import Supplier
 from apps.tenants.models import Tenant, TenantUser
 
@@ -52,6 +55,31 @@ class PlantModelTest(TestCase):
         self.assertEqual(plant.name, f"Processing Plant {unique_id}")
         self.assertEqual(plant.code, f"PP-{unique_id}")
         self.assertEqual(plant.plant_type, "processing")
+        self.assertEqual(plant.tenant, self.tenant)
+
+    def test_create_plant_without_code_generates_code(self):
+        """Plant code should be optional in API input (auto-generated if blank)."""
+        unique_id = uuid.uuid4().hex[:8]
+
+        factory = APIRequestFactory()
+        request = factory.post('/api/v1/plants/', {})
+        request.user = self.user
+        request.tenant = self.tenant
+
+        serializer = PlantSerializer(
+            data={
+                'name': f"Processing Plant {unique_id}",
+                'plant_type': 'processing',
+                'supplier': self.supplier.id,
+                'code': '',
+            },
+            context={'request': request},
+        )
+        serializer.is_valid(raise_exception=True)
+        plant = serializer.save(tenant=self.tenant)
+
+        self.assertTrue(isinstance(plant.code, str) and plant.code)
+        self.assertIn('-', plant.code)
         self.assertEqual(plant.tenant, self.tenant)
 
     def test_plant_str_representation(self):

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -254,11 +254,11 @@ const Suppliers: React.FC = () => {
   const submitPlant = async () => {
     if (!selectedSupplierId) return;
 
-    if (!plantForm.name.trim() || !plantForm.code.trim()) {
+    if (!plantForm.name.trim()) {
       showAlert({
         type: 'warning',
         title: 'Validation',
-        content: 'Plant name and code are required',
+        content: 'Plant name is required',
       });
       return;
     }
@@ -273,16 +273,22 @@ const Suppliers: React.FC = () => {
     }
 
     try {
-      await apiClient.post('plants/', {
+      const payload: Record<string, unknown> = {
         supplier: selectedSupplierId,
         name: plantForm.name.trim(),
-        code: plantForm.code.trim(),
         plant_type: plantForm.plant_type,
         manager: plantForm.manager,
         email: plantForm.email,
         phone: plantForm.phone,
         phone_type: plantForm.phone_type,
-      });
+      };
+
+      const code = plantForm.code.trim();
+      if (code) {
+        payload.code = code;
+      }
+
+      await apiClient.post('plants/', payload);
       setShowPlantModal(false);
       await loadSupplierPlants(selectedSupplierId);
     } catch (error: unknown) {
@@ -724,13 +730,13 @@ const Suppliers: React.FC = () => {
                 </FormGroup>
 
                 <FormGroup>
-                  <Label $theme={theme}>Code *</Label>
+                  <Label $theme={theme}>Code (optional)</Label>
                   <Input
                     $theme={theme}
                     type="text"
                     value={plantForm.code}
                     onChange={(e) => setPlantForm((p) => ({ ...p, code: e.target.value }))}
-                    required
+                    placeholder="Leave blank to auto-generate"
                   />
                 </FormGroup>
 

--- a/frontend/src/pages/Suppliers/Plants.tsx
+++ b/frontend/src/pages/Suppliers/Plants.tsx
@@ -323,11 +323,15 @@ const Plants: React.FC = () => {
     try {
       const values = await form.validateFields();
       setFormErrors({});
-      
-      const payload = {
+
+      const payload: Record<string, unknown> = {
         ...values,
         capacity: values.capacity ? parseInt(values.capacity) : null,
       };
+
+      if (typeof values.code === 'string' && values.code.trim() === '') {
+        delete payload.code;
+      }
       
       if (editingPlant) {
         await apiClient.patch(`plants/${editingPlant.id}/`, payload);
@@ -534,12 +538,11 @@ const Plants: React.FC = () => {
 
           <Form.Item
             name="code"
-            label={<><Label>Code<RequiredMark>*</RequiredMark></Label></>}
-            rules={[{ required: true, message: 'Plant code is required' }]}
+            label={<><Label>Code</Label></>}
             validateStatus={formErrors.code ? 'error' : ''}
             help={formErrors.code && <ErrorMessage>⚠ {formErrors.code[0]}</ErrorMessage>}
           >
-            <Input placeholder="Plant Code (e.g., PLT001)" />
+            <Input placeholder="Plant Code (optional; auto-generated if blank)" />
           </Form.Item>
 
           <Form.Item


### PR DESCRIPTION
Plant code inputs should NOT be required system-wide.

Changes:
- Backend: PlantSerializer now accepts blank/missing code and auto-generates a unique code on create (and if explicitly blanked on update)
- Frontend: removed required validation/asterisks for plant code in Suppliers plant-create modal and Plants management page; leaving blank triggers auto-generation
- Added backend test covering blank code generation

Verification:
- cd frontend && npm run build (passes)

Note: running Django tests locally fails during migrations due to missing pgvector extension in this environment (NotSupportedError: extension "vector" is not available).