### PR TITLE
Fix: AI widget document upload

### DIFF
--- a/frontend/src/components/AIAssistant/AIAgentWidget.tsx
+++ b/frontend/src/components/AIAssistant/AIAgentWidget.tsx
@@ -751,9 +751,8 @@ export const AIAgentWidget: React.FC = () => {
         form.append('file', file);
         form.append('session', sid);
 
-        const res = await businessApi.post('/ai-assistant/ai-documents/', form, {
-          headers: { 'Content-Type': 'multipart/form-data' },
-        });
+        const res = await businessApi.post('/ai-assistant/ai-documents/', form);
+
 
         const doc = (res.data && typeof res.data === 'object' ? (res.data as Record<string, unknown>) : {}) || {};
         const next: UploadedAttachment = {

--- a/frontend/src/services/aiService.ts
+++ b/frontend/src/services/aiService.ts
@@ -99,7 +99,7 @@ export const documentsApi = {
     const formData = new FormData();
     formData.append('file', file);
     if (sessionId) {
-      formData.append('session_id', sessionId);
+      formData.append('session', sessionId);
     }
 
     const res = await businessApi.post<DocumentUploadResponse>('/ai-assistant/ai-documents/', formData);


### PR DESCRIPTION
Fix 400 on /ai-assistant/ai-documents uploads: don’t force multipart Content-Type (let Axios set boundary) and send correct session field name.