### PR TITLE
Fix Recharts ResponsiveContainer warnings

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1441,3 +1441,4 @@ Deliverables:
 - 2026-03-31 — Backend: Contacts department fields (mobile/office phones + Sales responsibility arrays) — PR: #4225.
 - 2026-03-31 — Backend: Plants/Locations nested department contacts + Vertical (K2C) type option — PR: #4226.
 - 2026-03-31 — System Products: ranked search respects visibility (global inactive + tenant hides), tenant preference upsert + RLS, Option Lists superadmin delete — PR: #4232.
+- 2026-03-31 — Frontend: avoid Recharts ResponsiveContainer zero-size warnings — PR: #4240.

--- a/frontend/src/apps/admin-studio/pages/Metrics.tsx
+++ b/frontend/src/apps/admin-studio/pages/Metrics.tsx
@@ -358,7 +358,7 @@ export const Metrics: React.FC = () => {
         {/* Daily Usage Trend */}
         <ChartCard>
           <ChartTitle>Daily Usage Trends (Last 30 Days)</ChartTitle>
-          <ResponsiveContainer width="100%" height={300} minWidth={0} minHeight={0} debounce={150}>
+          <ResponsiveContainer width="100%" height={300} minWidth={1} minHeight={1} debounce={150}>
             <LineChart data={workflowMetrics.daily_usage}>
               <CartesianGrid strokeDasharray="3 3" stroke="rgba(0,0,0,0.1)" />
               <XAxis 
@@ -398,7 +398,7 @@ export const Metrics: React.FC = () => {
         {/* Execution Status Bar Chart */}
         <ChartCard>
           <ChartTitle>Execution Status Distribution</ChartTitle>
-          <ResponsiveContainer width="100%" height={300} minWidth={0} minHeight={0} debounce={150}>
+          <ResponsiveContainer width="100%" height={300} minWidth={1} minHeight={1} debounce={150}>
             <BarChart data={[
               { name: 'Completed', value: workflowMetrics.completed_executions },
               { name: 'In Progress', value: workflowMetrics.in_progress_executions },

--- a/frontend/src/components/Cockpit/AILearningMetricsWidget.tsx
+++ b/frontend/src/components/Cockpit/AILearningMetricsWidget.tsx
@@ -87,7 +87,7 @@ export const AILearningMetricsWidget: React.FC<AILearningMetricsWidgetProps> = (
           Confidence trend (last 30 days)
         </Text>
         <div style={{ width: '100%', minHeight: 120, minWidth: 0, marginTop: 8 }}>
-          <ResponsiveContainer width="100%" height={120} minWidth={0} minHeight={0} debounce={150}>
+          <ResponsiveContainer width="100%" height={120} minWidth={1} minHeight={1} debounce={150}>
             <LineChart data={m.confidenceTrend || defaultTrend}>
               <XAxis dataKey="day" hide />
               <YAxis domain={[0, 1]} hide />

--- a/frontend/src/components/FlowEditor/analytics/WorkflowAnalyticsDashboard.tsx
+++ b/frontend/src/components/FlowEditor/analytics/WorkflowAnalyticsDashboard.tsx
@@ -265,7 +265,7 @@ export const WorkflowAnalyticsDashboard: React.FC<WorkflowAnalyticsDashboardProp
 
     return (
       <Card title="Execution Trends" style={{ marginTop: 16 }}>
-        <ResponsiveContainer width="100%" height={300} minWidth={0} minHeight={0} debounce={150}>
+        <ResponsiveContainer width="100%" height={300} minWidth={1} minHeight={1} debounce={150}>
           <LineChart data={metrics.executions_by_day}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis 
@@ -300,7 +300,7 @@ export const WorkflowAnalyticsDashboard: React.FC<WorkflowAnalyticsDashboardProp
 
     return (
       <Card title="Execution Distribution (24h)" style={{ marginTop: 16 }}>
-        <ResponsiveContainer width="100%" height={250} minWidth={0} minHeight={0} debounce={150}>
+        <ResponsiveContainer width="100%" height={250} minWidth={1} minHeight={1} debounce={150}>
           <BarChart data={metrics.executions_by_hour}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis 
@@ -387,7 +387,7 @@ export const WorkflowAnalyticsDashboard: React.FC<WorkflowAnalyticsDashboardProp
       <Card title="Error Breakdown" style={{ marginTop: 16 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} md={12}>
-            <ResponsiveContainer width="100%" height={250} minWidth={0} minHeight={0} debounce={150}>
+            <ResponsiveContainer width="100%" height={250} minWidth={1} minHeight={1} debounce={150}>
               <PieChart>
                 <Pie
                   data={pieData}

--- a/frontend/src/components/Visualization/PurchaseOrderTrends.tsx
+++ b/frontend/src/components/Visualization/PurchaseOrderTrends.tsx
@@ -27,7 +27,7 @@ const PurchaseOrderTrends: React.FC<PurchaseOrderTrendsProps> = ({ data, height 
   return (
     <ChartContainer>
       <ChartTitle>Purchase Order Trends</ChartTitle>
-      <ResponsiveContainer width="100%" height={height} minWidth={0} minHeight={0} debounce={150}>
+      <ResponsiveContainer width="100%" height={height} minWidth={1} minHeight={1} debounce={150}>
         <LineChart
           data={data}
           margin={{

--- a/frontend/src/components/Visualization/SupplierPerformanceChart.tsx
+++ b/frontend/src/components/Visualization/SupplierPerformanceChart.tsx
@@ -30,7 +30,7 @@ const SupplierPerformanceChart: React.FC<SupplierPerformanceChartProps> = ({
   return (
     <ChartContainer>
       <ChartTitle>Supplier Performance</ChartTitle>
-      <ResponsiveContainer width="100%" height={height} minWidth={0} minHeight={0} debounce={150}>
+      <ResponsiveContainer width="100%" height={height} minWidth={1} minHeight={1} debounce={150}>
         <BarChart
           data={data}
           margin={{


### PR DESCRIPTION
Sets a small non-zero minWidth/minHeight on Recharts ResponsiveContainer instances to avoid width/height -1 warnings during initial layout/hidden renders.

Files:
- frontend/src/apps/admin-studio/pages/Metrics.tsx
- frontend/src/components/Cockpit/AILearningMetricsWidget.tsx
- frontend/src/components/FlowEditor/analytics/WorkflowAnalyticsDashboard.tsx
- frontend/src/components/Visualization/PurchaseOrderTrends.tsx
- frontend/src/components/Visualization/SupplierPerformanceChart.tsx

Verified:
- npm --prefix frontend run type-check

Log:
- .github/MASTER_PLAN.md (2026-03-31)