### PR TITLE
Fix Create Fulfillment crash + InquiryTemplates API path

### DIFF
--- a/frontend/src/components/Fulfillment/CreateFulfillmentModal.tsx
+++ b/frontend/src/components/Fulfillment/CreateFulfillmentModal.tsx
@@ -687,7 +687,7 @@ export const CreateFulfillmentModal: React.FC<CreateFulfillmentModalProps> = ({
     [selectedItems]
   );
 
-  const resetForm = () => {
+  function resetForm(): void {
     resetFulfillmentFields();
 
     if (!inquiry) {
@@ -696,16 +696,16 @@ export const CreateFulfillmentModal: React.FC<CreateFulfillmentModalProps> = ({
       setSelectedInquiryId('');
       setInquiryOptions([]);
     }
-  };
+  }
 
-  const handleClose = () => {
+  function handleClose(): void {
     if (!submitting) {
       resetForm();
       onClose();
     }
-  };
+  }
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
     e.preventDefault();
     setError(null);
 
@@ -759,7 +759,7 @@ export const CreateFulfillmentModal: React.FC<CreateFulfillmentModalProps> = ({
     } finally {
       setSubmitting(false);
     }
-  };
+  }
 
   if (!isOpen) return null;
 

--- a/frontend/src/pages/Admin/OptionLists/OptionListModal.test.tsx
+++ b/frontend/src/pages/Admin/OptionLists/OptionListModal.test.tsx
@@ -11,15 +11,6 @@ import { OptionListModal } from './OptionListModal';
 import * as apiService from '../../../services/apiService';
 import { ToastProvider } from '../../../hooks/useToast';
 
-vi.mock('../../../hooks/useToast', () => ({
-  useToast: () => ({
-    success: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warning: vi.fn(),
-  }),
-}));
-
 vi.mock(import('../../../hooks/useToast'), async (importOriginal) => {
   const actual = await importOriginal();
 
@@ -30,6 +21,7 @@ vi.mock(import('../../../hooks/useToast'), async (importOriginal) => {
       error: vi.fn(),
       info: vi.fn(),
       warning: vi.fn(),
+      dismiss: vi.fn(),
     }),
   };
 });

--- a/frontend/src/pages/InquiryTemplates.tsx
+++ b/frontend/src/pages/InquiryTemplates.tsx
@@ -267,7 +267,7 @@ const InquiryTemplates: React.FC = () => {
       if (entityFilter !== 'all') params.entity_type = entityFilter;
       if (statusFilter !== 'all') params.is_active = statusFilter;
       
-      const response = await apiClient.get('/api/v1/inquiry-templates/', { params });
+      const response = await apiClient.get('/inquiry-templates/', { params });
       setTemplates(response.data.results || response.data);
     } catch (error) {
       console.error('Failed to fetch templates:', error);
@@ -302,7 +302,7 @@ const InquiryTemplates: React.FC = () => {
     if (!confirmed) return;
 
     try {
-      await apiClient.delete(`/api/v1/inquiry-templates/${template.id}/`);
+      await apiClient.delete(`/inquiry-templates/${template.id}/`);
       setTemplates(prev => prev.filter(t => t.id !== template.id));
     } catch (error) {
       console.error('Failed to delete template:', error);
@@ -312,7 +312,7 @@ const InquiryTemplates: React.FC = () => {
   
   const handleToggleActive = async (template: InquiryTemplate) => {
     try {
-      const response = await apiClient.patch(`/api/v1/inquiry-templates/${template.id}/`, {
+      const response = await apiClient.patch(`/inquiry-templates/${template.id}/`, {
         is_active: !template.is_active,
       });
       setTemplates(prev => prev.map(t => 


### PR DESCRIPTION
Fixes:
- Create Fulfillment modal: hoist handlers to avoid TDZ/minifier ordering issue ("Cannot access 'de' before initialization").
- InquiryTemplates: remove duplicate /api/v1 prefix to stop /api/v1/api/v1 404s.
- OptionListModal tests: mock useToast without breaking ToastProvider export.

Validation:
- frontend: npm run test:ci
- frontend: npm run type-check
- frontend: npm run build