### PR TITLE
Fix: workflows 0026 migration percent placeholder

### DIFF
--- a/backend/tenant_apps/workflows/migrations/0026_add_tenant_to_stepassignment.py
+++ b/backend/tenant_apps/workflows/migrations/0026_add_tenant_to_stepassignment.py
@@ -30,11 +30,12 @@ def backfill_tenant_for_stepassignment(apps, schema_editor):
             WHERE tenant_id IS NULL;
 
             IF orphan_count > 0 THEN
-                RAISE EXCEPTION
-                    'Cannot backfill tenant_id: % StepAssignment row(s) have no resolvable '
-                    'tenant (form deleted or form.tenant_id is NULL). Resolve these rows before '
-                    're-running the migration.',
-                    orphan_count;
+                RAISE EXCEPTION (
+                    'Cannot backfill tenant_id: '
+                    || orphan_count
+                    || ' StepAssignment row(s) have no resolvable tenant (form deleted or form.tenant_id is NULL). '
+                    || 'Resolve these rows before re-running the migration.'
+                );
             END IF;
         END $$;
     """)


### PR DESCRIPTION
Fixes dev deploy migration failure (psycopg ProgrammingError: incomplete placeholder '%') by removing PL/pgSQL RAISE format placeholder usage in workflows 0026 backfill check and building the error message via string concatenation instead.