### PR TITLE
UniversalEntityForm: progressive disclosure + Cockpit inline create/view

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1499,3 +1499,4 @@ Deliverables:
 - 2026-03-31 — Settings: remove tenant branding + rename admin link label — PR: #4270.
 - 2026-03-31 — Auth: include user.is_active in JWT token obtain payload — PR: #4271.
 - 2026-03-31 — Frontend: fix Profile inactive status false-negative (normalize is_active) — PR: #4272.
+- 2026-03-31 — UniversalEntityForm: progressive disclosure + Cockpit inline create/view (is_advanced + Expand details toggle) — PR: #4277.

--- a/backend/apps/system/views/forms_schema.py
+++ b/backend/apps/system/views/forms_schema.py
@@ -372,6 +372,14 @@ class SystemFormSchemaView(APIView):
                 'accounting_contacts',
             ]
 
+            # Progressive disclosure support: non-key, non-required fields are considered "advanced".
+            # Clients can safely ignore this field (additive-only).
+            key_set = set(key_fields)
+            for mf in mapped_fields:
+                mf_key = str(mf.get('key') or '')
+                mf_required = bool(mf.get('required'))
+                mf['is_advanced'] = bool(mf_key and (mf_key not in key_set) and (not mf_required))
+
             return Response(
                 {
                     'name': 'Plant' if canonical == 'plants.plant' else 'Location',
@@ -388,29 +396,69 @@ class SystemFormSchemaView(APIView):
             'suppliers.supplier',
             'tenant_apps.suppliers.supplier',
         }:
-            return Response(
-                {
-                    'name': 'Supplier (Simplified)',
-                    'description': 'Simplified create/edit schema (HQ details only).',
-                    'fields': [
-                        {'key': 'name', 'label': 'Supplier Name', 'type': 'text', 'required': True, 'order': 0, 'ui': {}},
-                        {
-                            'key': 'address',
-                            'label': 'Headquarters Address',
-                            'type': 'textarea',
-                            'required': False,
-                            'order': 1,
-                            'ui': {'widget': 'textarea'},
-                        },
-                        {'key': 'city', 'label': 'Headquarters City', 'type': 'text', 'required': False, 'order': 2, 'ui': {}},
-                        {'key': 'state', 'label': 'Headquarters State', 'type': 'text', 'required': False, 'order': 3, 'ui': {}},
-                        {'key': 'zip_code', 'label': 'Headquarters ZIP Code', 'type': 'text', 'required': False, 'order': 4, 'ui': {}},
-                        {'key': 'country', 'label': 'Country', 'type': 'text', 'required': False, 'order': 5, 'ui': {}},
-                    ],
-                    'key_fields': ['name', 'address', 'city', 'state', 'zip_code', 'country'],
-                },
-                status=status.HTTP_200_OK,
-            )
+            schema = {
+                'name': 'Supplier (Simplified)',
+                'description': 'Simplified create/edit schema (HQ details only).',
+                'fields': [
+                    {
+                        'key': 'name',
+                        'label': 'Supplier Name',
+                        'type': 'text',
+                        'required': True,
+                        'order': 0,
+                        'ui': {},
+                    },
+                    {
+                        'key': 'address',
+                        'label': 'Headquarters Address',
+                        'type': 'textarea',
+                        'required': False,
+                        'order': 1,
+                        'ui': {'widget': 'textarea'},
+                    },
+                    {
+                        'key': 'city',
+                        'label': 'Headquarters City',
+                        'type': 'text',
+                        'required': False,
+                        'order': 2,
+                        'ui': {},
+                    },
+                    {
+                        'key': 'state',
+                        'label': 'Headquarters State',
+                        'type': 'text',
+                        'required': False,
+                        'order': 3,
+                        'ui': {},
+                    },
+                    {
+                        'key': 'zip_code',
+                        'label': 'Headquarters ZIP Code',
+                        'type': 'text',
+                        'required': False,
+                        'order': 4,
+                        'ui': {},
+                    },
+                    {
+                        'key': 'country',
+                        'label': 'Country',
+                        'type': 'text',
+                        'required': False,
+                        'order': 5,
+                        'ui': {},
+                    },
+                ],
+                'key_fields': ['name', 'address', 'city', 'state', 'zip_code', 'country'],
+            }
+
+            key_set = set(schema.get('key_fields') or [])
+            for mf in schema.get('fields') or []:
+                mf_key = str(mf.get('key') or '')
+                mf_required = bool(mf.get('required'))
+                mf['is_advanced'] = bool(mf_key and (mf_key not in key_set) and (not mf_required))
+
+            return Response(schema, status=status.HTTP_200_OK)
 
         if canonical in {
             'customer',
@@ -418,29 +466,69 @@ class SystemFormSchemaView(APIView):
             'customers.customer',
             'tenant_apps.customers.customer',
         }:
-            return Response(
-                {
-                    'name': 'Customer (Simplified)',
-                    'description': 'Simplified create/edit schema (HQ details only).',
-                    'fields': [
-                        {'key': 'name', 'label': 'Customer Name', 'type': 'text', 'required': True, 'order': 0, 'ui': {}},
-                        {
-                            'key': 'address',
-                            'label': 'Headquarters Address',
-                            'type': 'textarea',
-                            'required': False,
-                            'order': 1,
-                            'ui': {'widget': 'textarea'},
-                        },
-                        {'key': 'city', 'label': 'Headquarters City', 'type': 'text', 'required': False, 'order': 2, 'ui': {}},
-                        {'key': 'state', 'label': 'Headquarters State', 'type': 'text', 'required': False, 'order': 3, 'ui': {}},
-                        {'key': 'zip_code', 'label': 'Headquarters ZIP Code', 'type': 'text', 'required': False, 'order': 4, 'ui': {}},
-                        {'key': 'country', 'label': 'Country', 'type': 'text', 'required': False, 'order': 5, 'ui': {}},
-                    ],
-                    'key_fields': ['name', 'address', 'city', 'state', 'zip_code', 'country'],
-                },
-                status=status.HTTP_200_OK,
-            )
+            schema = {
+                'name': 'Customer (Simplified)',
+                'description': 'Simplified create/edit schema (HQ details only).',
+                'fields': [
+                    {
+                        'key': 'name',
+                        'label': 'Customer Name',
+                        'type': 'text',
+                        'required': True,
+                        'order': 0,
+                        'ui': {},
+                    },
+                    {
+                        'key': 'address',
+                        'label': 'Headquarters Address',
+                        'type': 'textarea',
+                        'required': False,
+                        'order': 1,
+                        'ui': {'widget': 'textarea'},
+                    },
+                    {
+                        'key': 'city',
+                        'label': 'Headquarters City',
+                        'type': 'text',
+                        'required': False,
+                        'order': 2,
+                        'ui': {},
+                    },
+                    {
+                        'key': 'state',
+                        'label': 'Headquarters State',
+                        'type': 'text',
+                        'required': False,
+                        'order': 3,
+                        'ui': {},
+                    },
+                    {
+                        'key': 'zip_code',
+                        'label': 'Headquarters ZIP Code',
+                        'type': 'text',
+                        'required': False,
+                        'order': 4,
+                        'ui': {},
+                    },
+                    {
+                        'key': 'country',
+                        'label': 'Country',
+                        'type': 'text',
+                        'required': False,
+                        'order': 5,
+                        'ui': {},
+                    },
+                ],
+                'key_fields': ['name', 'address', 'city', 'state', 'zip_code', 'country'],
+            }
+
+            key_set = set(schema.get('key_fields') or [])
+            for mf in schema.get('fields') or []:
+                mf_key = str(mf.get('key') or '')
+                mf_required = bool(mf.get('required'))
+                mf['is_advanced'] = bool(mf_key and (mf_key not in key_set) and (not mf_required))
+
+            return Response(schema, status=status.HTTP_200_OK)
 
         # get_entity_fields already supports aliases like 'customer', 'supplier', etc.
         fields = get_entity_fields(entity_type)
@@ -535,6 +623,14 @@ class SystemFormSchemaView(APIView):
         for k in required_keys + key_field_candidates:
             if k in present and k not in key_fields:
                 key_fields.append(k)
+
+        # Progressive disclosure support: non-key, non-required fields are considered "advanced".
+        # Clients can safely ignore this field (additive-only).
+        key_set = set(key_fields)
+        for mf in mapped_fields:
+            mf_key = str(mf.get('key') or '')
+            mf_required = bool(mf.get('required'))
+            mf['is_advanced'] = bool(mf_key and (mf_key not in key_set) and (not mf_required))
 
         schema = {
             'name': f'Universal Form: {entity_type}',

--- a/frontend/src/components/Cockpit/SmartSearch.tsx
+++ b/frontend/src/components/Cockpit/SmartSearch.tsx
@@ -31,7 +31,6 @@ import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
 // UniversalEntityForm usage consolidated via EntityFormSurface
 
 import { EntityFormSurface } from '../Shared';
-import { InquiryCreateModal } from '../Inquiry';
 import { EntityProfileHeader } from './EntityProfileHeader';
 import { AIOverviewCard } from './AIOverviewCard';
 import { useFavorites } from '../../hooks/useFavorites';
@@ -59,7 +58,7 @@ export interface RelationalChunk {
 // SmartSearch reacts to navigation path changes to implement continuous browsing.
 
 export interface InlineActionPayload {
-  action: 'create' | 'edit';
+  action: 'create' | 'edit' | 'view';
   entityType: string;
   contextData: any;
 }
@@ -83,7 +82,7 @@ export interface SmartSearchProps {
   /** Cancel inline create/edit */
   onInlineCancel?: () => void;
   /** Inline create/edit success */
-  onInlineSuccess?: () => void;
+  onInlineSuccess?: (created?: unknown) => void;
   /** Request an inline create action */
   onOpenInlineCreate?: (targetType: string, currentRecord: SearchEntity) => void;
 }
@@ -1428,159 +1427,121 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
 
         {quickCreateConfig.isOpen && (
           <div style={{ marginTop: 12 }}>
-            {String(quickCreateConfig.type).toLowerCase() === 'inquiry' ? (
-              <InquiryCreateModal
-                isOpen={true}
-                onClose={closeQuickCreate}
-                onSuccess={() => {
-                  if (activeEntity) {
-                    if (activeRelationTab !== 'more') {
-                      void loadRelationshipTab(activeRelationTab, activeEntity);
-                    }
-                    void loadRelationalChunks(activeEntity);
-                  }
-                  closeQuickCreate();
-                }}
-                enableSupplierPlantSelection={Boolean(
-                  quickCreateConfig.context?.customer || quickCreateConfig.context?.customer_id
-                )}
-                initialEntityType={
-                  quickCreateConfig.context?.customer || quickCreateConfig.context?.customer_id
+            <EntityFormSurface
+              entityType={quickCreateConfig.type}
+              mode="create"
+              variant="inline"
+              forceUniversal
+              isOpen={true}
+              onClose={closeQuickCreate}
+              context={{
+                customerId: quickCreateConfig.context?.customer || quickCreateConfig.context?.customer_id,
+                supplierId: quickCreateConfig.context?.supplier || quickCreateConfig.context?.supplier_id,
+                contactId: quickCreateConfig.context?.contact || quickCreateConfig.context?.contact_id,
+              }}
+              onSuccess={(created) => {
+                const row = (created && typeof created === 'object' ? (created as any) : {}) as any;
+                const createdId = String(row?.id ?? row?.uuid ?? row?.pk ?? '').trim();
+                const rawType = String(quickCreateConfig.type ?? '').toLowerCase();
+                const createdType =
+                  rawType === 'customers'
                     ? 'customer'
-                    : quickCreateConfig.context?.supplier || quickCreateConfig.context?.supplier_id
+                    : rawType === 'suppliers'
                       ? 'supplier'
-                      : undefined
-                }
-                initialEntityId={
-                  quickCreateConfig.context?.customer ||
-                  quickCreateConfig.context?.customer_id ||
-                  quickCreateConfig.context?.supplier ||
-                  quickCreateConfig.context?.supplier_id
-                }
-              />
-            ) : (
-              <EntityFormSurface
-                entityType={quickCreateConfig.type}
-                mode="create"
-                isOpen={true}
-                onClose={closeQuickCreate}
-                context={{
-                  customerId: quickCreateConfig.context?.customer || quickCreateConfig.context?.customer_id,
-                  supplierId: quickCreateConfig.context?.supplier || quickCreateConfig.context?.supplier_id,
-                  contactId: quickCreateConfig.context?.contact || quickCreateConfig.context?.contact_id,
-                }}
-                onSuccess={(created) => {
-                  const row = (created && typeof created === 'object' ? (created as any) : {}) as any;
-                  const createdId = String(row?.id ?? row?.uuid ?? row?.pk ?? '').trim();
-                  const rawType = String(quickCreateConfig.type ?? '').toLowerCase();
-                  const createdType =
-                    rawType === 'customers'
-                      ? 'customer'
-                      : rawType === 'suppliers'
-                        ? 'supplier'
-                        : rawType === 'contacts'
-                          ? 'contact'
-                          : rawType === 'products'
-                            ? 'product'
-                            : rawType === 'invoices'
-                              ? 'invoice'
-                              : rawType;
+                      : rawType === 'contacts'
+                        ? 'contact'
+                        : rawType === 'products'
+                          ? 'product'
+                          : rawType === 'invoices'
+                            ? 'invoice'
+                            : rawType;
 
-                  const createdName = String(row?.name ?? row?.title ?? row?.code ?? '').trim();
+                const createdName = String(row?.name ?? row?.title ?? row?.code ?? '').trim();
 
-                  if (createdId) {
-                    message.success(`Created ${formatEntityLabel(createdType)}${createdName ? `: ${createdName}` : ''}`);
-                  }
-
-                  // Master data creates are not always a "relation" of the currently focused entity.
-                  // Navigate to the created record so the user can immediately see/confirm it exists.
-                  const shouldNavigateToCreated = Boolean(
-                    createdId && ['customer', 'supplier', 'contact', 'product', 'invoice'].includes(createdType)
+                if (createdId) {
+                  message.success(
+                    `Created ${formatEntityLabel(createdType)}${createdName ? `: ${createdName}` : ''}`
                   );
+                }
 
-                  if (shouldNavigateToCreated) {
-                    handleSelectEntity({
-                      id: createdId,
-                      type: createdType,
-                      name: createdName || `New ${formatEntityLabel(createdType)}`,
-                    });
+                const shouldNavigateToCreated = Boolean(
+                  createdId && ['customer', 'supplier', 'contact', 'product', 'invoice'].includes(createdType)
+                );
 
-                    if (query?.trim()) {
-                      void searchEntities(query);
-                    }
+                if (shouldNavigateToCreated) {
+                  handleSelectEntity({
+                    id: createdId,
+                    type: createdType,
+                    name: createdName || `New ${formatEntityLabel(createdType)}`,
+                  });
 
-                    closeQuickCreate();
-                    return;
-                  }
-
-                  if (activeEntity) {
-                    if (activeRelationTab !== 'more') {
-                      void loadRelationshipTab(activeRelationTab, activeEntity);
-                    }
-                    void loadRelationalChunks(activeEntity);
+                  if (query?.trim()) {
+                    void searchEntities(query);
                   }
 
                   closeQuickCreate();
-                }}
-              />
-            )}
+                  return;
+                }
+
+                if (activeEntity) {
+                  if (activeRelationTab !== 'more') {
+                    void loadRelationshipTab(activeRelationTab, activeEntity);
+                  }
+                  void loadRelationalChunks(activeEntity);
+                }
+
+                closeQuickCreate();
+              }}
+            />
           </div>
         )}
 
         {inlineAction && activeEntity && (
           <div style={{ marginTop: 12 }}>
-            {String(inlineAction.entityType).toLowerCase() === 'inquiry' ? (
-              <InquiryCreateModal
-                isOpen={true}
-                onClose={() => onInlineCancel?.()}
-                onSuccess={() => {
-                  if (activeEntity) {
-                    if (activeRelationTab !== 'more') {
-                      void loadRelationshipTab(activeRelationTab, activeEntity);
-                    }
-                    void loadRelationalChunks(activeEntity);
+            <EntityFormSurface
+              entityType={inlineAction.entityType}
+              mode={inlineAction.action === 'view' ? 'view' : inlineAction.action === 'edit' ? 'edit' : 'create'}
+              entityId={
+                inlineAction.action === 'view' || inlineAction.action === 'edit'
+                  ? (inlineAction.contextData?.entityId ?? inlineAction.contextData?.id ?? activeEntity.id)
+                  : undefined
+              }
+              variant="inline"
+              forceUniversal
+              isOpen={true}
+              onClose={() => onInlineCancel?.()}
+              context={{
+                customerId: inlineAction.contextData?.customer || inlineAction.contextData?.customer_id,
+                supplierId: inlineAction.contextData?.supplier || inlineAction.contextData?.supplier_id,
+                contactId: inlineAction.contextData?.contact || inlineAction.contextData?.contact_id,
+              }}
+              onSuccess={(created) => {
+                const row = (created && typeof created === 'object' ? (created as any) : {}) as any;
+                const createdId = String(row?.id ?? row?.uuid ?? row?.pk ?? '').trim();
+                const createdName = String(row?.name ?? row?.title ?? row?.code ?? '').trim();
+
+                if (inlineAction.action === 'create' && createdId) {
+                  handleSelectEntity({
+                    id: createdId,
+                    type: String(inlineAction.entityType || ''),
+                    name: createdName || `New ${formatEntityLabel(String(inlineAction.entityType || 'record'))}`,
+                  });
+
+                  if (query?.trim()) {
+                    void searchEntities(query);
                   }
-                  onInlineSuccess?.();
-                }}
-                enableSupplierPlantSelection={Boolean(
-                  inlineAction.contextData?.customer || inlineAction.contextData?.customer_id
-                )}
-                initialEntityType={
-                  inlineAction.contextData?.customer || inlineAction.contextData?.customer_id
-                    ? 'customer'
-                    : inlineAction.contextData?.supplier || inlineAction.contextData?.supplier_id
-                      ? 'supplier'
-                      : undefined
                 }
-                initialEntityId={
-                  inlineAction.contextData?.customer ||
-                  inlineAction.contextData?.customer_id ||
-                  inlineAction.contextData?.supplier ||
-                  inlineAction.contextData?.supplier_id
-                }
-              />
-            ) : (
-              <EntityFormSurface
-                entityType={inlineAction.entityType}
-                mode="create"
-                isOpen={true}
-                onClose={() => onInlineCancel?.()}
-                context={{
-                  customerId: inlineAction.contextData?.customer || inlineAction.contextData?.customer_id,
-                  supplierId: inlineAction.contextData?.supplier || inlineAction.contextData?.supplier_id,
-                  contactId: inlineAction.contextData?.contact || inlineAction.contextData?.contact_id,
-                }}
-                onSuccess={() => {
-                  if (activeEntity) {
-                    if (activeRelationTab !== 'more') {
-                      void loadRelationshipTab(activeRelationTab, activeEntity);
-                    }
-                    void loadRelationalChunks(activeEntity);
+
+                if (activeEntity) {
+                  if (activeRelationTab !== 'more') {
+                    void loadRelationshipTab(activeRelationTab, activeEntity);
                   }
-                  onInlineSuccess?.();
-                }}
-              />
-            )}
+                  void loadRelationalChunks(activeEntity);
+                }
+
+                onInlineSuccess?.(created);
+              }}
+            />
           </div>
         )}
 
@@ -1588,6 +1549,7 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
           <EntityFormSurface
             entityType="sales-orders"
             mode="create"
+            variant="inline"
             isOpen={true}
             onClose={closeInlineSubview}
             onSuccess={() => closeInlineSubview()}

--- a/frontend/src/components/Shared/EntityFormSurface.tsx
+++ b/frontend/src/components/Shared/EntityFormSurface.tsx
@@ -40,11 +40,17 @@ export interface EntityFormSurfaceProps {
    */
   variant?: EntityFormSurfaceVariant;
 
+  /**
+   * When true, forces the UniversalEntityForm even if an enhanced renderer exists.
+   * Useful for embedded Cockpit panes where modals would break the UX.
+   */
+  forceUniversal?: boolean;
+
   isOpen: boolean;
   onClose: () => void;
   onSuccess?: (result: unknown) => void;
 
-  /** For edit mode */
+  /** For edit/view mode */
   entityId?: string | number;
 
   /** Seed values for universal schema-driven form */
@@ -70,6 +76,7 @@ export const EntityFormSurface: React.FC<EntityFormSurfaceProps> = ({
   entityType,
   mode,
   variant = 'modal',
+  forceUniversal = false,
   isOpen,
   onClose,
   onSuccess,
@@ -82,7 +89,7 @@ export const EntityFormSurface: React.FC<EntityFormSurfaceProps> = ({
   const useUniversalInquiryCreate = getRuntimeConfigBoolean('USE_UNIVERSAL_INQUIRY_CREATE', false);
 
   // Enhanced form: Inquiry (create) — can be swapped to UniversalEntityForm via runtime flag.
-  if (normalized === 'inquiry' && mode === 'create' && !useUniversalInquiryCreate) {
+  if (normalized === 'inquiry' && mode === 'create' && !useUniversalInquiryCreate && !forceUniversal) {
     const initialEntityType = context?.customerId
       ? 'customer'
       : context?.supplierId

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -65,6 +65,10 @@ type BackendField = {
   required?: boolean;
   placeholder?: string | null;
   help_text?: string;
+
+  /** Progressive disclosure flag from the backend schema generator (additive-only). */
+  is_advanced?: boolean;
+
   // Relationship metadata (schema endpoint)
   related_entity?: string | null;
   choices?: SchemaChoice[] | null;
@@ -216,7 +220,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     Record<string, Array<{ value: string; label: string }>>
   >({});
   const [loadingProducts, setLoadingProducts] = useState<Record<string, boolean>>({});
-  const [showAllFields, setShowAllFields] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const productSearchSeqRef = useRef<Record<string, number>>({});
 
@@ -284,7 +288,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   useEffect(() => {
     if (!isOpen) return;
 
-    setShowAllFields(false);
+    setShowAdvanced(false);
     setActiveMode(inferredMode);
     setRecordValues(null);
 
@@ -568,6 +572,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           label: f.label || f.key,
           type: isInlineArray ? 'inline_form_array' : f.choices?.length ? 'select' : String(f.type ?? 'text'),
           required: Boolean(f.required),
+          is_advanced: Boolean(f.is_advanced),
           options,
           placeholder: f.placeholder || undefined,
           help_text: f.help_text,
@@ -621,9 +626,9 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           return v === undefined || v === null || v === '';
         });
       if (missingFk.length) {
-        const missingHiddenFk = missingFk.filter((f) => !preferredKeySet.has(String(f.key).toLowerCase()));
-        if (missingHiddenFk.length && !showAllFields) {
-          setShowAllFields(true);
+        const missingHiddenFk = missingFk.filter((f) => Boolean(f.is_advanced));
+        if (missingHiddenFk.length && !showAdvanced) {
+          setShowAdvanced(true);
         }
 
         message.error(`Please select ${missingFk[0].label || missingFk[0].key}`);
@@ -773,7 +778,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
       onSuccess,
       preferredKeySet,
       scalarFields,
-      showAllFields,
+      showAdvanced,
     ]
   );
 
@@ -846,6 +851,16 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
 
   if (variant === 'inline' && !isOpen) return null;
 
+  const hasDisplayValue = (v: unknown): boolean => {
+    if (v === undefined || v === null) return false;
+    if (typeof v === 'string') return v.trim().length > 0;
+    if (typeof v === 'number') return true;
+    if (typeof v === 'boolean') return true;
+    if (Array.isArray(v)) return v.some((item) => hasDisplayValue(item));
+    if (typeof v === 'object') return Object.keys(v as Record<string, unknown>).length > 0;
+    return Boolean(v);
+  };
+
   const formatValue = (v: unknown): string => {
     if (v === undefined || v === null) return '';
     if (typeof v === 'boolean') return v ? 'Yes' : 'No';
@@ -869,10 +884,16 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
 
   const keyScalarFields = scalarFields.filter((f) => preferredKeySet.has(String(f.key).toLowerCase()));
   const otherScalarFields = scalarFields.filter((f) => !preferredKeySet.has(String(f.key).toLowerCase()));
-  const visibleScalarFields = [...keyScalarFields, ...(showAllFields ? otherScalarFields : [])];
+
+  const standardScalarFields = [...keyScalarFields, ...otherScalarFields.filter((f) => !f.is_advanced)];
+  const advancedScalarFields = otherScalarFields.filter((f) => Boolean(f.is_advanced));
+
+  const visibleScalarFields = [...standardScalarFields, ...(showAdvanced ? advancedScalarFields : [])];
+
+  const advancedFkFields = otherFkFields.filter((f) => Boolean(f.is_advanced));
 
   const showVisibilityToggle =
-    otherFkFields.length > 0 || otherScalarFields.length > 0;
+    advancedFkFields.length > 0 || advancedScalarFields.length > 0;
 
   const modeSwitchControls =
     entityId != null &&
@@ -906,7 +927,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
 
           {(keyFkFields.length > 0 || otherFkFields.length > 0) && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 10 }}>
-              {[...keyFkFields, ...(showAllFields ? otherFkFields : [])].map((f) => {
+              {[...keyFkFields, ...otherFkFields.filter((f) => !f.is_advanced), ...(showAdvanced ? otherFkFields.filter((f) => Boolean(f.is_advanced)) : [])].map((f) => {
                 const related = String(f.related_entity || '').toLowerCase();
                 const isProduct =
                   related.includes('system.product') ||
@@ -915,6 +936,10 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
                 const value = String((fkValues[f.key] as string | number | undefined) ?? '');
 
                 if (activeMode === 'view') {
+                  if (Boolean(f.is_advanced) && !hasDisplayValue(formInitialValues[f.key])) {
+                    return null;
+                  }
+
                   return (
                     <div key={f.key}>
                       <div
@@ -1036,19 +1061,23 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           {showVisibilityToggle && (
             <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 14 }}>
               <Button
-                type="link"
-                onClick={() => setShowAllFields((v) => !v)}
-                style={{ padding: 0, height: 'auto' }}
+                type="dashed"
+                onClick={() => setShowAdvanced((v) => !v)}
               >
-                {showAllFields ? 'Show fewer fields' : 'Show all fields'}
+                {showAdvanced ? 'Hide details' : 'Expand details'}
               </Button>
             </div>
           )}
 
           {activeMode === 'view' ? (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-              {visibleScalarFields.map((f) => (
-                <div key={f.key}>
+              {visibleScalarFields.map((f) => {
+                if (Boolean(f.is_advanced) && !hasDisplayValue(formInitialValues[f.key])) {
+                  return null;
+                }
+
+                return (
+                  <div key={f.key}>
                   <div
                     style={{
                       fontSize: 12,
@@ -1071,8 +1100,9 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
                   >
                     {formatValue(formInitialValues[f.key]) || '—'}
                   </div>
-                </div>
-              ))}
+                  </div>
+                );
+              })}
 
               <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 8 }}>
                 <Button onClick={onClose} disabled={submitting}>
@@ -1092,8 +1122,8 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
               isSubmitting={submitting}
               submitLabel={entityId ? 'Save' : 'Create'}
               keyFieldKeys={preferredKeys}
-              showAllFields={showAllFields}
-              onShowAllFieldsChange={setShowAllFields}
+              showAllFields={showAdvanced}
+              onShowAllFieldsChange={setShowAdvanced}
               showAllFieldsToggle={false}
               onSubmit={(data) => {
                 void submit(data);

--- a/frontend/src/pages/Cockpit/CockpitDashboard.tsx
+++ b/frontend/src/pages/Cockpit/CockpitDashboard.tsx
@@ -430,7 +430,7 @@ const WidgetIcon = styled.span`
 // ============================================================================
 
 type InlineActionState = {
-  action: 'create' | 'edit';
+  action: 'create' | 'edit' | 'view';
   entityType: string;
   contextData: any;
 } | null;
@@ -718,9 +718,19 @@ export const CockpitDashboard: React.FC = () => {
         <div style={{ padding: '16px 24px 0 24px' }}>
           <BreadcrumbBar
             extraCrumbs={
-              inlineAction
-                ? [{ label: `New ${inlineAction.entityType.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}` }]
-                : []
+              inlineAction?.action === 'create'
+                ? [{
+                    label: `New ${inlineAction.entityType
+                      .replace(/_/g, ' ')
+                      .replace(/\b\w/g, (c) => c.toUpperCase())}`,
+                  }]
+                : inlineAction?.action === 'edit'
+                  ? [{
+                      label: `Edit ${inlineAction.entityType
+                        .replace(/_/g, ' ')
+                        .replace(/\b\w/g, (c) => c.toUpperCase())}`,
+                    }]
+                  : []
             }
           />
         </div>
@@ -734,7 +744,27 @@ export const CockpitDashboard: React.FC = () => {
             onQueryChange={handleQueryChange}
             inlineAction={inlineAction}
             onInlineCancel={() => setInlineAction(null)}
-            onInlineSuccess={() => setInlineAction(null)}
+            onInlineSuccess={(created) => {
+              const row = (created && typeof created === 'object' ? (created as any) : {}) as any;
+              const createdId = String(row?.id ?? row?.uuid ?? row?.pk ?? '').trim();
+              const createdType = String(inlineAction?.entityType ?? '').trim();
+
+              if (createdId && createdType) {
+                setInlineAction({
+                  action: 'view',
+                  entityType: createdType,
+                  contextData: { ...(inlineAction?.contextData || {}), entityId: createdId },
+                });
+
+                const next = new URLSearchParams(searchParams);
+                next.set('cockpit_entity_type', createdType);
+                next.set('cockpit_entity_id', createdId);
+                setSearchParams(next, { replace: true });
+                return;
+              }
+
+              setInlineAction(null);
+            }}
             onOpenInlineCreate={openInlineCreate}
           />
         </HeroSearchInner>


### PR DESCRIPTION
Implements progressive disclosure for UniversalEntityForm and uses inline (non-modal) surfaces inside Cockpit SmartSearch.\n\nChanges:\n- Backend schema: add is_advanced flag (additive)\n- UniversalEntityForm: Expand details toggle; hide empty advanced fields in view mode\n- Cockpit: inline create switches to inline EntityFormSurface; post-create flips to view mode and syncs URL params