### PR TITLE
Fix(AI): include document_id in Swarm history

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -126,6 +126,10 @@ This file is the **append-only PR-referenceable execution log**.
 - Safety: wrapped WorkForms InProgress/History/Monitoring in ErrorBoundary.
 - PR: #4239
 
+### 2026-03-31 — AI chat: expose document metadata to Swarm
+- When a chat session includes a DOCUMENT message, Swarm history now includes `document_id` (and `file_url` when present) so tools like `parse_document(document_id)` can operate reliably.
+- PR: #4275
+
 ### 2026-03-30 — Docs: master plan gap analysis + roadmap hygiene
 - Updated `MASTER_PLAN.md` (canonical) with an industry-leader benchmark gap analysis (P0/P1/P2) and refreshed execution-ordered backlog.
 - Converted non-canonical roadmaps/plans into clearer **REFERENCE ONLY** docs (removed/neutralized misleading progress emphasis).

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -269,7 +269,16 @@ class ChatBotAPIViewSet(viewsets.ViewSet):
                             continue
 
                         if row.message_type == MessageTypeChoices.DOCUMENT:
-                            content = f"[Document] {content[:500]}"
+                            meta = row.metadata or {}
+                            document_id = meta.get('document_id')
+                            file_url = meta.get('file_url')
+                            original_filename = meta.get('original_filename') or content
+
+                            content = f"[Document] {str(original_filename)[:500]}"
+                            if document_id:
+                                content += f"\n- document_id: {document_id}"
+                            if file_url:
+                                content += f"\n- file_url: {file_url}"
 
                         history.append({'role': role, 'content': content})
                 except Exception:


### PR DESCRIPTION
When ChatMessage rows are of type DOCUMENT, include metadata (document_id + file_url) in the system history passed into the Swarm tool loop. This enables tools like parse_document(document_id) to work reliably when a user uploads a file.