### PR TITLE
Hierarchy: drill-down views

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -11,6 +11,11 @@ This file is the **append-only PR-referenceable execution log**.
 
 ## Active Initiative: V3.0 Final Push (Consolidation + Scale + Polish)
 
+### 2026-03-31 — Hierarchy: drill-down views
+- Supplier/Customer record pages show Plants/Locations with a dedicated drill-down (no flat contacts at the grandparent).
+- Added PlantDetailView + LocationDetailView with Contacts grouped by department (Sales/QA/Booking/Accounting).
+- PR: #4228
+
 ### 2026-03-30 — Docs: master plan gap analysis + roadmap hygiene
 - Updated `MASTER_PLAN.md` (canonical) with an industry-leader benchmark gap analysis (P0/P1/P2) and refreshed execution-ordered backlog.
 - Converted non-canonical roadmaps/plans into clearer **REFERENCE ONLY** docs (removed/neutralized misleading progress emphasis).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,6 +53,8 @@ import SupplierProducts from './pages/Suppliers/Products';
 import CustomerLocations from './pages/Customers/Locations';
 import CustomerProducts from './pages/Customers/Products';
 import PlantProducts from './pages/Plants/Products';
+import PlantDetailView from './pages/Plants/PlantDetailView';
+import LocationDetailView from './pages/Locations/LocationDetailView';
 import Carriers from './pages/Carriers';
 import AIAssistant from './pages/AIAssistant';
 import CallLog from './pages/Cockpit/CallLog';
@@ -252,7 +254,9 @@ const App: React.FC = () => {
                 <Route path="suppliers/contacts" element={<Contacts />} />
                 <Route path="suppliers/plants" element={<Plants />} />
                 <Route path="suppliers/:id/products" element={<SupplierProducts />} />
+                <Route path="plants/:id" element={<PlantDetailView />} />
                 <Route path="plants/:id/products" element={<PlantProducts />} />
+                <Route path="locations/:id" element={<LocationDetailView />} />
                 
                 {/* Customers & Related */}
                 <Route path="customers" element={<Customers />} />

--- a/frontend/src/pages/Entities/UniversalEntityRecordPage.tsx
+++ b/frontend/src/pages/Entities/UniversalEntityRecordPage.tsx
@@ -1,9 +1,11 @@
-import React, { useMemo } from 'react';
-import { Button } from 'antd';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Card, Spin, Table } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { EntityFormSurface } from '@/components/Shared';
 import type { EntityFormMode } from '@/components/Shared/EntityFormSurface';
+import { apiClient } from '@/services/apiService';
 
 type RouteParams = {
   id?: string;
@@ -35,6 +37,49 @@ export const UniversalEntityRecordPage: React.FC<UniversalEntityRecordPageProps>
 
   const entityId = id ? String(id) : undefined;
 
+  const normalizedEntityType = String(entityType || '').trim().toLowerCase();
+  const isSupplier = normalizedEntityType === 'supplier';
+  const isCustomer = normalizedEntityType === 'customer';
+
+  const showHierarchySection = mode === 'view' && Boolean(entityId) && (isSupplier || isCustomer);
+
+  const childEntityType = isSupplier ? 'plant' : 'location';
+  const childEntityDisplayName = isSupplier ? 'Plant' : 'Location';
+  const childLabel = isSupplier ? 'Plants' : 'Locations';
+  const childEndpoint = isSupplier ? 'plants/' : 'locations/';
+  const childFilterKey = isSupplier ? 'supplier' : 'customer';
+  const childDetailRouteBase = isSupplier ? '/plants' : '/locations';
+
+  const [childRows, setChildRows] = useState<Record<string, unknown>[]>([]);
+  const [childLoading, setChildLoading] = useState(false);
+  const [childCreateOpen, setChildCreateOpen] = useState(false);
+
+  const loadChildRows = useCallback(async () => {
+    if (!entityId || !showHierarchySection) return;
+    setChildLoading(true);
+    try {
+      const resp = await apiClient.get(childEndpoint, {
+        params: {
+          [childFilterKey]: entityId,
+          page_size: 50,
+          limit: 50,
+        },
+      });
+
+      const payload = resp.data as unknown;
+      const payloadObj = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null;
+      const rows = Array.isArray(payloadObj?.results) ? (payloadObj?.results as unknown[]) : (payload as unknown[]);
+
+      setChildRows((Array.isArray(rows) ? rows : []).filter((r) => r && typeof r === 'object') as Record<string, unknown>[]);
+    } finally {
+      setChildLoading(false);
+    }
+  }, [childEndpoint, childFilterKey, entityId, showHierarchySection]);
+
+  useEffect(() => {
+    void loadChildRows();
+  }, [loadChildRows]);
+
   const formMode: EntityFormMode = useMemo(() => {
     if (mode === 'create') return 'create';
     if (mode === 'edit') return 'edit';
@@ -46,6 +91,28 @@ export const UniversalEntityRecordPage: React.FC<UniversalEntityRecordPageProps>
     if (mode === 'edit') return `Edit ${entityType}`;
     return `${entityType}`;
   }, [entityType, mode]);
+
+  const childColumns: ColumnsType<Record<string, unknown>> = useMemo(() => {
+    if (isSupplier) {
+      return [
+        { title: 'Name', dataIndex: 'name', key: 'name' },
+        { title: 'Code', dataIndex: 'code', key: 'code' },
+        { title: 'Type', dataIndex: 'plant_type', key: 'plant_type' },
+        { title: 'Establishment #', dataIndex: 'plant_est_num', key: 'plant_est_num' },
+        { title: 'City', dataIndex: 'city', key: 'city' },
+        { title: 'State', dataIndex: 'state', key: 'state' },
+      ];
+    }
+
+    return [
+      { title: 'Name', dataIndex: 'name', key: 'name' },
+      { title: 'Code', dataIndex: 'code', key: 'code' },
+      { title: 'Type', dataIndex: 'location_type', key: 'location_type' },
+      { title: 'Establishment #', dataIndex: 'plant_est_num', key: 'plant_est_num' },
+      { title: 'City', dataIndex: 'city', key: 'city' },
+      { title: 'State', dataIndex: 'state', key: 'state' },
+    ];
+  }, [isSupplier]);
 
   return (
     <div style={{ padding: 16 }}>
@@ -97,6 +164,54 @@ export const UniversalEntityRecordPage: React.FC<UniversalEntityRecordPageProps>
           }
         }}
       />
+
+      {showHierarchySection && (
+        <Card
+          style={{ marginTop: 16 }}
+          title={childLabel}
+          extra={
+            <Button type="primary" onClick={() => setChildCreateOpen(true)}>
+              New {childEntityDisplayName}
+            </Button>
+          }
+        >
+          {childLoading ? (
+            <div style={{ padding: 12 }}>
+              <Spin />
+            </div>
+          ) : (
+            <Table
+              rowKey={(row) => String(row.id ?? '')}
+              columns={childColumns}
+              dataSource={childRows}
+              pagination={false}
+              size="small"
+              onRow={(row) => ({
+                onClick: () => {
+                  const rowId = String(row.id ?? '').trim();
+                  if (!rowId) return;
+                  navigate(`${childDetailRouteBase}/${encodeURIComponent(rowId)}`);
+                },
+              })}
+            />
+          )}
+        </Card>
+      )}
+
+      {showHierarchySection && (
+        <EntityFormSurface
+          entityType={childEntityType}
+          mode="create"
+          variant="modal"
+          isOpen={childCreateOpen}
+          onClose={() => setChildCreateOpen(false)}
+          onSuccess={() => {
+            setChildCreateOpen(false);
+            void loadChildRows();
+          }}
+          initialValues={{ [childFilterKey]: entityId }}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/Locations/LocationDetailView.tsx
+++ b/frontend/src/pages/Locations/LocationDetailView.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Button, Card, Empty, Spin, Tabs, Tag } from 'antd';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { EntityFormSurface } from '@/components/Shared';
+import { apiClient } from '@/services/apiService';
+
+type RouteParams = { id?: string };
+
+type ContactRow = {
+  id: string | number;
+  first_name?: string;
+  last_name?: string;
+  email?: string | null;
+  mobile_phone?: string | null;
+  office_phone?: string | null;
+  office_phone_ext?: string | null;
+  department?: string | null;
+  protein_types_responsible?: string[] | null;
+  items_responsible?: string[] | null;
+};
+
+const normalizeDept = (dept: unknown): string => {
+  const d = String(dept || '').trim().toLowerCase();
+  if (d === 'sales') return 'sales';
+  if (d === 'qa') return 'qa';
+  if (d === 'booking') return 'booking';
+  if (d === 'accounting') return 'accounting';
+  return 'sales';
+};
+
+const renderContact = (c: ContactRow) => {
+  const name = `${c.first_name || ''} ${c.last_name || ''}`.trim() || 'Unnamed';
+  const phones = [
+    c.mobile_phone ? `Mobile: ${c.mobile_phone}` : null,
+    c.office_phone ? `Office: ${c.office_phone}${c.office_phone_ext ? ` x${c.office_phone_ext}` : ''}` : null,
+  ].filter(Boolean);
+
+  return (
+    <Card key={String(c.id)} size="small" style={{ marginBottom: 10 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ fontWeight: 700, color: 'rgb(var(--color-text-primary))' }}>{name}</div>
+        {c.email ? (
+          <a href={`mailto:${c.email}`} style={{ color: 'rgb(var(--color-primary))' }}>
+            {c.email}
+          </a>
+        ) : null}
+      </div>
+
+      {phones.length ? (
+        <div style={{ marginTop: 6, fontSize: 12, color: 'rgb(var(--color-text-secondary))' }}>
+          {phones.join(' • ')}
+        </div>
+      ) : null}
+
+      {(c.protein_types_responsible?.length || 0) > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'rgb(var(--color-text-tertiary))' }}>
+            Protein Types
+          </div>
+          <div style={{ marginTop: 4, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {(c.protein_types_responsible || []).map((v) => (
+              <Tag key={v}>{v}</Tag>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {(c.items_responsible?.length || 0) > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'rgb(var(--color-text-tertiary))' }}>Items</div>
+          <div style={{ marginTop: 4, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {(c.items_responsible || []).map((v) => (
+              <Tag key={v}>{v}</Tag>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export const LocationDetailView: React.FC = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<RouteParams>();
+
+  const locationId = String(id || '').trim();
+
+  const [loadingContacts, setLoadingContacts] = useState(false);
+  const [contacts, setContacts] = useState<ContactRow[]>([]);
+
+  useEffect(() => {
+    if (!locationId) return;
+
+    let mounted = true;
+    const load = async () => {
+      setLoadingContacts(true);
+      try {
+        const resp = await apiClient.get('contacts/', {
+          params: { location: locationId, page_size: 200, limit: 200 },
+        });
+        const payload = resp.data as unknown;
+        const obj = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null;
+        const rows = Array.isArray(obj?.results) ? (obj?.results as unknown[]) : (payload as unknown[]);
+        const next = (Array.isArray(rows) ? rows : [])
+          .filter((r) => r && typeof r === 'object')
+          .map((r) => r as ContactRow);
+        if (mounted) setContacts(next);
+      } finally {
+        if (mounted) setLoadingContacts(false);
+      }
+    };
+
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [locationId]);
+
+  const grouped = useMemo(() => {
+    const buckets: Record<string, ContactRow[]> = {
+      sales: [],
+      qa: [],
+      booking: [],
+      accounting: [],
+    };
+
+    for (const c of contacts) {
+      buckets[normalizeDept(c.department)]?.push(c);
+    }
+
+    return buckets;
+  }, [contacts]);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Button onClick={() => navigate(-1)}>Back</Button>
+          <div style={{ fontSize: 16, fontWeight: 700, color: 'rgb(var(--color-text-primary))' }}>Location</div>
+        </div>
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <EntityFormSurface
+          entityType="location"
+          mode="view"
+          variant="inline"
+          isOpen={true}
+          entityId={locationId}
+          onClose={() => navigate('/customers')}
+        />
+      </div>
+
+      <Card style={{ marginTop: 16 }} title="Contacts">
+        {loadingContacts ? (
+          <div style={{ padding: 12 }}>
+            <Spin />
+          </div>
+        ) : (
+          <Tabs
+            items={[
+              {
+                key: 'sales',
+                label: `Sales (${grouped.sales.length})`,
+                children: grouped.sales.length ? grouped.sales.map(renderContact) : <Empty description="No sales contacts" />,
+              },
+              {
+                key: 'qa',
+                label: `QA (${grouped.qa.length})`,
+                children: grouped.qa.length ? grouped.qa.map(renderContact) : <Empty description="No QA contacts" />,
+              },
+              {
+                key: 'booking',
+                label: `Booking (${grouped.booking.length})`,
+                children: grouped.booking.length ? grouped.booking.map(renderContact) : <Empty description="No booking contacts" />,
+              },
+              {
+                key: 'accounting',
+                label: `Accounting (${grouped.accounting.length})`,
+                children: grouped.accounting.length ? grouped.accounting.map(renderContact) : <Empty description="No accounting contacts" />,
+              },
+            ]}
+          />
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default LocationDetailView;

--- a/frontend/src/pages/Plants/PlantDetailView.tsx
+++ b/frontend/src/pages/Plants/PlantDetailView.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Button, Card, Empty, Spin, Tabs, Tag } from 'antd';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { EntityFormSurface } from '@/components/Shared';
+import { apiClient } from '@/services/apiService';
+
+type RouteParams = { id?: string };
+
+type ContactRow = {
+  id: string | number;
+  first_name?: string;
+  last_name?: string;
+  email?: string | null;
+  mobile_phone?: string | null;
+  office_phone?: string | null;
+  office_phone_ext?: string | null;
+  department?: string | null;
+  protein_types_responsible?: string[] | null;
+  items_responsible?: string[] | null;
+};
+
+const normalizeDept = (dept: unknown): string => {
+  const d = String(dept || '').trim().toLowerCase();
+  if (d === 'sales') return 'sales';
+  if (d === 'qa') return 'qa';
+  if (d === 'booking') return 'booking';
+  if (d === 'accounting') return 'accounting';
+  return 'sales';
+};
+
+const renderContact = (c: ContactRow) => {
+  const name = `${c.first_name || ''} ${c.last_name || ''}`.trim() || 'Unnamed';
+  const phones = [
+    c.mobile_phone ? `Mobile: ${c.mobile_phone}` : null,
+    c.office_phone ? `Office: ${c.office_phone}${c.office_phone_ext ? ` x${c.office_phone_ext}` : ''}` : null,
+  ].filter(Boolean);
+
+  return (
+    <Card key={String(c.id)} size="small" style={{ marginBottom: 10 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ fontWeight: 700, color: 'rgb(var(--color-text-primary))' }}>{name}</div>
+        {c.email ? (
+          <a href={`mailto:${c.email}`} style={{ color: 'rgb(var(--color-primary))' }}>
+            {c.email}
+          </a>
+        ) : null}
+      </div>
+
+      {phones.length ? (
+        <div style={{ marginTop: 6, fontSize: 12, color: 'rgb(var(--color-text-secondary))' }}>
+          {phones.join(' • ')}
+        </div>
+      ) : null}
+
+      {(c.protein_types_responsible?.length || 0) > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'rgb(var(--color-text-tertiary))' }}>
+            Protein Types
+          </div>
+          <div style={{ marginTop: 4, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {(c.protein_types_responsible || []).map((v) => (
+              <Tag key={v}>{v}</Tag>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {(c.items_responsible?.length || 0) > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'rgb(var(--color-text-tertiary))' }}>Items</div>
+          <div style={{ marginTop: 4, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {(c.items_responsible || []).map((v) => (
+              <Tag key={v}>{v}</Tag>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export const PlantDetailView: React.FC = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<RouteParams>();
+
+  const plantId = String(id || '').trim();
+
+  const [loadingContacts, setLoadingContacts] = useState(false);
+  const [contacts, setContacts] = useState<ContactRow[]>([]);
+
+  useEffect(() => {
+    if (!plantId) return;
+
+    let mounted = true;
+    const load = async () => {
+      setLoadingContacts(true);
+      try {
+        const resp = await apiClient.get('contacts/', {
+          params: { plant: plantId, page_size: 200, limit: 200 },
+        });
+        const payload = resp.data as unknown;
+        const obj = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null;
+        const rows = Array.isArray(obj?.results) ? (obj?.results as unknown[]) : (payload as unknown[]);
+        const next = (Array.isArray(rows) ? rows : [])
+          .filter((r) => r && typeof r === 'object')
+          .map((r) => r as ContactRow);
+        if (mounted) setContacts(next);
+      } finally {
+        if (mounted) setLoadingContacts(false);
+      }
+    };
+
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [plantId]);
+
+  const grouped = useMemo(() => {
+    const buckets: Record<string, ContactRow[]> = {
+      sales: [],
+      qa: [],
+      booking: [],
+      accounting: [],
+    };
+
+    for (const c of contacts) {
+      buckets[normalizeDept(c.department)]?.push(c);
+    }
+
+    return buckets;
+  }, [contacts]);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Button onClick={() => navigate(-1)}>Back</Button>
+          <div style={{ fontSize: 16, fontWeight: 700, color: 'rgb(var(--color-text-primary))' }}>Plant</div>
+        </div>
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <EntityFormSurface
+          entityType="plant"
+          mode="view"
+          variant="inline"
+          isOpen={true}
+          entityId={plantId}
+          onClose={() => navigate('/suppliers')}
+        />
+      </div>
+
+      <Card style={{ marginTop: 16 }} title="Contacts">
+        {loadingContacts ? (
+          <div style={{ padding: 12 }}>
+            <Spin />
+          </div>
+        ) : (
+          <Tabs
+            items={[
+              {
+                key: 'sales',
+                label: `Sales (${grouped.sales.length})`,
+                children: grouped.sales.length ? grouped.sales.map(renderContact) : <Empty description="No sales contacts" />,
+              },
+              {
+                key: 'qa',
+                label: `QA (${grouped.qa.length})`,
+                children: grouped.qa.length ? grouped.qa.map(renderContact) : <Empty description="No QA contacts" />,
+              },
+              {
+                key: 'booking',
+                label: `Booking (${grouped.booking.length})`,
+                children: grouped.booking.length ? grouped.booking.map(renderContact) : <Empty description="No booking contacts" />,
+              },
+              {
+                key: 'accounting',
+                label: `Accounting (${grouped.accounting.length})`,
+                children: grouped.accounting.length ? grouped.accounting.map(renderContact) : <Empty description="No accounting contacts" />,
+              },
+            ]}
+          />
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default PlantDetailView;


### PR DESCRIPTION
Adds parent/child drill-down UX:
- Supplier/Customer record pages now show Plants/Locations (no flat Contacts at grandparent).
- New PlantDetailView + LocationDetailView pages group Contacts by department (Sales/QA/Booking/Accounting).
- Includes New Plant/New Location CTA that opens UniversalEntityForm prefilled with the parent id.

Notes:
- Relies on backend supporting contact.department and contact filtering by plant/location (and nested create support if you use the inline arrays).