### PR TITLE
V3 Phase 1.1: Expand system form schema contract

### DIFF
--- a/backend/apps/system/tests/test_product_validation.py
+++ b/backend/apps/system/tests/test_product_validation.py
@@ -19,39 +19,33 @@ class ProductValidationTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Set up test data once for all tests."""
-        # Create protein_type choice list
-        cls.protein_choice_list = SystemChoiceList.objects.create(
+        # Create protein_type choice list (may already be seeded by migrations)
+        cls.protein_choice_list, _created = SystemChoiceList.objects.get_or_create(
             slug='protein_type',
-            name='Protein Type',
-            description='Types of protein for products',
-            model_field_path='system.Product.protein_type',
-            is_extensible=False,
+            defaults={
+                'name': 'Protein Type',
+                'description': 'Types of protein for products',
+                'model_field_path': 'system.Product.protein_type',
+                'is_extensible': False,
+            },
         )
-        
-        # Create valid protein types
-        SystemChoiceItem.objects.bulk_create([
-            SystemChoiceItem(
-                choice_list=cls.protein_choice_list,
-                value='beef',
-                label='Beef',
-                order=1,
-                is_active=True,
-            ),
-            SystemChoiceItem(
-                choice_list=cls.protein_choice_list,
-                value='pork',
-                label='Pork',
-                order=2,
-                is_active=True,
-            ),
-            SystemChoiceItem(
-                choice_list=cls.protein_choice_list,
-                value='poultry',
-                label='Poultry',
-                order=3,
-                is_active=True,
-            ),
-        ])
+
+        # Ensure valid protein types exist
+        SystemChoiceItem.objects.update_or_create(
+            choice_list=cls.protein_choice_list,
+            value='beef',
+            defaults={'label': 'Beef', 'order': 1, 'is_active': True},
+        )
+        SystemChoiceItem.objects.update_or_create(
+            choice_list=cls.protein_choice_list,
+            value='pork',
+            defaults={'label': 'Pork', 'order': 2, 'is_active': True},
+        )
+        SystemChoiceItem.objects.update_or_create(
+            choice_list=cls.protein_choice_list,
+            value='poultry',
+            defaults={'label': 'Poultry', 'order': 3, 'is_active': True},
+        )
     
     def test_valid_protein_type_passes(self):
         """Test that valid protein_type values are accepted."""
@@ -148,13 +142,11 @@ class ProductValidationTest(TestCase):
     
     def test_inactive_protein_type_fails(self):
         """Test that inactive protein_type values are rejected."""
-        # Create inactive choice
-        SystemChoiceItem.objects.create(
+        # Create inactive choice (may already exist if seeded)
+        SystemChoiceItem.objects.update_or_create(
             choice_list=self.protein_choice_list,
             value='lamb',
-            label='Lamb',
-            order=4,
-            is_active=False,  # Inactive
+            defaults={'label': 'Lamb', 'order': 4, 'is_active': False},
         )
         
         product = Product(

--- a/backend/apps/system/views/forms_schema.py
+++ b/backend/apps/system/views/forms_schema.py
@@ -26,7 +26,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status
 
-from apps.system.services.entity_introspection import get_entity_fields
+from apps.system.services.entity_introspection import get_entity_display_fields, get_entity_fields
 
 
 _SKIP_FIELDS = {
@@ -80,22 +80,62 @@ class SystemFormSchemaView(APIView):
             return Response({'error': f'Entity not found: {entity_type}'}, status=status.HTTP_404_NOT_FOUND)
 
         mapped_fields = []
-        for f in fields:
+        for idx, f in enumerate(fields):
             name = str(f.get('name') or '').strip()
             if not name or name in _SKIP_FIELDS:
                 continue
+
+            introspected_type = str(f.get('field_type') or 'text')
+            mapped_type = _map_field_type(introspected_type)
+
+            relationship = None
+            ui: dict[str, Any] = {'read_only': bool(f.get('read_only', False))}
+
+            field_type_raw = introspected_type.lower()
+            related_entity = f.get('related_entity')
+
+            if field_type_raw in {'foreign_key', 'many_to_many'}:
+                kind = 'fk' if field_type_raw == 'foreign_key' else 'm2m'
+                display_field = None
+                if related_entity:
+                    try:
+                        display_fields = get_entity_display_fields(str(related_entity))
+                        display_field = display_fields[0] if display_fields else None
+                    except Exception:
+                        display_field = None
+
+                relationship = {
+                    'kind': kind,
+                    'entity_type': str(related_entity or ''),
+                    'display_field': display_field,
+                }
+                ui['widget'] = 'searchable_select'
+
+            elif f.get('choices'):
+                relationship = {
+                    'kind': 'choice',
+                    'entity_type': 'choice',
+                    'display_field': None,
+                }
+                ui['widget'] = 'select'
+
+            if mapped_type in {'textarea', 'date', 'datetime', 'email'}:
+                ui.setdefault('widget', mapped_type)
 
             mapped_fields.append(
                 {
                     'key': name,
                     'label': f.get('label') or name.replace('_', ' ').title(),
-                    'type': _map_field_type(str(f.get('field_type') or 'text')),
+                    'type': mapped_type,
                     'required': bool(f.get('is_required')),
-                    'placeholder': None,
+                    'placeholder': f.get('placeholder'),
                     'help_text': f.get('help_text') or '',
-                    # Future: relationship metadata / options injection
-                    'related_entity': f.get('related_entity'),
+                    'relationship': relationship,
+                    'ui': ui,
+                    # Backward-compat for existing clients
+                    'related_entity': related_entity,
                     'choices': f.get('choices') or None,
+                    'order': idx,
                 }
             )
 


### PR DESCRIPTION
Implements Phase 1.1 of docs/plans/V3_FINAL_PUSH_PERFECTION.md by expanding the existing GET /api/v1/system/forms/schema/ endpoint additively.

Changes:
- Add per-field relationship metadata (fk/m2m/choice) and ui metadata (widget/read_only)
- Preserve existing keys (related_entity, choices, key_fields) for backward compatibility
- Add stable order field for deterministic UI rendering
- Make ProductValidation system tests resilient when choice lists/items are seeded by migrations

Verification:
- python manage.py check --settings=projectmeats.settings.test
- python manage.py test apps.system --settings=projectmeats.settings.test

Follow-up:
- Will append a log entry to .github/MASTER_PLAN.md in this PR once the PR number is assigned.
