### PR TITLE
Fix: frontend type-check hardening

### DIFF
--- a/frontend/src/apps/admin-studio/pages/Dashboard.tsx
+++ b/frontend/src/apps/admin-studio/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { adminClient } from '@/services/apiService';
+import { showAlert } from '@/utils/uiDialogs';
 
 interface Blueprint {
   id: string;

--- a/frontend/src/components/Admin/TenantChoiceOverride.tsx
+++ b/frontend/src/components/Admin/TenantChoiceOverride.tsx
@@ -11,6 +11,7 @@ import type { ColumnsType } from 'antd/es/table';
 
 import { apiClient } from '../../services/apiService';
 import { useToast } from '../../hooks/useToast';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 const { Text } = Typography;
 

--- a/frontend/src/components/Cockpit/CockpitTour.tsx
+++ b/frontend/src/components/Cockpit/CockpitTour.tsx
@@ -248,7 +248,7 @@ export const CockpitTour: React.FC<CockpitTourProps> = ({
       continuous
       options={options}
       styles={styles}
-      callback={handleJoyrideCallback}
+      onEvent={handleJoyrideCallback}
       locale={{
         back: 'Back',
         close: 'Close',

--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -512,7 +512,12 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
   const [results, setResults] = useState<Record<string, SearchEntity[]>>({});
   const [resultCounts, setResultCounts] = useState<Record<string, number>>({});
   const [relationalChunks, setRelationalChunks] = useState<RelationalChunk[]>([]);
-  const { toggleFavorite: toggleFavoriteMutation, isFavorited, isLoading: isFavoritesLoading } = useFavorites();
+  const {
+    favorites,
+    toggleFavorite: toggleFavoriteMutation,
+    isFavorited,
+    isLoading: isFavoritesLoading,
+  } = useFavorites();
   const [hasMigratedLegacyFavorites, setHasMigratedLegacyFavorites] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const [isRelationsLoading, setIsRelationsLoading] = useState(false);

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
@@ -24,6 +24,7 @@ import { Eye, EyeOff, ChevronDown, ChevronUp, Zap } from 'lucide-react';
 import { ValidationRuleBuilder, ValidationRule } from './ValidationRuleBuilder';
 import { ConditionBuilder, ConditionRule, ConditionLogic } from './ConditionBuilder';
 import { useFlowEditor } from '../context';
+import { showAlert } from '@/utils/uiDialogs';
 import { getUpstreamOutputs, formatInheritanceSyntax, isInheritanceSyntax } from '../../../utils/flowUtils';
 import {
   PanelHeader,

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -8467,7 +8467,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         steps={tourSteps}
         run={runTour}
         stepIndex={tourStepIndex}
-        callback={handleTourCallback}
+        onEvent={handleTourCallback}
         continuous
         options={tourOptions}
         styles={tourStyles}

--- a/frontend/src/components/FlowEditor/hooks/useOnboardingTour.tsx
+++ b/frontend/src/components/FlowEditor/hooks/useOnboardingTour.tsx
@@ -300,8 +300,9 @@ export const tourOptions: Partial<Options> = {
   zIndex: 10050,
   showProgress: true,
   buttons: ['back', 'close', 'primary', 'skip'],
-  spotlightClicks: true,
-  disableOverlayClose: false,
+  // Allow clicking the highlighted target and avoid overlay clicks ending the tour.
+  blockTargetInteraction: false,
+  overlayClickAction: false,
 };
 
 export const tourStyles: PartialDeep<Styles> = {

--- a/frontend/src/components/Fulfillment/CreateFulfillmentModal.tsx
+++ b/frontend/src/components/Fulfillment/CreateFulfillmentModal.tsx
@@ -563,6 +563,17 @@ export const CreateFulfillmentModal: React.FC<CreateFulfillmentModalProps> = ({
     void loadInquiryDetail(selectedInquiryId);
   }, [inquiry, isOpen, loadInquiryDetail, selectedInquiryId]);
 
+  const resetFulfillmentFields = useCallback(() => {
+    setShippingType('tenant');
+    setSupplierId('');
+    setCarrierId('');
+    setTrackingNumbers('');
+    setEstimatedDelivery('');
+    setNotes('');
+    setLineItems([]);
+    setError(null);
+  }, []);
+
   // Initialize line items from inquiry products
   useEffect(() => {
     if (isOpen && resolvedInquiry?.products) {
@@ -675,17 +686,6 @@ export const CreateFulfillmentModal: React.FC<CreateFulfillmentModalProps> = ({
     ),
     [selectedItems]
   );
-
-  const resetFulfillmentFields = useCallback(() => {
-    setShippingType('tenant');
-    setSupplierId('');
-    setCarrierId('');
-    setTrackingNumbers('');
-    setEstimatedDelivery('');
-    setNotes('');
-    setLineItems([]);
-    setError(null);
-  }, []);
 
   const resetForm = () => {
     resetFulfillmentFields();

--- a/frontend/src/components/Inquiry/InquiryEmbeddedView.tsx
+++ b/frontend/src/components/Inquiry/InquiryEmbeddedView.tsx
@@ -278,7 +278,7 @@ export const InquiryEmbeddedView: React.FC<InquiryEmbeddedViewProps> = ({ inquir
             </Field>
             <Field $span={6}>
               <Label>Company</Label>
-              <ValueBox>{inquiry.contact_snapshot_company || inquiry.contact_company || '-'}</ValueBox>
+              <ValueBox>{inquiry.contact_snapshot_company || entityLabel || '-'}</ValueBox>
             </Field>
           </Grid>
         </Section>

--- a/frontend/src/components/ui/CountrySelect.tsx
+++ b/frontend/src/components/ui/CountrySelect.tsx
@@ -12,8 +12,14 @@ import { Select as AntSelect } from 'antd';
 import { COUNTRY_OPTIONS, DEFAULT_COUNTRY } from '../../utils/constants/countries';
 
 export interface CountrySelectProps {
-  value: string;
-  onChange: (value: string) => void;
+  /**
+   * Optional to support AntD Form.Item injecting value/onChange at runtime.
+   */
+  value?: string;
+  /**
+   * Optional to support AntD Form.Item injecting value/onChange at runtime.
+   */
+  onChange?: (value: string) => void;
   placeholder?: string;
   disabled?: boolean;
   allowClear?: boolean;
@@ -33,7 +39,7 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({
   return (
     <AntSelect
       value={effectiveValue || undefined}
-      onChange={(next) => onChange(String(next || DEFAULT_COUNTRY))}
+      onChange={(next) => onChange?.(String(next || DEFAULT_COUNTRY))}
       placeholder={placeholder}
       disabled={disabled}
       allowClear={allowClear}

--- a/frontend/src/components/ui/PhoneInput.tsx
+++ b/frontend/src/components/ui/PhoneInput.tsx
@@ -15,8 +15,14 @@ import { Theme } from '../../config/theme';
 import { useTheme } from '../../contexts/ThemeContext';
 
 export interface PhoneInputProps {
-  value: string;
-  onChange: (value: string) => void;
+  /**
+   * Optional to support AntD Form.Item injecting value/onChange at runtime.
+   */
+  value?: string;
+  /**
+   * Optional to support AntD Form.Item injecting value/onChange at runtime.
+   */
+  onChange?: (value: string) => void;
   placeholder?: string;
   error?: string;
   disabled?: boolean;
@@ -40,14 +46,14 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     // Strip formatting and pass raw digits
     const rawValue = e.target.value.replace(/\D/g, '');
-    onChange(rawValue);
+    onChange?.(rawValue);
   };
 
   return (
     <PhoneInputContainer>
       <StyledInputMask
         mask="(999) 999-9999"
-        value={value}
+        value={value ?? ''}
         onChange={handleChange}
         disabled={disabled}
         placeholder={placeholder}

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -33,6 +33,7 @@ import { apiClient } from '@/services/apiService';
 import { AdminGuard, AdminPage, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 import { getChoices, type ChoiceOption } from '@/services/choicesService';
+import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 
 import { TenantChoiceOverride } from '@/components/Admin/TenantChoiceOverride';
 
@@ -244,11 +245,11 @@ const OptionListsPage: React.FC = () => {
   ): Promise<boolean> => {
     if (!canEditProductOverrides) {
       message.info('Only tenant administrators can edit product overrides.');
-      return;
+      return false;
     }
 
     const pid = String(productId || '').trim();
-    if (!pid) return;
+    if (!pid) return false;
 
     const existing = productPreferences[pid];
     try {
@@ -267,7 +268,7 @@ const OptionListsPage: React.FC = () => {
         const resp = await apiClient.patch(`/system/product-preferences/${existing.id}/`, payload);
         const updated = resp.data as TenantProductPreference;
         setProductPreferences((prev) => ({ ...prev, [pid]: updated }));
-        return;
+        return true;
       }
 
       const payload: Record<string, unknown> = {
@@ -285,8 +286,43 @@ const OptionListsPage: React.FC = () => {
       const resp = await apiClient.post('/system/product-preferences/', payload);
       const created = resp.data as TenantProductPreference;
       setProductPreferences((prev) => ({ ...prev, [pid]: created }));
+      return true;
     } catch (err: any) {
       message.error(err?.response?.data?.detail || err?.response?.data?.error || 'Failed to save product override');
+      return false;
+    }
+  };
+
+  const deleteProductPreference = async (productId: string): Promise<boolean> => {
+    if (!canEditProductOverrides) {
+      message.info('Only tenant administrators can edit product overrides.');
+      return false;
+    }
+
+    const pid = String(productId || '').trim();
+    if (!pid) return false;
+
+    const existing = productPreferences[pid];
+    if (!existing?.id) {
+      setProductPreferences((prev) => {
+        const next = { ...prev };
+        delete next[pid];
+        return next;
+      });
+      return true;
+    }
+
+    try {
+      await apiClient.delete(`/system/product-preferences/${existing.id}/`);
+      setProductPreferences((prev) => {
+        const next = { ...prev };
+        delete next[pid];
+        return next;
+      });
+      return true;
+    } catch (err: any) {
+      message.error(err?.response?.data?.detail || err?.response?.data?.error || 'Failed to remove product override');
+      return false;
     }
   };
 

--- a/frontend/src/pages/Customers/Products.tsx
+++ b/frontend/src/pages/Customers/Products.tsx
@@ -16,6 +16,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, DeleteOutlined, ArrowLeftOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
 import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 interface Product {
   id: string;

--- a/frontend/src/pages/Plants/Products.tsx
+++ b/frontend/src/pages/Plants/Products.tsx
@@ -12,6 +12,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, DeleteOutlined, ArrowLeftOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
 import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 interface SystemProduct {
   id: string;

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -1192,6 +1192,12 @@ const Subtitle = styled.p`
   color: rgb(var(--color-text-secondary));
 `;
 
+const HelperText = styled.div<{ $theme: Theme }>`
+  margin-top: 6px;
+  font-size: 12px;
+  color: ${(props) => props.$theme.colors.textSecondary};
+`;
+
 const HeaderActions = styled.div`
   display: flex;
   gap: 10px;

--- a/frontend/src/pages/Suppliers/Plants.tsx
+++ b/frontend/src/pages/Suppliers/Plants.tsx
@@ -18,6 +18,7 @@ import { US_STATES } from '../../utils/constants/states';
 import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, EditOutlined, DeleteOutlined, AppstoreOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 // ============================================================================
 // TypeScript Interfaces

--- a/frontend/src/pages/Suppliers/Products.tsx
+++ b/frontend/src/pages/Suppliers/Products.tsx
@@ -12,6 +12,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, DeleteOutlined, ArrowLeftOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
 import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
+import { confirmDialog } from '@/utils/uiDialogs';
 
 interface AvailableItem {
   id: number;

--- a/frontend/src/types/country-list.d.ts
+++ b/frontend/src/types/country-list.d.ts
@@ -1,0 +1,8 @@
+declare module 'country-list' {
+  export interface CountryListItem {
+    code: string;
+    name: string;
+  }
+
+  export function getData(): CountryListItem[];
+}

--- a/frontend/src/utils/constants/countries.ts
+++ b/frontend/src/utils/constants/countries.ts
@@ -5,7 +5,7 @@
  * (many models default to "USA"). For other countries, we store the country name.
  */
 
-import { getData } from 'country-list';
+import { getData, type CountryListItem } from 'country-list';
 
 export interface CountryOption {
   value: string;
@@ -15,7 +15,7 @@ export interface CountryOption {
 
 export const DEFAULT_COUNTRY = 'USA';
 
-const raw = getData(); // [{ code: 'US', name: 'United States' }, ...]
+const raw: CountryListItem[] = getData(); // [{ code: 'US', name: 'United States' }, ...]
 
 const others: CountryOption[] = raw
   .filter((c) => c?.name && c.name !== 'United States')


### PR DESCRIPTION
Executes MASTER_PLAN P0: Type safety gate.\n\n- frontend type-check now passes (npm -C frontend run type-check)\n- Fix missing imports (confirmDialog/showAlert), missing HelperText, and a TDZ hook ordering bug\n- SmartSearch favorites section now uses persisted favorites from useFavorites()\n- AntD Form compatibility: CountrySelect/PhoneInput props made optional (value/onChange injected by Form.Item)\n- Added minimal type shim for country-list\n- Updated tours to react-joyride v3 API (onEvent, options.overlayClickAction/blockTargetInteraction)\n\nNo backend changes.