### PR TITLE
CI: Fix Master Pipeline run-name startup failure

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1497,3 +1497,5 @@ Deliverables:
 - 2026-03-31 — CI/CD: format deploy run name (🚀 Deploy: <env> - <PR title (PR#)>) — PR: #4304.
 - 2026-03-31 — Integrations: tenant webhooks + API keys (Celery dispatch + signing) — PR: #4306.
 - 2026-03-31 — Docs: V4.0 vision sprint (gap analysis, UX excellence, field ops, autonomous AI) — PR: #4308.
+- 2026-03-31 — CI/CD: hotfix Master Pipeline run-name startup failure (remove replace() expression; uat/main runs had 0 jobs) — PR: #4310.
+- 2026-03-31 — Note: the earlier "Pending work items (not shipped)" section is obsolete; see PRs #4306 and #4308.

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -3,19 +3,11 @@ name: Master Pipeline
 run-name: >-
   ${{
     github.event_name == 'pull_request'
-      && format('🔍 PR Check: {0}', github.event.pull_request.title)
-      || format(
-        '🚀 Deploy: {0} - {1}',
-        github.event_name == 'workflow_dispatch' && github.event.inputs.environment || github.ref_name,
-        replace(
-          replace(
-            replace(github.event.head_commit.message, '\n\n', ' — '),
-            '\n',
-            ' '
-          ),
-          '(#',
-          '(PR#:'
-        )
+      && format('🔍 PR Check: {0} (PR#{1})', github.event.pull_request.title, github.event.pull_request.number)
+      || (
+        github.event_name == 'workflow_dispatch'
+          && format('🚀 Deploy: {0} - manual', github.event.inputs.environment)
+          || format('🚀 Deploy: {0} - {1}', github.ref_name, github.event.head_commit.message)
       )
   }}
 


### PR DESCRIPTION
Hotfix: remove replace() usage from main-pipeline run-name. Recent deploy runs to uat/main completed instantly with 0 jobs (startup failure), likely due to unsupported expression functions. This change restores workflow startup.