### PR TITLE
Feature: CSV export for Purchase & Sales Orders

### DIFF
--- a/backend/apps/core/exporting.py
+++ b/backend/apps/core/exporting.py
@@ -1,0 +1,130 @@
+"""CSV export utilities.
+
+Provides a DRF ViewSet mixin that can stream CSV exports from list endpoints
+when the client requests `?format=csv`.
+
+This is designed for large datasets:
+- Uses StreamingHttpResponse (no materializing full dataset in RAM)
+- Reuses `get_queryset()` + `filter_queryset()` so tenant filtering and
+  user filters are honored
+
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import date, datetime
+from typing import Any, Callable, Iterable, Iterator, List, Sequence, Tuple, Union
+
+from django.http import StreamingHttpResponse
+from django.utils import timezone
+
+
+CsvAccessor = Union[str, Callable[[Any], Any]]
+CsvColumn = Tuple[str, CsvAccessor]
+
+
+def _normalize_cell(raw: Any) -> str:
+    if raw is None:
+        return ""
+
+    if isinstance(raw, (datetime, date)):
+        try:
+            if isinstance(raw, datetime) and timezone.is_aware(raw):
+                raw = timezone.localtime(raw)
+        except Exception:
+            pass
+        return raw.isoformat()
+
+    if isinstance(raw, (int, float, bool)):
+        return str(raw)
+
+    if isinstance(raw, str):
+        s = raw
+    else:
+        try:
+            s = str(raw)
+        except Exception:
+            s = ""
+
+    # Prevent Excel/Sheets formula injection.
+    # (Matches frontend behavior in frontend/src/utils/csv.ts)
+    if s and s.lstrip(" \t\r\n").startswith(("=", "+", "-", "@")):
+        return f"'{s}"
+
+    return s
+
+
+def _resolve_accessor(obj: Any, accessor: CsvAccessor) -> Any:
+    if callable(accessor):
+        return accessor(obj)
+
+    # Attribute path, e.g. "supplier.name".
+    current: Any = obj
+    for part in accessor.split("."):
+        if current is None:
+            return None
+        current = getattr(current, part, None)
+    return current
+
+
+class CsvExportMixin:
+    """Mixin that adds `?format=csv` support to list endpoints."""
+
+    csv_query_param: str = "format"
+    csv_query_value: str = "csv"
+
+    def is_csv_export_request(self) -> bool:
+        value = (self.request.query_params.get(self.csv_query_param) or "").strip().lower()
+        return value == self.csv_query_value
+
+    def get_csv_export_columns(self) -> Sequence[CsvColumn]:
+        """Return columns to export.
+
+        Override per-ViewSet.
+        """
+
+        raise NotImplementedError("get_csv_export_columns() must be implemented")
+
+    def get_csv_export_queryset(self, queryset):
+        """Allow viewsets to optimize queryset for export (select_related/prefetch)."""
+
+        return queryset
+
+    def get_csv_export_filename(self) -> str:
+        base = getattr(self, "basename", None) or self.__class__.__name__.replace("ViewSet", "").lower()
+        return f"{base}_{timezone.now().date().isoformat()}.csv"
+
+    def _iter_csv(self, queryset) -> Iterator[str]:
+        columns = list(self.get_csv_export_columns())
+        headers = [h for h, _ in columns]
+
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+
+        writer.writerow(headers)
+        yield buffer.getvalue()
+        buffer.seek(0)
+        buffer.truncate(0)
+
+        for obj in queryset.iterator(chunk_size=2000):
+            row = [_normalize_cell(_resolve_accessor(obj, accessor)) for _, accessor in columns]
+            writer.writerow(row)
+            yield buffer.getvalue()
+            buffer.seek(0)
+            buffer.truncate(0)
+
+    def list(self, request, *args, **kwargs):  # noqa: A003 - DRF signature
+        if not self.is_csv_export_request():
+            return super().list(request, *args, **kwargs)
+
+        queryset = self.filter_queryset(self.get_queryset())
+        queryset = self.get_csv_export_queryset(queryset)
+
+        response = StreamingHttpResponse(
+            streaming_content=self._iter_csv(queryset),
+            content_type="text/csv; charset=utf-8",
+        )
+        response["Content-Disposition"] = f'attachment; filename="{self.get_csv_export_filename()}"'
+        return response

--- a/backend/tenant_apps/purchase_orders/views.py
+++ b/backend/tenant_apps/purchase_orders/views.py
@@ -14,18 +14,36 @@ from tenant_apps.purchase_orders.serializers import (
     PurchaseOrderSerializer,
     PurchaseOrderHistorySerializer,
 )
+from apps.core.exporting import CsvExportMixin
 import logging
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
 
-class PurchaseOrderViewSet(viewsets.ModelViewSet):
+class PurchaseOrderViewSet(CsvExportMixin, viewsets.ModelViewSet):
     """ViewSet for managing purchase orders."""
 
     queryset = PurchaseOrder.objects.all()
     serializer_class = PurchaseOrderSerializer
     permission_classes = [IsAuthenticated]
+
+    def get_csv_export_columns(self):
+        return [
+            ("Order Number", "order_number"),
+            ("Supplier", "supplier.name"),
+            ("Product", "product.product_code"),
+            ("Item Description", "item_description"),
+            ("Total Amount", "total_amount"),
+            ("Status", "status"),
+            ("Payment Status", "payment_status"),
+            ("Order Date", "order_date"),
+            ("Delivery Date", "delivery_date"),
+            ("Created On", "created_on"),
+        ]
+
+    def get_csv_export_queryset(self, queryset):
+        return queryset.select_related("supplier", "product")
 
     def get_queryset(self):
         """Filter purchase orders by current tenant.

--- a/backend/tenant_apps/sales_orders/views.py
+++ b/backend/tenant_apps/sales_orders/views.py
@@ -13,17 +13,39 @@ from django.db import transaction
 from django.utils import timezone
 from tenant_apps.sales_orders.models import SalesOrder
 from tenant_apps.sales_orders.serializers import SalesOrderSerializer
+from apps.core.exporting import CsvExportMixin
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class SalesOrderViewSet(viewsets.ModelViewSet):
+class SalesOrderViewSet(CsvExportMixin, viewsets.ModelViewSet):
     """ViewSet for managing sales orders."""
 
     queryset = SalesOrder.objects.all()
     serializer_class = SalesOrderSerializer
     permission_classes = [IsAuthenticated]
+
+    def get_csv_export_columns(self):
+        return [
+            ("Sales Order #", "our_sales_order_num"),
+            ("Customer", "customer.name"),
+            ("Supplier", "supplier.name"),
+            ("Carrier", "carrier.name"),
+            ("Product", "product.product_code"),
+            ("Quantity", "quantity"),
+            ("Total Weight", "total_weight"),
+            ("Weight Unit", "weight_unit"),
+            ("Total Amount", "total_amount"),
+            ("Status", "status"),
+            ("Payment Status", "payment_status"),
+            ("Pick Up Date", "pick_up_date"),
+            ("Delivery Date", "delivery_date"),
+            ("Created On", "created_on"),
+        ]
+
+    def get_csv_export_queryset(self, queryset):
+        return queryset.select_related("customer", "supplier", "carrier", "product")
 
     def get_queryset(self):
         """Filter sales orders by current tenant.

--- a/frontend/src/pages/PurchaseOrders.tsx
+++ b/frontend/src/pages/PurchaseOrders.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from 'antd';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { confirmDialog, showAlert } from '@/utils/uiDialogs';
-import { apiService, PurchaseOrder, Supplier } from '../services/apiService';
+import { apiClient, apiService, PurchaseOrder, Supplier } from '../services/apiService';
 import { LocationSelector } from '../components/Shared';
 import PurchaseOrderWorkflow from '../components/Workflow/PurchaseOrderWorkflow';
 import { SmartProductAutocomplete } from '../components/Inquiry/SmartProductAutocomplete';
@@ -24,6 +24,12 @@ const Title = styled.h1`
   margin: 0;
 `;
 
+const HeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
 const AddButton = styled.button`
   background: rgb(var(--color-primary));
   color: white;
@@ -38,6 +44,27 @@ const AddButton = styled.button`
   &:hover {
     background: rgb(var(--color-primary-hover));
     transform: translateY(-1px);
+  }
+`;
+
+const SecondaryButton = styled.button`
+  background: transparent;
+  color: rgb(var(--color-text-primary));
+  border: 1px solid rgb(var(--color-border));
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover {
+    background: rgb(var(--color-surface-hover));
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 `;
 
@@ -535,6 +562,40 @@ const PurchaseOrders: React.FC = () => {
         { value: 'KG', label: 'KG' },
       ];
 
+  const [exporting, setExporting] = useState(false);
+
+  const exportToCsv = async () => {
+    try {
+      setExporting(true);
+
+      // Use backend streaming export (tenant-safe via get_queryset + filter_queryset)
+      const response = await apiClient.get('/purchase-orders/', {
+        params: { format: 'csv' },
+        responseType: 'blob',
+      });
+
+      const data = response.data as any;
+      const blob = data instanceof Blob ? data : new Blob([data]);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', `purchase_orders_${new Date().toISOString().split('T')[0]}.csv`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Error exporting purchase orders:', error);
+      showAlert({
+        title: 'Export Failed',
+        content: 'Could not export purchase orders. Please try again.',
+        type: 'error',
+      });
+    } finally {
+      setExporting(false);
+    }
+  };
+
   const loadData = async () => {
     try {
       setLoading(true);
@@ -773,7 +834,11 @@ const PurchaseOrders: React.FC = () => {
     <>
       <Header>
         <Title>Purchase Orders</Title>
-        <AddButton
+        <HeaderActions>
+          <SecondaryButton onClick={exportToCsv} disabled={exporting}>
+            {exporting ? 'Exporting...' : 'Export CSV'}
+          </SecondaryButton>
+          <AddButton
           onClick={() => {
             setFormData({
               order_number: getNextOrderNumber(),
@@ -803,7 +868,8 @@ const PurchaseOrders: React.FC = () => {
           }}
         >
           + Add Purchase Order
-        </AddButton>
+          </AddButton>
+        </HeaderActions>
       </Header>
 
       <StatsCards>

--- a/frontend/src/pages/SalesOrders/SalesOrders.tsx
+++ b/frontend/src/pages/SalesOrders/SalesOrders.tsx
@@ -76,6 +76,27 @@ const HeaderActions = styled.div`
   gap: 0.75rem;
 `;
 
+const SecondaryButton = styled.button`
+  padding: 0.75rem 1.25rem;
+  background: transparent;
+  color: rgb(var(--color-text-primary));
+  border: 1px solid rgb(var(--color-border));
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: rgb(var(--color-surface-hover));
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
 const PrimaryButton = styled.button`
   padding: 0.75rem 1.5rem;
   background: rgb(var(--color-primary));
@@ -435,6 +456,7 @@ export const SalesOrdersPage: React.FC = () => {
   const [orders, setOrders] = useState<SalesOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
   const [statusFilter, setStatusFilter] = useState<OrderStatus | 'all'>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedOrder, setSelectedOrder] = useState<SalesOrder | null>(null);
@@ -483,6 +505,32 @@ export const SalesOrdersPage: React.FC = () => {
   useEffect(() => {
     fetchOrders();
   }, []);
+
+  const exportToCsv = async () => {
+    try {
+      setExporting(true);
+      const response = await apiClient.get('sales-orders/', {
+        params: { format: 'csv' },
+        responseType: 'blob',
+      });
+
+      const data = response.data as any;
+      const blob = data instanceof Blob ? data : new Blob([data]);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', `sales_orders_${new Date().toISOString().split('T')[0]}.csv`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err: any) {
+      console.error('Error exporting sales orders:', err);
+      setError('Failed to export sales orders');
+    } finally {
+      setExporting(false);
+    }
+  };
 
   const fetchOrders = async () => {
     try {
@@ -542,6 +590,9 @@ export const SalesOrdersPage: React.FC = () => {
       <PageHeader>
         <PageTitle>Sales Orders</PageTitle>
         <HeaderActions>
+          <SecondaryButton onClick={exportToCsv} disabled={exporting}>
+            {exporting ? 'Exporting...' : 'Export CSV'}
+          </SecondaryButton>
           <PrimaryButton onClick={() => { setCreatePrefill(null); setIsModalOpen(true); }}>
             + New Sales Order
           </PrimaryButton>


### PR DESCRIPTION
Implements tenant-safe, streaming CSV exports for order lists.

Backend:
- Add apps.core.exporting.CsvExportMixin (streams CSV on ?format=csv)
- Enable CSV export on PurchaseOrderViewSet and SalesOrderViewSet (select_related to avoid N+1)

Frontend:
- Add 'Export CSV' buttons to Purchase Orders and Sales Orders list pages (downloads blob)

Validation:
- npm --prefix frontend run type-check
- python backend/manage.py test tenant_apps.purchase_orders tenant_apps.sales_orders