### PR TITLE
Fix: invitation resend email failures

### DIFF
--- a/backend/apps/tenants/invitation_email.py
+++ b/backend/apps/tenants/invitation_email.py
@@ -20,21 +20,13 @@ from .models import TenantInvitation
 logger = logging.getLogger(__name__)
 
 
-def schedule_invitation_email(invitation: TenantInvitation) -> None:
-    """Best-effort: send the invitation email after commit.
-
-    Safe to call multiple times. No-op if the invitation is not a pending 1:1 email invite.
-    """
-
-    if invitation.status != "pending" or not invitation.email:
-        return
-
+def _build_invitation_email(invitation: TenantInvitation) -> tuple[str, str, str]:
     base_url = getattr(settings, "FRONTEND_URL", "https://meatscentral.com")
     invite_url = f"{base_url}/signup?token={invitation.token}"
 
     subject = f"You've been invited to join {invitation.tenant.name} on Meats Central"
 
-    message = (
+    body = (
         "Hello,\n\n\n"
         f"You have been invited to join '{invitation.tenant.name}' as a {invitation.role}. "
         "Join us on Meats Central!\n\n\n"
@@ -45,21 +37,57 @@ def schedule_invitation_email(invitation: TenantInvitation) -> None:
         "The Meats Central Team"
     )
 
+    return subject, body, invite_url
+
+
+def send_invitation_email_now(invitation: TenantInvitation) -> None:
+    """Send invitation email immediately.
+
+    Use this when the caller needs immediate feedback (e.g., resend endpoint).
+    """
+
+    if invitation.status != "pending" or not invitation.email:
+        return
+
+    # Common operational misconfig: SendGrid backend enabled but no API key.
+    if (
+        str(getattr(settings, 'EMAIL_BACKEND', '')).endswith('SendgridBackend')
+        and not getattr(settings, 'SENDGRID_API_KEY', '')
+    ):
+        raise RuntimeError('SENDGRID_API_KEY is not set for SendGrid email backend')
+
+    subject, body, invite_url = _build_invitation_email(invitation)
+
+    logger.info(
+        "📤 Sending invitation email to %s (tenant=%s, role=%s, invite_url=%s)",
+        invitation.email,
+        invitation.tenant_id,
+        invitation.role,
+        invite_url,
+    )
+
+    send_mail(
+        subject=subject,
+        message=body,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[invitation.email],
+        fail_silently=False,
+    )
+
+
+def schedule_invitation_email(invitation: TenantInvitation) -> None:
+    """Best-effort: send the invitation email after commit.
+
+    Safe to call multiple times. No-op if the invitation is not a pending 1:1 email invite.
+    Email failures must never break invitation creation/resend.
+    """
+
+    if invitation.status != "pending" or not invitation.email:
+        return
+
     def _send() -> None:
         try:
-            logger.info(
-                "📤 Sending invitation email to %s (tenant=%s, role=%s)",
-                invitation.email,
-                invitation.tenant_id,
-                invitation.role,
-            )
-            send_mail(
-                subject=subject,
-                message=message,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[invitation.email],
-                fail_silently=False,
-            )
+            send_invitation_email_now(invitation)
         except Exception:
             logger.exception("❌ Failed to send invitation email to %s", invitation.email)
 

--- a/backend/apps/tenants/invitation_views.py
+++ b/backend/apps/tenants/invitation_views.py
@@ -13,7 +13,7 @@ from django.db.models import QuerySet
 import logging
 
 from apps.tenants.models import Tenant, TenantUser, TenantInvitation
-from apps.tenants.invitation_email import schedule_invitation_email
+from apps.tenants.invitation_email import schedule_invitation_email, send_invitation_email_now
 from apps.tenants.invitation_serializers import (
     TenantInvitationCreateSerializer,
     TenantInvitationListSerializer,
@@ -154,8 +154,18 @@ class TenantInvitationViewSet(viewsets.ModelViewSet):
         invitation.expires_at = timezone.now() + timezone.timedelta(days=7)
         invitation.save()
 
-        # Best-effort: resend email using the same helper as the post_save signal.
-        schedule_invitation_email(invitation)
+        # Resend should provide immediate feedback to the user.
+        try:
+            send_invitation_email_now(invitation)
+        except Exception as e:
+            logger.exception('Failed to send invitation resend email invitation_id=%s', invitation.id)
+            return Response(
+                {
+                    'error': 'Failed to send invitation email',
+                    'detail': str(e),
+                },
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
 
         logger.info("Resent invitation %s to %s", invitation.id, invitation.email)
 


### PR DESCRIPTION
Resend endpoint now sends invite email synchronously and returns actionable error details (e.g., SendGrid HTTP errors) instead of silently succeeding while delivery fails. Create-path remains best-effort via on_commit.