### PR TITLE
chore(scripts): standardize maintenance helpers

### DIFF
--- a/scripts/maintenance/fix_dev_domain.py
+++ b/scripts/maintenance/fix_dev_domain.py
@@ -1,146 +1,155 @@
-#!/usr/bin/env python
-"""
+#!/usr/bin/env python3
+"""fix_dev_domain.py
+
 Fix Dev Domain Mapping
-======================
-Maps dev-backend.meatscentral.com to the root tenant to resolve 403 Forbidden errors.
+
+Maps a domain (default: dev-backend.meatscentral.com) to a tenant slug (default: root)
+by creating/updating a TenantDomain record.
 
 Usage:
-    # Inside container:
-    python /app/scripts/fix_dev_domain.py
+  python scripts/maintenance/fix_dev_domain.py --help
+  python scripts/maintenance/fix_dev_domain.py --domain dev-backend.meatscentral.com --tenant-slug root
 
-    # Or via docker exec:
-    docker exec pm-backend python /app/scripts/fix_dev_domain.py
+Notes:
+- Intended to be run either inside the backend container or from the repo root.
+- Requires a reachable database.
 """
 
+from __future__ import annotations
+
+import argparse
 import os
 import sys
-import django
-
-# Setup Django environment
-sys.path.insert(0, '/app/backend')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'projectmeats.settings.development')
-
-try:
-    django.setup()
-except Exception as e:
-    print(f"❌ Failed to setup Django: {e}")
-    sys.exit(1)
-
-from apps.tenants.models import Tenant, TenantDomain
+from pathlib import Path
 
 
-def fix_domain():
-    """
-    Map dev-backend.meatscentral.com to root tenant.
-    
-    This fixes 403 Forbidden errors caused by TenantMiddleware
-    not being able to resolve a tenant from the subdomain.
-    """
-    print("=" * 60)
-    print("Fixing Dev Domain Mapping")
-    print("=" * 60)
-    print()
-    
+def _detect_backend_path() -> Path:
+    # Container layout
+    container_backend = Path('/app/backend')
+    if container_backend.exists():
+        return container_backend
+
+    # Repo layout: scripts/maintenance/*.py -> repo root is parents[2]
+    repo_root = Path(__file__).resolve().parents[2]
+    backend_dir = repo_root / 'backend'
+    return backend_dir
+
+
+def _setup_django(settings_module: str) -> int:
+    backend_dir = _detect_backend_path()
+    sys.path.insert(0, str(backend_dir))
+
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_module)
+
     try:
-        # 1. Get the Root Tenant
-        print("Step 1: Looking for root tenant...")
-        root_tenant = Tenant.objects.get(slug='root')
-        print(f"✅ Found Root Tenant:")
-        print(f"   ID: {root_tenant.id}")
-        print(f"   Name: {root_tenant.name}")
-        print(f"   Slug: {root_tenant.slug}")
-        print()
+        import django
 
-        # 2. Create/Update Domain Mapping
-        print("Step 2: Creating domain mapping...")
-        domain = "dev-backend.meatscentral.com"
-        
+        django.setup()
+    except Exception as e:
+        print(f"❌ Failed to setup Django ({settings_module}): {e}")
+        return 1
+
+    return 0
+
+
+def show_current_mappings() -> None:
+    from apps.tenants.models import TenantDomain
+
+    print('\n' + '=' * 60)
+    print('Current Domain Mappings')
+    print('=' * 60)
+
+    try:
+        mappings = TenantDomain.objects.select_related('tenant').all()
+        if not mappings:
+            print('No domain mappings found.')
+        else:
+            for mapping in mappings:
+                print(
+                    f"  {mapping.domain} → {mapping.tenant.name} "
+                    f"(slug: {mapping.tenant.slug}, primary: {mapping.is_primary})"
+                )
+    except Exception as e:
+        print(f'Could not fetch mappings: {e}')
+
+
+def fix_domain(domain: str, tenant_slug: str) -> int:
+    from apps.tenants.models import Tenant, TenantDomain
+
+    print('=' * 60)
+    print('Fixing Dev Domain Mapping')
+    print('=' * 60)
+
+    try:
+        print('Step 1: Looking for tenant...')
+        tenant = Tenant.objects.get(slug=tenant_slug)
+        print(f'✅ Found tenant: {tenant.name} (slug: {tenant.slug}, id: {tenant.id})')
+
+        print('Step 2: Creating/updating domain mapping...')
         obj, created = TenantDomain.objects.update_or_create(
             domain=domain,
-            defaults={
-                'tenant': root_tenant,
-                'is_primary': True
-            }
+            defaults={'tenant': tenant, 'is_primary': True},
         )
-        
-        if created:
-            print(f"✅ Created new domain mapping:")
-        else:
-            print(f"✅ Updated existing domain mapping:")
-        
-        print(f"   Domain: {obj.domain}")
-        print(f"   Tenant: {obj.tenant.name} (slug: {obj.tenant.slug})")
-        print(f"   Primary: {obj.is_primary}")
-        print()
 
-        # 3. Verify mapping
-        print("Step 3: Verifying mapping...")
-        verification = TenantDomain.objects.get(domain=domain)
-        if verification.tenant == root_tenant:
-            print("✅ Mapping verified successfully!")
-            print()
-            print("=" * 60)
-            print("Domain mapping complete!")
-            print("=" * 60)
-            print()
-            print("Next steps:")
-            print("1. Restart the backend container")
-            print("2. Try accessing dev-backend.meatscentral.com")
-            print("3. 403 errors should be resolved")
-            return 0
-        else:
-            print("❌ Verification failed: Mapping doesn't match")
+        print('✅ Created new mapping' if created else '✅ Updated existing mapping')
+        print(f'  Domain: {obj.domain}')
+        print(f'  Tenant: {obj.tenant.name} (slug: {obj.tenant.slug})')
+        print(f'  Primary: {obj.is_primary}')
+
+        print('Step 3: Verifying mapping...')
+        verification = TenantDomain.objects.select_related('tenant').get(domain=domain)
+        if verification.tenant_id != tenant.id:
+            print('❌ Verification failed: mapping does not match tenant')
             return 1
 
+        print('✅ Mapping verified successfully')
+        print('\nNext steps:')
+        print('1. Restart the backend container (if applicable)')
+        print(f'2. Try accessing {domain}')
+        return 0
+
     except Tenant.DoesNotExist:
-        print("❌ Error: Root tenant not found!")
-        print()
-        print("The 'root' tenant must exist before domain mapping.")
-        print()
-        print("To create the root tenant, run:")
-        print("  python manage.py create_super_tenant")
-        print()
+        print(f"❌ Error: tenant slug '{tenant_slug}' not found")
         return 1
-    
     except Exception as e:
-        print(f"❌ Unexpected error: {e}")
+        print(f'❌ Unexpected error: {e}')
         import traceback
+
         traceback.print_exc()
         return 1
 
 
-def show_current_mappings():
-    """Display all current domain mappings for debugging."""
-    print()
-    print("=" * 60)
-    print("Current Domain Mappings")
-    print("=" * 60)
-    
-    try:
-        mappings = TenantDomain.objects.select_related('tenant').all()
-        
-        if not mappings:
-            print("No domain mappings found.")
-        else:
-            for mapping in mappings:
-                print(f"  {mapping.domain} → {mapping.tenant.name} "
-                      f"(slug: {mapping.tenant.slug}, primary: {mapping.is_primary})")
-        
-        print("=" * 60)
-        print()
-    except Exception as e:
-        print(f"Could not fetch mappings: {e}")
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Create/update TenantDomain mapping for a domain.')
+    parser.add_argument('--domain', default='dev-backend.meatscentral.com', help='Domain to map')
+    parser.add_argument('--tenant-slug', default='root', help='Tenant slug to map the domain to')
+    parser.add_argument(
+        '--settings',
+        default='projectmeats.settings.development',
+        help='DJANGO_SETTINGS_MODULE to use (default: projectmeats.settings.development)',
+    )
+    parser.add_argument(
+        '--show',
+        action='store_true',
+        help='Print current domain mappings before/after the change',
+    )
 
+    args = parser.parse_args()
 
-if __name__ == "__main__":
-    # Show current state
-    show_current_mappings()
-    
-    # Apply fix
-    exit_code = fix_domain()
-    
-    # Show new state
-    if exit_code == 0:
+    setup_rc = _setup_django(args.settings)
+    if setup_rc != 0:
+        return setup_rc
+
+    if args.show:
         show_current_mappings()
-    
-    sys.exit(exit_code)
+
+    rc = fix_domain(args.domain, args.tenant_slug)
+
+    if rc == 0 and args.show:
+        show_current_mappings()
+
+    return rc
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/maintenance/remove_debug_logging.py
+++ b/scripts/maintenance/remove_debug_logging.py
@@ -1,106 +1,127 @@
 #!/usr/bin/env python3
-"""
-Script to remove temporary debug logging for staging.meatscentral.com and uat.meatscentral.com.
-Run this after verifying that staging/UAT is working correctly.
+"""remove_debug_logging.py
+
+Remove temporary [STAGING DEBUG] / [UAT DEBUG] logging blocks from middleware.
+
+This script is a one-off helper and should be run from the repository root.
 
 Usage:
-    python3 remove_debug_logging.py
+  python scripts/maintenance/remove_debug_logging.py --help
+  python scripts/maintenance/remove_debug_logging.py --middleware-file backend/apps/tenants/middleware.py
 """
 
+from __future__ import annotations
+
+import argparse
 import re
 import sys
 from pathlib import Path
 
 
-def remove_debug_logging():
-    """Remove all [STAGING DEBUG] and [UAT DEBUG] logging from middleware."""
-    middleware_file = Path("backend/apps/tenants/middleware.py")
-    backup_file = middleware_file.with_suffix('.py.backup')
-    
+def remove_debug_logging(middleware_file: Path, dry_run: bool) -> bool:
+    backup_file = middleware_file.with_suffix(middleware_file.suffix + '.backup')
+
     if not middleware_file.exists():
-        print(f"Error: Middleware file not found at {middleware_file}")
+        print(f'❌ Middleware file not found at {middleware_file}')
         return False
-    
-    # Read original content
-    with open(middleware_file, 'r') as f:
-        original_content = f.read()
-    
-    # Create backup
-    print(f"Creating backup at {backup_file}...")
-    with open(backup_file, 'w') as f:
-        f.write(original_content)
-    
-    # Process line by line to remove debug blocks
+
+    original_content = middleware_file.read_text(encoding='utf-8')
+
+    if not dry_run:
+        print(f'Creating backup at {backup_file}...')
+        backup_file.write_text(original_content, encoding='utf-8')
+
     lines = original_content.split('\n')
-    cleaned_lines = []
+    cleaned_lines: list[str] = []
     skip_block = False
-    block_indent = None
-    
+    block_indent: int | None = None
+
     for line in lines:
-        # Check for start of debug host block
-        # Note: This is string matching in source code, not URL validation
-        if 'is_debug_host' in line and '=' in line and ('staging.meatscentral.com' in line or 'uat.meatscentral.com' in line):
+        # Start of debug host block
+        if (
+            'is_debug_host' in line
+            and '=' in line
+            and ('staging.meatscentral.com' in line or 'uat.meatscentral.com' in line)
+        ):
             skip_block = True
             block_indent = len(line) - len(line.lstrip())
             continue
-        
-        # Check for debug_prefix definition
+
         if 'debug_prefix' in line and '=' in line and ('[STAGING DEBUG]' in line or '[UAT DEBUG]' in line):
             skip_block = True
             block_indent = len(line) - len(line.lstrip())
             continue
-        
-        # Check for if is_debug_host: conditions
+
         if 'if is_debug_host:' in line:
             skip_block = True
             block_indent = len(line) - len(line.lstrip())
             continue
-        
-        # If we're in a skip block
+
         if skip_block:
             current_indent = len(line) - len(line.lstrip())
-            
-            # Empty lines or lines more indented than block start - skip
-            if line.strip() == '' or current_indent > block_indent:
+
+            # Skip empty lines or deeper indentation
+            if line.strip() == '' or (block_indent is not None and current_indent > block_indent):
                 continue
-            else:
-                # We've dedented - stop skipping
-                skip_block = False
-                block_indent = None
-        
-        # Keep this line
+
+            # Dedented: stop skipping and keep processing this line
+            skip_block = False
+            block_indent = None
+
         cleaned_lines.append(line)
-    
-    # Join back together
+
     cleaned_content = '\n'.join(cleaned_lines)
-    
-    # Additional cleanup: remove any remaining debug references
-    cleaned_content = re.sub(r'\s*logger\.(info|error)\([^)]*\[(STAGING|UAT) DEBUG\][^)]*\)\s*', '', cleaned_content)
-    
-    # Write cleaned content
-    with open(middleware_file, 'w') as f:
-        f.write(cleaned_content)
-    
-    print(f"✓ Debug logging removed from {middleware_file}")
-    print(f"✓ Backup saved to {backup_file}")
-    print()
-    print("Next steps:")
-    print(f"1. Review the changes: git diff {middleware_file}")
-    print("2. Test the application to ensure it still works")
-    print(f"3. Commit the changes: git add {middleware_file} && git commit -m 'Remove temporary debug logging'")
-    print(f"4. Remove backup if satisfied: rm {backup_file}")
-    print(f"4. Remove backup if satisfied: rm {backup_file}")
-    
+
+    # Remove any remaining single-line debug statements
+    cleaned_content = re.sub(
+        r'\s*logger\.(info|error)\([^)]*\[(STAGING|UAT) DEBUG\][^)]*\)\s*',
+        '',
+        cleaned_content,
+    )
+
+    if dry_run:
+        print('✓ Dry run: no files written')
+        return True
+
+    middleware_file.write_text(cleaned_content, encoding='utf-8')
+
+    print(f'✓ Debug logging removed from {middleware_file}')
+    print(f'✓ Backup saved to {backup_file}')
+    print('\nNext steps:')
+    print(f'1. Review the changes: git diff {middleware_file}')
+    print('2. Test the application to ensure it still works')
+    print("3. Commit the changes: git add <file> && git commit -m 'Remove temporary debug logging'")
+    print(f'4. Remove backup if satisfied: rm {backup_file}')
+
     return True
 
 
-if __name__ == '__main__':
-    try:
-        success = remove_debug_logging()
-        sys.exit(0 if success else 1)
-    except Exception as e:
-        print(f"Error: {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Remove temporary staging/UAT debug logging blocks.')
+    parser.add_argument(
+        '--middleware-file',
+        type=Path,
+        default=Path('backend/apps/tenants/middleware.py'),
+        help='Path to tenants middleware.py (default: backend/apps/tenants/middleware.py)',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Do not write any files; only validate that the file can be read',
+    )
 
+    args = parser.parse_args()
+
+    try:
+        ok = remove_debug_logging(args.middleware_file, args.dry_run)
+        return 0 if ok else 1
+    except Exception as e:
+        print(f'❌ Error: {e}')
+        import traceback
+
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/maintenance/verify_staging_config.py
+++ b/scripts/maintenance/verify_staging_config.py
@@ -1,173 +1,203 @@
-#!/usr/bin/env python
-"""
-Verification script for staging.meatscentral.com configuration.
+#!/usr/bin/env python3
+"""verify_staging_config.py
 
-This script checks that all necessary configuration is in place for
-staging.meatscentral.com to work correctly.
+Verify staging.meatscentral.com configuration.
+
+This script is intended for one-off troubleshooting. It checks:
+- ALLOWED_HOSTS contains the configured domain
+- At least one active tenant exists
+- TenantDomain mapping exists and points to an active tenant
+- Logging config is able to emit INFO for apps.tenants.middleware
 
 Usage:
-    python verify_staging_config.py
+  python scripts/maintenance/verify_staging_config.py --help
+  python scripts/maintenance/verify_staging_config.py --domain staging.meatscentral.com
+
+Notes:
+- Requires Django settings and (for DB checks) a reachable database.
+- Safe to run: read-only.
 """
 
+from __future__ import annotations
+
+import argparse
 import os
 import sys
-
-# Add the backend directory to the Python path
-backend_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'backend')
-sys.path.insert(0, backend_dir)
-
-# Setup Django
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'projectmeats.settings.staging')
-
-import django
-django.setup()
-
-from django.conf import settings
-from apps.tenants.models import Tenant, TenantDomain
+from pathlib import Path
 
 
-def check_allowed_hosts():
-    """Check if staging.meatscentral.com is in ALLOWED_HOSTS."""
-    print("=" * 70)
-    print("1. Checking ALLOWED_HOSTS configuration...")
-    print("=" * 70)
-    
-    domain = "staging.meatscentral.com"
-    allowed_hosts = settings.ALLOWED_HOSTS
-    
-    print(f"ALLOWED_HOSTS: {allowed_hosts}")
-    
-    if domain in allowed_hosts or '*' in allowed_hosts:
-        print(f"✓ {domain} is allowed")
-        return True
-    else:
-        print(f"✗ {domain} is NOT in ALLOWED_HOSTS")
-        print(f"  Add it to STAGING_HOSTS in backend/projectmeats/settings/staging.py")
-        return False
+def _setup_django(settings_module: str) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    backend_dir = repo_root / 'backend'
+    sys.path.insert(0, str(backend_dir))
 
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_module)
 
-def check_tenant_domain():
-    """Check if TenantDomain entry exists for staging.meatscentral.com."""
-    print("\n" + "=" * 70)
-    print("2. Checking TenantDomain entry...")
-    print("=" * 70)
-    
-    domain = "staging.meatscentral.com"
-    
     try:
-        tenant_domain = TenantDomain.objects.get(domain=domain)
-        print(f"✓ TenantDomain entry exists")
-        print(f"  Domain: {tenant_domain.domain}")
-        print(f"  Tenant: {tenant_domain.tenant.slug} (ID: {tenant_domain.tenant.id})")
-        print(f"  Tenant Name: {tenant_domain.tenant.name}")
-        print(f"  Tenant Active: {tenant_domain.tenant.is_active}")
-        print(f"  Is Primary: {tenant_domain.is_primary}")
-        
-        if not tenant_domain.tenant.is_active:
-            print(f"✗ WARNING: Tenant '{tenant_domain.tenant.slug}' is INACTIVE")
-            return False
-        
+        import django
+
+        django.setup()
+    except Exception as e:
+        print(f"❌ Failed to setup Django ({settings_module}): {e}")
+        return 1
+
+    return 0
+
+
+def check_allowed_hosts(domain: str) -> bool:
+    from django.conf import settings
+
+    print('=' * 70)
+    print('1. Checking ALLOWED_HOSTS configuration...')
+    print('=' * 70)
+
+    allowed_hosts = settings.ALLOWED_HOSTS
+    print(f'ALLOWED_HOSTS: {allowed_hosts}')
+
+    if domain in allowed_hosts or '*' in allowed_hosts:
+        print(f'✓ {domain} is allowed')
         return True
-    except TenantDomain.DoesNotExist:
-        print(f"✗ No TenantDomain entry for {domain}")
-        print(f"\nTo fix this, run:")
-        print(f"  python manage.py add_tenant_domain --domain={domain} --tenant-slug=<TENANT_SLUG>")
-        print(f"\nAvailable tenants:")
-        
-        tenants = Tenant.objects.filter(is_active=True).values_list('slug', 'name')
-        for slug, name in tenants:
-            print(f"  - {slug}: {name}")
-        
+
+    print(f'✗ {domain} is NOT in ALLOWED_HOSTS')
+    print('  Add it to STAGING_HOSTS in backend/projectmeats/settings/staging.py')
+    return False
+
+
+def check_tenant_exists() -> bool:
+    from apps.tenants.models import Tenant
+
+    print('\n' + '=' * 70)
+    print('2. Checking active tenants...')
+    print('=' * 70)
+
+    try:
+        active_tenants = Tenant.objects.filter(is_active=True)
+        count = active_tenants.count()
+    except Exception as e:
+        print(f'✗ Could not query tenants (DB not reachable?): {e}')
         return False
 
+    print(f'Active tenants found: {count}')
 
-def check_tenant_exists():
-    """Check if any active tenants exist."""
-    print("\n" + "=" * 70)
-    print("3. Checking active tenants...")
-    print("=" * 70)
-    
-    active_tenants = Tenant.objects.filter(is_active=True)
-    count = active_tenants.count()
-    
-    print(f"Active tenants found: {count}")
-    
     if count == 0:
-        print("✗ No active tenants found")
-        print("  You need to create a tenant first using:")
-        print("  python manage.py create_tenant --schema-name=... --name=...")
+        print('✗ No active tenants found')
+        print('  Create a tenant first using:')
+        print('  python manage.py create_tenant --name=... --slug=...')
         return False
-    
-    print("✓ Active tenants:")
+
+    print('✓ Active tenants:')
     for tenant in active_tenants:
-        print(f"  - {tenant.slug}: {tenant.name} (ID: {tenant.id})")
-    
+        print(f'  - {tenant.slug}: {tenant.name} (ID: {tenant.id})')
+
     return True
 
 
-def check_logging_config():
-    """Check if logging is configured to capture debug messages."""
-    print("\n" + "=" * 70)
-    print("4. Checking logging configuration...")
-    print("=" * 70)
-    
-    import logging
-    
-    # Get the logger used by the middleware
-    logger = logging.getLogger('apps.tenants.middleware')
-    
-    print(f"Logger level: {logging.getLevelName(logger.level)}")
-    print(f"Effective level: {logging.getLevelName(logger.getEffectiveLevel())}")
-    
-    if logger.isEnabledFor(logging.INFO):
-        print("✓ INFO logging is enabled (debug logs will be visible)")
-        return True
-    else:
-        print("✗ INFO logging is disabled (debug logs will NOT be visible)")
-        print("  Update LOGGING configuration in settings to enable INFO level")
+def check_tenant_domain(domain: str) -> bool:
+    from apps.tenants.models import Tenant, TenantDomain
+
+    print('\n' + '=' * 70)
+    print('3. Checking TenantDomain entry...')
+    print('=' * 70)
+
+    try:
+        tenant_domain = TenantDomain.objects.select_related('tenant').get(domain=domain)
+    except TenantDomain.DoesNotExist:
+        print(f'✗ No TenantDomain entry for {domain}')
+        print('\nTo fix this, run:')
+        print(f'  python manage.py add_tenant_domain --domain={domain} --tenant-slug=<TENANT_SLUG>')
+        print('\nAvailable active tenants:')
+        for slug, name in Tenant.objects.filter(is_active=True).values_list('slug', 'name'):
+            print(f'  - {slug}: {name}')
+        return False
+    except Exception as e:
+        print(f'✗ Could not query TenantDomain (DB not reachable?): {e}')
         return False
 
+    print('✓ TenantDomain entry exists')
+    print(f'  Domain: {tenant_domain.domain}')
+    print(f'  Tenant: {tenant_domain.tenant.slug} (ID: {tenant_domain.tenant.id})')
+    print(f'  Tenant Name: {tenant_domain.tenant.name}')
+    print(f'  Tenant Active: {tenant_domain.tenant.is_active}')
+    print(f'  Is Primary: {tenant_domain.is_primary}')
 
-def main():
-    """Run all verification checks."""
-    print("\n" + "=" * 70)
-    print("STAGING.MEATSCENTRAL.COM CONFIGURATION VERIFICATION")
-    print("=" * 70)
-    print()
-    
+    if not tenant_domain.tenant.is_active:
+        print(f"✗ WARNING: Tenant '{tenant_domain.tenant.slug}' is INACTIVE")
+        return False
+
+    return True
+
+
+def check_logging_config() -> bool:
+    print('\n' + '=' * 70)
+    print('4. Checking logging configuration...')
+    print('=' * 70)
+
+    import logging
+
+    logger = logging.getLogger('apps.tenants.middleware')
+
+    print(f'Logger level: {logging.getLevelName(logger.level)}')
+    print(f'Effective level: {logging.getLevelName(logger.getEffectiveLevel())}')
+
+    if logger.isEnabledFor(logging.INFO):
+        print('✓ INFO logging is enabled (debug logs will be visible)')
+        return True
+
+    print('✗ INFO logging is disabled (debug logs will NOT be visible)')
+    print('  Update LOGGING configuration in settings to enable INFO level')
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Verify staging domain configuration (Django).')
+    parser.add_argument(
+        '--settings',
+        default='projectmeats.settings.staging',
+        help='DJANGO_SETTINGS_MODULE to use (default: projectmeats.settings.staging)',
+    )
+    parser.add_argument(
+        '--domain',
+        default='staging.meatscentral.com',
+        help='Domain to verify (default: staging.meatscentral.com)',
+    )
+
+    args = parser.parse_args()
+
+    setup_rc = _setup_django(args.settings)
+    if setup_rc != 0:
+        return setup_rc
+
+    print('\n' + '=' * 70)
+    print('STAGING CONFIGURATION VERIFICATION')
+    print('=' * 70)
+
     results = {
-        'ALLOWED_HOSTS': check_allowed_hosts(),
+        'ALLOWED_HOSTS': check_allowed_hosts(args.domain),
         'Active Tenants': check_tenant_exists(),
-        'TenantDomain': check_tenant_domain(),
+        'TenantDomain': check_tenant_domain(args.domain),
         'Logging': check_logging_config(),
     }
-    
-    print("\n" + "=" * 70)
-    print("SUMMARY")
-    print("=" * 70)
-    
+
+    print('\n' + '=' * 70)
+    print('SUMMARY')
+    print('=' * 70)
+
     all_passed = True
     for check, passed in results.items():
-        status = "✓ PASS" if passed else "✗ FAIL"
-        print(f"{status}: {check}")
+        status = '✓ PASS' if passed else '✗ FAIL'
+        print(f'{status}: {check}')
         if not passed:
             all_passed = False
-    
-    print("=" * 70)
-    
+
+    print('=' * 70)
+
     if all_passed:
-        print("\n✓ All checks passed! staging.meatscentral.com should work correctly.")
+        print('\n✓ All checks passed!')
         return 0
-    else:
-        print("\n✗ Some checks failed. Please fix the issues above.")
-        return 1
+
+    print('\n✗ Some checks failed. Please fix the issues above.')
+    return 1
 
 
 if __name__ == '__main__':
-    try:
-        sys.exit(main())
-    except Exception as e:
-        print(f"\n✗ Error running verification: {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
+    sys.exit(main())


### PR DESCRIPTION
Standardize key maintenance scripts under scripts/maintenance/:
- verify_staging_config.py: fix broken backend path, add argparse (--settings/--domain), safer Django setup
- fix_dev_domain.py: add argparse and make it runnable from repo root *or* inside container
- remove_debug_logging.py: add argparse + --dry-run, remove duplicated instructions, safer file handling

No workflow/deployment behavior changes.