### PR TITLE
chore(deps): bump vite-plugin-svgr to 5.0.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -100,7 +100,7 @@
         "tailwindcss": "3.4.19",
         "typescript": "^6.0.2",
         "vite": "^8.0.3",
-        "vite-plugin-svgr": "^4.5.0",
+        "vite-plugin-svgr": "^5.0.0",
         "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.2",
         "webpack": "^5.105.4",
@@ -14156,9 +14156,9 @@
       }
     },
     "node_modules/vite-plugin-svgr": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.5.0.tgz",
-      "integrity": "sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-5.0.0.tgz",
+      "integrity": "sha512-CZFWDtbWSLnF6C+uv8u7E5Ao6UVQYBpJrS6212XsEod/Lm4ErhOoFc01/po4ie5hqvMCr5KYrlMrSGQQEtMtBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14167,7 +14167,7 @@
         "@svgr/plugin-jsx": "^8.1.0"
       },
       "peerDependencies": {
-        "vite": ">=2.6.0"
+        "vite": ">=3.0.0"
       }
     },
     "node_modules/vite-plugin-svgr/node_modules/@rollup/pluginutils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -136,7 +136,7 @@
     "tailwindcss": "3.4.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.3",
-    "vite-plugin-svgr": "^4.5.0",
+    "vite-plugin-svgr": "^5.0.0",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.2",
     "webpack": "^5.105.4",


### PR DESCRIPTION
Supersedes #4137 (which became conflicting after other dependency merges).

- frontend: bump vite-plugin-svgr ^4.5.0 → ^5.0.0
- update package-lock accordingly

Validation:
- frontend: npm run type-check