### PR TITLE
Docs: require PR-only workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,19 @@ All branches **must** follow: `<type>/<short-description>`
 
 ---
 
+## 🧷 PR-Only Policy (Mandatory)
+
+**Do not commit directly to `development`, `uat`, or `main`.**
+
+All changes must follow:
+1. Create a new branch
+2. Open a Pull Request targeting `development`
+3. Merge via PR (squash merge preferred) and delete the branch
+
+This ensures review history, CI checks, and reliable rollbacks.
+
+---
+
 ## 🧹 Branch Hygiene
 
 **Critical: feature branches must be deleted after merging.**


### PR DESCRIPTION
Document PR-only policy: no direct commits to protected branches; always branch → PR → merge to development.