### PR TITLE
Enable editing entity notes

### DIFF
--- a/backend/tenant_apps/cockpit/serializers.py
+++ b/backend/tenant_apps/cockpit/serializers.py
@@ -44,10 +44,10 @@ class OrderSlotSerializer(serializers.ModelSerializer):
 
 
 class ActivityLogSerializer(serializers.ModelSerializer):
-    """Serializer for ActivityLog model."""
-    
+    """Read serializer for ActivityLog model."""
+
     created_by_name = serializers.SerializerMethodField()
-    
+
     class Meta:
         model = ActivityLog
         fields = [
@@ -64,12 +64,61 @@ class ActivityLogSerializer(serializers.ModelSerializer):
             "modified_on",
         ]
         read_only_fields = ["id", "created_on", "modified_on", "created_by_name"]
-    
+
     def get_created_by_name(self, obj):
         """Get the name of the user who created this log."""
         if obj.created_by:
             return f"{obj.created_by.first_name} {obj.created_by.last_name}".strip() or obj.created_by.username
         return "System"
+
+
+class ActivityLogCreateSerializer(serializers.ModelSerializer):
+    """Write serializer for creating ActivityLog notes.
+
+    We intentionally do NOT allow the client to set tenant/created_by.
+    """
+
+    class Meta:
+        model = ActivityLog
+        fields = [
+            "id",
+            "entity_type",
+            "entity_id",
+            "title",
+            "content",
+            "is_pinned",
+            "tags",
+            "created_on",
+            "modified_on",
+        ]
+        read_only_fields = ["id", "created_on", "modified_on"]
+
+
+class ActivityLogUpdateSerializer(serializers.ModelSerializer):
+    """Write serializer for editing existing ActivityLog notes.
+
+    Editing is limited to the note body/metadata. Entity linkage + author are immutable.
+    """
+
+    class Meta:
+        model = ActivityLog
+        fields = [
+            "id",
+            "title",
+            "content",
+            "is_pinned",
+            "tags",
+            "created_on",
+            "modified_on",
+        ]
+        read_only_fields = ["id", "created_on", "modified_on"]
+
+    def update(self, instance, validated_data):
+        validated_data.pop("entity_type", None)
+        validated_data.pop("entity_id", None)
+        validated_data.pop("created_by", None)
+        validated_data.pop("tenant", None)
+        return super().update(instance, validated_data)
 
 
 class ScheduledCallSerializer(serializers.ModelSerializer):

--- a/backend/tenant_apps/cockpit/views.py
+++ b/backend/tenant_apps/cockpit/views.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import ValidationError
 from rest_framework.views import APIView
+from rest_framework.exceptions import PermissionDenied
 
 from django.conf import settings
 from django.db.models import Q
@@ -21,6 +22,8 @@ from .serializers import (
     SupplierSlotSerializer,
     OrderSlotSerializer,
     ActivityLogSerializer,
+    ActivityLogCreateSerializer,
+    ActivityLogUpdateSerializer,
     ScheduledCallSerializer,
     UserWorkspaceLayoutSerializer,
 )
@@ -239,20 +242,26 @@ class ActivityLogViewSet(viewsets.ModelViewSet):
     
     Supports filtering by entity_type and entity_id for entity-specific note feeds.
     """
-    serializer_class = ActivityLogSerializer
     permission_classes = [IsAuthenticated]
-    
+
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return ActivityLogCreateSerializer
+        if self.action in ('update', 'partial_update'):
+            return ActivityLogUpdateSerializer
+        return ActivityLogSerializer
+
     def get_queryset(self):
         """Filter activity logs by tenant and optional entity filters."""
         if not hasattr(self.request, 'tenant') or not self.request.tenant:
             return ActivityLog.objects.none()
-        
+
         queryset = ActivityLog.objects.filter(tenant=self.request.tenant)
-        
+
         # Filter by entity if provided
         entity_type = self.request.query_params.get('entity_type')
         entity_id = self.request.query_params.get('entity_id')
-        
+
         if entity_type and entity_id:
             queryset = queryset.filter(entity_type=entity_type, entity_id=entity_id)
 
@@ -267,13 +276,36 @@ class ActivityLogViewSet(viewsets.ModelViewSet):
                 pass
 
         return queryset
-    
+
+    def _can_edit_log(self, log: ActivityLog) -> bool:
+        user = getattr(self.request, 'user', None)
+        if not user or not user.is_authenticated:
+            return False
+
+        if getattr(user, 'is_staff', False) or getattr(user, 'is_superuser', False):
+            return True
+
+        # For user-created notes, allow the author to edit.
+        if log.created_by_id and log.created_by_id == user.id:
+            return True
+
+        # System-generated notes (created_by is NULL) are not editable by normal users.
+        return False
+
     def perform_create(self, serializer):
         """Auto-assign tenant and created_by on create."""
-        serializer.save(
-            tenant=self.request.tenant,
-            created_by=self.request.user
-        )
+        serializer.save(tenant=self.request.tenant, created_by=self.request.user)
+
+    def perform_update(self, serializer):
+        log = self.get_object()
+        if not self._can_edit_log(log):
+            raise PermissionDenied('You do not have permission to edit this note')
+        serializer.save()
+
+    def perform_destroy(self, instance):
+        if not self._can_edit_log(instance):
+            raise PermissionDenied('You do not have permission to delete this note')
+        instance.delete()
 
 
 class ScheduledCallViewSet(viewsets.ModelViewSet):

--- a/frontend/src/components/Cockpit/NotesAndCallsDrawer.tsx
+++ b/frontend/src/components/Cockpit/NotesAndCallsDrawer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Drawer, Button, Input, List, Typography, Tag, Spin } from 'antd';
+import { Drawer, Button, Input, List, Typography, Tag, Spin, Modal } from 'antd';
 import styled from 'styled-components';
 import { businessApi } from '../../services/businessApi';
 
@@ -75,6 +75,12 @@ export const NotesAndCallsDrawer: React.FC<NotesAndCallsDrawerProps> = ({
   const [items, setItems] = useState<TimelineItem[]>([]);
   const [noteText, setNoteText] = useState('');
   const [savingNote, setSavingNote] = useState(false);
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [editId, setEditId] = useState<number | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editContent, setEditContent] = useState('');
+  const [savingEdit, setSavingEdit] = useState(false);
 
   const fetchTimeline = useCallback(async () => {
     if (!open) return;
@@ -162,6 +168,43 @@ export const NotesAndCallsDrawer: React.FC<NotesAndCallsDrawerProps> = ({
     }
   }, [entityId, entityType, fetchTimeline, noteText]);
 
+  const openEdit = useCallback((item: TimelineItem) => {
+    if (item.kind !== 'note') return;
+    const raw = String(item.id || '');
+    const noteId = Number(raw.startsWith('note:') ? raw.split(':')[1] : raw);
+    if (!Number.isFinite(noteId)) return;
+
+    setEditId(noteId);
+    setEditTitle(item.title || 'Note');
+    setEditContent(item.content || '');
+    setEditOpen(true);
+  }, []);
+
+  const handleSaveEdit = useCallback(async () => {
+    if (!editId) return;
+
+    const nextTitle = editTitle.trim() || 'Note';
+    const nextContent = editContent.trim();
+    if (!nextContent) return;
+
+    setSavingEdit(true);
+    try {
+      await businessApi.patch(`/workspace/activity-logs/${editId}/`, {
+        title: nextTitle,
+        content: nextContent,
+      });
+      setEditOpen(false);
+      setEditId(null);
+      setEditTitle('');
+      setEditContent('');
+      void fetchTimeline();
+    } catch (err) {
+      console.error('[NotesAndCallsDrawer] Failed to edit note', err);
+    } finally {
+      setSavingEdit(false);
+    }
+  }, [editContent, editId, editTitle, fetchTimeline]);
+
   return (
     <Drawer
       title={title}
@@ -190,12 +233,17 @@ export const NotesAndCallsDrawer: React.FC<NotesAndCallsDrawerProps> = ({
             <List.Item style={{ alignItems: 'flex-start' }}>
               <List.Item.Meta
                 title={
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
                     <Tag color={item.kind === 'note' ? 'blue' : 'gold'}>{item.kind.toUpperCase()}</Tag>
                     <span style={{ fontWeight: 600 }}>{item.title}</span>
-                    <Text type="secondary" style={{ marginLeft: 'auto' }}>
-                      {new Date(item.createdAt).toLocaleString()}
-                    </Text>
+                    <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+                      {item.kind === 'note' ? (
+                        <Button size="small" onClick={() => openEdit(item)}>
+                          Edit
+                        </Button>
+                      ) : null}
+                      <Text type="secondary">{new Date(item.createdAt).toLocaleString()}</Text>
+                    </div>
                   </div>
                 }
                 description={
@@ -213,6 +261,36 @@ export const NotesAndCallsDrawer: React.FC<NotesAndCallsDrawerProps> = ({
           )}
         />
       )}
+
+      <Modal
+        title="Edit Note"
+        open={editOpen}
+        onCancel={() => {
+          if (savingEdit) return;
+          setEditOpen(false);
+          setEditId(null);
+          setEditTitle('');
+          setEditContent('');
+        }}
+        onOk={() => void handleSaveEdit()}
+        okText="Save"
+        confirmLoading={savingEdit}
+        okButtonProps={{ disabled: !editContent.trim() }}
+        destroyOnClose
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <Input value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Title" />
+          <Input.TextArea
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            placeholder="Note"
+            autoSize={{ minRows: 4, maxRows: 10 }}
+          />
+          <Text type="secondary">
+            Only the note author (or staff) can edit.
+          </Text>
+        </div>
+      </Modal>
 
       <Composer>
         <Input.TextArea

--- a/frontend/src/components/Shared/ActivityFeed.tsx
+++ b/frontend/src/components/Shared/ActivityFeed.tsx
@@ -300,6 +300,10 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   const [formData, setFormData] = useState({ title: '', content: '' });
   const [submitting, setSubmitting] = useState(false);
 
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editData, setEditData] = useState({ title: '', content: '' });
+  const [savingEdit, setSavingEdit] = useState(false);
+
   // Fetch activity logs on mount and when entity changes
   useEffect(() => {
     fetchActivities();
@@ -360,6 +364,40 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   const handleCancel = () => {
     setFormData({ title: '', content: '' });
     setShowForm(false);
+  };
+
+  const startEdit = (activity: ActivityLog) => {
+    setEditingId(activity.id);
+    setEditData({
+      title: activity.title || 'Note',
+      content: activity.content || '',
+    });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditData({ title: '', content: '' });
+  };
+
+  const saveEdit = async () => {
+    if (!editingId) return;
+    if (!editData.content.trim()) return;
+
+    try {
+      setSavingEdit(true);
+      const response = await apiClient.patch(`workspace/activity-logs/${editingId}/`, {
+        title: editData.title.trim() || 'Note',
+        content: editData.content.trim(),
+      });
+
+      setActivities(activities.map((a) => (a.id === editingId ? { ...a, ...response.data } : a)));
+      cancelEdit();
+    } catch (err: any) {
+      console.error('Failed to update activity log:', err);
+      setError(err.response?.data?.detail || 'Failed to update note');
+    } finally {
+      setSavingEdit(false);
+    }
   };
 
   return (
@@ -423,19 +461,46 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
             activities.map((activity) => (
               <ActivityCard key={activity.id}>
                 <ActivityHeader>
-                  <ActivityTitle>
-                    {activity.title || 'Note'}
-                  </ActivityTitle>
+                  <ActivityTitle>{activity.title || 'Note'}</ActivityTitle>
                   <ActivityMeta>
-                    <MetaText>
-                      {activity.created_by_name || 'Unknown User'}
-                    </MetaText>
-                    <MetaText>
-                      {formatToLocal(activity.created_on)}
-                    </MetaText>
+                    <MetaText>{activity.created_by_name || 'Unknown User'}</MetaText>
+                    <MetaText>{formatToLocal(activity.created_on)}</MetaText>
+                    {editingId !== activity.id && (
+                      <CancelButton type="button" onClick={() => startEdit(activity)}>
+                        Edit
+                      </CancelButton>
+                    )}
                   </ActivityMeta>
                 </ActivityHeader>
-                <ActivityContent>{activity.content}</ActivityContent>
+
+                {editingId === activity.id ? (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <FormInput
+                      type="text"
+                      placeholder="Title (optional)"
+                      value={editData.title}
+                      onChange={(e) => setEditData({ ...editData, title: e.target.value })}
+                      disabled={savingEdit}
+                    />
+                    <FormTextarea
+                      placeholder="Enter your note..."
+                      value={editData.content}
+                      onChange={(e) => setEditData({ ...editData, content: e.target.value })}
+                      disabled={savingEdit}
+                      required
+                    />
+                    <FormActions>
+                      <CancelButton type="button" onClick={cancelEdit} disabled={savingEdit}>
+                        Cancel
+                      </CancelButton>
+                      <SubmitButton type="button" onClick={() => void saveEdit()} disabled={savingEdit || !editData.content.trim()}>
+                        {savingEdit ? 'Saving...' : 'Save Changes'}
+                      </SubmitButton>
+                    </FormActions>
+                  </div>
+                ) : (
+                  <ActivityContent>{activity.content}</ActivityContent>
+                )}
               </ActivityCard>
             ))
           )}


### PR DESCRIPTION
Adds an Edit button for ActivityLog notes (Call Logs / Notes) across Cockpit surfaces.

Backend:
- Split ActivityLog serializers (read/create/update)
- Enforce edit/delete permissions: author or staff (system notes are staff-only)

Frontend:
- NotesAndCallsDrawer: Edit note modal + PATCH
- Shared ActivityFeed: inline edit + PATCH

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>