### PR TITLE
Docs: clarify historical pending items

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1500,3 +1500,4 @@ Deliverables:
 - 2026-03-31 — CI/CD: hotfix Master Pipeline run-name startup failure (remove replace() expression; uat/main runs had 0 jobs) — PR: #4310.
 - 2026-03-31 — Note: the earlier "Pending work items (not shipped)" section is obsolete; see PRs #4306 and #4308.
 - 2026-03-31 — Auth: guest login UI (Try Demo as Guest) wired to /api/v1/auth/guest-login/ — PR: #4313.
+- 2026-03-31 — Docs: clarify historical pending items (handoff + Phase 5 execution summary) — PR: #4314.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,5 +1,11 @@
 # Handoff Document: Gap Analysis Project
 
+> ⚠️ **Historical Snapshot (Feb 2026)**
+> This document is preserved for context, but it no longer reflects current repo status.
+> For the current authoritative status, refer to:
+> - `MASTER_PLAN.md` (repo root)
+> - `.github/MASTER_PLAN.md` (append-only shipped PR log)
+
 **Date**: February 26, 2026  
 **Session**: Evening completion of Phase 6  
 **Overall Progress**: 51.7% complete (15/29 todos)
@@ -34,7 +40,8 @@
 
 ## 🚧 Pending PRs (Requires Manual Creation)
 
-**Why Manual**: `gh pr create` fails for fork→upstream PRs. Must create via web UI.
+> ⚠️ This section is **historical**. The referenced PRs/branches were merged long ago.
+> Use `gh pr list` and `.github/MASTER_PLAN.md` for current shipped state.
 
 ### 4 PRs Awaiting Merge
 

--- a/docs/PHASE5_EXECUTION_SUMMARY.md
+++ b/docs/PHASE5_EXECUTION_SUMMARY.md
@@ -1,5 +1,10 @@
 # Phase 5 Execution Summary
 
+> ⚠️ **Historical doc**
+> The “frontend pending” status in this document is out of date.
+> As of 2026-03-31, the frontend contains Workflow Execution UI integrations (e.g. `frontend/src/pages/MyTasks/MyTasks.tsx`, `frontend/src/pages/WorkForms/History.tsx`, `frontend/src/pages/WorkForms/InProgress.tsx`) using `frontend/src/services/workflowExecutionService.ts`.
+> Treat the remaining TODOs below as backlog ideas, not current status.
+
 ## ✅ Completed Tasks
 
 ### Backend Implementation (100% Complete)


### PR DESCRIPTION
These docs contained stale 'pending' sections (manual PR merges, Phase 5 frontend pending). Add clear historical banners and point to canonical plans/logs.