### PR TITLE
Quick Actions: survive available-forms 500 + Catalog Forms tab

### DIFF
--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2508,7 +2508,11 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
 
     @extend_schema(responses={200: AvailableQuickActionTargetSerializer(many=True)})
     def list(self, request, *args, **kwargs):
-        from apps.system.models.tenant_workform import TenantWorkForm, WorkFormStatusChoices
+        """Return legacy TenantForms only.
+
+        WorkForms (TenantWorkForm) should be fetched via /api/v1/tenant-workforms/
+        to avoid coupling this endpoint to the WorkForms editor data model.
+        """
 
         forms_qs = self.filter_queryset(self.get_queryset())
         forms_data = AvailableFormSerializer(forms_qs, many=True).data
@@ -2516,32 +2520,8 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
             row['type'] = 'form'
             row['node_count'] = None
 
-        workforms_qs = TenantWorkForm.objects.filter(
-            status__in=[WorkFormStatusChoices.ACTIVE, WorkFormStatusChoices.DRAFT]
-        ).order_by('name')
-        if not request.user.is_superuser:
-            workforms_qs = workforms_qs.filter(tenant=request.tenant)
-
-        workforms_data = []
-        for wf in workforms_qs:
-            workforms_data.append(
-                {
-                    'id': str(wf.id),
-                    'type': 'workflow',
-                    'name': wf.name,
-                    'description': wf.description or '',
-                    'icon': 'layers',
-                    'status': wf.status,
-                    'is_default': False,
-                    'is_quick_action_enabled': True,
-                    'step_count': 0,
-                    'node_count': wf.get_node_count(),
-                }
-            )
-
-        combined = list(forms_data) + workforms_data
-        combined.sort(key=lambda r: str(r.get('name') or '').lower())
-        return Response(combined)
+        forms_data.sort(key=lambda r: str(r.get('name') or '').lower())
+        return Response(forms_data)
 
 
 @extend_schema(tags=["Workflows", "Quick Actions"])

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -76,14 +76,16 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
       setIsLoading(true);
       setError(null);
       
-      const [actionsResponse, formsResponse, workformsResponse] = await Promise.all([
+      const [actionsResult, formsResult, workformsResult] = await Promise.allSettled([
         quickActionsService.getQuickActions(),
         quickActionsService.getAvailableForms(),
         getAvailableWorkForms(),
       ]);
 
+      const actionsResponse = actionsResult.status === 'fulfilled' ? actionsResult.value : { items: [] };
       setQuickActions(actionsResponse.items || []);
 
+      const formsResponse = formsResult.status === 'fulfilled' ? formsResult.value : [];
       const legacyForms = (Array.isArray(formsResponse) ? formsResponse : [])
         .filter((item) => (item.type ?? 'form') === 'form')
         .map((item) => ({
@@ -91,20 +93,39 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
           type: 'form' as const,
         }));
 
+      if (formsResult.status === 'rejected') {
+        console.warn('[QuickActions] Legacy available-forms failed; continuing with WorkForms only', formsResult.reason);
+      }
+
+      const workformsResponse = workformsResult.status === 'fulfilled' ? workformsResult.value : [];
       const workforms = (Array.isArray(workformsResponse) ? workformsResponse : [])
         .filter((wf) => wf.status === 'active' || wf.status === 'draft')
-        .map((wf) => ({
-          id: wf.id,
-          type: 'workflow' as const,
-          name: wf.name,
-          description: wf.description ?? '',
-          icon: 'layers',
-          status: wf.status,
-          is_default: false,
-          is_quick_action_enabled: true,
-          step_count: 0,
-          node_count: typeof wf.node_count === 'number' ? wf.node_count : 0,
-        }));
+        .map((wf) => {
+          const anyWf = wf as any;
+          const nodeCount =
+            typeof anyWf.node_count === 'number'
+              ? anyWf.node_count
+              : typeof anyWf.step_count === 'number'
+                ? anyWf.step_count
+                : 0;
+
+          return {
+            id: wf.id,
+            type: 'workflow' as const,
+            name: wf.name,
+            description: wf.description ?? '',
+            icon: 'layers',
+            status: wf.status,
+            is_default: false,
+            is_quick_action_enabled: true,
+            step_count: typeof anyWf.step_count === 'number' ? anyWf.step_count : 0,
+            node_count: nodeCount,
+          };
+        });
+
+      if (workformsResult.status === 'rejected') {
+        console.warn('[QuickActions] WorkForms list failed; continuing with legacy forms only', workformsResult.reason);
+      }
 
       const byKey = new Map<string, AvailableForm>();
       for (const item of [...legacyForms, ...workforms]) {
@@ -116,7 +137,7 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
       setAvailableForms(combined);
     } catch (err: any) {
       console.error('Failed to load quick actions:', err);
-      setError(err.message || 'Failed to load quick actions');
+      setError(err?.message || 'Failed to load quick actions');
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -46,6 +46,7 @@ import { Button } from '../../components/ui/Button';
 import { TemplateSelector } from '../../components/FlowEditor/templates/TemplateSelector';
 import { FLOW_TEMPLATES, FlowTemplate } from '../../components/FlowEditor/templates/flowTemplates';
 import { createFormSubmission, getAvailableWorkForms } from '../../services/workformsApi';
+import { listTenantForms as listLegacyTenantForms } from '../../services/tenantFormService';
 import { useWorkFormPermissions, getUpgradeMessage } from '../../hooks/useWorkFormPermissions';
 
 // ============================================================================
@@ -54,6 +55,7 @@ import { useWorkFormPermissions, getUpgradeMessage } from '../../hooks/useWorkFo
 
 interface CatalogItem {
   id: string;
+  kind?: 'form' | 'workform';
   name: string;
   description: string;
   status: 'draft' | 'active' | 'inactive' | 'archived';
@@ -522,54 +524,80 @@ const FormsFlowsCatalog: React.FC = () => {
   // Phase 4.2: Get user permissions
   const { permissions, isLoading: permissionsLoading } = useWorkFormPermissions();
 
-  // Fetch existing workflows (TenantWorkForm)
+  // Fetch existing items:
+  // - WorkForms: TenantWorkForm (new editor)
+  // - Forms: legacy TenantForm (data-capture forms)
   const {
     data: forms = [],
     isLoading,
     error,
   } = useQuery<CatalogItem[]>({
-    queryKey: ['tenant-workforms'],
+    queryKey: ['workforms-catalog-items'],
     queryFn: async () => {
-      try {
-        const workforms = await getAvailableWorkForms();
-        const nowIso = new Date().toISOString();
+      const nowIso = new Date().toISOString();
 
-        // Adapt TenantWorkForm list items into the catalog's expected shape.
-        return workforms.map((wf) => {
-          const anyWf = wf as any;
-          const updated = String(anyWf.updated_at ?? nowIso);
-          const created = String(anyWf.created_at ?? updated);
+      const [workformsResult, legacyFormsResult] = await Promise.allSettled([
+        getAvailableWorkForms(),
+        listLegacyTenantForms(),
+      ]);
 
-          return {
-            id: String(anyWf.id),
-            name: String(anyWf.name ?? 'Untitled WorkForm'),
-            description: String(anyWf.description ?? ''),
-            status: (anyWf.status as CatalogItem['status']) ?? 'draft',
-            icon: '🧩',
-            // Prefer node_count for workflows; used for the primary metric row.
-            node_count: typeof anyWf.node_count === 'number' ? anyWf.node_count : undefined,
-            edge_count: typeof anyWf.edge_count === 'number' ? anyWf.edge_count : undefined,
-            execution_count:
-              typeof anyWf.execution_count === 'number' ? anyWf.execution_count : undefined,
-            last_executed_at: anyWf.last_executed_at ? String(anyWf.last_executed_at) : undefined,
-            version: typeof anyWf.version === 'number' ? anyWf.version : undefined,
-            // Keep legacy fields present so existing UI doesn't crash.
-            entity_count:
-              typeof anyWf.node_count === 'number'
-                ? anyWf.node_count
-                : typeof anyWf.entity_count === 'number'
-                  ? anyWf.entity_count
-                  : 0,
-            is_multi_entity: true,
-            is_system_template: false,
-            created_at: created,
-            updated_at: updated,
-          };
-        });
-      } catch (error) {
-        logger.error('[Catalog] Error fetching workforms:', error);
-        return [];
+      const workforms = workformsResult.status === 'fulfilled' ? workformsResult.value : [];
+      if (workformsResult.status === 'rejected') {
+        logger.error('[Catalog] Error fetching workforms:', workformsResult.reason);
       }
+
+      const legacyForms = legacyFormsResult.status === 'fulfilled' ? legacyFormsResult.value : [];
+      if (legacyFormsResult.status === 'rejected') {
+        logger.error('[Catalog] Error fetching legacy forms:', legacyFormsResult.reason);
+      }
+
+      const mappedWorkforms: CatalogItem[] = (workforms || []).map((wf) => {
+        const anyWf = wf as any;
+        const updated = String(anyWf.updated_at ?? nowIso);
+        const created = String(anyWf.created_at ?? updated);
+
+        return {
+          id: String(anyWf.id),
+          kind: 'workform',
+          name: String(anyWf.name ?? 'Untitled WorkForm'),
+          description: String(anyWf.description ?? ''),
+          status: (anyWf.status as CatalogItem['status']) ?? 'draft',
+          icon: '🧩',
+          node_count: typeof anyWf.node_count === 'number' ? anyWf.node_count : undefined,
+          edge_count: typeof anyWf.edge_count === 'number' ? anyWf.edge_count : undefined,
+          execution_count: typeof anyWf.execution_count === 'number' ? anyWf.execution_count : undefined,
+          last_executed_at: anyWf.last_executed_at ? String(anyWf.last_executed_at) : undefined,
+          version: typeof anyWf.version === 'number' ? anyWf.version : undefined,
+          entity_count: typeof anyWf.node_count === 'number' ? anyWf.node_count : 0,
+          is_multi_entity: true,
+          is_system_template: false,
+          created_at: created,
+          updated_at: updated,
+        };
+      });
+
+      const mappedLegacyForms: CatalogItem[] = (Array.isArray(legacyForms) ? legacyForms : []).map((f: any) => {
+        const updated = String(f.updated_at ?? nowIso);
+        const created = String(f.created_at ?? updated);
+        return {
+          id: String(f.id),
+          kind: 'form',
+          name: String(f.name ?? 'Untitled Form'),
+          description: String(f.description ?? ''),
+          status: (f.status as CatalogItem['status']) ?? 'draft',
+          icon: f.icon || '📋',
+          entity_count: typeof f.entity_count === 'number' ? f.entity_count : 1,
+          is_multi_entity: Boolean(f.is_multi_entity),
+          is_system_template: false,
+          created_at: created,
+          updated_at: updated,
+          flow_data: f.flow_data,
+        };
+      });
+
+      const combined = [...mappedWorkforms, ...mappedLegacyForms];
+      combined.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+      return combined;
     },
   });
 
@@ -582,8 +610,9 @@ const FormsFlowsCatalog: React.FC = () => {
 
   // Helper to determine if an item should be classified as a Workflow (Logic)
   const isWorkflow = React.useCallback((form: CatalogItem) => {
-    // New system: TenantWorkForm list items include node_count.
-    if (typeof form.node_count === 'number') return true;
+    // Explicit kind overrides (Catalog merges legacy forms + WorkForms).
+    if (form.kind === 'workform') return true;
+    if (form.kind === 'form') return false;
 
     // Legacy heuristics (kept for backward compatibility).
     if (form.is_multi_entity) return true;
@@ -713,8 +742,34 @@ const FormsFlowsCatalog: React.FC = () => {
   };
 
   // Open a workform in the editor
-  const handleEditForm = (formId: string) => {
-    navigate(`/workforms/editor/${formId}`);
+  const handleEditForm = async (form: CatalogItem) => {
+    // WorkForms: open in editor
+    if (form.kind === 'workform' || typeof form.node_count === 'number') {
+      navigate(`/workforms/editor/${form.id}`);
+      return;
+    }
+
+    // Legacy forms: start a submission and take user to the in-progress runner
+    if (form.status === 'inactive' || form.status === 'archived') {
+      showAlert({
+        type: 'warning',
+        title: 'Form unavailable',
+        content: 'This form is not active and cannot be started.',
+      });
+      return;
+    }
+
+    try {
+      const submission = await createFormSubmission(form.id);
+      navigate(`/workforms/in-progress/${submission.id}`);
+    } catch (error) {
+      logger.error('[Catalog] Failed to start form submission', error);
+      showAlert({
+        type: 'error',
+        title: 'Error',
+        content: 'Failed to start form. Please try again.',
+      });
+    }
   };
 
   // Format date
@@ -920,7 +975,7 @@ const FormsFlowsCatalog: React.FC = () => {
         <GridContainer>
           {filteredForms.map((form) => (
             <FormCard key={form.id}>
-              <CardContent onClick={() => handleEditForm(form.id)} style={{ cursor: 'pointer' }}>
+              <CardContent onClick={() => void handleEditForm(form)} style={{ cursor: 'pointer' }}>
                 <FormCardHeader>
                   <FormIcon>{form.icon || '📋'}</FormIcon>
                   <FormInfo>
@@ -982,7 +1037,7 @@ const FormsFlowsCatalog: React.FC = () => {
             <FormCard key={form.id}>
               <CardContent
                 onClick={() => {
-                  handleEditForm(form.id);
+                  void handleEditForm(form);
                 }}
                 style={{ cursor: 'pointer' }}
               >


### PR DESCRIPTION
Fixes Quick Actions and Catalog resilience when legacy /api/v1/workflows/available-forms/ errors.\n\nFrontend:\n- QuickActionsContext now uses Promise.allSettled so a 500 on available-forms does not hide WorkForms.\n- WorkForms Catalog now merges legacy TenantForm items so the Forms tab is populated; clicking a legacy form starts a submission and routes to /workforms/in-progress/{submissionId}.\n\nBackend:\n- /api/v1/workflows/available-forms/ now returns legacy TenantForm only (no TenantWorkForm mixing).\n\nVerified:\n- npm --prefix frontend run type-check\n- python -m compileall backend/tenant_apps/workflows/views.py