### PR TITLE
Workforms: Friendly schedule trigger UI

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -32,6 +32,10 @@ import { useFormBuilderContext } from '../../../contexts/FormBuilderContext';
 // Configuration engine imports
 import { schemaRegistry } from '../config';
 import { NodeConfigSchema, ConfigSection, ConfigField } from '../config/types';
+import {
+  buildCronExpressionFromFriendlySchedule,
+  buildScheduleSummary,
+} from '../utils/scheduleCron';
 import { evaluateCondition } from '../config/conditionalLogic';
 import { validateField } from '../config/validationEngine';
 
@@ -352,6 +356,75 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
         return next;
       }
 
+      // Schedule trigger: keep UI business-friendly but always persist an underlying cron string.
+      if (semanticNodeType === 'triggerSchedule') {
+        const draft = { ...prev, [fieldId]: value } as any;
+        const mode = (draft.scheduleMode as string) || 'friendly';
+
+        // If user edits cron directly, force cron mode.
+        if (fieldId === 'cronExpression') {
+          const cron = String(value || '').trim();
+          const next = {
+            ...draft,
+            scheduleMode: 'cron',
+            cronExpression: cron,
+            schedule: cron,
+            scheduleSummary: cron ? `Cron: ${cron}` : undefined,
+          };
+          onUpdateNode(node.id, next);
+          return next;
+        }
+
+        // Switching modes: keep data consistent.
+        if (fieldId === 'scheduleMode') {
+          const nextMode = String(value || 'friendly');
+
+          if (nextMode === 'cron') {
+            const cron = String(draft.cronExpression || draft.schedule || '').trim();
+            const next = {
+              ...draft,
+              scheduleMode: 'cron',
+              cronExpression: cron,
+              schedule: cron,
+              scheduleSummary: cron ? `Cron: ${cron}` : draft.scheduleSummary,
+            };
+            onUpdateNode(node.id, next);
+            return next;
+          }
+
+          // Switch to friendly: regenerate cron from selections.
+          const cron = buildCronExpressionFromFriendlySchedule(draft);
+          const summary = buildScheduleSummary(draft);
+          const next = {
+            ...draft,
+            scheduleMode: 'friendly',
+            cronExpression: cron,
+            schedule: cron,
+            scheduleSummary: summary,
+          };
+          onUpdateNode(node.id, next);
+          return next;
+        }
+
+        // Friendly mode: regenerate cron + summary whenever the user changes schedule inputs.
+        if (mode !== 'cron') {
+          const cron = buildCronExpressionFromFriendlySchedule(draft);
+          const summary = buildScheduleSummary(draft);
+          const next = {
+            ...draft,
+            cronExpression: cron,
+            schedule: cron,
+            scheduleSummary: summary,
+          };
+          onUpdateNode(node.id, next);
+          return next;
+        }
+
+        // Cron mode: just update the field.
+        onUpdateNode(node.id, draft);
+        return draft;
+      }
+
       const next = { ...prev, [fieldId]: value };
       onUpdateNode(node.id, next);
 
@@ -493,6 +566,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       case 'text':
       case 'textarea':
       case 'number':
+      case 'time':
       case 'email':
       case 'password':
       case 'codeEditor':

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -8598,10 +8598,15 @@ function getDefaultNodeData(nodeTypeId: string): Record<string, any> {
     defaults.maxOutputs = 0;
   }
 
-  // Auto-extract defaults from schema to fix DynamicConfigPanel visibility conditions
+  // Auto-extract defaults from schema to fix DynamicConfigPanel visibility conditions.
+  // Prefer the specific nodeTypeId schema (e.g., triggerSchedule) over the rendered ReactFlow type
+  // (e.g., trigger) so newly-created nodes pick up the correct defaults.
   try {
-    if (schemaRegistry.hasSchema(resolvedType)) {
-      const schema = schemaRegistry.getSchema(resolvedType);
+    const schemaIdsToTry = Array.from(new Set([nodeTypeId, resolvedType]));
+
+    schemaIdsToTry.forEach((schemaId) => {
+      if (!schemaRegistry.hasSchema(schemaId)) return;
+      const schema = schemaRegistry.getSchema(schemaId);
       schema.sections.forEach((section) => {
         section.fields.forEach((field) => {
           if (field.defaultValue !== undefined && defaults[field.id] === undefined) {
@@ -8609,9 +8614,9 @@ function getDefaultNodeData(nodeTypeId: string): Record<string, any> {
           }
         });
       });
-    }
+    });
   } catch {
-    logger.warn(`Could not extract schema defaults for ${resolvedType}`);
+    logger.warn(`Could not extract schema defaults for ${nodeTypeId}`);
   }
 
   return defaults;

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
@@ -60,6 +60,7 @@ export function renderTextField(
             field.type === 'number' ? 'number'
             : field.type === 'email' ? 'email'
             : field.type === 'password' ? 'password'
+            : field.type === 'time' ? 'time'
             : 'text'
           }
           value={value || ''}

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -2663,9 +2663,9 @@ const triggerManualSchema: NodeConfigSchema = {
 const triggerScheduleSchema: NodeConfigSchema = {
   nodeType: 'triggerSchedule',
   displayName: 'Schedule Trigger',
-  description: 'Run workflow on schedule',
+  description: 'Run workflow on a schedule',
   icon: Clock,
-  version: '1.0.0',
+  version: '2.0.0',
   tags: ['trigger', 'schedule'],
   contextAware: false,
   sections: [
@@ -2676,23 +2676,131 @@ const triggerScheduleSchema: NodeConfigSchema = {
       defaultExpanded: true,
       fields: [
         {
-          id: 'cronExpression',
-          type: 'text',
-          label: 'Cron Expression',
-          placeholder: '0 9 * * MON-FRI',
-          helpText: 'Standard cron syntax',
+          id: 'scheduleMode',
+          type: 'select',
+          label: 'Mode',
+          options: [
+            { value: 'friendly', label: 'Simple (Recommended)' },
+            { value: 'cron', label: 'Cron (Advanced)' },
+          ],
+          defaultValue: 'friendly',
+          helpText: 'Use the simple scheduler unless you need a custom cron expression.',
+          validation: [{ type: 'required', message: 'Select a mode' }],
+        },
+        {
+          id: 'frequency',
+          type: 'select',
+          label: 'Frequency',
+          options: [
+            { value: 'hourly', label: 'Hourly' },
+            { value: 'daily', label: 'Daily' },
+            { value: 'weekly', label: 'Weekly' },
+            { value: 'monthly', label: 'Monthly' },
+          ],
+          defaultValue: 'daily',
           required: true,
+          conditional: { field: 'scheduleMode', operator: 'equals', value: 'friendly' },
+          validation: [{ type: 'required', message: 'Select a frequency' }],
+        },
+        {
+          id: 'atTime',
+          type: 'time',
+          label: 'Time',
+          placeholder: '09:00',
+          defaultValue: '09:00',
+          required: true,
+          conditional: { field: 'scheduleMode', operator: 'equals', value: 'friendly' },
+          helpText: 'For hourly schedules, only the minutes are used.',
+          validation: [{ type: 'required', message: 'Time is required' }],
+        },
+        {
+          id: 'daysOfWeek',
+          type: 'multiselect',
+          label: 'Days of Week',
+          options: [
+            { value: 'MON', label: 'Monday' },
+            { value: 'TUE', label: 'Tuesday' },
+            { value: 'WED', label: 'Wednesday' },
+            { value: 'THU', label: 'Thursday' },
+            { value: 'FRI', label: 'Friday' },
+            { value: 'SAT', label: 'Saturday' },
+            { value: 'SUN', label: 'Sunday' },
+          ],
+          defaultValue: ['MON'],
+          required: true,
+          conditional: {
+            logic: 'AND',
+            conditions: [
+              { field: 'scheduleMode', operator: 'equals', value: 'friendly' },
+              { field: 'frequency', operator: 'equals', value: 'weekly' },
+            ],
+          },
+          validation: [{ type: 'required', message: 'Select at least one day' }],
+        },
+        {
+          id: 'dayOfMonth',
+          type: 'number',
+          label: 'Day of Month',
+          placeholder: '1',
+          defaultValue: 1,
+          required: true,
+          conditional: {
+            logic: 'AND',
+            conditions: [
+              { field: 'scheduleMode', operator: 'equals', value: 'friendly' },
+              { field: 'frequency', operator: 'equals', value: 'monthly' },
+            ],
+          },
+          validation: [
+            { type: 'required', message: 'Day of month is required' },
+            { type: 'min', value: 1, message: 'Minimum is 1' },
+            { type: 'max', value: 31, message: 'Maximum is 31' },
+          ],
         },
         {
           id: 'timezone',
-          type: 'text',
+          type: 'select',
           label: 'Timezone',
-          placeholder: 'America/New_York',
+          options: [
+            { value: 'UTC', label: 'UTC' },
+            { value: 'America/New_York', label: 'Eastern Time (US)' },
+            { value: 'America/Chicago', label: 'Central Time (US)' },
+            { value: 'America/Denver', label: 'Mountain Time (US)' },
+            { value: 'America/Los_Angeles', label: 'Pacific Time (US)' },
+            { value: 'Europe/London', label: 'London (GMT/BST)' },
+            { value: 'Australia/Sydney', label: 'Sydney (AEST/AEDT)' },
+          ],
           defaultValue: 'UTC',
+          helpText: 'Used for display; actual execution timezone depends on scheduler support.',
         },
-      ]
-    }
-  ]
+        {
+          id: 'cronExpression',
+          type: 'text',
+          label: 'Cron Expression',
+          placeholder: '0 9 * * 1-5',
+          helpText: 'Generated automatically in Simple mode. In Cron mode, you can edit directly.',
+          conditional: {
+            logic: 'OR',
+            conditions: [
+              { field: 'scheduleMode', operator: 'equals', value: 'cron' },
+              { field: 'showAdvancedCron', operator: 'equals', value: true },
+            ],
+          },
+          validation: [
+            { type: 'required', message: 'Cron expression is required' },
+            { type: 'pattern', value: '^[^\n\r]+$', message: 'Invalid cron expression' },
+          ],
+        },
+        {
+          id: 'showAdvancedCron',
+          type: 'toggle',
+          label: 'Show Cron Preview',
+          defaultValue: false,
+          conditional: { field: 'scheduleMode', operator: 'equals', value: 'friendly' },
+        },
+      ],
+    },
+  ],
 };
 
 const triggerWebhookSchema: NodeConfigSchema = {

--- a/frontend/src/components/FlowEditor/config/types.ts
+++ b/frontend/src/components/FlowEditor/config/types.ts
@@ -24,6 +24,7 @@ export type FieldType =
   | 'multiselect'       // Dropdown selection (multiple)
   | 'toggle'            // Boolean toggle switch
   | 'number'            // Number input
+  | 'time'              // Time picker (HH:MM)
   | 'date'              // Date picker
   | 'datetime'          // Date + time picker
   | 'color'             // Color picker

--- a/frontend/src/components/FlowEditor/nodes/TriggerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/TriggerNode.tsx
@@ -111,6 +111,8 @@ export const TriggerNode = React.memo<NodeProps<Node<TriggerNodeData>>>((props) 
     eventType,
     formId,
   } = data;
+
+  const scheduleSummary = (data as any)?.scheduleSummary as string | undefined;
   
   // Get the appropriate node type definition
   const nodeTypeMap = {
@@ -149,10 +151,12 @@ export const TriggerNode = React.memo<NodeProps<Node<TriggerNodeData>>>((props) 
         
         {(schedule || webhookUrl || eventEntity || formId) && (
           <TriggerConfig>
-            {triggerType === 'schedule' && schedule && (
+            {triggerType === 'schedule' && (scheduleSummary || schedule) && (
               <ConfigRow>
                 <ConfigLabel>Schedule:</ConfigLabel>
-                <ConfigValue>{schedule}</ConfigValue>
+                <ConfigValue title={schedule || scheduleSummary}>
+                  {scheduleSummary || schedule}
+                </ConfigValue>
               </ConfigRow>
             )}
             

--- a/frontend/src/components/FlowEditor/utils/scheduleCron.ts
+++ b/frontend/src/components/FlowEditor/utils/scheduleCron.ts
@@ -1,0 +1,110 @@
+export type ScheduleFrequency = 'hourly' | 'daily' | 'weekly' | 'monthly';
+
+const clampInt = (value: unknown, min: number, max: number, fallback: number) => {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(n)));
+};
+
+export const parseTimeOfDay = (raw: unknown): { hour: number; minute: number } => {
+  const s = String(raw ?? '').trim();
+  const match = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(s);
+  if (!match) return { hour: 9, minute: 0 };
+  return { hour: Number(match[1]), minute: Number(match[2]) };
+};
+
+const DOW_TO_CRON: Record<string, number> = {
+  SUN: 0,
+  MON: 1,
+  TUE: 2,
+  WED: 3,
+  THU: 4,
+  FRI: 5,
+  SAT: 6,
+};
+
+const DOW_LABEL: Record<string, string> = {
+  SUN: 'Sun',
+  MON: 'Mon',
+  TUE: 'Tue',
+  WED: 'Wed',
+  THU: 'Thu',
+  FRI: 'Fri',
+  SAT: 'Sat',
+};
+
+export type FriendlyScheduleConfig = {
+  scheduleMode?: 'friendly' | 'cron';
+  frequency?: ScheduleFrequency;
+  atTime?: string;
+  daysOfWeek?: string[];
+  dayOfMonth?: number;
+  timezone?: string;
+};
+
+export function buildCronExpressionFromFriendlySchedule(config: FriendlyScheduleConfig): string {
+  const frequency: ScheduleFrequency =
+    (config.frequency as ScheduleFrequency) || 'daily';
+
+  const { hour, minute } = parseTimeOfDay(config.atTime ?? '09:00');
+  const dom = clampInt(config.dayOfMonth, 1, 31, 1);
+
+  if (frequency === 'hourly') {
+    // Every hour at the selected minute
+    return `${minute} * * * *`;
+  }
+
+  if (frequency === 'weekly') {
+    const rawDays = Array.isArray(config.daysOfWeek) ? config.daysOfWeek : [];
+    const cronDays = rawDays
+      .map((d) => DOW_TO_CRON[String(d).toUpperCase()])
+      .filter((n) => Number.isFinite(n));
+
+    const uniqSorted = Array.from(new Set(cronDays)).sort((a, b) => a - b);
+    const dow = uniqSorted.length > 0 ? uniqSorted.join(',') : '1'; // default Monday
+
+    return `${minute} ${hour} * * ${dow}`;
+  }
+
+  if (frequency === 'monthly') {
+    return `${minute} ${hour} ${dom} * *`;
+  }
+
+  // daily
+  return `${minute} ${hour} * * *`;
+}
+
+export function buildScheduleSummary(config: FriendlyScheduleConfig): string {
+  const frequency: ScheduleFrequency =
+    (config.frequency as ScheduleFrequency) || 'daily';
+
+  const { hour, minute } = parseTimeOfDay(config.atTime ?? '09:00');
+  const hh = String(hour).padStart(2, '0');
+  const mm = String(minute).padStart(2, '0');
+
+  let summary = '';
+
+  if (frequency === 'hourly') {
+    summary = `Hourly at :${mm}`;
+  } else if (frequency === 'daily') {
+    summary = `Daily at ${hh}:${mm}`;
+  } else if (frequency === 'weekly') {
+    const rawDays = Array.isArray(config.daysOfWeek) ? config.daysOfWeek : [];
+    const days = rawDays
+      .map((d) => DOW_LABEL[String(d).toUpperCase()] || String(d))
+      .filter(Boolean);
+
+    const dayLabel = days.length > 0 ? days.join(', ') : 'Mon';
+    summary = `Weekly on ${dayLabel} at ${hh}:${mm}`;
+  } else if (frequency === 'monthly') {
+    const dom = clampInt(config.dayOfMonth, 1, 31, 1);
+    summary = `Monthly on day ${dom} at ${hh}:${mm}`;
+  }
+
+  const tz = String(config.timezone ?? 'UTC').trim();
+  if (tz && tz !== 'UTC') {
+    summary += ` (${tz})`;
+  }
+
+  return summary;
+}


### PR DESCRIPTION
Replaces raw cron input with business-friendly scheduler (frequency/days/time) while still generating and persisting a cron expression for execution. Includes a cron advanced mode and improves Trigger node display to show a human summary when available.