### PR TITLE
Feat: Option Lists CSV export

### DIFF
--- a/frontend/src/components/Admin/AdminTable.tsx
+++ b/frontend/src/components/Admin/AdminTable.tsx
@@ -35,6 +35,7 @@
 
 import React, { useState, useMemo, useCallback } from 'react';
 import styled from 'styled-components';
+import { buildCsv, downloadCsv } from '@/utils/csv';
 import { LoadingSkeleton } from './LoadingSkeleton';
 import { EmptyState } from './EmptyState';
 
@@ -208,58 +209,18 @@ export function AdminTable<T extends Record<string, any>>({
     );
   }
 
-  const normalizeCsvCell = (raw: unknown): string => {
-    if (raw == null) return '';
-    if (raw instanceof Date) return raw.toISOString();
-    if (typeof raw === 'string') return raw;
-    if (typeof raw === 'number' || typeof raw === 'boolean' || typeof raw === 'bigint') return String(raw);
-
-    try {
-      return JSON.stringify(raw);
-    } catch {
-      return String(raw);
-    }
-  };
-
-  const escapeCsvCell = (value: string): string => {
-    const next = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-    const needsQuotes = /[\n",]/.test(next);
-    const escaped = next.replace(/"/g, '""');
-    return needsQuotes ? `"${escaped}"` : escaped;
-  };
-
-  const downloadCsv = (fileName: string, csv: string) => {
-    if (typeof document === 'undefined') return;
-
-    const safeName = fileName.toLowerCase().endsWith('.csv') ? fileName : `${fileName}.csv`;
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.setAttribute('download', safeName);
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-
-    URL.revokeObjectURL(url);
-  };
-
   const handleExportCsv = () => {
     const exportColumns = columns.filter((c) => c.exportable !== false);
-    const headers = exportColumns.map((c) => escapeCsvCell(String(c.exportLabel ?? c.label ?? c.key)));
+    const headers = exportColumns.map((c) => String(c.exportLabel ?? c.label ?? c.key));
 
-    const rows = sortedData.map((row) => {
-      return exportColumns
-        .map((c) => {
-          const raw = resolveValue(row, c.key);
-          const exported = c.exportValue ? c.exportValue(raw, row) : raw;
-          return escapeCsvCell(normalizeCsvCell(exported));
-        })
-        .join(',');
-    });
+    const rows = sortedData.map((row) =>
+      exportColumns.map((c) => {
+        const raw = resolveValue(row, c.key);
+        return c.exportValue ? c.exportValue(raw, row) : raw;
+      })
+    );
 
-    const csv = [headers.join(','), ...rows].join('\n');
+    const csv = buildCsv({ headers, rows });
     downloadCsv(csvExport?.fileName ?? 'export.csv', csv);
   };
 

--- a/frontend/src/pages/Admin/OptionLists/index.tsx
+++ b/frontend/src/pages/Admin/OptionLists/index.tsx
@@ -27,13 +27,14 @@ import {
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
+import { DownloadOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
 
 import { apiClient } from '@/services/apiService';
 import { AdminGuard, AdminPage, EmptyState, LoadingSkeleton } from '@/components/Admin';
 import { useAdminPermissions } from '@/hooks/useAdminPermissions';
 import { getChoices, type ChoiceOption } from '@/services/choicesService';
 import { confirmDialog, showAlert } from '@/utils/uiDialogs';
+import { buildCsv, downloadCsv } from '@/utils/csv';
 
 import { TenantChoiceOverride } from '@/components/Admin/TenantChoiceOverride';
 
@@ -362,6 +363,92 @@ const OptionListsPage: React.FC = () => {
       return name.includes(q) || desc.includes(q) || id.includes(q);
     });
   }, [customLists, searchQuery]);
+
+  const exportDate = new Date().toISOString().split('T')[0];
+
+  const exportSystemListsCsv = () => {
+    if (loading || filteredSystemLists.length === 0) {
+      message.info('No system choice lists to export.');
+      return;
+    }
+
+    const headers = [
+      'Name',
+      'Slug',
+      'Description',
+      'Items Count',
+      'Extensible',
+      'Reorderable',
+      'Model Field Path',
+      'Updated At',
+    ];
+
+    const rows = filteredSystemLists.map((l) => [
+      l.name,
+      l.slug,
+      l.description,
+      l.items_count,
+      l.is_extensible,
+      l.is_reorderable,
+      l.model_field_path,
+      l.updated_at,
+    ]);
+
+    downloadCsv(`system-choice-lists_${exportDate}.csv`, buildCsv({ headers, rows }));
+  };
+
+  const exportCustomListsCsv = () => {
+    if (customLoading || filteredCustomLists.length === 0) {
+      message.info('No custom tenant lists to export.');
+      return;
+    }
+
+    const headers = ['Name', 'ID', 'Description', 'Option Count', 'Active', 'Updated At'];
+    const rows = filteredCustomLists.map((l) => [l.name, l.id, l.description, l.option_count, l.is_active, l.updated_at]);
+
+    downloadCsv(`custom-lists_${exportDate}.csv`, buildCsv({ headers, rows }));
+  };
+
+  const exportMasterProductsCsv = () => {
+    if (productsLoading || productPrefsLoading || filteredMasterProducts.length === 0) {
+      message.info('No master products to export.');
+      return;
+    }
+
+    const headers = [
+      'Product Code',
+      'System Name',
+      'Protein Type',
+      'Category',
+      'System Active',
+      'Tenant Display Name',
+      'Tenant Internal Code',
+      'Tenant Active',
+      'Tenant Favorite',
+      'Tenant Sort Order',
+      'Tenant Notes',
+    ];
+
+    const rows = filteredMasterProducts.map((p) => {
+      const pref = productPreferences[String(p.id)];
+      const tenantActive = pref ? Boolean(pref.is_active) : Boolean(p.is_active ?? true);
+      return [
+        p.product_code,
+        p.name,
+        p.protein_type,
+        p.category,
+        Boolean(p.is_active ?? true),
+        pref?.display_name ?? '',
+        pref?.internal_code ?? '',
+        tenantActive,
+        Boolean(pref?.is_favorite ?? false),
+        pref?.sort_order ?? 0,
+        pref?.notes ?? '',
+      ];
+    });
+
+    downloadCsv(`master-products_${exportDate}.csv`, buildCsv({ headers, rows }));
+  };
 
   const openCreateCustomList = () => {
     if (!canEdit) {
@@ -754,9 +841,36 @@ const OptionListsPage: React.FC = () => {
               Add Product
             </Button>
           )}
+          {activeTab === 'system' && (
+            <Button
+              icon={<DownloadOutlined />}
+              onClick={exportMasterProductsCsv}
+              disabled={productsLoading || productPrefsLoading || filteredMasterProducts.length === 0}
+            >
+              Export Products
+            </Button>
+          )}
+          {activeTab === 'system' && (
+            <Button
+              icon={<DownloadOutlined />}
+              onClick={exportSystemListsCsv}
+              disabled={loading || filteredSystemLists.length === 0}
+            >
+              Export Choice Lists
+            </Button>
+          )}
           {activeTab === 'custom' && (
             <Button type="primary" icon={<PlusOutlined />} onClick={openCreateCustomList}>
               Create Custom List
+            </Button>
+          )}
+          {activeTab === 'custom' && (
+            <Button
+              icon={<DownloadOutlined />}
+              onClick={exportCustomListsCsv}
+              disabled={customLoading || filteredCustomLists.length === 0}
+            >
+              Export Custom Lists
             </Button>
           )}
           <Input.Search

--- a/frontend/src/utils/csv.ts
+++ b/frontend/src/utils/csv.ts
@@ -1,0 +1,56 @@
+export interface BuildCsvOptions {
+  headers: string[];
+  rows: unknown[][];
+}
+
+const normalizeCsvCell = (raw: unknown): string => {
+  if (raw == null) return '';
+  if (raw instanceof Date) return raw.toISOString();
+
+  const asString =
+    typeof raw === 'string'
+      ? raw
+      : typeof raw === 'number' || typeof raw === 'boolean' || typeof raw === 'bigint'
+        ? String(raw)
+        : (() => {
+            try {
+              return JSON.stringify(raw);
+            } catch {
+              return String(raw);
+            }
+          })();
+
+  // Prevent Excel/Sheets formula injection on export.
+  if (/^[\t\r\n ]*[=+\-@]/.test(asString)) return `'${asString}`;
+  return asString;
+};
+
+const escapeCsvCell = (value: string): string => {
+  const next = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const needsQuotes = /[\n",]/.test(next);
+  const escaped = next.replace(/"/g, '""');
+  return needsQuotes ? `"${escaped}"` : escaped;
+};
+
+export const buildCsv = ({ headers, rows }: BuildCsvOptions): string => {
+  const headerLine = headers.map((h) => escapeCsvCell(String(h ?? ''))).join(',');
+  const lines = rows.map((row) => row.map((cell) => escapeCsvCell(normalizeCsvCell(cell))).join(','));
+  return [headerLine, ...lines].join('\n');
+};
+
+export const downloadCsv = (fileName: string, csv: string) => {
+  if (typeof document === 'undefined') return;
+
+  const safeName = fileName.toLowerCase().endsWith('.csv') ? fileName : `${fileName}.csv`;
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', safeName);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
Admin list builder: adds reusable CSV utility (with formula-injection protection), refactors AdminTable export to use it, and adds Export CSV actions to Admin → Option Lists for Master Products, System Choice Lists, and Custom Tenant Lists.