### PR TITLE
Fix(CI): workflow startup_failure (artifact actions)

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -449,7 +449,7 @@ jobs:
           bandit -r apps/ tenant_apps/ -ll || true
 
       - name: Upload Bandit results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bandit-report
@@ -481,7 +481,7 @@ jobs:
           npm audit || true
 
       - name: Upload npm audit results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: npm-audit-report
@@ -578,7 +578,7 @@ jobs:
           npx @cyclonedx/cyclonedx-npm --output-file sbom-javascript.json
 
       - name: Upload SBOMs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: sbom-reports
           path: |
@@ -593,7 +593,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
 
       - name: Display summary
         run: |


### PR DESCRIPTION
Fix Master Pipeline startup_failure (0 jobs) by replacing invalid artifact action majors: actions/upload-artifact@v7 and actions/download-artifact@v8 -> @v4.