### PR TITLE
Chore: disable i18next support notice

### DIFF
--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -27,6 +27,7 @@ i18n
   .init({
     resources,
     debug: false,
+    showSupportNotice: false,
     fallbackLng: 'en',
     supportedLngs: supportedLanguages,
     interpolation: {


### PR DESCRIPTION
Disables i18next's built-in Locize support notice banner (console.info) by setting showSupportNotice: false in frontend i18n init config.