### PR TITLE
Test: Playwright E2E foundation

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -126,6 +126,14 @@ This file is the **append-only PR-referenceable execution log**.
 - Safety: wrapped WorkForms InProgress/History/Monitoring in ErrorBoundary.
 - PR: #4239
 
+### 2026-03-31 — Test: Playwright E2E foundation
+- Added Playwright E2E coverage for:
+  - Suppliers drilldown (Suppliers → Plants → create contact → verify Department choices)
+  - Workforms editor (add Manual Trigger + Form Process → Layout → verify no overlap between top-level nodes)
+- Added root `npm run test:e2e` script delegating to frontend.
+- Added stable `data-testid` hooks for Suppliers drilldown flows.
+- PR: #4274
+
 ### 2026-03-30 — Docs: master plan gap analysis + roadmap hygiene
 - Updated `MASTER_PLAN.md` (canonical) with an industry-leader benchmark gap analysis (P0/P1/P2) and refreshed execution-ordered backlog.
 - Converted non-canonical roadmaps/plans into clearer **REFERENCE ONLY** docs (removed/neutralized misleading progress emphasis).

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,12 @@ coverage/
 .nyc_output/
 htmlcov/
 
+# Playwright
+playwright-report/
+test-results/
+frontend/playwright-report/
+frontend/test-results/
+
 # Temporary files
 tmp/
 temp/

--- a/frontend/e2e/entity_hierarchy.spec.ts
+++ b/frontend/e2e/entity_hierarchy.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function login(page: Page) {
+  await page.goto('/');
+
+  const testEmail = process.env.TEST_USER_EMAIL || 'admin@meatscentral.com';
+  const testPassword = process.env.TEST_USER_PASSWORD || 'Admin123!';
+
+  await page.fill('input[type="email"], input[type="text"]', testEmail);
+  await page.fill('input[type="password"]', testPassword);
+  await page.click('button:has-text("Login"), button:has-text("Sign In")');
+
+  await page.waitForURL(/\/(dashboard|home|workforms)/i, { timeout: 10000 });
+}
+
+test.describe('Entity Hierarchy: Suppliers → Plants → Contacts', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('drilldown works and Plant Contact Department options are present', async ({ page }) => {
+    await page.goto('/suppliers');
+
+    const firstSupplierRow = page.locator('[data-testid^="supplier-row-"]').first();
+    await expect(firstSupplierRow).toBeVisible({ timeout: 15000 });
+    await firstSupplierRow.click();
+
+    // Plants panel should render
+    await expect(page.getByText('Plants')).toBeVisible();
+
+    // Verify the Plant create form renders
+    await page.locator('[data-testid="supplier-create-plant"]').click();
+    await expect(page.locator('[data-testid="plant-create-modal"]')).toBeVisible();
+    await page.locator('[data-testid="plant-create-modal"]').locator('text=×').first().click();
+
+    // Select first Plant and open Contact modal
+    const firstPlantRow = page.locator('[data-testid^="plant-row-"]').first();
+    await expect(firstPlantRow).toBeVisible({ timeout: 15000 });
+    await firstPlantRow.click();
+
+    await page.locator('[data-testid="plant-create-contact"]').click();
+    await expect(page.locator('[data-testid="plant-contact-modal"]')).toBeVisible();
+
+    // Open department dropdown and verify choices
+    await page.locator('[aria-label="Department"]').click();
+    await expect(page.getByText('Sales', { exact: true })).toBeVisible();
+    await expect(page.getByText('Quality Assurance', { exact: true })).toBeVisible();
+    await expect(page.getByText('Booking', { exact: true })).toBeVisible();
+    await expect(page.getByText('Accounting', { exact: true })).toBeVisible();
+  });
+});

--- a/frontend/e2e/workforms_editor.spec.ts
+++ b/frontend/e2e/workforms_editor.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function login(page: Page) {
+  await page.goto('/');
+
+  const testEmail = process.env.TEST_USER_EMAIL || 'admin@meatscentral.com';
+  const testPassword = process.env.TEST_USER_PASSWORD || 'Admin123!';
+
+  await page.fill('input[type="email"], input[type="text"]', testEmail);
+  await page.fill('input[type="password"]', testPassword);
+  await page.click('button:has-text("Login"), button:has-text("Sign In")');
+
+  await page.waitForURL(/\/(dashboard|home|workforms)/i, { timeout: 10000 });
+}
+
+type Rect = { top: number; left: number; right: number; bottom: number };
+
+function rectsOverlap(a: Rect, b: Rect, padding = 2) {
+  return !(
+    a.right - padding < b.left + padding ||
+    a.left + padding > b.right - padding ||
+    a.bottom - padding < b.top + padding ||
+    a.top + padding > b.bottom - padding
+  );
+}
+
+test.describe('Workforms Editor: Layout stability', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('auto-layout prevents overlaps after adding Trigger + Form Process', async ({ page }) => {
+    await page.goto('/admin-studio');
+
+    await expect(page.locator('.react-flow')).toBeVisible({ timeout: 15000 });
+
+    // Ensure we have at least one Trigger on the canvas
+    const addTriggerBtn = page.getByRole('button', { name: /\+ Add Manual Trigger/i });
+    if (await addTriggerBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await addTriggerBtn.click();
+    }
+
+    // Open the node palette (Tab toggles it)
+    const searchInput = page.locator('input[placeholder*="Search nodes"]');
+    if (!(await searchInput.isVisible().catch(() => false))) {
+      await page.keyboard.press('Tab');
+    }
+    await expect(searchInput).toBeVisible({ timeout: 5000 });
+
+    await searchInput.fill('Form Process');
+
+    // Click the palette item
+    const formProcessItem = page.locator('.node-palette').getByText('Form Process').first();
+    await expect(formProcessItem).toBeVisible({ timeout: 5000 });
+    await formProcessItem.click();
+
+    // Apply auto-layout
+    await page.locator('button:has-text("Layout")').click();
+    await page.waitForTimeout(800);
+
+    // Only validate overlap for top-level nodes we intentionally added.
+    // (Container nodes will naturally overlap their children in the DOM bounds.)
+    const nodes = page.locator(
+      '.react-flow__node[data-type="triggerManual"], .react-flow__node[data-type="formProcess"]'
+    );
+    const nodeCount = await nodes.count();
+    expect(nodeCount).toBeGreaterThanOrEqual(2);
+
+    const rects: Rect[] = await nodes.evaluateAll((els) =>
+      els.map((el) => {
+        const r = el.getBoundingClientRect();
+        return { top: r.top, left: r.left, right: r.right, bottom: r.bottom };
+      })
+    );
+
+    // Verify no overlaps between those nodes
+    for (let i = 0; i < rects.length; i++) {
+      for (let j = i + 1; j < rects.length; j++) {
+        expect(rectsOverlap(rects[i], rects[j])).toBeFalsy();
+      }
+    }
+  });
+});

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -775,7 +775,7 @@ const Suppliers: React.FC = () => {
 
       {showPlantModal && (
         <FormOverlay>
-          <FormContainer $theme={theme}>
+          <FormContainer $theme={theme} data-testid="plant-create-modal">
             <FormHeader $theme={theme}>
               <FormTitle $theme={theme}>Add New Plant</FormTitle>
               <CloseButton $theme={theme} onClick={() => setShowPlantModal(false)}>×</CloseButton>
@@ -941,7 +941,7 @@ const Suppliers: React.FC = () => {
 
       {showContactModal && (
         <FormOverlay>
-          <FormContainer $theme={theme}>
+          <FormContainer $theme={theme} data-testid="plant-contact-modal">
             <FormHeader $theme={theme}>
               <FormTitle $theme={theme}>Add Plant Contact</FormTitle>
               <CloseButton $theme={theme} onClick={() => setShowContactModal(false)}>×</CloseButton>
@@ -1082,6 +1082,7 @@ const Suppliers: React.FC = () => {
                 <React.Fragment key={supplier.id}>
                 <TableRow
                   key={supplier.id}
+                  data-testid={`supplier-row-${supplier.id}`}
                   $theme={theme}
                   onClick={() => void toggleSupplierDrilldown(supplier)}
                   role="button"
@@ -1135,7 +1136,12 @@ const Suppliers: React.FC = () => {
                           <ExpandedHeader>
                             <ExpandedTitle>Plants</ExpandedTitle>
                             <ExpandedActions>
-                              <SmallButton type="button" onClick={openCreatePlant} disabled={!selectedSupplierId}>
+                              <SmallButton
+                                data-testid="supplier-create-plant"
+                                type="button"
+                                onClick={openCreatePlant}
+                                disabled={!selectedSupplierId}
+                              >
                                 + New Plant
                               </SmallButton>
                               <SmallButton
@@ -1156,6 +1162,7 @@ const Suppliers: React.FC = () => {
                               {supplierPlants.map((plant) => (
                                 <ChildListItem
                                   key={plant.id}
+                                  data-testid={`plant-row-${plant.id}`}
                                   type="button"
                                   $active={selectedPlantId === plant.id}
                                   onClick={() => setSelectedPlantId(plant.id)}
@@ -1191,7 +1198,12 @@ const Suppliers: React.FC = () => {
                           <ExpandedHeader>
                             <ExpandedTitle>Plant Details & Contacts</ExpandedTitle>
                             <ExpandedActions>
-                              <SmallButton type="button" onClick={openCreatePlantContact} disabled={!selectedPlantId}>
+                              <SmallButton
+                                data-testid="plant-create-contact"
+                                type="button"
+                                onClick={openCreatePlantContact}
+                                disabled={!selectedPlantId}
+                              >
                                 + New Contact
                               </SmallButton>
                             </ExpandedActions>

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "playwright": "^1.58.2"
+  },
+  "scripts": {
+    "test:e2e": "npm --prefix frontend run test:e2e --"
   }
 }


### PR DESCRIPTION
Adds two core Playwright E2E specs:
- Suppliers drilldown: Suppliers → Plants → +New Contact verifies Department options
- Workforms editor: add Manual Trigger + Form Process, run Layout, assert no overlap between top-level nodes

Also:
- Adds stable data-testid hooks on Suppliers page for E2E selectors
- Adds root-level npm script: test:e2e (delegates to frontend)
- Ignores Playwright output dirs (playwright-report/, test-results/)