### PR TITLE
chore(frontend): tighten TS error typing

### DIFF
--- a/frontend/src/components/FlowEditor/HistoryDrawer.tsx
+++ b/frontend/src/components/FlowEditor/HistoryDrawer.tsx
@@ -17,6 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import { Drawer, Timeline, Typography, Tag, Avatar, Button, Empty, Spin, message } from 'antd';
 import { ClockCircleOutlined, UserOutlined, RollbackOutlined } from '@ant-design/icons';
+import { getErrorMessage } from '@/hooks/useToast';
 import { businessApi } from '@/services/businessApi';
 import styled from 'styled-components';
 
@@ -170,10 +171,11 @@ export const HistoryDrawer: React.FC<HistoryDrawerProps> = ({
         `/workflows/form-submissions/${submissionId}/history/`
       );
       setHistory(response.data || []);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Failed to fetch history:', err);
-      setError(err.response?.data?.message || 'Failed to load history');
-      message.error('Failed to load version history');
+      const errMsg = getErrorMessage(err, 'Failed to load history');
+      setError(errMsg);
+      message.error(errMsg);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/Shared/LocationSelector.tsx
+++ b/frontend/src/components/Shared/LocationSelector.tsx
@@ -15,6 +15,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Theme } from '../../config/theme';
 import { useTheme } from '../../contexts/ThemeContext';
+import { getErrorMessage } from '../../hooks/useToast';
 import { Location } from '../../types/index';
 import { apiClient } from '../../services/apiService';
 
@@ -64,21 +65,36 @@ export const LocationSelector: React.FC<LocationSelectorProps> = ({
       const raw = response.data as unknown;
       const data = Array.isArray(raw)
         ? (raw as Location[])
-        : ((raw as any)?.results || []) as Location[];
+        : (() => {
+            const obj = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : null;
+            const results = obj && Array.isArray(obj.results) ? (obj.results as Location[]) : [];
+            return results;
+          })();
 
       setLocations(data);
-    } catch (err: any) {
+    } catch (err: unknown) {
+      type AxiosishError = {
+        response?: {
+          status?: unknown;
+        };
+        code?: unknown;
+      };
+
+      const e = err as AxiosishError;
+      const status = typeof e.response?.status === 'number' ? e.response.status : null;
+      const code = typeof e.code === 'string' ? e.code : null;
+
       // Graceful error handling for RLS and auth failures
-      if (err.response?.status === 403) {
+      if (status === 403) {
         setFetchError('Access denied - insufficient permissions');
         console.error('[LocationSelector] RLS policy rejected request:', err);
-      } else if (err.response?.status === 401) {
+      } else if (status === 401) {
         setFetchError('Authentication required');
         console.error('[LocationSelector] Not authenticated:', err);
-      } else if (err.code === 'ECONNABORTED') {
+      } else if (code === 'ECONNABORTED') {
         setFetchError('Request timeout - please try again');
       } else {
-        setFetchError('Failed to load locations');
+        setFetchError(getErrorMessage(err, 'Failed to load locations'));
         console.error('[LocationSelector] Error fetching locations:', err);
       }
     } finally {

--- a/frontend/src/components/Shared/PaymentHistoryList.tsx
+++ b/frontend/src/components/Shared/PaymentHistoryList.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { getErrorMessage } from '../../hooks/useToast';
 import { apiClient } from '../../services/apiService';
 import { formatCurrency } from '../../shared/utils';
 import { formatDateLocal } from '../../utils/formatters';
@@ -156,9 +157,9 @@ export const PaymentHistoryList: React.FC<PaymentHistoryListProps> = ({
       });
       
       setPayments(sortedPayments);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error fetching payment history:', err);
-      setError('Failed to load payment history');
+      setError(getErrorMessage(err, 'Failed to load payment history'));
     } finally {
       setLoading(false);
     }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,8 @@
 
     /* Linting */
     "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
TypeScript strictness lockdown follow-up:
- frontend/tsconfig.json explicitly sets noImplicitAny + strictNullChecks (in addition to strict)
- Convert a few representative err:any patterns to err:unknown using shared getErrorMessage()
- Remove an as any usage when normalizing paginated LocationSelector responses

Validated: npm run type-check