### PR TITLE
Fix: Outlook reconnect decryption

### DIFF
--- a/backend/apps/integrations/management/commands/diagnose_oauth_encryption.py
+++ b/backend/apps/integrations/management/commands/diagnose_oauth_encryption.py
@@ -80,29 +80,23 @@ class Command(BaseCommand):
             )
             return
 
-        # Derive Fernet from OAUTH_ENCRYPTION_KEY (the active storage mechanism).
-        try:
-            key = ExternalAuthProvider._get_encryption_key()
-        except Exception as e:
-            self.stdout.write(
-                json.dumps(
-                    {
-                        'ok': False,
-                        'tenant_id': tenant_id,
-                        'provider_type': provider_type,
-                        'provider_id': row.id,
-                        'token_type': token_type,
-                        'error_type': 'DATA_MISSING',
-                        'message': f'Cannot load OAUTH_ENCRYPTION_KEY: {type(e).__name__}: {e}',
-                    }
-                )
-            )
-            return
+        # Attempt decryption using the same multi-key logic used by the model.
+        keys = ExternalAuthProvider._get_decryption_keys()
+        results = []
+        plaintext = None
 
-        fernet = Fernet(key)
+        for idx, key in enumerate(keys):
+            try:
+                fernet = Fernet(key)
+                plaintext = fernet.decrypt(str(encrypted).encode('utf-8'))
+                results.append({'key_index': idx, 'ok': True})
+                break
+            except InvalidToken:
+                results.append({'key_index': idx, 'ok': False, 'error_type': 'INVALID_TOKEN'})
+            except Exception as e:
+                results.append({'key_index': idx, 'ok': False, 'error_type': type(e).__name__, 'message': str(e)})
 
-        try:
-            plaintext = fernet.decrypt(str(encrypted).encode('utf-8'))
+        if plaintext is not None:
             self.stdout.write(
                 json.dumps(
                     {
@@ -113,35 +107,24 @@ class Command(BaseCommand):
                         'token_type': token_type,
                         'token_length': len(plaintext or b''),
                         'message': 'Decryption OK',
+                        'attempts': results,
                     }
                 )
             )
-        except InvalidToken:
-            self.stdout.write(
-                json.dumps(
-                    {
-                        'ok': False,
-                        'tenant_id': tenant_id,
-                        'provider_type': provider_type,
-                        'provider_id': row.id,
-                        'token_type': token_type,
-                        'error_type': 'INVALID_TOKEN',
-                        'message': 'cryptography.fernet.InvalidToken (key mismatch or token was re-encrypted with a different key).',
-                        'hint': 'Reconnect Outlook for this tenant to refresh encrypted tokens.',
-                    }
-                )
+            return
+
+        self.stdout.write(
+            json.dumps(
+                {
+                    'ok': False,
+                    'tenant_id': tenant_id,
+                    'provider_type': provider_type,
+                    'provider_id': row.id,
+                    'token_type': token_type,
+                    'error_type': 'INVALID_TOKEN',
+                    'message': 'Token could not be decrypted with any configured key (env OAUTH_ENCRYPTION_KEY or SECRET_KEY-derived).',
+                    'hint': 'Reconnect Outlook for this tenant to refresh encrypted tokens.',
+                    'attempts': results,
+                }
             )
-        except Exception as e:
-            self.stdout.write(
-                json.dumps(
-                    {
-                        'ok': False,
-                        'tenant_id': tenant_id,
-                        'provider_type': provider_type,
-                        'provider_id': row.id,
-                        'token_type': token_type,
-                        'error_type': 'UNKNOWN',
-                        'message': f'{type(e).__name__}: {e}',
-                    }
-                )
-            )
+        )

--- a/backend/apps/integrations/microsoft/encryption.py
+++ b/backend/apps/integrations/microsoft/encryption.py
@@ -8,7 +8,7 @@ CRITICAL: Never store raw Microsoft access tokens in plaintext.
 from django.conf import settings
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from base64 import urlsafe_b64encode
 import logging
 
@@ -44,7 +44,7 @@ class TokenEncryptionService:
         salt = b'projectmeats_oauth_encryption_v1'
         
         # Derive 32 bytes using PBKDF2
-        kdf = PBKDF2(
+        kdf = PBKDF2HMAC(
             algorithm=hashes.SHA256(),
             length=32,
             salt=salt,

--- a/backend/apps/integrations/models.py
+++ b/backend/apps/integrations/models.py
@@ -1,12 +1,31 @@
-"""
+"""apps.integrations.models
+
 ExternalAuthProvider model for storing encrypted OAuth tokens.
+
+This project historically supported multiple token encryption mechanisms:
+- OAUTH_ENCRYPTION_KEY (preferred when set)
+- SECRET_KEY-derived Fernet key (fallback; used by older code paths)
+
+To prevent false "reconnect required" failures when deployments/config drift, we
+attempt decryption with both keys.
 """
+
+import logging
 import os
+from base64 import urlsafe_b64encode
 from datetime import timedelta
 
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+_DERIVED_SALT = b'projectmeats_oauth_encryption_v1'
+_DERIVED_ITERATIONS = 100000
 
 
 class ExternalAuthProvider(models.Model):
@@ -81,18 +100,48 @@ class ExternalAuthProvider(models.Model):
         return f"{self.tenant.name} - {self.get_provider_type_display()}"
     
     @staticmethod
-    def _get_encryption_key():
+    def _derive_key_from_secret(secret_key: str) -> bytes:
+        """Derive a Fernet key from Django SECRET_KEY.
+
+        This matches `apps.integrations.microsoft.encryption.TokenEncryptionService`.
         """
-        Get encryption key from environment.
-        In production, use a secure key management service.
-        """
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=_DERIVED_SALT,
+            iterations=_DERIVED_ITERATIONS,
+        )
+        raw = kdf.derive(secret_key.encode('utf-8'))
+        return urlsafe_b64encode(raw)
+
+    @classmethod
+    def _get_derived_encryption_key(cls) -> bytes:
+        return cls._derive_key_from_secret(settings.SECRET_KEY)
+
+    @staticmethod
+    def _get_env_encryption_key() -> bytes | None:
         key = os.environ.get('OAUTH_ENCRYPTION_KEY')
         if not key:
-            raise ValueError(
-                "OAUTH_ENCRYPTION_KEY environment variable not set. "
-                "Generate one with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'"
-            )
-        return key.encode()
+            return None
+        return key.encode('utf-8')
+
+    @classmethod
+    def _get_primary_encryption_key(cls) -> bytes:
+        """Return the encryption key used for NEW token writes."""
+        return cls._get_env_encryption_key() or cls._get_derived_encryption_key()
+
+    @classmethod
+    def _get_decryption_keys(cls) -> list[bytes]:
+        """Return keys to try during decryption (most-preferred first)."""
+        keys: list[bytes] = []
+        env_key = cls._get_env_encryption_key()
+        if env_key:
+            keys.append(env_key)
+        derived = cls._get_derived_encryption_key()
+        # Avoid duplicates if someone set OAUTH_ENCRYPTION_KEY equal to derived key.
+        if derived not in keys:
+            keys.append(derived)
+        return keys
     
     def set_encrypted_token(self, token_type: str, token: str):
         """
@@ -105,8 +154,8 @@ class ExternalAuthProvider(models.Model):
         if not token:
             return
         
-        fernet = Fernet(self._get_encryption_key())
-        encrypted = fernet.encrypt(token.encode())
+        fernet = Fernet(self._get_primary_encryption_key())
+        encrypted = fernet.encrypt(token.encode('utf-8'))
         
         if token_type == 'access':
             self.access_token = encrypted.decode()
@@ -125,25 +174,31 @@ class ExternalAuthProvider(models.Model):
         Returns:
             Decrypted token string
         """
-        fernet = Fernet(self._get_encryption_key())
-        
         if token_type == 'access':
             encrypted = self.access_token
         elif token_type == 'refresh':
             encrypted = self.refresh_token
         else:
             raise ValueError(f"Invalid token type: {token_type}")
-        
+
         if not encrypted:
             return None
-        
-        try:
-            return fernet.decrypt(encrypted.encode()).decode()
-        except InvalidToken as e:
-            # Preserve InvalidToken so callers can differentiate key-mismatch from other failures.
-            raise
-        except Exception as e:
-            raise ValueError(f"Failed to decrypt token: {str(e)}")
+
+        last_err: Exception | None = None
+        for key in self._get_decryption_keys():
+            try:
+                fernet = Fernet(key)
+                return fernet.decrypt(str(encrypted).encode('utf-8')).decode('utf-8')
+            except InvalidToken as e:
+                last_err = e
+                continue
+            except Exception as e:
+                last_err = e
+                continue
+
+        if isinstance(last_err, InvalidToken):
+            raise last_err
+        raise InvalidToken()
     
     def is_token_expired(self) -> bool:
         """

--- a/backend/apps/integrations/test_encryption_fallback.py
+++ b/backend/apps/integrations/test_encryption_fallback.py
@@ -1,0 +1,46 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from cryptography.fernet import Fernet
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.integrations.models import ExternalAuthProvider
+from apps.tenants.models import Tenant
+
+
+class ExternalAuthProviderEncryptionFallbackTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='enc-user', password='pass')
+        self.tenant = Tenant.objects.create(
+            name='Enc Tenant',
+            slug='enc-tenant',
+            contact_email='enc@example.com',
+            created_by=self.user,
+        )
+
+    def test_decrypt_falls_back_to_secret_key_derived_key(self):
+        """If an env key is present but the token was encrypted with the derived key,
+        we should still decrypt successfully (prevents false reconnect-required errors).
+        """
+
+        provider = ExternalAuthProvider.objects.create(
+            tenant=self.tenant,
+            provider_type='microsoft',
+            is_active=True,
+            token_expiry=timezone.now() + timedelta(days=1),
+            access_token='placeholder',
+        )
+
+        plaintext = 'access-token-123'
+
+        # Encrypt using the SECRET_KEY-derived key (simulate old code path / missing env key).
+        with patch.dict('os.environ', {}, clear=True):
+            provider.set_encrypted_token('access', plaintext)
+            provider.save()
+
+        # Now set an unrelated env key; decrypt should fall back and still succeed.
+        wrong_env_key = Fernet.generate_key().decode('utf-8')
+        with patch.dict('os.environ', {'OAUTH_ENCRYPTION_KEY': wrong_env_key}, clear=True):
+            self.assertEqual(provider.get_decrypted_token('access'), plaintext)


### PR DESCRIPTION
Fix persistent "Outlook needs to be reconnected" by allowing ExternalAuthProvider to decrypt tokens encrypted with either OAUTH_ENCRYPTION_KEY or SECRET_KEY-derived Fernet key (backward compatible). Updates diagnose_oauth_encryption output; adds regression test.