### PR TITLE
Stabilize AI Assistant + Workforms API (V3.0)

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -125,6 +125,11 @@ This file is the **append-only PR-referenceable execution log**.
 
 ## Phase 9.5: Preemptive Hardening & Advanced UX (Workforms Editor)
 
+### 2026-03-30 — Phase 9.5: AI Assistant + Workforms API Stabilization (V3.0)
+- AI Assistant uploads: assert RLS session vars via `set_current_tenant()` inside the upload save transaction (reduces intermittent RLS write failures).
+- FlowEditor node schemas: `formProcessSchema` now uses `nodeType: 'formProcess'` and registers a legacy alias for `formMultiStepContainer`.
+- Entity API: `_get_entity_or_404` now resolves entity types case-insensitively and maps short-names (e.g., `Inquiry`) to canonical keys.
+
 ### 2026-03-27 — Phase 9.5: Admin Workspace Hardening
 - Invitations: resend action now uses the shared invitation email helper (extracted from `signals.py`), and create prefers the current request tenant.
 - Tenant Users: admins can remove a user (hard delete) as long as the role is not `owner`.

--- a/backend/apps/system/views/entity_viewset.py
+++ b/backend/apps/system/views/entity_viewset.py
@@ -341,10 +341,38 @@ class EntityViewSet(viewsets.ViewSet):
     def _get_entity_or_404(self, request, *, type, pk):
         tenant = request.tenant
 
-        if type not in self.MODEL_MAP:
-            raise ValueError(f'Unknown entity type: {type}')
+        raw_type = str(type or '').strip()
+        if not raw_type:
+            raise ValueError('Unknown entity type:')
 
-        app_label, model_name = self.MODEL_MAP[type]
+        # Allow case-insensitive and short-name inputs (e.g., "Inquiry" instead of "inquiry").
+        candidate = raw_type.replace('-', '_').strip()
+        candidate_lc = candidate.lower()
+
+        resolved_type = None
+        if candidate_lc in self.MODEL_MAP:
+            resolved_type = candidate_lc
+        else:
+            import re
+
+            # CamelCase/PascalCase -> snake_case
+            snake = re.sub(r'(.)([A-Z][a-z]+)', r'\1_\2', candidate)
+            snake = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', snake).lower()
+            if snake in self.MODEL_MAP:
+                resolved_type = snake
+            elif snake.endswith('s') and snake[:-1] in self.MODEL_MAP:
+                resolved_type = snake[:-1]
+            else:
+                # Map model/app short names (e.g., Inquiry, inquiries) to canonical keys.
+                for key, (app_label, model_name) in self.MODEL_MAP.items():
+                    if candidate_lc == model_name.lower() or candidate_lc == app_label.lower():
+                        resolved_type = key
+                        break
+
+        if not resolved_type:
+            raise ValueError(f'Unknown entity type: {raw_type}')
+
+        app_label, model_name = self.MODEL_MAP[resolved_type]
         try:
             Model = apps.get_model(app_label, model_name)
         except LookupError as exc:
@@ -355,7 +383,7 @@ class EntityViewSet(viewsets.ViewSet):
         else:
             entity = Model.objects.get(pk=pk)
 
-        return entity, type, Model
+        return entity, resolved_type, Model
 
     def _entity_type_for_model(self, model):
         """Best-effort mapping from Django model to Cockpit entity type string."""

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -432,26 +432,34 @@ class AIDocumentViewSet(viewsets.ModelViewSet):
             raise ValidationError('Tenant context required.')
 
         tenant_id = str(getattr(tenant, 'id', '') or '')
-        if tenant_id:
-            # Defense-in-depth: assert RLS vars right before the write.
-            try:
-                with connection.cursor() as cursor:
-                    cursor.execute("SET app.current_tenant_id = %s", [tenant_id])
-                    cursor.execute("SET app.current_tenant = %s", [tenant_id])
-            except Exception:
-                logger.warning('AIDocument upload: failed to assert RLS session vars', exc_info=True)
 
         try:
-            instance = serializer.save(
-                tenant=tenant,
-                owner=self.request.user,
-                original_filename=getattr(self.request.FILES.get('file'), 'name', ''),
-                content_type=getattr(self.request.FILES.get('file'), 'content_type', '') or '',
-                file_size=getattr(self.request.FILES.get('file'), 'size', 0) or 0,
-            )
-        except Exception as e:
+            from django.db import transaction
             from django.db.utils import DatabaseError, ProgrammingError
             from rest_framework.exceptions import ValidationError
+
+            from apps.tenants.rls import set_current_tenant
+
+            with transaction.atomic():
+                # Defense-in-depth: assert RLS vars on the active connection inside the write transaction.
+                if tenant_id:
+                    rls = set_current_tenant(tenant_id)
+                    if not rls.ok:
+                        logger.warning(
+                            'AIDocument upload: failed to assert RLS session vars tenant=%s err=%s',
+                            tenant_id,
+                            rls.error,
+                            exc_info=True,
+                        )
+
+                instance = serializer.save(
+                    tenant=tenant,
+                    owner=self.request.user,
+                    original_filename=getattr(self.request.FILES.get('file'), 'name', ''),
+                    content_type=getattr(self.request.FILES.get('file'), 'content_type', '') or '',
+                    file_size=getattr(self.request.FILES.get('file'), 'size', 0) or 0,
+                )
+        except Exception as e:
 
             if isinstance(e, ValidationError):
                 raise

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -448,7 +448,7 @@ export const formSchema: NodeConfigSchema = {
  * into a cohesive workflow with navigation and behavior settings.
  */
 export const formProcessSchema: NodeConfigSchema = {
-  nodeType: 'formMultiStepContainer',
+  nodeType: 'formProcess',
   displayName: 'Form Process',
   description: 'Container for multi-step forms with navigation controls',
   icon: Package,
@@ -944,6 +944,8 @@ const buildAllSchemas = (): NodeConfigSchema[] => [
   // === CORE SCHEMAS (Phase 1-3) ===
   formSchema,  // NEW: Primary form step schema (Phase E - 2026-02-19)
   formProcessSchema,
+  // Backward compatibility: legacy node type for the same concept.
+  { ...formProcessSchema, nodeType: 'formMultiStepContainer' },
   formBookSchema,
   formProcessGroupSchema,
   createRecordSchema,


### PR DESCRIPTION
Includes:
- AIDocument uploads: assert RLS session vars via apps.tenants.rls.set_current_tenant() inside transaction.atomic.
- FlowEditor node schemas: formProcessSchema nodeType aligned to 'formProcess' and registers legacy alias for 'formMultiStepContainer'.
- Entity API: _get_entity_or_404 now case-insensitive and maps short-name inputs (e.g., Inquiry) to canonical keys.
- Docs: append Phase 9.5 stabilization log entry.

Validation:
- python -m compileall backend/tenant_apps/ai_assistant backend/apps/system
- frontend: npm run type-check