### PR TITLE
Frontend: fix Profile inactive status false-negative

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1469,3 +1469,4 @@ Deliverables:
 - 2026-03-31 — Frontend: hierarchy drilldown routing (deep-link plants/locations + contacts filters) — PR: #4265.
 - 2026-03-31 — Settings: remove tenant branding + rename admin link label — PR: #4270.
 - 2026-03-31 — Auth: include user.is_active in JWT token obtain payload — PR: #4271.
+- 2026-03-31 — Frontend: fix Profile inactive status false-negative (normalize is_active) — PR: #4272.

--- a/frontend/src/pages/Suppliers.test.tsx
+++ b/frontend/src/pages/Suppliers.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Suppliers from './Suppliers';
 import * as apiService from '../services/apiService';
 
@@ -46,9 +47,19 @@ vi.mock('../contexts/ThemeContext', () => ({
 }));
 
 // Wrapper component for tests
-const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <BrowserRouter>{children}</BrowserRouter>
-);
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>{children}</BrowserRouter>
+    </QueryClientProvider>
+  );
+};
 
 describe('Suppliers Component', () => {
   beforeEach(() => {

--- a/frontend/src/services/authService.test.ts
+++ b/frontend/src/services/authService.test.ts
@@ -48,7 +48,7 @@ describe('AuthService', () => {
       
       const newService = new AuthService();
       expect(newService.getToken()).toBe('test-token');
-      expect(newService.getUser()).toEqual({ id: 1, username: 'test' });
+      expect(newService.getUser()).toEqual(expect.objectContaining({ id: 1, username: 'test' }));
     });
 
     it('handles invalid JSON in stored user gracefully', () => {
@@ -166,7 +166,7 @@ describe('AuthService', () => {
       
       const newService = new AuthService();
       const result = await newService.getCurrentUser();
-      expect(result).toEqual(user);
+      expect(result).toEqual(expect.objectContaining(user));
     });
   });
 });

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -9,6 +9,28 @@
 import { apiClient } from './apiService';
 import { config } from '../config/runtime';
 import { UserProfile } from '../types';
+
+const normalizeUserProfile = (raw: any): UserProfile => {
+  const isActive =
+    typeof raw?.is_active === 'boolean'
+      ? raw.is_active
+      : typeof raw?.isActive === 'boolean'
+        ? raw.isActive
+        : true;
+
+  return {
+    id: Number(raw?.id ?? 0),
+    username: String(raw?.username ?? ''),
+    email: String(raw?.email ?? ''),
+    first_name: String(raw?.first_name ?? ''),
+    last_name: String(raw?.last_name ?? ''),
+    is_active: isActive,
+    is_staff: typeof raw?.is_staff === 'boolean' ? raw.is_staff : undefined,
+    is_superuser: typeof raw?.is_superuser === 'boolean' ? raw.is_superuser : undefined,
+    role: raw?.role,
+    tenants: raw?.tenants,
+  };
+};
 import {
   storeTokens,
   clearTokens,
@@ -58,7 +80,7 @@ export class AuthService {
     const storedUser = localStorage.getItem('user');
     if (storedUser) {
       try {
-        this.user = JSON.parse(storedUser);
+        this.user = normalizeUserProfile(JSON.parse(storedUser));
       } catch (error) {
         console.error('Error parsing stored user data:', error);
         localStorage.removeItem('user');
@@ -79,8 +101,9 @@ export class AuthService {
       if (access && refresh) {
         // JWT login successful
         storeTokens(access, refresh);
-        this.user = user;
-        localStorage.setItem('user', JSON.stringify(user));
+        const normalizedUser = normalizeUserProfile(user);
+        this.user = normalizedUser;
+        localStorage.setItem('user', JSON.stringify(normalizedUser));
         
         // Store tenant information
         if (tenants && tenants.length > 0) {
@@ -91,7 +114,7 @@ export class AuthService {
         }
 
         console.debug('[Auth] JWT login successful');
-        return user;
+        return normalizedUser;
       }
       
       throw new Error('Invalid JWT response');
@@ -116,8 +139,9 @@ export class AuthService {
 
     // Store legacy token
     localStorage.setItem('authToken', token);
-    this.user = user;
-    localStorage.setItem('user', JSON.stringify(user));
+    const normalizedUser = normalizeUserProfile(user);
+    this.user = normalizedUser;
+    localStorage.setItem('user', JSON.stringify(normalizedUser));
     
     // Store tenant information
     if (tenants && tenants.length > 0) {
@@ -127,7 +151,7 @@ export class AuthService {
       localStorage.setItem('tenantSlug', primaryTenant.tenant__slug);
     }
 
-    return user;
+    return normalizedUser;
   }
 
   async signUp(credentials: SignUpCredentials): Promise<UserProfile> {
@@ -161,8 +185,9 @@ export class AuthService {
         localStorage.setItem('authToken', token);
       }
       
-      this.user = user;
-      localStorage.setItem('user', JSON.stringify(user));
+      const normalizedUser = normalizeUserProfile(user);
+      this.user = normalizedUser;
+      localStorage.setItem('user', JSON.stringify(normalizedUser));
 
       // CRITICAL FIX: Store the new tenant context immediately
       if (tenant) {
@@ -171,7 +196,7 @@ export class AuthService {
         localStorage.setItem('tenantSlug', tenant.slug);
       }
 
-      return user;
+      return normalizedUser;
     } catch (error: any) {
       // Enhanced error handling to capture validation errors
       const serverData = error.response?.data;
@@ -227,7 +252,7 @@ export class AuthService {
     const storedUser = localStorage.getItem('user');
     if (storedUser) {
       try {
-        this.user = JSON.parse(storedUser);
+        this.user = normalizeUserProfile(JSON.parse(storedUser));
         return this.user;
       } catch (error) {
         console.error('Error parsing stored user data:', error);


### PR DESCRIPTION
Fixes the Profile page showing 'Inactive Account' due to older stored user payloads missing is_active.\n\n- Normalizes UserProfile on read/write (defaults missing is_active -> true)\n- Ensures login/legacyLogin/signUp return normalized user\n- Fixes Suppliers.test.tsx wrapper to include QueryClientProvider\n\nValidation: frontend test:ci passed.