### PR TITLE
Docs: remove stale pending labels

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1501,3 +1501,4 @@ Deliverables:
 - 2026-03-31 — Note: the earlier "Pending work items (not shipped)" section is obsolete; see PRs #4306 and #4308.
 - 2026-03-31 — Auth: guest login UI (Try Demo as Guest) wired to /api/v1/auth/guest-login/ — PR: #4313.
 - 2026-03-31 — Docs: clarify historical pending items (handoff + Phase 5 execution summary) — PR: #4314.
+- 2026-03-31 — Docs: remove stale pending labels (handoff + Phase 5 docs headings) — PR: #4315.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -38,12 +38,12 @@
 
 ---
 
-## 🚧 Pending PRs (Requires Manual Creation)
+## 📦 Historical PR Links (Merged)
 
 > ⚠️ This section is **historical**. The referenced PRs/branches were merged long ago.
 > Use `gh pr list` and `.github/MASTER_PLAN.md` for current shipped state.
 
-### 4 PRs Awaiting Merge
+### 4 PR links (historical)
 
 1. **Phase 6.2: Security Hardening**  
    https://github.com/Meats-Central/ProjectMeats/compare/development...Vacilator:ProjectMeats-1:feat/gap-analysis-phase6-2-security-hardening?expand=1

--- a/docs/PHASE5_EXECUTION_SUMMARY.md
+++ b/docs/PHASE5_EXECUTION_SUMMARY.md
@@ -55,7 +55,7 @@
    - File: `backend/tenant_apps/workflows/migrations/0010_workflowexecution.py`
    - Status: Applied successfully ✓
 
-### Frontend Implementation (50% Complete)
+### Frontend Implementation (Historical Snapshot)
 
 1. **Enhanced Catalog with Tabs** ✅
    - Location: `frontend/src/pages/WorkForms/Catalog.tsx`

--- a/docs/PHASE5_IMPLEMENTATION_REPORT.md
+++ b/docs/PHASE5_IMPLEMENTATION_REPORT.md
@@ -113,7 +113,7 @@ python manage.py migrate workflows
 
 ---
 
-### 2. Frontend Implementation (50% Complete)
+### 2. Frontend Implementation (Historical Snapshot)
 
 #### A. Enhanced Catalog with Tabs ✅
 **File**: `frontend/src/pages/WorkForms/Catalog.tsx`


### PR DESCRIPTION
Renames a few historical headings that still said 'Pending' or '50% complete' so repo searches don't imply unfinished work.