### PR TITLE
Fix FlowEditor overlaps + selection ring

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.responsive.css
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.responsive.css
@@ -40,6 +40,17 @@
 }
 
 /* ============================================================================
+   Phase 9.7: Selected node visibility
+   ============================================================================ */
+
+.pm-node.is-selected {
+  border: 2px solid rgb(var(--color-primary)) !important;
+  box-shadow: 0 0 0 3px rgba(var(--color-primary), 0.4) !important;
+  transform: scale(1.02);
+  transition: all 0.2s ease-in-out;
+}
+
+/* ============================================================================
    Mobile Styles (< 600px)
    ============================================================================ */
 

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2188,7 +2188,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
   }, [setNodes, onNodesChangeBase]);
   
   // React Flow instance for viewport controls
-  const { setCenter: reactFlowSetCenter, ...reactFlowInstance } = useReactFlow();
+  const {
+    setCenter: reactFlowSetCenter,
+    getNodes: reactFlowGetNodes,
+    getEdges: reactFlowGetEdges,
+    ...reactFlowInstance
+  } = useReactFlow();
   
   // ============================================================================
   // CONFIG PANEL PORTAL - Enhanced with full styling (2026-02-24)
@@ -3629,6 +3634,25 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     [setNodes, setEdges]
   );
 
+  const applyAutoLayoutAfterNextPaint = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        const currentNodes = reactFlowGetNodes();
+        const currentEdges = reactFlowGetEdges();
+
+        const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(currentNodes, currentEdges, {
+          direction: 'TB',
+          nodeSpacing: 60,
+          rankSpacing: 120,
+        });
+
+        setNodes(layoutedNodes);
+        setEdges(layoutedEdges);
+        setHasUnsavedChanges(true);
+      });
+    });
+  }, [reactFlowGetNodes, reactFlowGetEdges, setNodes, setEdges]);
+
   const handleClickToAddNode = useCallback(
     (nodeTypeId: string) => {
       if (readOnly) return;
@@ -3771,7 +3795,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           setEdges(connectionResult.edges);
           setHasUnsavedChanges(true);
         } else {
-          applyAutoLayoutImmediate(nextNodes, nextEdges);
+          setNodes(nextNodes);
+          setEdges(nextEdges);
+          setHasUnsavedChanges(true);
+          applyAutoLayoutAfterNextPaint();
         }
         return;
       }
@@ -3842,7 +3869,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           setEdges(connectionResult.edges);
           setHasUnsavedChanges(true);
         } else {
-          applyAutoLayoutImmediate(nextNodes, nextEdges);
+          setNodes(nextNodes);
+          setEdges(nextEdges);
+          setHasUnsavedChanges(true);
+          applyAutoLayoutAfterNextPaint();
         }
       } else {
         const nextEdges: Edge[] = [...edges];
@@ -3882,7 +3912,10 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           setEdges(connectionResult.edges);
           setHasUnsavedChanges(true);
         } else {
-          applyAutoLayoutImmediate(nextNodes, nextEdges);
+          setNodes(nextNodes);
+          setEdges(nextEdges);
+          setHasUnsavedChanges(true);
+          applyAutoLayoutAfterNextPaint();
         }
       }
     },
@@ -3896,7 +3929,9 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       generateNodeId,
       selectedNode,
       selectedNodeId,
-      applyAutoLayoutImmediate,
+      setNodes,
+      setEdges,
+      applyAutoLayoutAfterNextPaint,
     ]
   );
 

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -461,6 +461,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
 
   return (
     <NodeContainer 
+      className={`pm-node${selected ? ' is-selected' : ''}`}
       $color={nodeType.color} 
       $selected={selected}
       $status={status}

--- a/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
@@ -622,7 +622,7 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
       {/* Container custom UI */}
       <ContainerWrapper 
           isExpanded={isExpanded}
-          className={`${selected ? 'selected' : ''} ${data.isDropTarget ? 'drag-over' : ''}`}
+          className={`pm-node ${selected ? 'selected is-selected' : ''} ${data.isDropTarget ? 'drag-over' : ''}`}
         >
           <ContainerHeader
             onClick={(e) => {

--- a/frontend/src/components/FlowEditor/utils/autoLayout.ts
+++ b/frontend/src/components/FlowEditor/utils/autoLayout.ts
@@ -65,8 +65,12 @@ export const getLayoutedElements = (
   dagreGraph.setDefaultEdgeLabel(() => ({}));
 
   topLevelNodes.forEach((node) => {
-    const width = node.width || 280;
-    const height = node.height || 100;
+    const styleWidth = typeof (node.style as any)?.width === 'number' ? (node.style as any).width : undefined;
+    const styleHeight = typeof (node.style as any)?.height === 'number' ? (node.style as any).height : undefined;
+
+    const width = node.measured?.width ?? node.width ?? styleWidth ?? 280;
+    const height = node.measured?.height ?? node.height ?? styleHeight ?? 100;
+
     dagreGraph.setNode(node.id, { width, height });
   });
 
@@ -83,8 +87,14 @@ export const getLayoutedElements = (
     const nodeWithPosition = dagreGraph.node(node.id);
     if (!nodeWithPosition) return node;
 
-    const x = nodeWithPosition.x - (node.width || 280) / 2;
-    const y = nodeWithPosition.y - (node.height || 100) / 2;
+    const styleWidth = typeof (node.style as any)?.width === 'number' ? (node.style as any).width : undefined;
+    const styleHeight = typeof (node.style as any)?.height === 'number' ? (node.style as any).height : undefined;
+
+    const width = node.measured?.width ?? node.width ?? styleWidth ?? 280;
+    const height = node.measured?.height ?? node.height ?? styleHeight ?? 100;
+
+    const x = nodeWithPosition.x - width / 2;
+    const y = nodeWithPosition.y - height / 2;
 
     return {
       ...node,


### PR DESCRIPTION
## What
- Prevent sequential node add overlaps by deferring auto-layout until after the next paint (measured node dimensions are available).
- Improve dagre sizing by preferring `node.measured` (and `node.style` fallbacks) over `node.width/height`.
- Make selection highly visible by adding a `.pm-node.is-selected` ring + slight scale for both BaseNode and FormProcess containers.

## Verification
- `cd frontend && npm run type-check`