### PR TITLE
Frontend: hierarchy drilldown routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -253,7 +253,9 @@ const App: React.FC = () => {
                   element={<UniversalEntityRecordPage entityType="supplier" basePath="/suppliers" mode="view" />}
                 />
                 <Route path="suppliers/contacts" element={<Contacts />} />
+                <Route path="suppliers/:supplierId/contacts" element={<Contacts />} />
                 <Route path="suppliers/plants" element={<Plants />} />
+                <Route path="suppliers/:supplierId/plants" element={<Plants />} />
                 <Route path="suppliers/:id/products" element={<SupplierProducts />} />
                 <Route path="plants/:id" element={<PlantDetailView />} />
                 <Route path="plants/:id/products" element={<PlantProducts />} />
@@ -274,7 +276,9 @@ const App: React.FC = () => {
                   element={<UniversalEntityRecordPage entityType="customer" basePath="/customers" mode="view" />}
                 />
                 <Route path="customers/contacts" element={<Contacts />} />
+                <Route path="customers/:customerId/contacts" element={<Contacts />} />
                 <Route path="customers/locations" element={<CustomerLocations />} />
+                <Route path="customers/:customerId/locations" element={<CustomerLocations />} />
                 <Route path="customers/:id/products" element={<CustomerProducts />} />
                 
                 {/* Orders */}

--- a/frontend/src/pages/Contacts.tsx
+++ b/frontend/src/pages/Contacts.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { logger } from '@/utils/logger';
 import { apiService, Contact } from '../services/apiService';
 import { apiClient } from '../services/apiService';
@@ -322,10 +322,19 @@ const SubmitButton = styled.button`
 
 const Contacts: React.FC = () => {
   const location = useLocation();
+  const { supplierId, customerId } = useParams<{ supplierId?: string; customerId?: string }>();
+  const [searchParams] = useSearchParams();
+
+  const contactFilters = {
+    supplier: supplierId ?? searchParams.get('supplier') ?? undefined,
+    customer: customerId ?? searchParams.get('customer') ?? undefined,
+    plant: searchParams.get('plant') ?? undefined,
+    location: searchParams.get('location') ?? undefined,
+  };
 
   const contactsQuery = useQuery({
-    queryKey: ['contacts'],
-    queryFn: apiService.getContacts,
+    queryKey: ['contacts', contactFilters.supplier, contactFilters.customer, contactFilters.plant, contactFilters.location],
+    queryFn: () => apiService.getContacts(contactFilters),
   });
 
   const contacts = contactsQuery.data ?? [];
@@ -359,10 +368,12 @@ const Contacts: React.FC = () => {
 
   // Detect context from URL path
   useEffect(() => {
-    if (location.pathname.includes('/suppliers/contacts')) {
+    if (location.pathname.startsWith('/suppliers')) {
       setEntityType('supplier');
-    } else if (location.pathname.includes('/customers/contacts')) {
+    } else if (location.pathname.startsWith('/customers')) {
       setEntityType('customer');
+    } else {
+      setEntityType('');
     }
   }, [location.pathname]);
 

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -793,7 +793,7 @@ const Customers: React.FC = () => {
                               </SmallButton>
                               <SmallButton
                                 type="button"
-                                onClick={() => navigate('/customers/locations', { state: { customerId: customer.id } })}
+                                onClick={() => navigate(`/customers/${customer.id}/locations`)}
                               >
                                 Manage
                               </SmallButton>

--- a/frontend/src/pages/Customers/Locations.tsx
+++ b/frontend/src/pages/Customers/Locations.tsx
@@ -11,7 +11,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { Table, Input, Button, Modal, Form, Select, message, Tag, Space } from 'antd';
 import { confirmDialog } from '@/utils/uiDialogs';
 import { CountrySelect } from '../../components/ui';
@@ -183,6 +183,8 @@ const ErrorMessage = styled.div`
 const CustomerLocations: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { customerId } = useParams<{ customerId?: string }>();
+  const [searchParams] = useSearchParams();
   const [form] = Form.useForm();
   
   // State
@@ -196,34 +198,48 @@ const CustomerLocations: React.FC = () => {
   const [searchText, setSearchText] = useState('');
   const [formErrors, setFormErrors] = useState<FormErrors>({});
 
-  // Detect context from navigation state (Phase 4 pattern)
+  // Detect context from URL (preferred) or navigation state (fallback)
   useEffect(() => {
     const state = location.state as any;
-    if (state?.customerId) {
-      setContextCustomerId(state.customerId);
-    }
-  }, [location]);
+
+    const paramId = customerId ? Number(customerId) : NaN;
+    const queryCustomer = searchParams.get('customer');
+    const queryId = queryCustomer ? Number(queryCustomer) : NaN;
+    const stateId = state?.customerId ? Number(state.customerId) : NaN;
+
+    const nextContext =
+      (Number.isFinite(paramId) && paramId > 0 ? paramId : null) ??
+      (Number.isFinite(queryId) && queryId > 0 ? queryId : null) ??
+      (Number.isFinite(stateId) && stateId > 0 ? stateId : null);
+
+    setContextCustomerId(nextContext);
+  }, [location.state, customerId, searchParams]);
 
   useEffect(() => {
-    loadLocations();
     loadCustomers();
   }, []);
+
+  useEffect(() => {
+    loadLocations(contextCustomerId);
+  }, [contextCustomerId]);
 
   useEffect(() => {
     filterLocations();
   }, [locations, searchText, contextCustomerId]);
 
-  const loadLocations = async () => {
+  const loadLocations = async (customerFilterId: number | null) => {
     try {
       setLoading(true);
+      const params = customerFilterId ? { customer: customerFilterId } : undefined;
+
       // Try multiple possible endpoints
       let response;
       try {
-        response = await apiClient.get('locations/');
+        response = await apiClient.get('locations/', { params });
       } catch (err: any) {
         if (err.response?.status === 404) {
           // Try alternative endpoint
-          response = await apiClient.get('api/v1/locations/');
+          response = await apiClient.get('api/v1/locations/', { params });
         } else {
           throw err;
         }
@@ -320,7 +336,7 @@ const CustomerLocations: React.FC = () => {
     try {
       await apiClient.delete(`locations/${loc.id}/`);
       message.success('Location deleted successfully');
-      loadLocations();
+      loadLocations(contextCustomerId);
     } catch (error: any) {
       console.error('Error deleting location:', error);
       message.error('Failed to delete location');
@@ -341,7 +357,7 @@ const CustomerLocations: React.FC = () => {
       }
       
       setShowModal(false);
-      loadLocations();
+      loadLocations(contextCustomerId);
     } catch (error: any) {
       if (error.response?.status === 400) {
         setFormErrors(error.response.data);
@@ -431,7 +447,10 @@ const CustomerLocations: React.FC = () => {
           <Button
             type="link"
             icon={<EditOutlined />}
-            onClick={() => handleEdit(record)}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleEdit(record);
+            }}
           >
             Edit
           </Button>
@@ -439,7 +458,10 @@ const CustomerLocations: React.FC = () => {
             type="link"
             danger
             icon={<DeleteOutlined />}
-            onClick={() => handleDelete(record)}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleDelete(record);
+            }}
           >
             Delete
           </Button>
@@ -487,6 +509,17 @@ const CustomerLocations: React.FC = () => {
         dataSource={filteredLocations as any}
         rowKey="id"
         loading={loading}
+        onRow={(record) => {
+          const rec = record as Location;
+          return {
+            onClick: () => {
+              const cid = contextCustomerId ?? rec.customer ?? undefined;
+              const base = cid ? `/customers/${cid}/contacts` : '/customers/contacts';
+              navigate(`${base}?location=${rec.id}`);
+            },
+            style: { cursor: 'pointer' },
+          };
+        }}
         pagination={{
           pageSize: 20,
           showSizeChanger: true,

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -806,7 +806,7 @@ const Suppliers: React.FC = () => {
                               </SmallButton>
                               <SmallButton
                                 type="button"
-                                onClick={() => navigate('/suppliers/plants', { state: { supplierId: supplier.id } })}
+                                onClick={() => navigate(`/suppliers/${supplier.id}/plants`)}
                               >
                                 Manage
                               </SmallButton>

--- a/frontend/src/pages/Suppliers/Plants.tsx
+++ b/frontend/src/pages/Suppliers/Plants.tsx
@@ -11,7 +11,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { Table, Input, Button, Modal, Form, Select, Checkbox, message, Tag, Space } from 'antd';
 import { CountrySelect, PhoneInput } from '../../components/ui';
 import { US_STATES } from '../../utils/constants/states';
@@ -192,6 +192,8 @@ const ErrorMessage = styled.div`
 const Plants: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { supplierId } = useParams<{ supplierId?: string }>();
+  const [searchParams] = useSearchParams();
   const [form] = Form.useForm();
   
   // State
@@ -205,27 +207,41 @@ const Plants: React.FC = () => {
   const [searchText, setSearchText] = useState('');
   const [formErrors, setFormErrors] = useState<FormErrors>({});
 
-  // Detect context from navigation state (Phase 4 pattern)
+  // Detect context from URL (preferred) or navigation state (fallback)
   useEffect(() => {
     const state = location.state as any;
-    if (state?.supplierId) {
-      setContextSupplierId(state.supplierId);
-    }
-  }, [location]);
+
+    const paramId = supplierId ? Number(supplierId) : NaN;
+    const querySupplier = searchParams.get('supplier');
+    const queryId = querySupplier ? Number(querySupplier) : NaN;
+    const stateId = state?.supplierId ? Number(state.supplierId) : NaN;
+
+    const nextContext =
+      (Number.isFinite(paramId) && paramId > 0 ? paramId : null) ??
+      (Number.isFinite(queryId) && queryId > 0 ? queryId : null) ??
+      (Number.isFinite(stateId) && stateId > 0 ? stateId : null);
+
+    setContextSupplierId(nextContext);
+  }, [location.state, supplierId, searchParams]);
 
   useEffect(() => {
-    loadPlants();
     loadSuppliers();
   }, []);
+
+  useEffect(() => {
+    loadPlants(contextSupplierId);
+  }, [contextSupplierId]);
 
   useEffect(() => {
     filterPlants();
   }, [plants, searchText, contextSupplierId]);
 
-  const loadPlants = async () => {
+  const loadPlants = async (supplierFilterId: number | null) => {
     try {
       setLoading(true);
-      const response = await apiClient.get('plants/');
+      const response = await apiClient.get('plants/', {
+        params: supplierFilterId ? { supplier: supplierFilterId } : undefined,
+      });
       setPlants(response.data.results || response.data);
     } catch (error) {
       console.error('Error loading plants:', error);
@@ -322,7 +338,7 @@ const Plants: React.FC = () => {
     try {
       await apiClient.delete(`plants/${plant.id}/`);
       message.success('Plant deleted successfully');
-      loadPlants();
+      loadPlants(contextSupplierId);
     } catch (error: any) {
       console.error('Error deleting plant:', error);
       message.error('Failed to delete plant');
@@ -351,7 +367,7 @@ const Plants: React.FC = () => {
       }
       
       setShowModal(false);
-      loadPlants();
+      loadPlants(contextSupplierId);
     } catch (error: any) {
       if (error.response?.status === 400) {
         setFormErrors(error.response.data);
@@ -391,7 +407,12 @@ const Plants: React.FC = () => {
       sorter: (a, b) => (a.supplier_name || '').localeCompare(b.supplier_name || ''),
       render: (text, record) => (
         record.supplier ? (
-          <SupplierLink onClick={() => handleSupplierClick(record.supplier!)}>
+          <SupplierLink
+            onClick={(e) => {
+              e.stopPropagation();
+              handleSupplierClick(record.supplier!);
+            }}
+          >
             {text || 'Unknown'}
           </SupplierLink>
         ) : '-'
@@ -453,7 +474,10 @@ const Plants: React.FC = () => {
           <Button
             type="link"
             icon={<AppstoreOutlined />}
-            onClick={() => navigate(`/plants/${record.id}/products`, { state: { plant: record } })}
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/plants/${record.id}/products`, { state: { plant: record } });
+            }}
             size="small"
           >
             Products
@@ -461,7 +485,10 @@ const Plants: React.FC = () => {
           <Button
             type="link"
             icon={<EditOutlined />}
-            onClick={() => handleEdit(record)}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleEdit(record);
+            }}
           >
             Edit
           </Button>
@@ -469,7 +496,10 @@ const Plants: React.FC = () => {
             type="link"
             danger
             icon={<DeleteOutlined />}
-            onClick={() => handleDelete(record)}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleDelete(record);
+            }}
           >
             Delete
           </Button>
@@ -517,6 +547,17 @@ const Plants: React.FC = () => {
         dataSource={filteredPlants as any}
         rowKey="id"
         loading={loading}
+        onRow={(record) => {
+          const rec = record as Plant;
+          return {
+            onClick: () => {
+              const sid = contextSupplierId ?? rec.supplier ?? undefined;
+              const base = sid ? `/suppliers/${sid}/contacts` : '/suppliers/contacts';
+              navigate(`${base}?plant=${rec.id}`);
+            },
+            style: { cursor: 'pointer' },
+          };
+        }}
         pagination={{
           pageSize: 20,
           showSizeChanger: true,

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -738,8 +738,11 @@ export class ApiService {
   }
 
   // Contacts
-  async getContacts(): Promise<Contact[]> {
-    const response = await apiClient.get('/contacts/');
+  async getContacts(params?: { supplier?: number | string; customer?: number | string; plant?: number | string; location?: number | string }): Promise<Contact[]> {
+    const filteredParams = params
+      ? Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== ''))
+      : undefined;
+    const response = await apiClient.get('/contacts/', { params: filteredParams });
     return response.data.results || response.data;
   }
 


### PR DESCRIPTION
Add deep-link-safe hierarchy drilldowns:\n- /suppliers/:supplierId/plants and /customers/:customerId/locations routes (plus :id contacts routes)\n- Plants/Locations pages accept URL params/query params for context (no longer state-only)\n- Row-click drilldown: Plant -> filtered contacts, Location -> filtered contacts\n- Contacts list supports supplier/customer/plant/location filtering via query params\n\nAdditive + non-breaking: legacy routes still work.