### PR TITLE
Fix test_document_upload endpoint path

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1444,3 +1444,4 @@ Deliverables:
 - 2026-03-31 — Frontend: avoid Recharts ResponsiveContainer zero-size warnings — PR: #4240.
 - 2026-03-31 — Docs: refresh canonical MASTER_PLAN runtime issues snapshot (mark suggest-nodes + chart warnings resolved) — PR: #4241.
 - 2026-03-31 — Email Ingestion Monitor: show reconnect CTA when Outlook not connected (error_code=not_connected) — PR: #4243.
+- 2026-03-31 — Ops: align test_document_upload diagnostic command to /api/v1/ai-assistant/ai-documents/ — PR: #4244.

--- a/backend/tenant_apps/ai_assistant/management/commands/test_document_upload.py
+++ b/backend/tenant_apps/ai_assistant/management/commands/test_document_upload.py
@@ -154,7 +154,7 @@ class Command(BaseCommand):
             data['session'] = session_id
 
         factory = APIRequestFactory()
-        req = factory.post('/api/v1/ai-assistant/documents/', data=data, format='multipart')
+        req = factory.post('/api/v1/ai-assistant/ai-documents/', data=data, format='multipart')
         # Ensure tenant context exists even without middleware.
         req.tenant = tenant
         # For parity with middleware resolution.


### PR DESCRIPTION
Aligns the diagnostic management command test_document_upload to the actual DRF router path (/api/v1/ai-assistant/ai-documents/), avoiding confusing reproductions.

Verified: python -m compileall on the command.