### PR TITLE
Admin Workspace: show/edit master products

### DIFF
--- a/backend/apps/system/serializers.py
+++ b/backend/apps/system/serializers.py
@@ -270,21 +270,12 @@ class ConfigAuditLogSummarySerializer(serializers.ModelSerializer):
 # === PRODUCT SERIALIZERS ===
 
 class SystemProductSerializer(serializers.ModelSerializer):
-    """
-    Serializer for system-wide products (read-only).
-    
-    System products are the master catalog shared by all tenants.
-    Created via: python manage.py seed_system_products
-    
-    Validation Layer (Phase 3):
-    - Enforces protein_type against SystemChoiceList
-    - Prevents "Zombie Products" with invalid categories
-    - Maintains cascade filtering data contract
-    """
+    """Read serializer for system-wide products."""
+
     category_display = serializers.CharField(source='get_category_display', read_only=True)
     is_frozen = serializers.BooleanField(read_only=True)
     is_fresh = serializers.BooleanField(read_only=True)
-    
+
     class Meta:
         model = Product
         fields = [
@@ -314,49 +305,36 @@ class SystemProductSerializer(serializers.ModelSerializer):
             'created_at',
             'updated_at',
         ]
+        read_only_fields = fields
+
+
+class SystemProductWriteSerializer(serializers.ModelSerializer):
+    """Write serializer for staff-managed Product updates."""
+
+    category_display = serializers.CharField(source='get_category_display', read_only=True)
+    is_frozen = serializers.BooleanField(read_only=True)
+    is_fresh = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = Product
+        fields = SystemProductSerializer.Meta.fields
         read_only_fields = [
             'id',
-            'product_code',
-            'name',
-            'description',
-            'category',
             'category_display',
-            'protein_type',
-            'fresh_or_frozen',
             'is_frozen',
             'is_fresh',
-            'package_type',
-            'carton_type',
-            'unit_weight',
-            'uom',
-            'pcs_per_carton',
-            'namp_code',
-            'usda_code',
-            'ub_code',
-            'edible_or_inedible',
-            'net_or_catch',
-            'tested_product',
-            'is_active',
-            'is_system',
             'created_at',
             'updated_at',
         ]
-    
+
     def validate_protein_type(self, value):
-        """
-        Validate protein_type against SystemChoiceList.
-        
-        This provides early validation at the API layer before
-        the model's clean() method runs.
-        """
         from apps.system.validators.product_validators import validate_protein_type
-        
+
         if value:
-            # Normalize and validate
             normalized_value = value.lower().strip()
             validate_protein_type(normalized_value)
             return normalized_value
-        return value  # All fields read-only
+        return ''
 
 
 class TenantProductPreferenceSerializer(serializers.ModelSerializer):

--- a/backend/apps/system/views/product_viewset.py
+++ b/backend/apps/system/views/product_viewset.py
@@ -21,25 +21,14 @@ from apps.system.services.product_visibility import visible_products_qs
 logger = logging.getLogger(__name__)
 
 
-class SystemProductViewSet(viewsets.ReadOnlyModelViewSet):
+class SystemProductViewSet(viewsets.ModelViewSet):
+    """ViewSet for system-wide products.
+
+    - GET is available to authenticated users (tenant visibility rules apply).
+    - Writes are restricted to staff users (Admin Workspace power feature).
     """
-    Read-only ViewSet for system products.
-    
-    All tenants share the same product catalog (system.Product).
-    Products are created via management command: python manage.py seed_system_products
-    
-    Permissions:
-    - Authenticated users can view all system products
-    - System products are READ-ONLY (managed by admins only)
-    
-    Filters:
-    - Search: product_code, name, description
-    - Filter: category, protein_type, fresh_or_frozen, is_active
-    - Ordering: product_code, name, category, unit_weight
-    """
-    
-    queryset = Product.objects.filter(is_active=True)
-    permission_classes = [permissions.IsAuthenticated]
+
+    queryset = Product.objects.all()
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     
     # Search fields
@@ -59,33 +48,38 @@ class SystemProductViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = ['product_code', 'name', 'category', 'unit_weight', 'created_at']
     ordering = ['product_code']
     
+    def get_permissions(self):
+        if self.request.method in permissions.SAFE_METHODS:
+            return [permissions.IsAuthenticated()]
+        return [permissions.IsAdminUser()]
+
     def get_serializer_class(self):
-        """Return appropriate serializer based on action."""
-        from apps.system.serializers import SystemProductSerializer
-        return SystemProductSerializer
+        from apps.system.serializers import SystemProductSerializer, SystemProductWriteSerializer
+
+        if self.request.method in permissions.SAFE_METHODS:
+            return SystemProductSerializer
+        return SystemProductWriteSerializer
     
     def get_queryset(self):
         """Return products visible to the current tenant.
 
-        Three-tier strategy:
-        - System products (golden list) are visible by default.
-        - Tenants can hide/override via TenantProductPreference.
-        - Tenant custom products are represented as system.Product rows with
-          is_system=False and are visible only to the owning tenant.
-
-        Cascade filtering (protein → product):
-        - ?protein=beef&protein=pork - Multiple protein types (lowercase slugs)
-        - ?protein_type=beef - Single protein type
-        - Case-insensitive matching for backward compatibility
+        Staff users get the full catalog (optionally including inactive).
+        Regular users get tenant-visible products only.
         """
 
-        # Base queryset is active products; visibility rules are applied next.
+        include_inactive_raw = str(self.request.query_params.get('include_inactive') or '').lower()
+        include_inactive = include_inactive_raw in ('1', 'true', 'yes')
+
         queryset = Product.objects.all()
 
-        tenant = getattr(self.request, "tenant", None)
-        queryset = visible_products_qs(tenant=tenant, qs=queryset)
+        if self.request.user.is_staff or self.request.user.is_superuser:
+            if not include_inactive:
+                queryset = queryset.filter(is_active=True)
+            return queryset
 
-        # Prefetch tenant preference rows for serializer/UI overlays.
+        tenant = getattr(self.request, "tenant", None)
+        queryset = visible_products_qs(tenant=tenant, qs=queryset, include_inactive=include_inactive)
+
         if tenant:
             queryset = queryset.prefetch_related(
                 Prefetch(
@@ -94,9 +88,7 @@ class SystemProductViewSet(viewsets.ReadOnlyModelViewSet):
                 )
             )
 
-        # Protein type filtering (comma-separated, case-insensitive)
         protein_param = self.request.query_params.get("protein") or self.request.query_params.get("protein_type")
-
         if protein_param:
             from django.db.models import Q
 
@@ -105,7 +97,6 @@ class SystemProductViewSet(viewsets.ReadOnlyModelViewSet):
             for p in proteins:
                 q_objects |= Q(protein_type__iexact=p)
             queryset = queryset.filter(q_objects)
-            logger.debug(f"Filtered products by protein types: {proteins}")
 
         return queryset
     

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -9,13 +9,14 @@
  */
 import React, { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Button, Card, Input, Modal, Space, Table, Tabs, Tag, Typography, message } from 'antd';
+import { Button, Card, Divider, Form, Input, Modal, Select, Space, Switch, Table, Tabs, Tag, Typography, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
 
 import { apiClient } from '@/services/apiService';
 import { AdminGuard, AdminPage, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
+import { getChoices, type ChoiceOption } from '@/services/choicesService';
 
 import { TenantChoiceOverride } from '@/components/Admin/TenantChoiceOverride';
 
@@ -25,6 +26,25 @@ import { TenantListModal, type TenantList } from './TenantListModal';
 const { Text } = Typography;
 
 type ActiveTabKey = 'system' | 'custom' | 'overrides';
+
+interface MasterProduct {
+  id: string;
+  product_code: string;
+  name: string;
+  description?: string;
+  category?: string;
+  protein_type?: string;
+  fresh_or_frozen?: string;
+  package_type?: string;
+  carton_type?: string;
+  unit_weight?: string | number | null;
+  uom?: string;
+  tested_product?: boolean;
+  is_active?: boolean;
+  is_system?: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
 
 interface SystemChoiceList {
   id: string;
@@ -58,6 +78,13 @@ const OptionListsPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [editingList, setEditingList] = useState<SystemChoiceList | null>(null);
 
+  const [products, setProducts] = useState<MasterProduct[]>([]);
+  const [productsLoading, setProductsLoading] = useState(false);
+  const [productModalOpen, setProductModalOpen] = useState(false);
+  const [editingProduct, setEditingProduct] = useState<MasterProduct | null>(null);
+  const [savingProduct, setSavingProduct] = useState(false);
+  const [proteinChoices, setProteinChoices] = useState<ChoiceOption[]>([]);
+
   const [customLists, setCustomLists] = useState<CustomTenantList[]>([]);
   const [customLoading, setCustomLoading] = useState(false);
   const [editingCustomList, setEditingCustomList] = useState<CustomTenantList | null>(null);
@@ -71,10 +98,13 @@ const OptionListsPage: React.FC = () => {
     // Only run on mount / tab param change
   }, [searchParams]);
 
+  const canEditProducts = permissions.role === 'superuser';
+
   useEffect(() => {
     if (!canView) return;
     void loadChoiceLists();
     void loadCustomLists();
+    void loadMasterProducts();
   }, [canView]);
 
   const loadChoiceLists = async () => {
@@ -109,6 +139,27 @@ const OptionListsPage: React.FC = () => {
     }
   };
 
+  const loadMasterProducts = async () => {
+    setProductsLoading(true);
+    try {
+      const response = await apiClient.get('/system/products/', {
+        params: {
+          include_inactive: true,
+          page_size: 500,
+        },
+      });
+      const raw = response.data as any;
+      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
+      setProducts(data);
+    } catch (error) {
+      console.error('Failed to load master products:', error);
+      message.error('Failed to load master products');
+      setProducts([]);
+    } finally {
+      setProductsLoading(false);
+    }
+  };
+
   const filteredSystemLists = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
     if (!q) return lists;
@@ -120,6 +171,19 @@ const OptionListsPage: React.FC = () => {
       return name.includes(q) || slug.includes(q) || desc.includes(q);
     });
   }, [lists, searchQuery]);
+
+  const filteredMasterProducts = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return products;
+
+    return products.filter((p) => {
+      const code = String(p.product_code || '').toLowerCase();
+      const name = String(p.name || '').toLowerCase();
+      const protein = String(p.protein_type || '').toLowerCase();
+      const category = String(p.category || '').toLowerCase();
+      return code.includes(q) || name.includes(q) || protein.includes(q) || category.includes(q);
+    });
+  }, [products, searchQuery]);
 
   const filteredCustomLists = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -311,6 +375,147 @@ const OptionListsPage: React.FC = () => {
     },
   ];
 
+  const [productForm] = Form.useForm();
+
+  useEffect(() => {
+    if (!productModalOpen) return;
+
+    void (async () => {
+      try {
+        const opts = await getChoices('protein_type');
+        setProteinChoices(opts);
+      } catch {
+        setProteinChoices([]);
+      }
+    })();
+  }, [productModalOpen]);
+
+  useEffect(() => {
+    if (!productModalOpen) return;
+
+    if (editingProduct) {
+      productForm.setFieldsValue({
+        product_code: editingProduct.product_code,
+        name: editingProduct.name,
+        protein_type: editingProduct.protein_type || '',
+        category: editingProduct.category || 'OTHER',
+        is_active: Boolean(editingProduct.is_active ?? true),
+        is_system: Boolean(editingProduct.is_system ?? true),
+      });
+      return;
+    }
+
+    productForm.resetFields();
+    productForm.setFieldsValue({
+      product_code: '',
+      name: '',
+      protein_type: '',
+      category: 'OTHER',
+      is_active: true,
+      is_system: true,
+    });
+  }, [editingProduct, productForm, productModalOpen]);
+
+  const handleSaveProduct = async (values: any) => {
+    if (!canEditProducts) {
+      message.info('Only superusers can modify master products.');
+      return;
+    }
+
+    setSavingProduct(true);
+    try {
+      const payload = {
+        product_code: String(values.product_code || '').trim(),
+        name: String(values.name || '').trim(),
+        protein_type: String(values.protein_type || '').trim() || '',
+        category: String(values.category || 'OTHER'),
+        is_active: Boolean(values.is_active),
+        is_system: Boolean(values.is_system),
+      };
+
+      if (editingProduct?.id) {
+        await apiClient.patch(`/system/products/${editingProduct.id}/`, payload);
+        message.success('Product updated');
+      } else {
+        await apiClient.post('/system/products/', payload);
+        message.success('Product created');
+      }
+
+      setProductModalOpen(false);
+      setEditingProduct(null);
+      await loadMasterProducts();
+    } catch (err: any) {
+      message.error(err?.response?.data?.detail || err?.response?.data?.error || 'Failed to save product');
+    } finally {
+      setSavingProduct(false);
+    }
+  };
+
+  const productColumns: ColumnsType<MasterProduct> = [
+    {
+      title: 'Code',
+      dataIndex: 'product_code',
+      key: 'product_code',
+      width: 160,
+      render: (value: string) => <Text strong>{value}</Text>,
+    },
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
+      render: (value: string) => <Text>{value}</Text>,
+    },
+    {
+      title: 'Protein',
+      dataIndex: 'protein_type',
+      key: 'protein_type',
+      width: 120,
+      render: (value: string) => <Text type="secondary">{value || '—'}</Text>,
+    },
+    {
+      title: 'Category',
+      dataIndex: 'category',
+      key: 'category',
+      width: 120,
+      render: (value: string) => <Text type="secondary">{value || '—'}</Text>,
+      responsive: ['md'],
+    },
+    {
+      title: 'Active',
+      dataIndex: 'is_active',
+      key: 'is_active',
+      width: 90,
+      render: (isActive: boolean) => (isActive ? <Tag color="green">Active</Tag> : <Tag>Inactive</Tag>),
+    },
+    {
+      title: 'System',
+      dataIndex: 'is_system',
+      key: 'is_system',
+      width: 90,
+      render: (isSystem: boolean) => (isSystem ? <Tag color="blue">System</Tag> : <Tag>Custom</Tag>),
+      responsive: ['md'],
+    },
+    {
+      title: 'Actions',
+      key: 'actions',
+      width: 120,
+      render: (_: unknown, record) => (
+        <Space>
+          <Button
+            type="default"
+            disabled={!canEditProducts}
+            onClick={() => {
+              setEditingProduct(record);
+              setProductModalOpen(true);
+            }}
+          >
+            Edit
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
   return (
     <AdminPage
       title="Option Lists"
@@ -318,6 +523,19 @@ const OptionListsPage: React.FC = () => {
       icon="📋"
       headerExtras={
         <Space wrap>
+          {activeTab === 'system' && (
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              disabled={!canEditProducts}
+              onClick={() => {
+                setEditingProduct(null);
+                setProductModalOpen(true);
+              }}
+            >
+              Add Product
+            </Button>
+          )}
           {activeTab === 'custom' && (
             <Button type="primary" icon={<PlusOutlined />} onClick={openCreateCustomList}>
               Create Custom List
@@ -335,8 +553,9 @@ const OptionListsPage: React.FC = () => {
             onClick={() => {
               void loadChoiceLists();
               void loadCustomLists();
+              void loadMasterProducts();
             }}
-            loading={loading || customLoading}
+            loading={loading || customLoading || productsLoading}
           />
         </Space>
       }
@@ -372,10 +591,39 @@ const OptionListsPage: React.FC = () => {
                   label: 'System Choice Lists',
                   children: (
                     <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-                      <Card size="small" title="Master Products">
+                      <Card
+                        size="small"
+                        title="Master Products"
+                        extra={!canEditProducts ? <Tag>View only</Tag> : <Tag color="green">Editable</Tag>}
+                      >
                         <Text type="secondary">
-                          Tier 1 system catalog used across product selectors. This is seeded and maintained centrally.
+                          System products power product selectors (Inquiry products, workflow quick create, etc.).
+                          {canEditProducts
+                            ? ' You can add/edit products here.'
+                            : ' Contact a superuser to modify this list.'}
                         </Text>
+                        <Divider style={{ margin: '12px 0' }} />
+
+                        {productsLoading ? (
+                          <LoadingSkeleton type="card" rows={2} />
+                        ) : filteredMasterProducts.length === 0 ? (
+                          <EmptyState
+                            icon="📦"
+                            title={searchQuery ? 'No matches' : 'No products returned'}
+                            message={
+                              searchQuery
+                                ? 'No master products match your search.'
+                                : 'No master products were returned from the API.'
+                            }
+                          />
+                        ) : (
+                          <Table
+                            rowKey="id"
+                            columns={productColumns}
+                            dataSource={filteredMasterProducts}
+                            pagination={{ pageSize: 10, showSizeChanger: true }}
+                          />
+                        )}
                       </Card>
 
                       {filteredSystemLists.length === 0 ? (
@@ -472,6 +720,82 @@ const OptionListsPage: React.FC = () => {
           }}
           onSaved={() => void loadCustomLists()}
         />
+
+        <Modal
+          open={productModalOpen}
+          title={editingProduct ? 'Edit Master Product' : 'Add Master Product'}
+          onCancel={() => {
+            if (savingProduct) return;
+            setProductModalOpen(false);
+            setEditingProduct(null);
+          }}
+          okText={savingProduct ? 'Saving…' : 'Save'}
+          okButtonProps={{
+            loading: savingProduct,
+            disabled: savingProduct || !canEditProducts,
+          }}
+          cancelButtonProps={{ disabled: savingProduct }}
+          onOk={() => productForm.submit()}
+          destroyOnClose
+        >
+          <Form form={productForm} layout="vertical" onFinish={handleSaveProduct}>
+            <Form.Item
+              name="product_code"
+              label="Product Code"
+              rules={[{ required: true, message: 'Product code is required' }]}
+            >
+              <Input placeholder="e.g., BEEF-RIBEYE-001" disabled={savingProduct} />
+            </Form.Item>
+
+            <Form.Item
+              name="name"
+              label="Name"
+              rules={[{ required: true, message: 'Name is required' }]}
+            >
+              <Input placeholder="e.g., Ribeye" disabled={savingProduct} />
+            </Form.Item>
+
+            <Form.Item name="protein_type" label="Protein Type">
+              <Select
+                showSearch
+                allowClear
+                placeholder="Select protein type"
+                options={proteinChoices.map((o) => ({ value: o.value, label: o.label }))}
+                disabled={savingProduct}
+              />
+            </Form.Item>
+
+            <Form.Item name="category" label="Category">
+              <Select
+                disabled={savingProduct}
+                options={[
+                  { value: 'BEEF', label: 'Beef' },
+                  { value: 'PORK', label: 'Pork' },
+                  { value: 'POULTRY', label: 'Poultry' },
+                  { value: 'SEAFOOD', label: 'Seafood' },
+                  { value: 'LAMB', label: 'Lamb' },
+                  { value: 'VEAL', label: 'Veal' },
+                  { value: 'GAME', label: 'Game' },
+                  { value: 'OTHER', label: 'Other' },
+                ]}
+              />
+            </Form.Item>
+
+            <Form.Item name="is_active" label="Active" valuePropName="checked">
+              <Switch disabled={savingProduct} />
+            </Form.Item>
+
+            <Form.Item name="is_system" label="System Product" valuePropName="checked">
+              <Switch disabled={savingProduct} />
+            </Form.Item>
+
+            {!canEditProducts && (
+              <div style={{ marginTop: 8 }}>
+                <Text type="secondary">Only superusers can edit master products.</Text>
+              </div>
+            )}
+          </Form>
+        </Modal>
       </AdminGuard>
     </AdminPage>
   );


### PR DESCRIPTION
Fixes Admin Workspace > Option Lists where the 'Master Products' section was only a placeholder card. Adds a Master Products table + add/edit modal. Backend: makes /api/v1/system/products/ writable for staff via a write serializer (GET remains tenant-visible for regular users).