### PR TITLE
Workforms: fix config field types + AI node suggestions

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -11,8 +11,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 ## Operational Notes
 
-- **2026-03-31** — Workforms editor: DynamicConfigPanel now supports `formReference` and `keyValue` schema field types (removes the "Unknown field type" placeholder for real node configs). (PR: TBD)
-- **2026-03-31** — Workforms AI Suggestions: aligned prompt + backend fallback suggestions to canonical node type IDs; added frontend canonicalization + guard to prevent adding unknown suggested nodes. (PR: TBD)
+- **2026-03-31** — Workforms editor: DynamicConfigPanel now supports `formReference` and `keyValue` schema field types (removes the "Unknown field type" placeholder for real node configs). (PR: #4319)
+- **2026-03-31** — Workforms AI Suggestions: aligned prompt + backend fallback suggestions to canonical node type IDs; added frontend canonicalization + guard to prevent adding unknown suggested nodes. (PR: #4319)
 
 - **2026-03-31** — Workforms editor: Form Submitted trigger config now lists saved FormProcess nodes via a dynamic dropdown (label: title/display-name + created date). (PR: #4318)
 

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -11,6 +11,9 @@ This file is the **append-only PR-referenceable execution log**.
 
 ## Operational Notes
 
+- **2026-03-31** — Workforms editor: DynamicConfigPanel now supports `formReference` and `keyValue` schema field types (removes the "Unknown field type" placeholder for real node configs). (PR: TBD)
+- **2026-03-31** — Workforms AI Suggestions: aligned prompt + backend fallback suggestions to canonical node type IDs; added frontend canonicalization + guard to prevent adding unknown suggested nodes. (PR: TBD)
+
 - **2026-03-31** — Workforms editor: Form Submitted trigger config now lists saved FormProcess nodes via a dynamic dropdown (label: title/display-name + created date). (PR: #4318)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)

--- a/backend/tenant_apps/workflows/services/prompter.py
+++ b/backend/tenant_apps/workflows/services/prompter.py
@@ -427,60 +427,74 @@ class AIPrompter:
         if industry_type == 'processor':
             suggestions = [
                 {
-                    "type": "input",
+                    "type": "form",
                     "label": "Log Temperature",
-                    "description": "Record batch temperature",
-                    "reasoning": "USDA compliance requirement",
-                    "priority": 1
+                    "description": "Capture batch/lot temperature and time",
+                    "reasoning": "USDA/HACCP data collection step",
+                    "priority": 1,
                 },
                 {
-                    "type": "condition",
-                    "label": "Temperature Check",
-                    "description": "If > 40°F trigger alert",
-                    "reasoning": "Critical control point",
-                    "priority": 2
-                }
+                    "type": "conditionIf",
+                    "label": "Temperature Breach?",
+                    "description": "Branch if > 40°F (or tenant threshold)",
+                    "reasoning": "Critical Control Point validation",
+                    "priority": 2,
+                },
+                {
+                    "type": "actionEmail",
+                    "label": "Notify QA Manager",
+                    "description": "Alert QA on breach",
+                    "reasoning": "Immediate escalation required for compliance",
+                    "priority": 3,
+                },
             ]
         elif industry_type == 'distributor':
             suggestions = [
                 {
-                    "type": "action",
+                    "type": "actionUpdateRecord",
                     "label": "Update Inventory",
-                    "description": "Sync stock levels",
+                    "description": "Sync stock levels for the shipment",
                     "reasoning": "Maintain accurate counts",
-                    "priority": 1
+                    "priority": 1,
                 },
                 {
-                    "type": "action",
+                    "type": "actionEmail",
                     "label": "Notify Warehouse",
-                    "description": "Send dispatch email",
+                    "description": "Send dispatch/ready-to-pick notification",
                     "reasoning": "Coordinate logistics",
-                    "priority": 2
-                }
+                    "priority": 2,
+                },
+                {
+                    "type": "endSuccess",
+                    "label": "Complete",
+                    "description": "Mark workflow complete",
+                    "reasoning": "Close out the flow cleanly",
+                    "priority": 3,
+                },
             ]
         else:  # wholesale (default)
             suggestions = [
                 {
-                    "type": "input",
+                    "type": "form",
                     "label": "Enter Invoice Details",
-                    "description": "Line items and totals",
-                    "reasoning": "Required for payment",
-                    "priority": 1
+                    "description": "Capture line items and totals",
+                    "reasoning": "Required for payment / reconciliation",
+                    "priority": 1,
                 },
                 {
-                    "type": "action",
+                    "type": "dataTransform",
                     "label": "Calculate Total",
-                    "description": "Sum with tax",
-                    "reasoning": "Generate final amount",
-                    "priority": 2
+                    "description": "Compute totals (tax/fees) from line items",
+                    "reasoning": "Normalize and validate amount fields",
+                    "priority": 2,
                 },
                 {
-                    "type": "approval",
+                    "type": "pendingApproval",
                     "label": "Finance Review",
-                    "description": "Approve payment",
-                    "reasoning": "Policy requirement",
-                    "priority": 3
-                }
+                    "description": "Wait for finance approval",
+                    "reasoning": "Policy/compliance checkpoint",
+                    "priority": 3,
+                },
             ]
         
         return {

--- a/backend/tenant_apps/workflows/services/tests/test_prompter.py
+++ b/backend/tenant_apps/workflows/services/tests/test_prompter.py
@@ -19,21 +19,29 @@ class AIPrompterTestCase(TestCase):
         self.tenant.custom_data = {"industry_type": "processor"}
         self.current_flow = {
             "nodes": [
-                {"id": "node1", "type": "trigger", "data": {"label": "Start"}},
-                {"id": "node2", "type": "input", "data": {"label": "Enter Data"}}
+                {"id": "node1", "type": "triggerManual", "data": {"label": "Start"}},
+                {"id": "node2", "type": "form", "data": {"label": "Enter Data"}},
             ]
         }
     
     def test_load_template_success(self):
         template = self.prompter.load_template()
         self.assertIn("Meat Industry Workflow Architect", template)
+        self.assertIn("triggerManual", template)
+        self.assertIn("conditionIf", template)
     
     def test_parse_ai_response_valid(self):
         valid_response = json.dumps({
             "suggestions": [
-                {"type": "condition", "label": "Check Temp", "description": "If > 40°F", "reasoning": "Safety", "priority": 1}
+                {
+                    "type": "conditionIf",
+                    "label": "Temperature Breach?",
+                    "description": "Branch if > 40°F",
+                    "reasoning": "Safety",
+                    "priority": 1,
+                }
             ],
-            "confidence": 0.95
+            "confidence": 0.95,
         })
         parsed = self.prompter.parse_ai_response(valid_response)
         self.assertEqual(len(parsed["suggestions"]), 1)

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -54,12 +54,18 @@ import {
   renderValidationBuilder,
 } from '../config/fieldRenderers/complexRenderers';
 import { NestedChildrenRenderer } from './NestedChildrenRenderer';
+import { listTenantForms } from '../../../services/workformsApi';
 
 // Import shared styled components
 import {
   Section,
   SectionHeader,
   SectionTitle,
+  FormField,
+  Label,
+  Input,
+  Select,
+  HelpText,
 } from './shared/StyledComponents';
 
 const MemoNestedChildrenRenderer = React.memo(NestedChildrenRenderer);
@@ -166,6 +172,11 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
 
+  // Tenant forms cache for schema fields like `formReference`
+  const [tenantForms, setTenantForms] = useState<any[]>([]);
+  const [tenantFormsLoading, setTenantFormsLoading] = useState(false);
+  const [tenantFormsError, setTenantFormsError] = useState<string | null>(null);
+
   // Phase E.3: Compute upstream variables for data inheritance
   const { variables: upstreamVariables } = useUpstreamVariables({
     currentNodeId: node?.id || '',
@@ -200,6 +211,34 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     
     return resolvedSchema;
   }, [node?.type, node?.id, node?.data]);
+
+  const schemaNeedsTenantForms = useMemo(() => {
+    if (!schema) return false;
+    return (schema.sections || []).some((s) => (s.fields || []).some((f) => f.type === 'formReference'));
+  }, [schema]);
+
+  useEffect(() => {
+    if (!schemaNeedsTenantForms) return;
+    if (tenantFormsLoading) return;
+
+    // Fetch once per panel lifetime; if the current selection references a form
+    // that isn't in the list (legacy/archived), we still display it.
+    setTenantFormsLoading(true);
+    setTenantFormsError(null);
+
+    listTenantForms()
+      .then((forms) => {
+        setTenantForms(Array.isArray(forms) ? forms : []);
+      })
+      .catch((err: any) => {
+        console.error('[DynamicConfigPanel] Failed to load tenant forms:', err);
+        setTenantForms([]);
+        setTenantFormsError('Failed to load forms');
+      })
+      .finally(() => {
+        setTenantFormsLoading(false);
+      });
+  }, [schemaNeedsTenantForms]);
 
   // Reset form data when node changes
   useEffect(() => {
@@ -635,6 +674,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
         });
         break;
       
+      case 'fieldMapping':
       case 'field-mapping':
         renderedField = renderFieldMapping({
           ...commonProps,
@@ -645,6 +685,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
         });
         break;
       
+      case 'variablePicker':
       case 'variable-picker':
         renderedField = renderVariablePicker({
           ...commonProps,
@@ -658,6 +699,130 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       case 'validation-builder':
         renderedField = renderValidationBuilder(commonProps);
         break;
+
+      case 'formReference': {
+        const selected = (value as string) || '';
+        const title = typeof field.placeholder === 'string' ? field.placeholder : 'Select a form...';
+
+        const forms = (tenantForms || []).slice().sort((a: any, b: any) => {
+          const aT = new Date(a?.created_at || 0).getTime();
+          const bT = new Date(b?.created_at || 0).getTime();
+          return bT - aT;
+        });
+
+        renderedField = (
+          <FormField key={field.id}>
+            <Label>{field.label}</Label>
+            <Select
+              value={selected}
+              onChange={(e) => commonProps.onChange(e.target.value)}
+              disabled={field.disabled || commonProps.disabled || tenantFormsLoading}
+              $hasError={Boolean(error)}
+            >
+              <option value="">
+                {tenantFormsLoading ? 'Loading forms...' : title}
+              </option>
+              {selected && !forms.some((f: any) => String(f?.id) === String(selected)) && (
+                <option value={selected}>{selected} (legacy)</option>
+              )}
+              {forms.map((f: any) => {
+                const name = f?.title || f?.display_name || f?.displayName || f?.name || `Form ${f?.id}`;
+                const createdLabel = f?.created_at
+                  ? new Date(f.created_at).toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'short',
+                      day: '2-digit',
+                    })
+                  : null;
+
+                return (
+                  <option key={f.id} value={f.id}>
+                    {createdLabel ? `${name} — ${createdLabel}` : name}
+                  </option>
+                );
+              })}
+            </Select>
+            {field.helpText && !error && <HelpText>{field.helpText}</HelpText>}
+            {tenantFormsError && <ErrorMessage>{tenantFormsError}</ErrorMessage>}
+            {error && <ErrorMessage>{error}</ErrorMessage>}
+          </FormField>
+        );
+        break;
+      }
+
+      case 'keyValue': {
+        const pairs: Array<{ key: string; value: string }> = Array.isArray(value)
+          ? value
+          : Array.isArray(field.defaultValue)
+            ? (field.defaultValue as any)
+            : [];
+
+        const placeholderKey = (field.placeholder as any)?.key || 'Key';
+        const placeholderValue = (field.placeholder as any)?.value || 'Value';
+        const addText = (field as any).addButtonText || '+ Add';
+
+        const updatePair = (idx: number, patch: Partial<{ key: string; value: string }>) => {
+          const next = pairs.map((p, i) => (i === idx ? { ...p, ...patch } : p));
+          commonProps.onChange(next);
+        };
+
+        const removePair = (idx: number) => {
+          const next = pairs.filter((_, i) => i != idx);
+          commonProps.onChange(next);
+        };
+
+        const addPair = () => {
+          commonProps.onChange([...(pairs || []), { key: '', value: '' }]);
+        };
+
+        renderedField = (
+          <FormField key={field.id}>
+            <Label>{field.label}</Label>
+            <KeyValueList>
+              {pairs.length === 0 && (
+                <KeyValueEmpty>None configured yet.</KeyValueEmpty>
+              )}
+              {pairs.map((p, idx) => (
+                <KeyValueRow key={`${field.id}-${idx}`}>
+                  <Input
+                    value={p?.key ?? ''}
+                    placeholder={placeholderKey}
+                    onChange={(e) => updatePair(idx, { key: e.target.value })}
+                    disabled={field.disabled || commonProps.disabled}
+                  />
+                  <Input
+                    value={p?.value ?? ''}
+                    placeholder={placeholderValue}
+                    onChange={(e) => updatePair(idx, { value: e.target.value })}
+                    disabled={field.disabled || commonProps.disabled}
+                  />
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => removePair(idx)}
+                    disabled={field.disabled || commonProps.disabled}
+                    style={{ padding: '6px 10px' }}
+                  >
+                    Remove
+                  </Button>
+                </KeyValueRow>
+              ))}
+              <Button
+                type="button"
+                variant="primary"
+                onClick={addPair}
+                disabled={field.disabled || commonProps.disabled}
+                style={{ alignSelf: 'flex-start' }}
+              >
+                {addText}
+              </Button>
+            </KeyValueList>
+            {field.helpText && !error && <HelpText>{field.helpText}</HelpText>}
+            {error && <ErrorMessage>{error}</ErrorMessage>}
+          </FormField>
+        );
+        break;
+      }
 
       case 'info':
         renderedField = (
@@ -777,7 +942,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
         renderedField = (
           <PlaceholderField key={field.id}>
             <PlaceholderLabel>{field.label}</PlaceholderLabel>
-            <PlaceholderHint>Unknown field type: {field.type}</PlaceholderHint>
+            <PlaceholderHint>Configuration field type not supported yet.</PlaceholderHint>
           </PlaceholderField>
         );
     }
@@ -1102,6 +1267,24 @@ const PlaceholderHint = styled.div`
   font-size: 12px;
   color: rgb(var(--color-text-tertiary));
   font-style: italic;
+`;
+
+const KeyValueList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const KeyValueRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 8px;
+  align-items: center;
+`;
+
+const KeyValueEmpty = styled.div`
+  font-size: 12px;
+  color: rgb(var(--color-text-secondary));
 `;
 
 const ErrorPanel = styled.div`

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -4025,6 +4025,11 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     (nodeTypeId: string, position?: { x: number; y: number }) => {
       if (readOnly) return;
 
+      if (!NODE_TYPE_REGISTRY[nodeTypeId]) {
+        toast.error(`Unknown node type suggestion: ${nodeTypeId}`, { duration: 4000 });
+        return;
+      }
+
       // Container creation is complex (pages, layout, etc.) — route through the existing click-to-add flow.
       if (!position || isFormProcessContainerType(nodeTypeId)) {
         handleClickToAddNode(nodeTypeId);

--- a/frontend/src/services/aiNodeSuggestionService.ts
+++ b/frontend/src/services/aiNodeSuggestionService.ts
@@ -30,6 +30,14 @@ export function canonicalizeNodeTypeId(rawType: string): string {
     triggerScheduled: 'triggerSchedule',
     triggerSchedule: 'triggerSchedule',
 
+    // Generic legacy categories (from older prompt/fallback versions)
+    trigger: 'triggerManual',
+    input: 'form',
+    condition: 'conditionIf',
+    approval: 'pendingApproval',
+    action: 'actionCreateRecord',
+    end: 'endSuccess',
+
     // Forms (legacy variants)
     FormStepSingle: 'form',
     formStepSingle: 'form',

--- a/manifests/ai_standards/suggestion_engine_v1.prompt
+++ b/manifests/ai_standards/suggestion_engine_v1.prompt
@@ -46,20 +46,39 @@ Given a partial workflow and business context, suggest the **next 1-3 logical st
 
 ---
 
-## Available Node Types (JSON Schema)
+## Available Node Types (STRICT IDs)
+
+Only output `type` values from the list below. These are the canonical node type IDs used by the Workforms editor.
 
 ```json
 {
-  "trigger": {"description": "Starts a workflow", "examples": ["New Supplier", "Temperature Check"]},
-  "input": {"description": "Collects data", "examples": ["Enter Lot Number", "Scan Barcode"]},
-  "condition": {"description": "If/else logic", "examples": ["If Temp > 40°F", "If Overdue"]},
-  "action": {"description": "Performs operation", "examples": ["Send Email", "Update Inventory"]},
-  "approval": {"description": "Human review", "examples": ["Manager Approval", "QA Inspection"]},
-  "loop": {"description": "Repeats steps", "examples": ["For Each Pallet", "While Available"]},
-  "parallel": {"description": "Simultaneous paths", "examples": ["Check Stock AND Notify"]},
-  "end": {"description": "Terminates workflow", "examples": ["Complete", "Cancelled"]}
+  "triggerManual": {"description": "User starts workflow manually"},
+  "triggerSchedule": {"description": "Runs on a schedule"},
+  "triggerWebhook": {"description": "Triggered by inbound webhook"},
+  "triggerEvent": {"description": "Triggered by record create/update/delete"},
+  "triggerForm": {"description": "Triggered when a form is submitted"},
+
+  "form": {"description": "Collect data via a single form step"},
+  "formProcess": {"description": "Multi-step form container"},
+
+  "conditionIf": {"description": "If/Else branching"},
+
+  "actionCreateRecord": {"description": "Create a new record"},
+  "actionUpdateRecord": {"description": "Update an existing record"},
+  "actionEmail": {"description": "Send an email notification"},
+  "actionHTTP": {"description": "Call an external HTTP API"},
+
+  "pendingApproval": {"description": "Wait for a human approval"},
+  "timerDelay": {"description": "Wait for a fixed delay"},
+  "dataTransform": {"description": "Transform/shape data for downstream steps"},
+
+  "endSuccess": {"description": "Successful terminal"},
+  "endError": {"description": "Error terminal"},
+  "endCancel": {"description": "Cancelled terminal"}
 }
 ```
+
+If you would have suggested a generic type like "input", "action", "approval", or "condition", map it to the closest valid node above (e.g., input→form, condition→conditionIf, approval→pendingApproval).
 
 ---
 


### PR DESCRIPTION
## Summary
- DynamicConfigPanel now renders formReference and keyValue schema fields, and supports legacy aliases (fieldMapping/variablePicker).
- Removed the user-facing 'Unknown field type:' text from config panels.
- AI Suggestions: prompt + backend fallback suggestions now use canonical node type IDs; frontend canonicalization expanded; editor blocks unknown suggested node types from being added.

## Verification
- npm --prefix frontend run type-check
- pytest -q backend/tenant_apps/workflows/services/tests/test_prompter.py