### PR TITLE
Fix Quick Actions JWT gate + add V3.5 audits

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1446,3 +1446,12 @@ Deliverables:
 - 2026-03-31 — Email Ingestion Monitor: show reconnect CTA when Outlook not connected (error_code=not_connected) — PR: #4243.
 - 2026-03-31 — Ops: align test_document_upload diagnostic command to /api/v1/ai-assistant/ai-documents/ — PR: #4244.
 - 2026-03-31 — Workflows: DocumentUploadCard uses real ai-documents upload (fallback to simulated if endpoint missing) — PR: #4245.
+
+### 2026-03-31T14:27:41Z — V3.5 refactor transition (feature freeze)
+- Feature development is **halted** pending completion of the V3.5 Enterprise Refactor Roadmap.
+- New audits:
+  - `docs/audits/SYSTEM_ERRORS_2026.md`
+  - `docs/audits/UI_UX_DEBT_2026.md`
+  - `docs/audits/API_SCHEMA_DRIFT.md`
+- New remediation blueprint:
+  - `docs/plans/V3_5_ENTERPRISE_REFACTOR_ROADMAP.md`

--- a/docs/audits/API_SCHEMA_DRIFT.md
+++ b/docs/audits/API_SCHEMA_DRIFT.md
@@ -1,0 +1,74 @@
+# API_SCHEMA_DRIFT (Type Safety Alignment Audit)
+
+**Generated**: 2026-03-31
+
+Goal: Reduce 400 Bad Request and runtime payload mismatches by aligning backend schemas (drf-spectacular + Django choices) with frontend TypeScript types.
+
+---
+
+## 1) drf-spectacular configuration (backend)
+
+Evidence:
+- `backend/projectmeats/settings/base.py` includes `drf_spectacular`
+- DRF `DEFAULT_SCHEMA_CLASS` set to `drf_spectacular.openapi.AutoSchema`
+- `SPECTACULAR_SETTINGS` present (API metadata configured)
+
+**Recommendation:**
+- Ensure the OpenAPI schema is generated in CI and used to generate TypeScript client/types (or at least compared for drift).
+
+---
+
+## 2) High-signal drift: documents upload type mismatch
+
+Backend:
+- `tenant_apps.ai_assistant.serializers.AIDocumentSerializer` returns fields including:
+  - `content_type`
+  - `file_size`
+  - `processing_status`
+  - `original_filename`
+
+Frontend type:
+- `frontend/src/types/index.ts:UploadedDocument` includes:
+  - `file_type`
+  - `document_type`
+  - `extracted_text`, `extracted_data`
+
+**Risk:**
+- UI may assume fields that backend doesn’t return (or names differ), causing undefined access and incomplete UX.
+
+**Recommendation:**
+- Either:
+  1) Update frontend type(s) to match backend serializer exactly (preferred), or
+  2) Extend backend serializer to include compatible aliases (e.g., `file_type` mirroring `content_type`) in an additive manner.
+
+---
+
+## 3) Choices alignment (backend TextChoices/IntegerChoices)
+
+Backend contains many `models.TextChoices` (examples):
+- `apps.core.models.WeightUnitChoices`
+- `tenant_apps.workflows.models.FormSubmissionStatus`, `StepSubmissionStatus`
+- `apps.system.models.tenant_workform.WorkFormStatusChoices`
+
+Frontend contains many string unions (various files under `frontend/src/types/`).
+
+**Risk:**
+- Status strings or enum values drift (case/underscore) → 400s on POST/PATCH or silent UI breakage.
+
+**Recommendation:**
+- Generate TS enums/unions from OpenAPI schema.
+- Add a small “schema drift” unit test comparing:
+  - backend choices → schema → generated types
+  - frontend unions used in forms/mutations
+
+---
+
+## 4) Suggested enforcement
+
+- Prefer `unknown` at API boundary → parse into typed objects.
+- Add zod/type-guards for high-churn payloads:
+  - Workflows
+  - Forms/submissions
+  - Quick Actions
+  - Documents
+

--- a/docs/audits/SYSTEM_ERRORS_2026.md
+++ b/docs/audits/SYSTEM_ERRORS_2026.md
@@ -1,0 +1,143 @@
+# SYSTEM_ERRORS_2026 (Repository Diagnostic Sweep)
+
+**Generated**: 2026-03-31
+
+Scope (requested):
+1. Backend: find APIViews/ViewSets overriding `perform_create` / `get_queryset` without explicit tenant enforcement.
+2. Frontend: unhandled promise rejections, missing ErrorBoundary around lazy routes, excessive `any` in API contracts, non-standard data fetching.
+3. Output: actionable findings and remediation directions.
+
+> Notes on methodology
+> - This is a *heuristic* sweep. Some ViewSets inherit tenant filtering from base classes (e.g., `TenantFilteredModelViewSet`) so a missing `.filter(tenant=...)` inside the override is not automatically a bug.
+> - For shared-schema multi-tenancy, **correctness requires BOTH**:
+>   - Application filtering by `request.tenant`
+>   - DB enforcement via RLS (`app.current_tenant` set + policies)
+
+---
+
+## A) Backend multi-tenancy enforcement findings
+
+### A1) `perform_create` overrides: candidates lacking explicit tenant assignment
+
+Heuristic scan found **3** candidates where the first ~60 lines after `def perform_create(self, serializer):` did not include `request.tenant` / `tenant=`.
+
+1) `backend/apps/core/views.py`
+- `perform_create` saves **user preferences**, scoped by `user=self.request.user`.
+- This is not tenant-owned data; **OK** (but ensure endpoints never leak other users’ prefs).
+
+2) `backend/tenant_apps/ai_assistant/views.py` (`ChatSessionViewSet.perform_create`)
+- Saves chat sessions owned by `request.user`.
+- Tenant isolation is enforced in `get_queryset()` via `owner=self.request.user`.
+- **Risk**: If any other endpoint later filters by tenant without owner, these records may be ambiguous. Consider optionally persisting `tenant_id` on chat sessions if product requirements evolve.
+
+3) `backend/tenant_apps/workflows/mixins.py`
+- Mixin `perform_create` calls `super().perform_create(serializer)` and invalidates cache.
+- **OK** assuming the parent `perform_create` sets tenant/created_by correctly.
+
+**Recommendation:**
+- For tenant-owned models, enforce a single base pattern:
+  - `get_queryset()` always tenant-filtered (or via tenant base class)
+  - `perform_create()` always sets `tenant=request.tenant`
+  - For write paths, assert RLS context where needed (`set_current_tenant()` inside transaction) when policies require.
+
+### A2) `get_queryset` overrides: candidates lacking explicit tenant filtering
+
+Heuristic scan flagged **11** `get_queryset` bodies without inline `tenant=` filtering. Most are expected and safe:
+- System/tenants admin views should filter by user permissions rather than tenant FK.
+- Some tenant app viewsets use base class filtering (`TenantFilteredModelViewSet`) so `super().get_queryset()` is already tenant-scoped.
+
+**High-signal check to perform during remediation:**
+- Confirm `TenantFilteredModelViewSet.get_queryset()` always applies `.filter(tenant=request.tenant)` and returns `.none()` when tenant context is missing.
+- Confirm the middleware asserts `app.current_tenant` session variable for DB RLS.
+
+### A3) RLS/session variable enforcement gaps (pattern-level)
+
+Even when `request.tenant` filtering is correct, you can still get:
+- false “0 results” if RLS session vars aren’t set
+- hard 500s if RLS policies reject writes and app treats it as unexpected
+
+**Recommended standard:**
+- For complex write endpoints (uploads, multi-row writes, background actions), assert tenant RLS session variables inside a transaction:
+  - `apps.tenants.rls.set_current_tenant(tenant_id)`
+  - optionally also `cursor.execute('SET app.current_tenant = %s', [tenant_id])` for defense-in-depth
+
+---
+
+## B) Frontend reliability / error handling findings
+
+### B1) Unhandled promise rejections
+- No global `window.addEventListener('unhandledrejection', ...)` handler was found.
+- This is not inherently wrong because most requests are wrapped in `try/catch`, but it reduces observability.
+
+**Recommendation:**
+- Add an `unhandledrejection` handler (and optionally `error` handler) that logs to the centralized logger and Sentry (when enabled) with redaction.
+
+### B2) ErrorBoundary coverage for lazy routes
+- `frontend/src/App.tsx` wraps the app in `ProductionErrorBoundary`.
+- Lazy-loaded routes (`CockpitPage`, `WorkFormsEditor`) are wrapped in `<Suspense fallback={<Skeleton/>}>`.
+- Admin workspace routes are additionally wrapped in `AdminErrorBoundary`.
+
+**Status:** Coverage looks strong; no immediate action required.
+
+### B3) `any` usage in API boundaries (signal)
+`any` occurs widely across the codebase, including in data payloads and API contracts.
+
+Examples/patterns:
+- `Record<string, any>` / `value: any` in form submission and autosave plumbing
+- JSON-like “flow_data” and node definitions typed as `any`
+
+**Risk:**
+- schema drift causes 400s/500s and runtime UI failures that TS cannot catch.
+
+**Recommendation:**
+- Introduce a “no-`any` at the API boundary” rule:
+  - keep `unknown` from API
+  - validate/parse via zod or explicit type guards
+  - then pass typed data into UI
+
+### B4) Data fetching not using React Query
+The following files were detected using `useEffect` with direct `businessApi`/`apiClient` calls (non-exhaustive list):
+- `frontend/src/pages/Suppliers.tsx`
+- `frontend/src/pages/Customers.tsx`
+- `frontend/src/pages/Contacts.tsx`
+- `frontend/src/pages/Inquiries.tsx`
+- `frontend/src/pages/Suppliers/Plants.tsx`
+- `frontend/src/pages/Customers/Locations.tsx`
+- `frontend/src/pages/Admin/OptionLists/index.tsx`
+- `frontend/src/pages/Admin/Configurations/index.tsx`
+- `frontend/src/pages/Fulfillments.tsx`
+- many widgets (Cockpit dashboard) and several modals
+
+**Risk:**
+- inconsistent caching
+- duplicated loading/error state handling
+- increased chance of unhandled rejection
+
+**Recommendation:**
+- Migrate high-traffic list/detail screens to React Query (or the standardized caching layer if different), starting with:
+  - Suppliers/Customers list + detail
+  - Contacts
+  - Inquiries
+  - Option Lists
+
+---
+
+## C) Immediate high-signal regressions to fix next
+
+1) **Quick Actions JWT gate**
+- `QuickActionsContext` currently checks `localStorage.authToken` only; JWT sessions store `accessToken`.
+- Impact: Quick Actions may appear empty / fail to show workforms even though unified fetch code exists.
+
+---
+
+## D) Remediation checklist (for V3.5 roadmap)
+
+- Backend: tenant enforcement
+  - [ ] Confirm all tenant-owned ViewSets inherit a tenant-filtering base class and never return cross-tenant rows.
+  - [ ] Confirm write paths assert RLS tenant vars for sensitive/complex writes.
+
+- Frontend: reliability
+  - [ ] Add global unhandled rejection handler + Sentry capture.
+  - [ ] Migrate top list/detail pages to React Query.
+  - [ ] Reduce `any` at API boundary (introduce parsers/validators).
+

--- a/docs/audits/UI_UX_DEBT_2026.md
+++ b/docs/audits/UI_UX_DEBT_2026.md
@@ -1,0 +1,88 @@
+# UI_UX_DEBT_2026 (Enterprise UI/UX Consolidation Audit)
+
+**Generated**: 2026-03-31
+
+Goal: Identify UI duplication and inconsistencies vs tier-1 enterprise SaaS patterns (Salesforce Lightning, Ant Design Pro), especially around tables, modals, spacing tokens, and nested entity drill-down UX.
+
+---
+
+## 1) Duplicated UI primitives (high signal)
+
+### Tables
+Observed multiple table implementations:
+- `frontend/src/components/Shared/ResponsiveTable.tsx` (custom)
+- `frontend/src/components/Admin/AdminTable.tsx` (custom)
+- Raw HTML tables in some pages (e.g., WorkForms history)
+- AntD tables in other surfaces
+
+**Debt / risk:**
+- inconsistent sorting/filtering/pagination UX
+- inconsistent mobile behavior
+- duplicated accessibility fixes
+
+**Recommendation (enterprise baseline):**
+- Standardize on AntD `Table` + a single wrapper for responsiveness and common column renderers.
+- Deprecate “one-off” custom tables where feasible.
+
+### Modals
+Numerous modal patterns:
+- `frontend/src/components/Modal/Modal.tsx` (custom)
+- Many feature-local modals (FlowEditor modals, form-builder modals, inquiry modals, fulfillment modals)
+
+**Debt / risk:**
+- inconsistent keyboard trap/escape behavior
+- inconsistent z-index layering
+- inconsistent padding/spacing
+
+**Recommendation:**
+- Standardize on AntD `Modal` and create one minimal wrapper for:
+  - default width/breakpoints
+  - consistent footer layout
+  - safe scroll behavior
+  - focus management
+
+---
+
+## 2) Spacing/padding token consistency
+
+Patterns show mixed styling strategies:
+- styled-components with hardcoded padding values
+- CSS variables in some surfaces
+- occasional bespoke sizing
+
+**Recommendation:**
+- Establish a shared spacing scale (e.g., 4/8/12/16/24/32) and enforce via theme tokens / CSS vars.
+- Avoid per-component padding “guessing”.
+
+---
+
+## 3) Nested entity flows (Grandparent → Parent → Child)
+
+Target enterprise flow:
+- List view → row click → detail view
+- Detail view has child tabs/sections with embedded child lists
+- URL structure reflects hierarchy
+
+Current drift indicators (needs confirm per module):
+- Some pages still rely on flat routes and local state expand/collapse
+- Some list pages use explicit name links/buttons rather than row-click drilldowns
+
+**Recommendation:**
+- Make hierarchy navigation URL-first and consistent:
+  - `/suppliers/:id/plants`
+  - `/suppliers/:id/plants/:plantId/contacts`
+  - `/customers/:id/locations`
+  - `/customers/:id/locations/:locationId/contacts`
+
+---
+
+## 4) “Great Deletion Part 2” candidates
+
+Candidates for refactor/deletion (pattern-based):
+- redundant table components (keep 1)
+- redundant modal wrappers (keep 1)
+- redundant card/list primitives when AntD covers the use case
+
+**Non-breaking strategy:**
+- Wrap old components around new primitives first, then delete internal duplication.
+

--- a/docs/plans/V3_5_ENTERPRISE_REFACTOR_ROADMAP.md
+++ b/docs/plans/V3_5_ENTERPRISE_REFACTOR_ROADMAP.md
@@ -1,0 +1,95 @@
+# V3.5 ENTERPRISE REFACTOR ROADMAP (Remediation Blueprint)
+
+**Created**: 2026-03-31
+
+This roadmap is synthesized from:
+- `docs/audits/SYSTEM_ERRORS_2026.md`
+- `docs/audits/UI_UX_DEBT_2026.md`
+- `docs/audits/API_SCHEMA_DRIFT.md`
+
+## Guiding Principle
+**Freeze feature development** until:
+- tenant isolation is provably correct (app + RLS)
+- API boundary is type-safe enough to prevent recurring 400/500 regressions
+- UI primitives are consolidated to an enterprise-grade standard set
+
+---
+
+## Phase 1 — Critical Path (500s, 400s, RLS violations)
+
+### 1.1 Tenant enforcement hardening
+- Validate tenant base ViewSet behavior:
+  - `TenantFilteredModelViewSet.get_queryset()` always tenant filters
+  - returns `.none()` when tenant is missing
+- Standardize write enforcement:
+  - ensure tenant set on creates
+  - assert RLS vars in complex writes where needed
+
+### 1.2 API boundary error normalization
+- Ensure write endpoints return structured 400s with actionable messages (no raw tracebacks)
+- Add global frontend `unhandledrejection` handler to capture + surface actionable error UI
+
+### 1.3 JWT/legacy auth drift cleanup (blocking UX bugs)
+- Fix Quick Actions JWT gating (accessToken vs authToken)
+- Audit any other “legacy-only” token checks in contexts/services
+
+**Acceptance criteria:**
+- No tenant-scoped endpoint can return cross-tenant data.
+- Common failure modes yield 400 with structured payload.
+- No “empty UI due to token key mismatch” regressions.
+
+---
+
+## Phase 2 — Component Consolidation (The Great Deletion Part 2)
+
+### 2.1 Tables
+- Choose one primary table primitive (AntD Table + wrapper)
+- Replace:
+  - `AdminTable` and/or `ResponsiveTable` duplication where feasible
+- Standardize pagination, empty states, row-click drilldowns
+
+### 2.2 Modals
+- Standardize on AntD `Modal` + one thin wrapper
+- Remove feature-local modal shells where they are redundant
+
+### 2.3 Spacing/layout tokens
+- Enforce a single spacing scale via CSS vars/theme
+
+**Acceptance criteria:**
+- One table abstraction used across core CRUD.
+- One modal abstraction.
+- Consistent spacing across pages.
+
+---
+
+## Phase 3 — UX / Flow Alignment (Nested drill-downs, routing correctness)
+
+### 3.1 Hierarchy routing
+- Ensure URLs reflect entity drill-downs:
+  - suppliers → plants → contacts
+  - customers → locations → contacts
+
+### 3.2 Consistent navigation patterns
+- row-click drilldowns
+- consistent breadcrumbs
+- deep-link safe tabs (already adopted in WorkForms + Cockpit)
+
+**Acceptance criteria:**
+- A user can navigate hierarchy without losing context and without “state-only” navigation.
+
+---
+
+## Phase 4 — Performance & Query Efficiency
+
+### 4.1 Frontend
+- Replace ad-hoc `useEffect` fetching with React Query for core lists
+- Add memoization only where measured (avoid cargo-cult)
+
+### 4.2 Backend
+- Eliminate N+1 with `select_related/prefetch_related` and aggregate annotations where needed
+- Enforce query plan guardrails for high-traffic endpoints
+
+**Acceptance criteria:**
+- Largest lists render without N+1.
+- Network calls deduped and cached appropriately.
+

--- a/frontend/src/contexts/QuickActionsContext.test.tsx
+++ b/frontend/src/contexts/QuickActionsContext.test.tsx
@@ -13,10 +13,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QuickActionsProvider, useQuickActions } from './QuickActionsContext';
+import { getAvailableWorkForms } from '@/services/workformsApi';
 import { quickActionsService, formSubmissionService } from '../services/quickActionsService';
 import { showAlert } from '@/utils/uiDialogs';
 
 // Mock services
+vi.mock('@/services/workformsApi', () => ({
+  getAvailableWorkForms: vi.fn(),
+}));
+
 vi.mock('../services/quickActionsService', () => ({
   quickActionsService: {
     getQuickActions: vi.fn(),
@@ -105,6 +110,7 @@ describe('QuickActionsContext', () => {
     // Default mock responses
     vi.mocked(quickActionsService.getQuickActions).mockResolvedValue({ items: mockQuickActions });
     vi.mocked(quickActionsService.getAvailableForms).mockResolvedValue(mockAvailableForms);
+    vi.mocked(getAvailableWorkForms).mockResolvedValue([] as any);
     vi.mocked(quickActionsService.updateQuickActions).mockImplementation(async (items) => ({
       success: true,
       items,
@@ -152,8 +158,27 @@ describe('QuickActionsContext', () => {
       expect(screen.getByTestId('forms-count')).toHaveTextContent('2');
     });
 
+    it('should load quick actions on mount when authenticated via JWT accessToken', async () => {
+      // Token must look like a non-expired JWT for jwtService.getAccessToken() to return it
+      const exp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+      localStorageMock = { accessToken: `header.${btoa(JSON.stringify({ exp }))}.sig` };
+
+      render(
+        <QuickActionsProvider>
+          <TestConsumer />
+        </QuickActionsProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('ready');
+      });
+
+      expect(quickActionsService.getQuickActions).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('actions-count')).toHaveTextContent('2');
+    });
+
     it('should not load when not authenticated', async () => {
-      localStorageMock = {}; // No auth token
+      localStorageMock = {}; // No JWT or legacy token
       
       render(
         <QuickActionsProvider>

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -6,6 +6,7 @@
  */
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import { getAvailableWorkForms } from '@/services/workformsApi';
+import { getAccessToken } from '@/services/jwtService';
 import { showAlert } from '@/utils/uiDialogs';
 import {
   quickActionsService,
@@ -122,8 +123,8 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
   }, []);
 
   useEffect(() => {
-    // Only load if user is authenticated
-    const token = localStorage.getItem('authToken');
+    // Only load if user is authenticated (JWT or legacy token)
+    const token = getAccessToken();
     if (token) {
       refreshQuickActions();
     } else {


### PR DESCRIPTION
Fixes Quick Actions initialization gating to work with JWT sessions (accessToken) as well as legacy authToken. Adds Vitest coverage for JWT mode.\n\nAlso adds requested audit outputs + V3.5 refactor roadmap and logs feature-freeze transition in .github/MASTER_PLAN.md (timestamp 2026-03-31).