### PR TITLE
Fix AI Swarm + Universal Search execution issues

### DIFF
--- a/backend/apps/core/services/universal_search.py
+++ b/backend/apps/core/services/universal_search.py
@@ -279,19 +279,19 @@ class UniversalSearchService:
         return combined
     
     def _search_entity(
-        self, 
-        entity_type: str, 
-        search_text: str, 
-        limit: int = 10
-    ) -> List[Dict[str, Any]]:
+        self,
+        entity_type: str,
+        search_text: str,
+        limit: int = 10,
+    ) -> Dict[str, Any]:
         """Search a single entity type."""
         config = SEARCHABLE_ENTITIES.get(entity_type)
         if not config:
-            return []
-        
+            return {'items': [], 'total_count': 0}
+
         Model = self._get_model(entity_type)
         if not Model:
-            return []
+            return {'items': [], 'total_count': 0}
         
         try:
             # Build query
@@ -314,11 +314,16 @@ class UniversalSearchService:
             else:
                 # If the user is effectively filtering by entity type (e.g. query="purchase"),
                 # show the most recent records for that type.
-                ordering = '-created_at'
-                if not any(f.name == 'created_at' for f in Model._meta.fields):
+                field_names = {f.name for f in Model._meta.fields}
+                if 'created_at' in field_names:
+                    ordering = '-created_at'
+                elif 'created_on' in field_names:
+                    ordering = '-created_on'
+                else:
                     ordering = '-id'
                 queryset = base_qs.order_by(ordering)
 
+            total_count = queryset.count()
             queryset = queryset[:limit]
             
             # Format results
@@ -338,11 +343,14 @@ class UniversalSearchService:
                     'score': 1.0,  # Basic relevance (can be enhanced)
                 })
             
-            return results
+            return {
+                'items': results,
+                'total_count': total_count,
+            }
             
         except Exception as e:
             logger.error(f"Search error for {entity_type}: {e}")
-            return []
+            return {'items': [], 'total_count': 0}
 
     def get_record_detail(self, entity_type: str, entity_id: str | int) -> Optional[Dict[str, Any]]:
         """Fetch a single record detail payload for a given entity type.
@@ -493,9 +501,12 @@ class UniversalSearchService:
             counts: dict[str, int] = {}
 
             for entity_type in types_to_search:
-                results = self._search_entity(entity_type, normalized_query, limit_per_type)
-                all_results.extend(results)
-                counts[entity_type] = len(results)
+                result = self._search_entity(entity_type, normalized_query, limit_per_type)
+                items = result.get('items') if isinstance(result.get('items'), list) else []
+                total_count = int(result.get('total_count') or 0)
+
+                all_results.extend(items)
+                counts[entity_type] = total_count
 
             # Sort by score (can enhance with relevance ranking)
             all_results.sort(key=lambda x: x.get("score", 0), reverse=True)
@@ -506,7 +517,8 @@ class UniversalSearchService:
                 "operator": operator_type,
                 "results": all_results,
                 "counts": counts,
-                "total": len(all_results),
+                "total": sum(counts.values()),
+                "returned": len(all_results),
             }
 
         # Short TTL keeps search results fresh while protecting the database.

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -676,13 +676,10 @@ class ToolExecutor:
         service = UniversalSearchService(tenant=tenant)
         results = service.search(query, limit_per_type=limit_int, entity_types=entity_types)
 
-        # UniversalSearchService returns a stable dict, but we defensively normalize the "empty" case.
+        # UniversalSearchService returns a stable dict with a flat `results` list.
         results_obj = results if isinstance(results, dict) else {'results': results}
         groups = results_obj.get('results') if isinstance(results_obj.get('results'), list) else []
-        total = 0
-        for g in groups:
-            if isinstance(g, dict) and isinstance(g.get('items'), list):
-                total += len(g.get('items') or [])
+        total = len(groups)
 
         message = None
         if total == 0:
@@ -844,7 +841,7 @@ class ToolExecutor:
             )
             data = [
                 {
-                    'bucket': (r['bucket'].date().isoformat() if r.get('bucket') else None),
+                    'bucket': (r['bucket'].isoformat() if r.get('bucket') else None),
                     'orders': int(r.get('orders') or 0),
                     'value': float(r.get('value') or 0),
                     'averageValue': float(r.get('averageValue') or 0),

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -181,7 +181,7 @@ class ChatBotAPIViewSet(viewsets.ViewSet):
             # right before tool execution to avoid "0 records found" due to missing RLS session vars.
             try:
                 with connection.cursor() as cursor:
-                    cursor.execute(f"SET app.current_tenant = '{tenant_id}'")
+                    cursor.execute('SET app.current_tenant = %s', [tenant_id])
             except Exception as e:
                 logger.warning('Failed to SET app.current_tenant=%s: %s', tenant_id, str(e), exc_info=True)
                 return Response(


### PR DESCRIPTION
- Swarm executor: fix purchase_order_trends bucket serialization (no .date() on TruncMonth bucket) and correct total count for flat UniversalSearch results.\n- AI assistant view: parameterize SET app.current_tenant to prevent SQL injection.\n- UniversalSearchService: compute total counts before slicing and improve ordering fallback (created_at/created_on).