### PR TITLE
feat(floweditor): canonical node titles + inline edit

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -425,6 +425,30 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
         return draft;
       }
 
+      // Canonical node title: keep legacy keys in sync for backwards compatibility.
+      if (fieldId === 'title') {
+        const next: any = {
+          ...prev,
+          title: value,
+          label: value,
+        };
+
+        if (typeof (prev as any).containerName === 'string') next.containerName = value;
+        if (typeof (prev as any).name === 'string') next.name = value;
+
+        onUpdateNode(node.id, next);
+
+        if (field) {
+          const error = validateField(field, value, next);
+          setErrors((errs) => ({
+            ...errs,
+            [fieldId]: error || '',
+          }));
+        }
+
+        return next;
+      }
+
       const next = { ...prev, [fieldId]: value };
       onUpdateNode(node.id, next);
 

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -6194,22 +6194,29 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   // Batch 4: Handler to update node title
   const handleNodeTitleChange = useCallback((nodeId: string, newTitle: string) => {
     logger.debug('[UnifiedFlowEditor] Updating node title', { nodeId, newTitle });
-    
-    setNodes(nds => 
-      nds.map(node => {
-        if (node.id === nodeId) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              label: newTitle,
-            },
-          };
-        }
-        return node;
+
+    setNodes((nds) =>
+      nds.map((node) => {
+        if (node.id !== nodeId) return node;
+
+        const current: any = node.data || {};
+        const next: any = {
+          ...current,
+          title: newTitle,
+          label: newTitle,
+        };
+
+        // Backward compatibility: keep legacy title keys in sync when present.
+        if (typeof current.containerName === 'string') next.containerName = newTitle;
+        if (typeof current.name === 'string') next.name = newTitle;
+
+        return {
+          ...node,
+          data: next,
+        };
       })
     );
-    
+
     setHasUnsavedChanges(true);
   }, [setNodes]);
 
@@ -6577,7 +6584,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
         data: {
           ...defaultData,      // Default node data (fields, actions, etc.)
           ...node.data,        // Template-specific data
-          label: node.data.label || nodeDef?.name || node.type, // Ensure label exists
+          title: node.data.title || node.data.label || nodeDef?.name || node.type,
+          label: node.data.label || node.data.title || nodeDef?.name || node.type, // Ensure label exists
           // Add registry metadata for proper styling
           color: nodeDef?.color,
           icon: nodeDef?.icon,

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -72,26 +72,26 @@ export const formSchema: NodeConfigSchema = {
       description: 'Core configuration for this form step',
       fields: [
         {
-          id: 'name',
+          id: 'title',
           type: 'text',
-          label: 'Step Name',
+          label: 'Title',
           placeholder: 'e.g., Customer Contact Info',
-          helpText: 'Internal name for this step (shown in workflow editor)',
+          helpText: 'Internal title for this step (shown in workflow editor)',
           required: true,
           validation: [
             {
               type: 'required',
-              message: 'Step name is required'
+              message: 'Title is required'
             },
             {
               type: 'minLength',
               value: 3,
-              message: 'Name must be at least 3 characters'
+              message: 'Title must be at least 3 characters'
             },
             {
               type: 'maxLength',
               value: 100,
-              message: 'Name must be less than 100 characters'
+              message: 'Title must be less than 100 characters'
             }
           ]
         },
@@ -468,17 +468,17 @@ export const formProcessSchema: NodeConfigSchema = {
       description: 'Basic information about this form process',
       fields: [
         {
-          id: 'containerName',
+          id: 'title',
           type: 'text',
-          label: 'Container Name',
+          label: 'Title',
           placeholder: 'e.g., Customer Onboarding Form',
-          helpText: 'Display name for this form process',
+          helpText: 'Display title for this form process',
           defaultValue: 'New Form Process',
           required: true,
           validation: [
-            { type: 'required', message: 'Container name is required' },
-            { type: 'minLength', value: 3, message: 'Container name must be at least 3 characters' },
-            { type: 'maxLength', value: 100, message: 'Container name must be at most 100 characters' }
+            { type: 'required', message: 'Title is required' },
+            { type: 'minLength', value: 3, message: 'Title must be at least 3 characters' },
+            { type: 'maxLength', value: 100, message: 'Title must be at most 100 characters' }
           ]
         },
         {
@@ -615,17 +615,17 @@ export const formProcessGroupSchema: NodeConfigSchema = {
       description: 'Basic information about this form group',
       fields: [
         {
-          id: 'containerName',
+          id: 'title',
           type: 'text',
-          label: 'Group Name',
+          label: 'Title',
           placeholder: 'e.g., Customer Information Section',
-          helpText: 'Display name for this form group',
+          helpText: 'Display title for this form group',
           defaultValue: 'New Form Group',
           required: true,
           validation: [
-            { type: 'required', message: 'Group name is required' },
-            { type: 'minLength', value: 3, message: 'Group name must be at least 3 characters' },
-            { type: 'maxLength', value: 100, message: 'Group name must be at most 100 characters' }
+            { type: 'required', message: 'Title is required' },
+            { type: 'minLength', value: 3, message: 'Title must be at least 3 characters' },
+            { type: 'maxLength', value: 100, message: 'Title must be at most 100 characters' }
           ]
         },
         {

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components';
 import { Handle, Position, NodeToolbar, useStore } from '@xyflow/react';
 import { Edit2, Trash2, ChevronDown, ChevronUp, Lock, Unlock, ArrowUp, ArrowDown } from 'lucide-react';
 import { NodeTypeDefinition } from '../nodeTypes';
+import { formatEntityTypeLabel } from '../utils/formatEntityTypeLabel';
 import type { NodeBadgeStatus } from '../components/NodeBadge';
 import { NodeIcon, NodeIconType } from '../components/NodeIcons';
 
@@ -376,7 +377,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
 }) => {
   const nodeType = nodeTypeProp ?? FALLBACK_NODE_TYPE;
   const {
-    label = nodeType.name,
+    label,
     status = 'draft',
     stepNumber,
     errorMessage,
@@ -401,9 +402,12 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
 
   const connectionInProcess = useStore((s: any) => Boolean(s.connectionInProcess));
 
+  const entityFallbackTitle = formatEntityTypeLabel((data as any)?.entityType ?? (data as any)?.entity_type);
+  const resolvedTitle = String(((data as any)?.title ?? label ?? entityFallbackTitle ?? nodeType.name) || nodeType.name);
+
   // Batch 4: Title editing state
   const [isEditingTitle, setIsEditingTitle] = useState(false);
-  const [editedTitle, setEditedTitle] = useState(label);
+  const [editedTitle, setEditedTitle] = useState(resolvedTitle);
   
   // Sprint 1: Drag state
   const [isDragging, setIsDragging] = useState(false);
@@ -431,7 +435,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
     if (!onTitleChange) return;
     e.stopPropagation();
     setIsEditingTitle(true);
-    setEditedTitle(label);
+    setEditedTitle(resolvedTitle);
   };
   
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -439,7 +443,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
   };
   
   const handleTitleBlur = () => {
-    if (onTitleChange && editedTitle !== label) {
+    if (onTitleChange && editedTitle !== resolvedTitle) {
       onTitleChange(editedTitle);
     }
     setIsEditingTitle(false);
@@ -449,7 +453,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
     if (e.key === 'Enter') {
       handleTitleBlur();
     } else if (e.key === 'Escape') {
-      setEditedTitle(label);
+      setEditedTitle(resolvedTitle);
       setIsEditingTitle(false);
     }
   };
@@ -467,7 +471,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
       onDragEnd={() => setIsDragging(false)}
 
       role="article"
-      aria-label={`${nodeType.name} node: ${data.label || 'Untitled'}`}
+      aria-label={`${nodeType.name} node: ${resolvedTitle || 'Untitled'}`}
       aria-selected={selected}
       tabIndex={0}
     >
@@ -585,7 +589,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
             onDoubleClick={handleTitleDoubleClick}
             title={onTitleChange ? "Double-click to edit" : undefined}
           >
-            {label}
+            {resolvedTitle}
             {isDirty && <span style={{ marginLeft: '4px', fontSize: '16px' }} title="Unsaved changes">*</span>}
           </NodeTitle>
         )}

--- a/frontend/src/components/FlowEditor/nodes/FormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormNode.tsx
@@ -591,7 +591,11 @@ export const FormNode = React.memo<NodeProps<Node<FormNodeData>>>(({ id, data, s
     [draggingStepId, sortedSteps, repositionSteps]
   );
 
-  const title = data.containerName || data.label || 'Form';
+  const onTitleChange = (data as any).onTitleChange as ((newTitle: string) => void) | undefined;
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [draftTitle, setDraftTitle] = useState('');
+
+  const title = (data as any).title || data.containerName || data.label || 'Form';
   const description = data.containerDescription || 'Multi-step form';
 
   // Field library grouped by entity across steps
@@ -700,7 +704,48 @@ export const FormNode = React.memo<NodeProps<Node<FormNodeData>>>(({ id, data, s
 
       <Header className="custom-drag-handle">
         <TitleBlock>
-          <Title title={title}>{title}</Title>
+          {isEditingTitle ? (
+            <input
+              className="nodrag"
+              value={draftTitle}
+              onChange={(e) => setDraftTitle(e.target.value)}
+              onBlur={() => {
+                const next = draftTitle.trim();
+                if (onTitleChange && next && next !== title) onTitleChange(next);
+                setIsEditingTitle(false);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  (e.target as HTMLInputElement).blur();
+                } else if (e.key === 'Escape') {
+                  setIsEditingTitle(false);
+                }
+              }}
+              autoFocus
+              style={{
+                width: '100%',
+                fontWeight: 900,
+                fontSize: '13px',
+                borderRadius: 8,
+                border: '1px solid rgb(var(--color-border))',
+                padding: '6px 8px',
+              }}
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <Title
+              title={title}
+              onDoubleClick={(e) => {
+                if (!onTitleChange) return;
+                e.stopPropagation();
+                setDraftTitle(String(title));
+                setIsEditingTitle(true);
+              }}
+              style={{ cursor: onTitleChange ? 'text' : 'default' }}
+            >
+              {title}
+            </Title>
+          )}
           <SubTitle title={description}>{description}</SubTitle>
         </TitleBlock>
         <Badge>
@@ -712,7 +757,7 @@ export const FormNode = React.memo<NodeProps<Node<FormNodeData>>>(({ id, data, s
       <TabsRow className="nodrag">
         {sortedSteps.map((s, idx) => {
           const sd: any = s.data || {};
-          const label = sd.stepTitle || sd.label || `Step ${idx + 1}`;
+          const label = sd.title || sd.stepTitle || sd.label || `Step ${idx + 1}`;
           const active = s.id === activeStepId;
           return (
             <StepTab

--- a/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
@@ -498,6 +498,8 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
   selected,
 }) => {
   const [isExpanded, setIsExpanded] = useState(data.isExpanded ?? true);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [draftTitle, setDraftTitle] = useState('');
   
   // Use hooks to access all nodes/edges
   const allNodes = useNodes();
@@ -622,7 +624,15 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
           isExpanded={isExpanded}
           className={`${selected ? 'selected' : ''} ${data.isDropTarget ? 'drag-over' : ''}`}
         >
-          <ContainerHeader onClick={handleHeaderClick}>
+          <ContainerHeader
+            onClick={(e) => {
+              if (isEditingTitle) {
+                e.stopPropagation();
+                return;
+              }
+              handleHeaderClick(e);
+            }}
+          >
             <ExpandIcon>
               {isExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
             </ExpandIcon>
@@ -632,7 +642,52 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
             </ContainerIcon>
             
             <ContainerTitle>
-              <h3>{data.containerName || data.label || 'Unnamed Container'}</h3>
+              {isEditingTitle ? (
+                <input
+                  className="nodrag"
+                  value={draftTitle}
+                  onChange={(e) => setDraftTitle(e.target.value)}
+                  onBlur={() => {
+                    const onTitleChange = (data as any).onTitleChange as ((newTitle: string) => void) | undefined;
+                    const currentTitle = String((data as any).title || data.containerName || data.label || '').trim();
+                    const next = draftTitle.trim();
+                    if (onTitleChange && next && next !== currentTitle) onTitleChange(next);
+                    setIsEditingTitle(false);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      (e.target as HTMLInputElement).blur();
+                    } else if (e.key === 'Escape') {
+                      setIsEditingTitle(false);
+                    }
+                  }}
+                  autoFocus
+                  style={{
+                    width: '100%',
+                    fontWeight: 700,
+                    fontSize: '16px',
+                    borderRadius: 8,
+                    border: '1px solid rgba(255,255,255,0.45)',
+                    padding: '6px 8px',
+                    background: 'rgba(255,255,255,0.16)',
+                    color: 'white',
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                />
+              ) : (
+                <h3
+                  onDoubleClick={(e) => {
+                    const onTitleChange = (data as any).onTitleChange as ((newTitle: string) => void) | undefined;
+                    if (!onTitleChange) return;
+                    e.stopPropagation();
+                    setDraftTitle(String((data as any).title || data.containerName || data.label || ''));
+                    setIsEditingTitle(true);
+                  }}
+                  style={{ cursor: (data as any).onTitleChange ? 'text' : 'default' }}
+                >
+                  {(data as any).title || data.containerName || data.label || 'Unnamed Container'}
+                </h3>
+              )}
               {data.containerDescription && (
                 <p>{data.containerDescription}</p>
               )}

--- a/frontend/src/components/FlowEditor/utils/formatEntityTypeLabel.ts
+++ b/frontend/src/components/FlowEditor/utils/formatEntityTypeLabel.ts
@@ -1,0 +1,22 @@
+/**
+ * Format a FlowEditor entityType into a human-readable label.
+ *
+ * Examples:
+ * - purchase_order -> Purchase Order
+ * - purchase-order -> Purchase Order
+ */
+export function formatEntityTypeLabel(entityType?: string | null): string {
+  if (!entityType) return '';
+
+  const normalized = String(entityType)
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!normalized) return '';
+
+  return normalized
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
@@ -11,6 +11,7 @@
  */
 import { Node } from '@xyflow/react';
 import { NODE_TYPE_REGISTRY } from '../nodeTypes';
+import { formatEntityTypeLabel } from './formatEntityTypeLabel';
 
 const LEGACY_FORM_STEP_TYPE_MAP: Record<string, 'form'> = {
   formStep: 'form',
@@ -43,6 +44,40 @@ export function normalizeNodeData(node: Node): Node {
       ...(node.data || {}),
     },
   } as Node;
+
+  // --------------------------------------------------------------------------
+  // Canonical title normalization: prefer data.title
+  // --------------------------------------------------------------------------
+  {
+    const data: any = next.data || {};
+
+    const existingTitle = data.title;
+    const legacyTitle =
+      data.name ??
+      data.label ??
+      data.containerName ??
+      data.groupName ??
+      data.stepTitle ??
+      data.displayTitle;
+
+    const entityFallback = formatEntityTypeLabel(data.entityType ?? data.entity_type);
+
+    const resolvedTitle =
+      (typeof existingTitle === 'string' && existingTitle.trim() ? existingTitle : undefined) ??
+      (typeof legacyTitle === 'string' && legacyTitle.trim() ? legacyTitle : undefined) ??
+      (entityFallback ? entityFallback : undefined);
+
+    if (resolvedTitle) {
+      next = {
+        ...next,
+        data: {
+          ...(next.data || {}),
+          title: resolvedTitle,
+          label: (next.data as any)?.label ?? resolvedTitle,
+        },
+      } as Node;
+    }
+  }
 
   // --------------------------------------------------------------------------
   // ParentId consistency: sync ReactFlow parentId ↔ node.data.parentId
@@ -91,6 +126,9 @@ export function normalizeNodeData(node: Node): Node {
 
     const existingLabel = (next.data as any)?.label;
     const existingContainerName = (next.data as any)?.containerName;
+    const existingTitle = (next.data as any)?.title;
+
+    const resolvedTitle = existingTitle ?? existingLabel ?? existingContainerName ?? 'Form Process';
 
     return {
       ...next,
@@ -98,7 +136,9 @@ export function normalizeNodeData(node: Node): Node {
       data: {
         ...(next.data || {}),
         nodeType: canonicalNodeType,
-        label: existingLabel ?? existingContainerName ?? 'Form Process',
+        title: resolvedTitle,
+        label: existingLabel ?? resolvedTitle,
+        containerName: existingContainerName ?? resolvedTitle,
         // Ensure group semantics are enabled
         isGroup: true,
         // Ensure required sizing metadata exists for downstream logic


### PR DESCRIPTION
- Consolidate node title fields to data.title for form + formProcess schemas (legacy keys mapped in nodeNormalization)\n- BaseNode/FormNode/FormProcessNode display title fallback and support double-click inline editing\n- UnifiedFlowEditor title change now updates data.title + legacy keys