### PR TITLE
Cockpit: ensure inquiries ordered newest-first

### DIFF
--- a/backend/apps/system/views/entity_viewset.py
+++ b/backend/apps/system/views/entity_viewset.py
@@ -505,8 +505,15 @@ class EntityViewSet(viewsets.ViewSet):
             return qs
 
         candidates = [
-            'created_at',
+            # Tenant-app models typically use created_on/modified_on
+            'modified_on',
+            'created_on',
+            # Inquiries use inquiry_date as their primary business timestamp
+            'inquiry_date',
+            # System models typically use created_at/updated_at
             'updated_at',
+            'created_at',
+            # Legacy timestamp field names
             'date_time_stamp',
             'date_time_stamp_created',
         ]


### PR DESCRIPTION
Fixes Cockpit relationship ordering so newly created inquiries reliably show in the top of Customer → Inquiries (list is capped to 10 items).

- EntityViewSet._order_queryset_recent_first now prefers modified_on/created_on/inquiry_date when present, before created_at/updated_at.

Verification:
- python -m compileall .
