### PR TITLE
Fix: harden Sentry capture (backend + frontend)

### DIFF
--- a/backend/apps/core/exceptions.py
+++ b/backend/apps/core/exceptions.py
@@ -1,17 +1,61 @@
-"""
-Custom exception handler for ProjectMeats API.
+"""Custom exception handler for ProjectMeats API.
 
 Provides centralized error handling and logging for Django REST Framework.
+
+Sentry hardening: ensure 5xx errors are captured even when we return a
+friendly Response body.
 """
+
 import logging
-from rest_framework.views import exception_handler as drf_exception_handler
-from rest_framework.response import Response
-from rest_framework import status
+
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.http import Http404
 from django.db import DatabaseError
+from django.http import Http404
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler as drf_exception_handler
 
 logger = logging.getLogger(__name__)
+
+try:
+    import sentry_sdk
+except Exception:  # pragma: no cover
+    sentry_sdk = None
+
+
+def _capture_exception(exc, context, response_status: int | None = None) -> None:
+    if not sentry_sdk:
+        return
+
+    request = context.get("request")
+    view = context.get("view")
+
+    with sentry_sdk.push_scope() as scope:
+        if response_status is not None:
+            scope.set_tag("http.status_code", response_status)
+
+        if request is not None:
+            scope.set_tag("http.method", getattr(request, "method", "unknown"))
+            scope.set_tag("http.path", getattr(request, "path", "unknown"))
+
+            try:
+                if hasattr(request, "tenant") and request.tenant:
+                    scope.set_tag("tenant.id", str(request.tenant.id))
+                    scope.set_tag("tenant.slug", getattr(request.tenant, "slug", "unknown"))
+            except Exception:
+                pass
+
+            try:
+                user = getattr(request, "user", None)
+                if user and getattr(user, "is_authenticated", False):
+                    scope.set_user({"id": str(user.id), "username": getattr(user, "username", None)})
+            except Exception:
+                pass
+
+        if view is not None:
+            scope.set_tag("drf.view", view.__class__.__name__)
+
+        sentry_sdk.capture_exception(exc)
 
 
 def exception_handler(exc, context):
@@ -33,7 +77,7 @@ def exception_handler(exc, context):
         # Log the error with context
         view = context.get('view', None)
         request = context.get('request', None)
-        
+
         logger.error(
             f'API Error: {exc.__class__.__name__} - {str(exc)}',
             extra={
@@ -45,6 +89,10 @@ def exception_handler(exc, context):
             },
             exc_info=True
         )
+
+        if response.status_code >= 500:
+            _capture_exception(exc, context, response_status=response.status_code)
+
         return response
 
     # Handle Django validation errors
@@ -86,6 +134,9 @@ def exception_handler(exc, context):
             },
             exc_info=True
         )
+
+        _capture_exception(exc, context, response_status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
         return Response(
             {
                 'error': 'Database Error',
@@ -104,7 +155,9 @@ def exception_handler(exc, context):
         },
         exc_info=True
     )
-    
+
+    _capture_exception(exc, context, response_status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
     return Response(
         {
             'error': 'Internal Server Error',

--- a/backend/projectmeats/settings/base.py
+++ b/backend/projectmeats/settings/base.py
@@ -567,7 +567,15 @@ OPENAI_TEMPERATURE = float(os.environ.get("OPENAI_TEMPERATURE", "0.7"))
 
 SENTRY_ENABLED = os.environ.get("SENTRY_ENABLED", "").lower() in ("true", "1", "yes")
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
-SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "development")
+
+# Prefer explicit SENTRY_ENVIRONMENT, otherwise mirror the deployment environment.
+# (Supports the requested DJANGO_ENV input without requiring it.)
+SENTRY_ENVIRONMENT = (
+    os.environ.get("SENTRY_ENVIRONMENT")
+    or os.environ.get("DJANGO_ENV")
+    or os.environ.get("ENVIRONMENT")
+    or "development"
+)
 
 # Used by the AI assistant "get_recent_errors" tool (Phase 7: Sentry-GitHub-Copilot loop)
 SENTRY_AUTH_TOKEN = os.environ.get("SENTRY_AUTH_TOKEN")
@@ -576,13 +584,16 @@ SENTRY_BASE_URL = os.environ.get("SENTRY_BASE_URL", "https://sentry.io")
 
 if SENTRY_ENABLED and SENTRY_DSN:
     import sentry_sdk
+    from sentry_sdk.integrations.celery import CeleryIntegration
     from sentry_sdk.integrations.django import DjangoIntegration
-    
+
+    env_norm = (SENTRY_ENVIRONMENT or "development").strip().lower()
+
     # Determine sample rate based on environment
     traces_sample_rate = 1.0  # Default for dev/uat
-    if SENTRY_ENVIRONMENT == "production":
+    if env_norm in {"prod", "production"}:
         traces_sample_rate = 0.1  # 10% sampling in production to reduce costs
-    
+
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[
@@ -591,24 +602,23 @@ if SENTRY_ENABLED and SENTRY_DSN:
                 middleware_spans=True,    # Track middleware performance
                 signals_spans=True,       # Track Django signals
             ),
+            CeleryIntegration(),
         ],
         environment=SENTRY_ENVIRONMENT,
-        
+
         # Performance Monitoring
         traces_sample_rate=traces_sample_rate,
         profiles_sample_rate=0.0,  # Disabled until needed (can enable later)
-        
+
         # Error Filtering
         before_send=lambda event, hint: (
             # Filter out 404 errors to keep signal-to-noise ratio high
-            None if event.get("exception", {}).get("values", [{}])[0]
-                        .get("type") == "Http404" 
-            else event
+            None if event.get("exception", {}).get("values", [{}])[0].get("type") == "Http404" else event
         ),
-        
+
         # Release Tracking
         release=os.environ.get("GIT_COMMIT_SHA", "unknown"),  # Set by CI/CD
-        
+
         # Additional Options
         # Required for Seer (user-impact analysis) + richer debugging context.
         send_default_pii=True,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,10 +20,6 @@ import { CockpitPinnedToolsProvider } from './contexts/CockpitPinnedToolsContext
 import { ToastProvider } from './hooks/useToast';
 import Layout from './components/Layout/Layout';
 import './i18n/config'; // Initialize i18n
-import { initSentry } from './utils/sentry'; // Initialize Sentry
-
-// Initialize Sentry for error tracking and performance monitoring
-initSentry();
 
 // Create QueryClient for data fetching (React Query)
 const queryClient = new QueryClient({

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode, useCallback, useMemo } from 'react';
 import { UserProfile } from '../types';
 import { authService, LoginCredentials, SignUpCredentials } from '../services/authService';
+import { clearSentryUser, setSentryTenant, setSentryUser } from '../utils/sentry';
 
 interface AuthContextType {
   user: UserProfile | null;
@@ -31,9 +32,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       try {
         const currentUser = await authService.getCurrentUser();
         setUser(currentUser);
+
+        if (currentUser) {
+          const tenantId = localStorage.getItem('tenantId') || undefined;
+          setSentryUser(String(currentUser.id), currentUser.email, tenantId, currentUser.username);
+          if (tenantId) setSentryTenant(tenantId);
+        } else {
+          clearSentryUser();
+        }
       } catch (error) {
         console.error('Failed to initialize auth:', error);
         setUser(null);
+        clearSentryUser();
       } finally {
         setLoading(false);
       }
@@ -47,6 +57,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       const loggedInUser = await authService.login(credentials);
       setUser(loggedInUser);
+
+      if (loggedInUser) {
+        const tenantId = localStorage.getItem('tenantId') || undefined;
+        setSentryUser(String(loggedInUser.id), loggedInUser.email, tenantId, loggedInUser.username);
+        if (tenantId) setSentryTenant(tenantId);
+      } else {
+        clearSentryUser();
+      }
     } catch (error) {
       setUser(null);
       throw error;
@@ -60,6 +78,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       const newUser = await authService.signUp(credentials);
       setUser(newUser);
+
+      if (newUser) {
+        const tenantId = localStorage.getItem('tenantId') || undefined;
+        setSentryUser(String(newUser.id), newUser.email, tenantId, newUser.username);
+        if (tenantId) setSentryTenant(tenantId);
+      } else {
+        clearSentryUser();
+      }
     } catch (error) {
       setUser(null);
       throw error;
@@ -73,9 +99,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       await authService.logout();
       setUser(null);
+      clearSentryUser();
     } catch (error) {
       console.error('Logout error:', error);
       setUser(null);
+      clearSentryUser();
     } finally {
       setLoading(false);
     }
@@ -85,9 +113,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       const currentUser = await authService.getCurrentUser();
       setUser(currentUser);
+
+      if (currentUser) {
+        const tenantId = localStorage.getItem('tenantId') || undefined;
+        setSentryUser(String(currentUser.id), currentUser.email, tenantId, currentUser.username);
+        if (tenantId) setSentryTenant(tenantId);
+      } else {
+        clearSentryUser();
+      }
     } catch (error) {
       console.error('Failed to refresh user:', error);
       setUser(null);
+      clearSentryUser();
     }
   }, []);
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import * as Sentry from '@sentry/react';
 import App from './App';
 
 // Make search diagnostic available in browser console
@@ -15,6 +16,8 @@ initGlobalErrorHandlers('frontend');
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <Sentry.ErrorBoundary fallback={<div style={{ padding: 24 }}>Something went wrong.</div>}>
+      <App />
+    </Sentry.ErrorBoundary>
   </React.StrictMode>
 );

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -10,6 +10,7 @@
  * - Session expired modal instead of hard redirects
  */
 import axios, { AxiosError as AxiosErrorType, InternalAxiosRequestConfig } from 'axios';
+import * as Sentry from '@sentry/react';
 import { config } from '../config/runtime';
 import { logger } from '../utils/logger';
 import {
@@ -199,6 +200,36 @@ apiClient.interceptors.response.use(
         url: originalRequest?.url,
         method: originalRequest?.method,
       });
+
+      // Sentry hardening: capture the original axios error with context before we
+      // replace it with a friendly message.
+      try {
+        Sentry.withScope((scope) => {
+          scope.setTag('http.status_code', status);
+          scope.setTag('http.method', originalRequest?.method || 'unknown');
+          scope.setTag('http.url', originalRequest?.url || 'unknown');
+          scope.setTag('tenant.id', localStorage.getItem('tenantId') || 'unknown');
+          scope.setContext('http', {
+            status,
+            method: originalRequest?.method,
+            url: originalRequest?.url,
+            baseURL: (originalRequest as any)?.baseURL,
+          });
+          scope.setContext('auth', {
+            isUsingJwt: isUsingJwt(),
+            hasAuthHeader: Boolean(originalRequest?.headers?.Authorization),
+          });
+
+          const data = (error.response as any)?.data;
+          if (data !== undefined) {
+            scope.setExtra('response.data', typeof data === 'string' ? data.slice(0, 2000) : data);
+          }
+
+          Sentry.captureException(error);
+        });
+      } catch {
+        // best-effort
+      }
 
       return Promise.reject(new Error(friendlyMessage));
     }

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -172,11 +172,12 @@ export const initSentry = (config?: SentryConfig): void => {
 /**
  * Set user context for error tracking
  */
-export const setSentryUser = (userId: string, email?: string, tenant?: string): void => {
+export const setSentryUser = (userId: string, email?: string, tenant?: string, username?: string): void => {
   Sentry.setUser({
     id: userId,
     email,
     tenant,
+    username,
   });
 };
 


### PR DESCRIPTION
Implements Sentry hardening so errors aren’t swallowed and alerting automations can fire.

Backend
- Capture exceptions for 5xx responses in DRF exception handler
- Environment derived from SENTRY_ENVIRONMENT or DJANGO_ENV/ENVIRONMENT
- Add CeleryIntegration to capture task failures

Frontend
- Wrap root React tree in Sentry.ErrorBoundary
- Capture 5xx in axios response interceptor with request context before returning friendly error
- Bind Sentry user (id/email/username + tenant tag) on login/signup/refresh; clear on logout

Validation
- python backend/manage.py test apps.core
- npm --prefix frontend run type-check