### PR TITLE
Fix: workflows created_on/modified_on hotfix

### DIFF
--- a/backend/tenant_apps/workflows/migrations/0031_fix_missing_created_on_modified_on.py
+++ b/backend/tenant_apps/workflows/migrations/0031_fix_missing_created_on_modified_on.py
@@ -1,0 +1,69 @@
+"""workflows 0031 hotfix: ensure created_on/modified_on exist.
+
+Production drift was observed where the tables below were missing TimestampModel columns
+(created_on/modified_on), resulting in ProgrammingError when querying via ORM.
+
+This migration is intentionally idempotent: it adds columns only when absent, and
+backfills values from created_at/updated_at.
+
+IMPORTANT: reverse is a NO-OP. Forward is conditional and may do nothing on a DB that
+already has the columns; dropping columns on reverse would be unsafe.
+"""
+
+from django.db import migrations
+
+
+_ADD_COLUMNS_SQL = """
+DO $$
+DECLARE
+    t TEXT;
+    src_col TEXT;
+    dst_col TEXT;
+BEGIN
+    FOR t, src_col, dst_col IN VALUES
+        ('workflows_tenantform',     'created_at', 'created_on'),
+        ('workflows_tenantform',     'updated_at', 'modified_on'),
+        ('workflows_tenantlist',     'created_at', 'created_on'),
+        ('workflows_tenantlist',     'updated_at', 'modified_on'),
+        ('workflows_tenantworkflow', 'created_at', 'created_on'),
+        ('workflows_tenantworkflow', 'updated_at', 'modified_on')
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name  = t
+              AND column_name = dst_col
+        ) THEN
+            -- Step 1: Add the column as nullable so no DEFAULT is needed.
+            EXECUTE format(
+                'ALTER TABLE %I ADD COLUMN %I timestamp with time zone',
+                t, dst_col
+            );
+            -- Step 2: Back-fill every row from the corresponding source column.
+            EXECUTE format(
+                'UPDATE %I SET %I = %I WHERE %I IS NULL',
+                t, dst_col, src_col, dst_col
+            );
+            -- Step 3: Add the NOT NULL constraint now that every row has a value.
+            EXECUTE format(
+                'ALTER TABLE %I ALTER COLUMN %I SET NOT NULL',
+                t, dst_col
+            );
+        END IF;
+    END LOOP;
+END $$;
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflows", "0030_tenantworkformexecution"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=_ADD_COLUMNS_SQL,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/backend/tenant_apps/workflows/services/versioning.py
+++ b/backend/tenant_apps/workflows/services/versioning.py
@@ -153,7 +153,7 @@ class FormVersionService:
             history.append({
                 'version_number': version.version_number,
                 'change_summary': version.change_summary,
-                'created_at': version.created_at.isoformat(),
+                'created_at': version.created_on.isoformat(),
                 'created_by': version.created_by.email if version.created_by else 'System',
                 'is_current': version.is_current
             })

--- a/scripts/infrastructure_diagnostics.py
+++ b/scripts/infrastructure_diagnostics.py
@@ -1,0 +1,132 @@
+"""Infrastructure diagnostics helpers.
+
+These helpers are used by:
+- backend/apps/core/management/commands/check_infrastructure.py
+- backend/tenant_apps/workflows/tests/test_infrastructure_diagnostics.py
+
+The functions are intentionally lightweight and safe to run in CI:
+- Redis: uses Django cache backend.
+- OpenAI: checks env + a small API call (models list) when configured.
+- Sentry: checks Hub.client; optionally emits a test message.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+
+def test_redis_connectivity() -> Dict[str, Any]:
+    """Verify Django cache can round-trip a key."""
+
+    try:
+        from django.core.cache import cache
+
+        cache.set('infrastructure:redis:test', 'REDIS_OK', timeout=5)
+        value = cache.get('infrastructure:redis:test')
+
+        ok = value == 'REDIS_OK'
+        return {
+            'service': 'Redis',
+            'status': 'CONNECTED' if ok else 'FAILED',
+            'message': 'Cache round-trip succeeded' if ok else 'Cache round-trip failed',
+            'details': {'test_passed': ok},
+        }
+    except Exception as exc:  # pragma: no cover
+        return {
+            'service': 'Redis',
+            'status': 'FAILED',
+            'message': str(exc),
+            'details': {'test_passed': False},
+        }
+
+
+def test_openai_connectivity() -> Dict[str, Any]:
+    """Verify OpenAI is configured and reachable."""
+
+    api_key = os.environ.get('OPENAI_API_KEY', '').strip()
+    if not api_key:
+        return {
+            'service': 'OpenAI',
+            'status': 'NOT_CONFIGURED',
+            'message': 'OPENAI_API_KEY is not set',
+            'details': {'test_passed': False},
+        }
+
+    try:
+        # Imported inside the function so environments without the dependency
+        # can still import this module.
+        from openai import OpenAI  # type: ignore
+
+        client = OpenAI(api_key=api_key)
+        models = client.models.list()
+        model_ids = [m.id for m in getattr(models, 'data', []) if getattr(m, 'id', None)]
+
+        return {
+            'service': 'OpenAI',
+            'status': 'CONNECTED',
+            'message': 'OpenAI API reachable',
+            'details': {
+                'test_passed': True,
+                'available_models': model_ids,
+            },
+        }
+    except Exception as exc:  # pragma: no cover
+        return {
+            'service': 'OpenAI',
+            'status': 'FAILED',
+            'message': str(exc),
+            'details': {'test_passed': False},
+        }
+
+
+def test_sentry_connectivity() -> Dict[str, Any]:
+    """Verify Sentry SDK is configured (DSN set) and can emit a test message."""
+
+    try:
+        from sentry_sdk import Hub, capture_message  # type: ignore
+
+        client = getattr(Hub, 'current', None)
+        client = getattr(client, 'client', None)
+
+        dsn = getattr(client, 'dsn', None)
+        if not dsn:
+            return {
+                'service': 'Sentry',
+                'status': 'NOT_CONFIGURED',
+                'message': 'Sentry is not configured (no DSN)',
+                'details': {'test_passed': False},
+            }
+
+        capture_message('Infrastructure diagnostic: Sentry connectivity check')
+        return {
+            'service': 'Sentry',
+            'status': 'CONNECTED',
+            'message': 'Sentry SDK configured',
+            'details': {'test_passed': True},
+        }
+    except Exception as exc:  # pragma: no cover
+        return {
+            'service': 'Sentry',
+            'status': 'FAILED',
+            'message': str(exc),
+            'details': {'test_passed': False},
+        }
+
+
+def run_full_diagnostic() -> Dict[str, Any]:
+    """Run all checks and return a normalized summary payload."""
+
+    results = [
+        test_redis_connectivity(),
+        test_openai_connectivity(),
+        test_sentry_connectivity(),
+    ]
+
+    services = {r.get('service', f'service-{idx}'): r for idx, r in enumerate(results)}
+    overall_status = 'READY' if all(r.get('status') == 'CONNECTED' for r in results) else 'INCOMPLETE'
+
+    return {
+        'overall_status': overall_status,
+        'services': services,
+    }


### PR DESCRIPTION
Adds an idempotent hotfix migration to ensure workflows_* tables have created_on/modified_on (backfilled from created_at/updated_at), and fixes versioning service to use version.created_on.\n\nAlso restores the expected scripts.infrastructure_diagnostics module (used by check_infrastructure command + tests), so workflows test suite passes.\n\nVerified: python backend/manage.py test tenant_apps.workflows --verbosity=2