### PR TITLE
Fix Sync Now CTA when Outlook not connected

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1443,3 +1443,4 @@ Deliverables:
 - 2026-03-31 — System Products: ranked search respects visibility (global inactive + tenant hides), tenant preference upsert + RLS, Option Lists superadmin delete — PR: #4232.
 - 2026-03-31 — Frontend: avoid Recharts ResponsiveContainer zero-size warnings — PR: #4240.
 - 2026-03-31 — Docs: refresh canonical MASTER_PLAN runtime issues snapshot (mark suggest-nodes + chart warnings resolved) — PR: #4241.
+- 2026-03-31 — Email Ingestion Monitor: show reconnect CTA when Outlook not connected (error_code=not_connected) — PR: #4243.

--- a/frontend/src/utils/emailSyncDiagnostics.tsx
+++ b/frontend/src/utils/emailSyncDiagnostics.tsx
@@ -35,7 +35,13 @@ export const getEmailSyncErrorCode = (data: unknown): EmailSyncErrorCode => {
 };
 
 export const emailSyncNeedsReconnect = (code: EmailSyncErrorCode): boolean => {
-  return code === 'decryption_failed' || code === 'token_invalid' || code === 'token_refresh_failed' || code === 'token_missing';
+  return (
+    code === 'not_connected' ||
+    code === 'decryption_failed' ||
+    code === 'token_invalid' ||
+    code === 'token_refresh_failed' ||
+    code === 'token_missing'
+  );
 };
 
 export const buildEmailSyncCtaMessage = (


### PR DESCRIPTION
Treats error_code=not_connected as a reconnect-required state so the Email Ingestion Monitor shows the Open Email Integrations CTA (instead of a generic error).\n\nVerified: npm --prefix frontend run type-check