### PR TITLE
Fix UAT deploy blocked by Trivy scan

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -258,12 +258,29 @@ jobs:
       contents: read
       security-events: write
     steps:
+      # SARIF generation should not gate deployments.
+      # Trivy's SARIF mode may include all severities, which can incorrectly fail the job
+      # even when CRITICAL/HIGH are 0. We enforce severity thresholds in a separate step.
       - name: Run Trivy vulnerability scanner (SARIF)
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
           format: 'sarif'
           output: 'trivy-results-backend.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          scanners: 'vuln'
+          vuln-type: 'os,library'
+          exit-code: '0'
+        env:
+          TRIVY_USERNAME: ${{ secrets.DO_ACCESS_TOKEN }}
+          TRIVY_PASSWORD: ${{ secrets.DO_ACCESS_TOKEN }}
+
+      - name: Enforce Trivy severity gate (CRITICAL,HIGH)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
+          format: 'table'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           scanners: 'vuln'
@@ -448,12 +465,27 @@ jobs:
       contents: read
       security-events: write
     steps:
+      # SARIF generation should not gate deployments (see backend scan notes).
       - name: Run Trivy vulnerability scanner (SARIF)
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
           format: 'sarif'
           output: 'trivy-results-frontend.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          scanners: 'vuln'
+          vuln-type: 'os,library'
+          exit-code: '0'
+        env:
+          TRIVY_USERNAME: ${{ secrets.DO_ACCESS_TOKEN }}
+          TRIVY_PASSWORD: ${{ secrets.DO_ACCESS_TOKEN }}
+
+      - name: Enforce Trivy severity gate (CRITICAL,HIGH)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
+          format: 'table'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           scanners: 'vuln'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,8 +46,12 @@ RUN npm run build \
 
 # Runtime with nginx and npm installed
 FROM nginx:alpine
-RUN apk add --no-cache nodejs npm bash gettext \
-    && rm -rf /var/cache/apk/* /tmp/*  # Clean up apk cache
+
+# Pull in Alpine security fixes for base packages (e.g., libpng/zlib) before installing runtime deps.
+RUN apk update \
+    && apk upgrade --no-cache \
+    && apk add --no-cache nodejs npm bash gettext \
+    && rm -rf /var/cache/apk/* /tmp/*
 
 # Copy configs to 'templates' directory (NOT conf.d) to prevent auto-loading
 # This prevents Nginx from automatically including them


### PR DESCRIPTION
UAT deploy run 23800903824 was blocked by Trivy scans.\n\nChanges:\n- reusable-deploy.yml: SARIF generation is non-blocking (exit-code 0); CRITICAL/HIGH enforcement moved to dedicated step.\n- frontend/Dockerfile: apk upgrade to pull in Alpine security fixes (libpng/zlib) before runtime deps.\n\nExpected result: Security Scan jobs behave consistently and UAT deploy can proceed once image rebuild completes.