### PR TITLE
Supplier plants: remove capacity from create modal

### DIFF
--- a/frontend/src/pages/Suppliers/Plants.tsx
+++ b/frontend/src/pages/Suppliers/Plants.tsx
@@ -332,7 +332,6 @@ const Plants: React.FC = () => {
 
       const payload: Record<string, unknown> = {
         ...values,
-        capacity: values.capacity ? parseInt(values.capacity) : null,
       };
 
       if (typeof values.code === 'string' && values.code.trim() === '') {
@@ -660,9 +659,7 @@ const Plants: React.FC = () => {
             <Input placeholder="Facility Manager Name" />
           </Form.Item>
 
-          <Form.Item name="capacity" label={<Label>Capacity</Label>}>
-            <Input type="number" placeholder="Annual Capacity (tons)" />
-          </Form.Item>
+
         </Form>
       </Modal>
     </PageContainer>


### PR DESCRIPTION
Removes the Capacity input from the Supplier → Plants creation/edit modal and stops sending/overwriting capacity from that form.

Verification:
- cd frontend && npm run build