### PR TITLE
fix(floweditor): auto-map triggers Apply Changes

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -489,9 +489,10 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     const nextData = (updatedNode.data || {}) as Record<string, unknown>;
     setFormData(nextData);
 
-    // Stage the full updated node data into shadow state so dirty tracking is reliable
-    // and the outer Apply/Discard bar appears after applying suggestions.
-    onUpdateNode(node.id, nextData as Record<string, any>);
+    // Stage only the relevant mapping patch into shadow state.
+    // The shadow-state hook expects partial updates; passing the entire formData can
+    // accidentally merge unrelated keys and make dirty detection flaky.
+    onUpdateNode(node.id, { fieldMappings: (nextData as any).fieldMappings } as Record<string, any>);
 
     // UX: hide applied suggestions so the user gets immediate feedback.
     setRejectedSuggestionIds((prev) => {
@@ -520,9 +521,10 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     const nextData = (updatedNode.data || {}) as Record<string, unknown>;
     setFormData(nextData);
 
-    // Stage the full updated node data into shadow state so dirty tracking is reliable
-    // and the outer Apply/Discard bar appears after applying suggestions.
-    onUpdateNode(node.id, nextData as Record<string, any>);
+    // Stage only the relevant mapping patch into shadow state.
+    // The shadow-state hook expects partial updates; passing the entire formData can
+    // accidentally merge unrelated keys and make dirty detection flaky.
+    onUpdateNode(node.id, { fieldMappings: (nextData as any).fieldMappings } as Record<string, any>);
 
     // UX: hide the auto-applied suggestions from the list.
     const autoAppliedIds = (autoMap.suggestions || []).filter((s) => s.autoApply).map((s) => s.id);


### PR DESCRIPTION
When Smart Auto-Map suggestions are applied in DynamicConfigPanel, stage a partial {fieldMappings} patch into shadow state so isDirty becomes true and the Apply Changes CTA appears.