### PR TITLE
AI assistant: diagnostics recent-errors alias

### DIFF
--- a/backend/tenant_apps/ai_assistant/urls.py
+++ b/backend/tenant_apps/ai_assistant/urls.py
@@ -46,6 +46,8 @@ urlpatterns = [
     path('review/pending/', PendingReviewView.as_view(), name='pending-review'),
     path('tools/openapi/', ToolsOpenAPIView.as_view(), name='tools-openapi'),
     path('errors/recent/', RecentErrorsAPIView.as_view(), name='ai-recent-errors'),
+    # Backward/ops-friendly alias (admin-only): matches runbooks that refer to /diagnostics/recent-errors/
+    path('diagnostics/recent-errors/', RecentErrorsAPIView.as_view(), name='ai-diagnostics-recent-errors'),
 
     # Supporting endpoints
     path('review/<uuid:feedback_id>/resolve/', PendingReviewResolveAPIView.as_view(), name='ai-review-resolve'),


### PR DESCRIPTION
Adds a backwards-compatible alias route:
- /api/v1/ai-assistant/diagnostics/recent-errors/ → RecentErrorsAPIView (admin-only)

This matches ops/runbook references while keeping the existing /errors/recent/ endpoint intact.

Validation:
- python -m compileall backend/tenant_apps/ai_assistant