### PR TITLE
Fix: SmartSearch quick action crash + i18next banner

### DIFF
--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -783,7 +783,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
   /**
    * Handle quick action click
    */
-  const handleQuickAction = useCallback((action: SearchEntity) => {
+  const handleQuickAction = (action: SearchEntity) => {
     const actionType = action.metadata?.action as string | undefined;
     const entityId = (action.metadata?.entityId as string | number | undefined) ?? action.id;
 
@@ -905,7 +905,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
       default:
         console.warn('Unhandled quick action:', actionType, 'for entity', entityId);
     }
-  }, [activeEntity, navigate, navigation.path, onOpenInlineCreate, openQuickCreate, query, searchParams, setSearchParams]);
+  };
 
   /**
    * Toggle favorite

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -26,6 +26,7 @@ i18n
   .use(initReactI18next)
   .init({
     resources,
+    debug: false,
     fallbackLng: 'en',
     supportedLngs: supportedLanguages,
     interpolation: {


### PR DESCRIPTION
Fix production TDZ crash in SmartSearch quick actions and disable i18next debug to remove Locize console banner.