### PR TITLE
Fix: Payment history pagination + 5xx circuit breaker

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -126,6 +126,11 @@ This file is the **append-only PR-referenceable execution log**.
 - Safety: wrapped WorkForms InProgress/History/Monitoring in ErrorBoundary.
 - PR: #4239
 
+### 2026-03-31 — Fix: payment history pagination + 5xx circuit breaker
+- PaymentHistoryList: handle DRF paginated responses (`results`) safely before sorting (prevents `.sort is not a function` crash).
+- API service: intercept 500/502/503/504 in axios response interceptors (apiClient + adminClient) to avoid auth refresh/logout loops during upstream outages.
+- PR: #4273
+
 ### 2026-03-30 — Docs: master plan gap analysis + roadmap hygiene
 - Updated `MASTER_PLAN.md` (canonical) with an industry-leader benchmark gap analysis (P0/P1/P2) and refreshed execution-ordered backlog.
 - Converted non-canonical roadmaps/plans into clearer **REFERENCE ONLY** docs (removed/neutralized misleading progress emphasis).

--- a/frontend/src/components/Shared/PaymentHistoryList.tsx
+++ b/frontend/src/components/Shared/PaymentHistoryList.tsx
@@ -148,17 +148,24 @@ export const PaymentHistoryList: React.FC<PaymentHistoryListProps> = ({
       setError(null);
       
       const response = await apiClient.get('payments/', {
-        params: { [entityType]: entityId }
+        params: { [entityType]: entityId },
       });
-      
+
+      const raw: unknown = response.data;
+      const responseData: PaymentTransaction[] =
+        Array.isArray(raw) ? (raw as PaymentTransaction[]) : Array.isArray((raw as any)?.results) ? ((raw as any).results as PaymentTransaction[]) : [];
+
       // Sort by payment date (newest first)
-      const sortedPayments = response.data.sort((a: PaymentTransaction, b: PaymentTransaction) => {
-        return new Date(b.payment_date).getTime() - new Date(a.payment_date).getTime();
-      });
-      
+      const sortedPayments = responseData
+        .slice()
+        .sort((a: PaymentTransaction, b: PaymentTransaction) => {
+          return new Date(b.payment_date).getTime() - new Date(a.payment_date).getTime();
+        });
+
       setPayments(sortedPayments);
     } catch (err: unknown) {
       console.error('Error fetching payment history:', err);
+      setPayments([]);
       setError(getErrorMessage(err, 'Failed to load payment history'));
     } finally {
       setLoading(false);

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -184,9 +184,27 @@ apiClient.interceptors.response.use(
   (response) => response,
   async (error: AxiosErrorType) => {
     const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean; _retryCount?: number };
+
+    const status = error.response?.status;
+
+    // Circuit breaker: do NOT trigger auth refresh flows for transient upstream/server errors.
+    if (status && [500, 502, 503, 504].includes(status)) {
+      const friendlyMessage =
+        status === 502
+          ? 'Server temporarily unreachable. Please try again shortly.'
+          : 'Server error. Please try again shortly.';
+
+      logger.error('[API] Server error (circuit breaker)', {
+        status,
+        url: originalRequest?.url,
+        method: originalRequest?.method,
+      });
+
+      return Promise.reject(new Error(friendlyMessage));
+    }
     
     // Log the error for debugging
-    if (error.response?.status === 401) {
+    if (status === 401) {
       console.warn('[API] 401 Unauthorized:', {
         url: originalRequest?.url,
         method: originalRequest?.method,
@@ -198,7 +216,7 @@ apiClient.interceptors.response.use(
     }
     
     // Handle 401 Unauthorized
-    if (error.response?.status === 401 && originalRequest && !originalRequest._retry) {
+    if (status === 401 && originalRequest && !originalRequest._retry) {
       // Prevent infinite retry loops
       const retryCount = (originalRequest._retryCount || 0) + 1;
       if (retryCount > 2) {
@@ -278,9 +296,27 @@ adminClient.interceptors.response.use(
   (response) => response,
   async (error: AxiosErrorType) => {
     const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean; _retryCount?: number };
+
+    const status = error.response?.status;
+
+    // Circuit breaker: do NOT trigger auth refresh flows for transient upstream/server errors.
+    if (status && [500, 502, 503, 504].includes(status)) {
+      const friendlyMessage =
+        status === 502
+          ? 'Server temporarily unreachable. Please try again shortly.'
+          : 'Server error. Please try again shortly.';
+
+      logger.error('[Admin API] Server error (circuit breaker)', {
+        status,
+        url: originalRequest?.url,
+        method: originalRequest?.method,
+      });
+
+      return Promise.reject(new Error(friendlyMessage));
+    }
     
     // Log the error for debugging
-    if (error.response?.status === 401) {
+    if (status === 401) {
       console.warn('[Admin API] 401 Unauthorized:', {
         url: originalRequest?.url,
         method: originalRequest?.method,


### PR DESCRIPTION
- Prevent PaymentHistoryList crash when payments endpoint returns DRF pagination (results)
- Add 5xx (500/502/503/504) circuit breaker in apiService interceptors (apiClient + adminClient) to avoid token-refresh/logout loops during upstream outages

Verified:
- npm --prefix frontend run type-check
- npm --prefix frontend run test:ci