### PR TITLE
Fix inquiry product dropdown + tour lockup

### DIFF
--- a/frontend/src/components/Calls/InquiryCallModal.tsx
+++ b/frontend/src/components/Calls/InquiryCallModal.tsx
@@ -219,7 +219,7 @@ const Error = styled.div`
 const LinesTable = styled.div`
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  overflow: visible;
 `;
 
 const LinesHeader = styled.div`

--- a/frontend/src/components/Cockpit/CockpitTour.tsx
+++ b/frontend/src/components/Cockpit/CockpitTour.tsx
@@ -248,7 +248,7 @@ export const CockpitTour: React.FC<CockpitTourProps> = ({
       continuous
       options={options}
       styles={styles}
-      onEvent={handleJoyrideCallback}
+      callback={handleJoyrideCallback}
       locale={{
         back: 'Back',
         close: 'Close',

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -8467,7 +8467,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         steps={tourSteps}
         run={runTour}
         stepIndex={tourStepIndex}
-        onEvent={handleTourCallback}
+        callback={handleTourCallback}
         continuous
         options={tourOptions}
         styles={tourStyles}


### PR DESCRIPTION
Fixes two UX blockers:

1) InquiryCallModal: product autocomplete dropdown was clipped by an ancestor with overflow:hidden. Set LinesTable overflow to visible.
2) Workform editor (and CockpitTour): Joyride callback was incorrectly wired as onEvent; react-joyride expects callback. This prevented stepIndex progression + TARGET_NOT_FOUND handling, causing grey overlay lockups (reported at tutorial step 5).

Verification:
- npm run build
