### PR TITLE
Fix URL-synced tabs (WorkForms + Cockpit)

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -119,6 +119,13 @@ This file is the **append-only PR-referenceable execution log**.
 - Save payload continues to persist Workforms as `type="workflow"` + `workflow_id`.
 - PR: #4238
 
+### 2026-03-31 — Fix: URL-synced tabs (WorkForms + Cockpit)
+- WorkForms: Tabs are now URL-driven (AntD Tabs activeKey derived from location.pathname; onChange navigates to `/workforms/{key}`); deep links like `/workforms/in-progress/:id` are routed.
+- In Progress: `/workforms/in-progress/:id` now mounts correctly and resumes the submission modal via QuickActionsContext.
+- Cockpit: `/cockpit` is now a layout with URL-driven Tabs and nested routes (`/cockpit/dashboard`, `/cockpit/process-monitor`, `/cockpit/calls`); `/calls` redirects to `/cockpit/calls`.
+- Safety: wrapped WorkForms InProgress/History/Monitoring in ErrorBoundary.
+- PR: #4239
+
 ### 2026-03-30 — Docs: master plan gap analysis + roadmap hygiene
 - Updated `MASTER_PLAN.md` (canonical) with an industry-leader benchmark gap analysis (P0/P1/P2) and refreshed execution-ordered backlog.
 - Converted non-canonical roadmaps/plans into clearer **REFERENCE ONLY** docs (removed/neutralized misleading progress emphasis).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,6 +91,7 @@ import AdminErrorBoundary from './components/Admin/AdminErrorBoundary';
 import { ErrorBoundary as ProductionErrorBoundary } from './components/common/ErrorBoundary';
 import { logger } from './utils/logger';
 const CockpitPage = lazy(() => import('./pages/Cockpit'));
+import CockpitDashboard from './pages/Cockpit/CockpitDashboard';
 import ProcessMonitor from './pages/Cockpit/ProcessMonitor';
 import CockpitEntityRedirect from './pages/Cockpit/CockpitEntityRedirect';
 import { NotificationPreferences } from './pages/Settings/index';
@@ -297,7 +298,7 @@ const App: React.FC = () => {
                 <Route path="carriers" element={<Carriers />} />
                 <Route path="contacts" element={<Contacts />} />
                 <Route path="ai-assistant" element={<AIAssistant />} />
-                <Route path="calls" element={<CallLog />} />
+                <Route path="calls" element={<Navigate to="/cockpit/calls" replace />} />
                 <Route path="call-log" element={<Navigate to="/calls" replace />} />
                 <Route path="processes" element={<Navigate to="/forms-flows/catalog" replace />} />
                 <Route path="reports" element={<Reports />} />
@@ -318,6 +319,7 @@ const App: React.FC = () => {
                   <Route index element={<Navigate to="/workforms/tasks" replace />} />
                   <Route path="tasks" element={<MyTasks />} />
                   <Route path="in-progress" element={<WorkFormsInProgress />} />
+                  <Route path="in-progress/:id" element={<WorkFormsInProgress />} />
                   <Route path="monitoring" element={<WorkFormsMonitoring />} />
                   <Route path="catalog" element={<WorkFormsCatalog />} />
                   <Route path="history" element={<WorkFormsHistory />} />
@@ -410,10 +412,13 @@ const App: React.FC = () => {
                       <CockpitPage />
                     </Suspense>
                   }
-                />
-                <Route path="cockpit/process-monitor" element={<ProcessMonitor />} />
-                {/* Legacy deep-link route (redirects into /cockpit breadcrumb UX) */}
-                <Route path="cockpit/entity/:entityType/:entityId" element={<CockpitEntityRedirect />} />
+                >
+                  <Route index element={<Navigate to="/cockpit/dashboard" replace />} />
+                  <Route path="dashboard" element={<CockpitDashboard />} />
+                  <Route path="process-monitor" element={<ProcessMonitor />} />
+                  <Route path="calls" element={<CallLog />} />
+                  <Route path="entity/:entityType/:entityId" element={<CockpitEntityRedirect />} />
+                </Route>
                 {/* Note: /workspace now points to Admin Workspace, not Cockpit */}
               </Route>
             </Routes>

--- a/frontend/src/pages/Cockpit/index.tsx
+++ b/frontend/src/pages/Cockpit/index.tsx
@@ -1,20 +1,15 @@
 /**
  * Cockpit Page - Search-First Command Center
  *
- * Main Cockpit command center featuring the dashboard and hero omnibox search.
- *
- * Implements Phase 7 consolidation: search-first navigation without Smart Wizard mode.
+ * Cockpit layout with URL-synchronized sub-navigation.
  *
  * Created: 2026-02-04 - Phase 1.2 Cockpit Enhancement
  */
 import React from 'react';
 import styled from 'styled-components';
-import { Target } from 'lucide-react';
-import CockpitDashboard from './CockpitDashboard';
-
-// ============================================================================
-// Constants
-// ============================================================================
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Tabs } from 'antd';
+import { Target, LayoutGrid, Workflow, PhoneCall } from 'lucide-react';
 
 // ============================================================================
 // Styled Components
@@ -23,7 +18,7 @@ import CockpitDashboard from './CockpitDashboard';
 const Container = styled.div`
   min-height: calc(100vh - 64px);
   background: rgb(var(--color-background));
-  
+
   @media (max-width: 768px) {
     min-height: calc(100vh - 56px);
   }
@@ -33,12 +28,11 @@ const Header = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 24px;
+  padding: 20px 24px 0;
   background: rgb(var(--color-surface));
-  border-bottom: 1px solid rgb(var(--color-border));
-  
+
   @media (max-width: 640px) {
-    padding: 16px;
+    padding: 16px 16px 0;
     flex-wrap: wrap;
     gap: 12px;
   }
@@ -68,7 +62,7 @@ const HeaderTitle = styled.h1`
   font-weight: 700;
   color: rgb(var(--color-text-primary));
   margin: 0;
-  
+
   @media (max-width: 640px) {
     font-size: 20px;
   }
@@ -78,10 +72,34 @@ const HeaderSubtitle = styled.p`
   font-size: 14px;
   color: rgb(var(--color-text-secondary));
   margin: 4px 0 0;
-  
+
   @media (max-width: 640px) {
     font-size: 13px;
   }
+`;
+
+const StyledTabs = styled(Tabs)`
+  padding: 0 24px;
+  background: rgb(var(--color-surface));
+  border-bottom: 1px solid rgb(var(--color-border));
+
+  .ant-tabs-nav {
+    margin: 0;
+  }
+
+  .ant-tabs-content-holder {
+    display: none;
+  }
+
+  @media (max-width: 640px) {
+    padding: 0 16px;
+  }
+`;
+
+const TabLabel = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 `;
 
 const Content = styled.main``;
@@ -90,7 +108,37 @@ const Content = styled.main``;
 // Component
 // ============================================================================
 
+const TAB_ITEMS = [
+  { key: 'dashboard', label: 'Dashboard', icon: <LayoutGrid size={18} /> },
+  { key: 'process-monitor', label: 'Process Monitor', icon: <Workflow size={18} /> },
+  { key: 'calls', label: 'Calls', icon: <PhoneCall size={18} /> },
+] as const;
+
 const CockpitPage: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const activeKey = React.useMemo(() => {
+    const pathname = location.pathname;
+    if (pathname.startsWith('/cockpit/process-monitor')) return 'process-monitor';
+    if (pathname.startsWith('/cockpit/calls')) return 'calls';
+    return 'dashboard';
+  }, [location.pathname]);
+
+  const items = React.useMemo(
+    () =>
+      TAB_ITEMS.map((t) => ({
+        key: t.key,
+        label: (
+          <TabLabel>
+            {t.icon}
+            <span>{t.label}</span>
+          </TabLabel>
+        ),
+      })),
+    []
+  );
+
   return (
     <Container>
       <Header>
@@ -104,9 +152,11 @@ const CockpitPage: React.FC = () => {
           </HeaderTitleGroup>
         </HeaderLeft>
       </Header>
-      
+
+      <StyledTabs activeKey={activeKey} items={items} onChange={(key) => navigate(`/cockpit/${key}`)} />
+
       <Content id="cockpit-content" role="tabpanel">
-        <CockpitDashboard />
+        <Outlet />
       </Content>
     </Container>
   );
@@ -114,5 +164,4 @@ const CockpitPage: React.FC = () => {
 
 export default CockpitPage;
 
-// Also export named for explicit imports
 export { CockpitPage };

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -17,6 +17,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 import { showAlert } from '@/utils/uiDialogs';
 import { 
   CheckCircle, XCircle, Calendar, Search, Download, 
@@ -653,7 +654,8 @@ const FormsFlowsHistory: React.FC = () => {
   const currentData = activeTab === 'submissions' ? submissions : workflowExecutions;
   
   return (
-    <Container role="region" aria-label="Form History">
+    <ErrorBoundary>
+      <Container role="region" aria-label="Form History">
       {/* Tabs */}
       <TabsContainer>
         <Tab
@@ -927,7 +929,8 @@ const FormsFlowsHistory: React.FC = () => {
           )}
         </>
       )}
-    </Container>
+      </Container>
+    </ErrorBoundary>
   );
 };
 

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -17,6 +17,8 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useParams } from 'react-router-dom';
+import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 import { confirmDialog, showAlert } from '@/utils/uiDialogs';
 import { Play, Clock, Filter, RefreshCw, FileText, X } from 'lucide-react';
 import { businessApi } from '../../services/businessApi';
@@ -443,7 +445,21 @@ const FormsFlowsInProgress: React.FC = () => {
   const [cancelingId, setCancelingId] = useState<string | null>(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [selectedSubmission, setSelectedSubmission] = useState<FormSubmission | null>(null);
+
+  const { id: submissionId } = useParams<{ id?: string }>();
   const { resumeSubmission } = useQuickActions();
+
+  useEffect(() => {
+    if (!submissionId) return;
+
+    resumeSubmission(submissionId).catch(() => {
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to load the selected in-progress workflow. Please try again.',
+      });
+    });
+  }, [resumeSubmission, submissionId]);
   
   // Fetch in-progress submissions
   const fetchSubmissions = async () => {
@@ -540,7 +556,8 @@ const FormsFlowsInProgress: React.FC = () => {
   };
   
   return (
-    <Container role="region" aria-label="In Progress Forms">
+    <ErrorBoundary resetKeys={[submissionId, filterMode, searchQuery]}>
+      <Container role="region" aria-label="In Progress Forms">
       <Toolbar>
         <ToolbarLeft>
           <SearchInput
@@ -664,7 +681,8 @@ const FormsFlowsInProgress: React.FC = () => {
           </ModalActions>
         </ModalContent>
       </Modal>
-    </Container>
+      </Container>
+    </ErrorBoundary>
   );
 };
 

--- a/frontend/src/pages/WorkForms/Monitoring.tsx
+++ b/frontend/src/pages/WorkForms/Monitoring.tsx
@@ -11,10 +11,15 @@
 
 import React from 'react';
 
+import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 import ProcessMonitor from '../Cockpit/ProcessMonitor';
 
 export const Monitoring: React.FC = () => {
-  return <ProcessMonitor />;
+  return (
+    <ErrorBoundary>
+      <ProcessMonitor />
+    </ErrorBoundary>
+  );
 };
 
 export default Monitoring;

--- a/frontend/src/pages/WorkForms/index.tsx
+++ b/frontend/src/pages/WorkForms/index.tsx
@@ -1,20 +1,21 @@
 /**
  * WorkForms Layout Component
- * 
+ *
  * Parent layout for the WorkForms section with sub-navigation tabs.
  * Implements Phase 1 of the Cockpit & WorkForms Enhancement Plan.
- * 
+ *
  * Created: 2026-02-03
  * Updated: 2026-02-04 - Renamed from Forms & Flows to WorkForms
- * 
+ *
  * Features:
- * - Sub-navigation tabs (My Tasks, In Progress, Catalog, History)
+ * - URL-synchronized AntD Tabs (deep-link safe)
  * - Badge support for action item counts
  * - Responsive layout
  */
 import React from 'react';
-import { Outlet, NavLink, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { Tabs } from 'antd';
 import { CheckSquare, Clock, BookOpen, History, FileText, Workflow } from 'lucide-react';
 import { useActionItems } from '../../contexts/ActionItemsContext';
 import { useAuth } from '../../contexts/AuthContext';
@@ -24,11 +25,12 @@ import { useAuth } from '../../contexts/AuthContext';
 // ============================================================================
 
 interface TabItem {
+  key: string;
   path: string;
   label: string;
   icon: React.ReactNode;
   badgeKey?: string;
-  adminOnly?: boolean; // New: Restrict to admin users
+  adminOnly?: boolean;
 }
 
 // ============================================================================
@@ -36,12 +38,12 @@ interface TabItem {
 // ============================================================================
 
 const TABS: TabItem[] = [
-  { path: '/workforms/tasks', label: 'My Tasks', icon: <CheckSquare size={18} />, badgeKey: 'actionRequired' },
-  { path: '/workforms/in-progress', label: 'In Progress', icon: <Clock size={18} /> },
-  { path: '/workforms/monitoring', label: 'Monitoring', icon: <Workflow size={18} /> },
-  { path: '/workforms/catalog', label: 'Catalog', icon: <BookOpen size={18} /> },
-  { path: '/workforms/history', label: 'History', icon: <History size={18} /> },
-  { path: '/workforms/editor', label: 'Editor', icon: <FileText size={18} />, adminOnly: true },
+  { key: 'tasks', path: '/workforms/tasks', label: 'My Tasks', icon: <CheckSquare size={18} />, badgeKey: 'actionRequired' },
+  { key: 'in-progress', path: '/workforms/in-progress', label: 'In Progress', icon: <Clock size={18} /> },
+  { key: 'monitoring', path: '/workforms/monitoring', label: 'Monitoring', icon: <Workflow size={18} /> },
+  { key: 'catalog', path: '/workforms/catalog', label: 'Catalog', icon: <BookOpen size={18} /> },
+  { key: 'history', path: '/workforms/history', label: 'History', icon: <History size={18} /> },
+  { key: 'editor', path: '/workforms/editor', label: 'Editor', icon: <FileText size={18} />, adminOnly: true },
 ];
 
 // ============================================================================
@@ -51,7 +53,7 @@ const TABS: TabItem[] = [
 const Container = styled.div`
   min-height: calc(100vh - 64px);
   background: rgb(var(--color-background));
-  
+
   @media (max-width: 768px) {
     min-height: calc(100vh - 56px);
   }
@@ -63,8 +65,7 @@ const Header = styled.div`
   justify-content: space-between;
   padding: 20px 24px 0;
   background: rgb(var(--color-surface));
-  border-bottom: 1px solid rgb(var(--color-border));
-  
+
   @media (max-width: 640px) {
     padding: 16px 16px 0;
     flex-wrap: wrap;
@@ -102,64 +103,28 @@ const HeaderSubtitle = styled.p`
   margin: 4px 0 0;
 `;
 
-const TabNav = styled.nav`
-  display: flex;
-  gap: 4px;
+const StyledTabs = styled(Tabs)`
   padding: 0 24px;
   background: rgb(var(--color-surface));
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
-  
-  &::-webkit-scrollbar {
+  border-bottom: 1px solid rgb(var(--color-border));
+
+  .ant-tabs-nav {
+    margin: 0;
+  }
+
+  .ant-tabs-content-holder {
     display: none;
   }
-  
+
   @media (max-width: 640px) {
     padding: 0 16px;
-    gap: 0;
   }
 `;
 
-const TabLink = styled(NavLink)`
-  display: flex;
+const TabLabel = styled.span`
+  display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  color: rgb(var(--color-text-secondary));
-  text-decoration: none;
-  border-bottom: 2px solid transparent;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-  flex-shrink: 0;
-  
-  &:hover {
-    color: rgb(var(--color-text-primary));
-    background: rgb(var(--color-surface-hover));
-  }
-  
-  &.active {
-    color: rgb(var(--color-primary));
-    border-bottom-color: rgb(var(--color-primary));
-  }
-  
-  &:focus-visible {
-    outline: 2px solid rgb(var(--color-primary));
-    outline-offset: -2px;
-    border-radius: 4px;
-  }
-  
-  @media (max-width: 640px) {
-    padding: 12px 12px;
-    font-size: 13px;
-    gap: 6px;
-    
-    span {
-      /* Hide label text on small screens if needed, show icon */
-    }
-  }
 `;
 
 const TabBadge = styled.span`
@@ -179,7 +144,7 @@ const TabBadge = styled.span`
 
 const Content = styled.main`
   padding: 24px;
-  
+
   @media (max-width: 640px) {
     padding: 16px;
   }
@@ -191,20 +156,40 @@ const Content = styled.main`
 
 const WorkFormsLayout: React.FC = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const { counts } = useActionItems();
   const { isAdmin } = useAuth();
-  
-  // Map badgeKey to counts
+
   const badgeCounts: Record<string, number> = {
     actionRequired: counts.total,
     overdue: counts.overdue,
     dueToday: counts.due_today,
     dueThisWeek: counts.due_this_week,
   };
-  
-  // Filter tabs based on admin status
-  const visibleTabs = TABS.filter(tab => !tab.adminOnly || isAdmin);
-  
+
+  const visibleTabs = React.useMemo(() => TABS.filter((tab) => !tab.adminOnly || isAdmin), [isAdmin]);
+
+  const activeKey = React.useMemo(() => {
+    const pathname = location.pathname;
+    const match = visibleTabs.find((tab) => pathname === tab.path || pathname.startsWith(`${tab.path}/`));
+    return match?.key ?? visibleTabs[0]?.key ?? 'tasks';
+  }, [location.pathname, visibleTabs]);
+
+  const tabItems = React.useMemo(
+    () =>
+      visibleTabs.map((tab) => ({
+        key: tab.key,
+        label: (
+          <TabLabel>
+            {tab.icon}
+            <span>{tab.label}</span>
+            {tab.badgeKey && badgeCounts[tab.badgeKey] > 0 && <TabBadge>{badgeCounts[tab.badgeKey]}</TabBadge>}
+          </TabLabel>
+        ),
+      })),
+    [badgeCounts, visibleTabs]
+  );
+
   return (
     <Container>
       <Header>
@@ -218,24 +203,13 @@ const WorkFormsLayout: React.FC = () => {
           </div>
         </HeaderLeft>
       </Header>
-      
-      <TabNav role="tablist">
-        {visibleTabs.map((tab) => (
-          <TabLink
-            key={tab.path}
-            to={tab.path}
-            role="tab"
-            aria-selected={location.pathname === tab.path}
-          >
-            {tab.icon}
-            <span>{tab.label}</span>
-            {tab.badgeKey && badgeCounts[tab.badgeKey] && badgeCounts[tab.badgeKey] > 0 && (
-              <TabBadge>{badgeCounts[tab.badgeKey]}</TabBadge>
-            )}
-          </TabLink>
-        ))}
-      </TabNav>
-      
+
+      <StyledTabs
+        activeKey={activeKey}
+        items={tabItems}
+        onChange={(key) => navigate(`/workforms/${key}`)}
+      />
+
       <Content>
         <Outlet />
       </Content>


### PR DESCRIPTION
Refactor WorkForms + Cockpit sub-navigation to be URL-driven and deep-link safe.

WorkForms:
- Replace NavLink tab strip with AntD Tabs
- activeKey derived from location.pathname
- onChange navigates to /workforms/{key}
- Add missing route /workforms/in-progress/:id and auto-resume modal via QuickActionsContext

Cockpit:
- Convert /cockpit into a layout with AntD Tabs + <Outlet/>
- Nest routes: /cockpit/dashboard, /cockpit/process-monitor, /cockpit/calls
- Redirect /calls -> /cockpit/calls

Stability:
- Wrap WorkForms InProgress/History/Monitoring in ErrorBoundary

Verified:
- npm --prefix frontend run type-check