### PR TITLE
Frontend: Contacts list via React Query

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1459,3 +1459,4 @@ Deliverables:
 - 2026-03-31 — Frontend: add global runtime `unhandledrejection` + `error` handlers via centralized logger/Sentry — PR: #4248.
 - 2026-03-31 — Frontend: Suppliers list fetch uses React Query (useQuery) + refetch on create/update/delete — PR: #4251.
 - 2026-03-31 — Frontend: Customers list fetch uses React Query (useQuery) + refetch on create/update/delete — PR: #4252.
+- 2026-03-31 — Frontend: Contacts list fetch uses React Query (useQuery) + refetch on create/update/delete — PR: #4253.

--- a/frontend/src/pages/Contacts.tsx
+++ b/frontend/src/pages/Contacts.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
+import { logger } from '@/utils/logger';
 import { apiService, Contact } from '../services/apiService';
 import { apiClient } from '../services/apiService';
 import { formatUsPhone } from '@/utils/phone';
@@ -320,8 +322,21 @@ const SubmitButton = styled.button`
 
 const Contacts: React.FC = () => {
   const location = useLocation();
-  const [contacts, setContacts] = useState<Contact[]>([]);
-  const [loading, setLoading] = useState(true);
+
+  const contactsQuery = useQuery({
+    queryKey: ['contacts'],
+    queryFn: apiService.getContacts,
+  });
+
+  const contacts = contactsQuery.data ?? [];
+  const loading = contactsQuery.isLoading;
+
+  useEffect(() => {
+    if (contactsQuery.error) {
+      logger.error('[Contacts] Error loading contacts:', contactsQuery.error);
+    }
+  }, [contactsQuery.error]);
+
   const [showForm, setShowForm] = useState(false);
   const [editingContact, setEditingContact] = useState<Contact | null>(null);
   
@@ -372,28 +387,13 @@ const Contacts: React.FC = () => {
       
       setEntityOptions(options);
     } catch (err) {
-      console.error(`Failed to fetch ${entityType} options:`, err);
+      logger.error(`[Contacts] Failed to fetch ${entityType} options:`, err);
       setEntityOptions([]);
     } finally {
       setLoadingEntities(false);
     }
   };
 
-  useEffect(() => {
-    loadContacts();
-  }, []);
-
-  const loadContacts = async () => {
-    try {
-      setLoading(true);
-      const data = await apiService.getContacts();
-      setContacts(data);
-    } catch (error) {
-      console.error('Error loading contacts:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -404,7 +404,7 @@ const Contacts: React.FC = () => {
         await apiService.createContact(formData);
       }
 
-      await loadContacts();
+      await contactsQuery.refetch();
       setShowForm(false);
       setEditingContact(null);
       setEntityId('');
@@ -421,13 +421,15 @@ const Contacts: React.FC = () => {
     } catch (error: unknown) {
       // Log detailed error information
       const err = error as Error & { response?: { status: number; data: unknown }; stack?: string };
-      console.error('Error saving contact:', {
+      logger.error('[Contacts] Error saving contact:', {
         message: err.message || 'Unknown error',
         stack: err.stack || 'No stack trace available',
-        response: err.response ? {
-          status: err.response.status,
-          data: err.response.data
-        } : 'No response data'
+        response: err.response
+          ? {
+              status: err.response.status,
+              data: err.response.data,
+            }
+          : 'No response data',
       });
       // Display user-friendly error to the UI
       alert(`Failed to save contact: ${err.message || 'Please try again later'}`);
@@ -460,10 +462,10 @@ const Contacts: React.FC = () => {
       try {
         await apiService.deleteContact(id);
         alert('Contact deleted successfully!');
-        await loadContacts(); // Re-fetch to update the list
+        await contactsQuery.refetch(); // Re-fetch to update the list
       } catch (error: unknown) {
         // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
-        console.error('Error deleting contact:', error);
+        logger.error('[Contacts] Error deleting contact:', error);
         const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
         const errorMessage = err?.response?.data?.detail 
           || err?.response?.data?.message 


### PR DESCRIPTION
Refactors Contacts page to load contacts via React Query (useQuery) instead of mount-time useEffect fetch. Keeps UX the same and refetches after create/update/delete.