### PR TITLE
Fix supplier quick-create Save button

### DIFF
--- a/frontend/src/components/FormSubmission/QuickCreateModal.tsx
+++ b/frontend/src/components/FormSubmission/QuickCreateModal.tsx
@@ -649,12 +649,25 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
         </ModalBody>
 
         <ModalFooter>
-          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            disabled={isSubmitting}
+          >
             Cancel
           </Button>
-          <Button 
-            variant="primary" 
-            onClick={handleSubmit} 
+          <Button
+            type="button"
+            variant="primary"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (isSubmitting) return;
+              void handleSubmit();
+            }}
             disabled={isLoading || isSubmitting || fields.length === 0}
           >
             {isSubmitting ? (
@@ -827,12 +840,25 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
         </ModalBody>
 
         <ModalFooter>
-          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            disabled={isSubmitting}
+          >
             Cancel
           </Button>
           <Button
+            type="button"
             variant="primary"
-            onClick={handleSubmit}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (isSubmitting) return;
+              void handleSubmit();
+            }}
             disabled={isLoading || isSubmitting || fields.length === 0}
           >
             {isSubmitting ? (


### PR DESCRIPTION
Fixes QuickCreateModal footer buttons so Create/Cancel clicks cannot be swallowed by parent overlays/forms (common cause of “Save does nothing” on New Supplier).

- Set footer buttons `type="button"`
- Stop event propagation
- Guard against double-submit

Verification: `cd frontend && npm run type-check`