### PR TITLE
chore(frontend): replace hardcoded hex colors

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/LiveFormPreview.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/LiveFormPreview.tsx
@@ -80,7 +80,7 @@ const FormTitle = styled.h2`
 
 const FormDescription = styled.p`
   font-size: 14px;
-  color: #666;
+  color: rgb(var(--color-text-secondary));
   margin: 0 0 24px 0;
   line-height: 1.6;
 `;
@@ -117,7 +117,7 @@ const RequiredStar = styled.span`
 
 const HelpText = styled.span`
   font-size: 12px;
-  color: #666;
+  color: rgb(var(--color-text-secondary));
   font-weight: 400;
   display: flex;
   align-items: center;

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.responsive.css
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.responsive.css
@@ -289,13 +289,13 @@
 
   /* High contrast for printing */
   .react-flow__node {
-    border: 2px solid #000 !important;
-    background: #fff !important;
-    color: #000 !important;
+    border: 2px solid rgb(var(--color-text-primary)) !important;
+    background: rgb(var(--color-surface)) !important;
+    color: rgb(var(--color-text-primary)) !important;
   }
 
   .react-flow__edge-path {
-    stroke: #000 !important;
+    stroke: rgb(var(--color-text-primary)) !important;
     stroke-width: 2px !important;
   }
 }

--- a/frontend/src/components/FlowEditor/hooks/useOnboardingTour.tsx
+++ b/frontend/src/components/FlowEditor/hooks/useOnboardingTour.tsx
@@ -208,7 +208,13 @@ export const workflowEditorTourSteps: Step[] = [
           <li>Add more nodes and connect them</li>
           <li>Click <strong>Save</strong> when done</li>
         </ol>
-        <p style={{ margin: '8px 0 0 0', fontSize: '14px', color: '#666' }}>
+        <p
+          style={{
+            margin: '8px 0 0 0',
+            fontSize: '14px',
+            color: 'rgb(var(--color-text-secondary))',
+          }}
+        >
           💡 Press <code>Shift+?</code> anytime to see all keyboard shortcuts
         </p>
       </div>

--- a/frontend/src/components/QuickActions/QuickActionsEditor.tsx
+++ b/frontend/src/components/QuickActions/QuickActionsEditor.tsx
@@ -398,7 +398,7 @@ const FormName = styled.div`
 
 const FormMeta = styled.div`
   font-size: 12px;
-  color: #666;
+  color: rgb(var(--color-text-secondary));
 `;
 
 const AddButton = styled.button<{ $theme: Theme }>`


### PR DESCRIPTION
Replaces a small set of runtime hardcoded hex colors with CSS variable tokens (QuickActions, FlowEditor preview, onboarding tour, and print styles).