### PR TITLE
WorkForms: runtime execute + catalog delete

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -11,6 +11,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 ## Operational Notes
 
+- **2026-03-31** — WorkForms runtime: Quick Actions workflow items now execute via `/workforms/execute/:id` (not editor). Backend adds `POST /api/v1/tenant-workforms/:id/execute/` to create `TenantWorkFormExecution` and run async via Celery; adds `/api/v1/workflows/workform-executions/` and surfaces active executions in WorkForms Monitoring; Catalog supports deleting draft/archived WorkForms with confirmation. (PR: #4320)
+
 - **2026-03-31** — Workforms editor: DynamicConfigPanel now supports `formReference` and `keyValue` schema field types (removes the "Unknown field type" placeholder for real node configs). (PR: #4319)
 - **2026-03-31** — Workforms AI Suggestions: aligned prompt + backend fallback suggestions to canonical node type IDs; added frontend canonicalization + guard to prevent adding unknown suggested nodes. (PR: #4319)
 

--- a/backend/apps/system/tasks.py
+++ b/backend/apps/system/tasks.py
@@ -197,6 +197,65 @@ def pin_workflow_versions(workflow_id):
     }
 
 
+@shared_task(name='system.execute_workform_execution')
+def execute_workform_execution(execution_id: str, tenant_id: str) -> dict:
+    """Execute a TenantWorkFormExecution asynchronously.
+
+    This is used by the UI runtime route (/tenant-workforms/{id}/execute/) so
+    Quick Actions can *run* workflows without blocking the request thread.
+    """
+
+    from apps.tenants.rls import set_current_tenant
+
+    rls = set_current_tenant(str(tenant_id))
+    if not rls.ok:
+        logger.warning('[WorkFormExecution] Skipping execution=%s (RLS set failed: %s)', execution_id, rls.error)
+        return {'success': False, 'error': rls.error}
+
+    from tenant_apps.workflows.models import TenantWorkFormExecution, TenantWorkFormExecutionStatus
+    from apps.system.services.workform_engine import WorkFormEngine
+
+    execution = (
+        TenantWorkFormExecution.objects.select_related('workform', 'tenant')
+        .filter(id=execution_id, tenant_id=tenant_id)
+        .first()
+    )
+    if not execution:
+        return {'success': False, 'error': 'Execution not found'}
+
+    workform = execution.workform
+    initial_data = execution.initial_data or {}
+
+    try:
+        engine = WorkFormEngine(
+            workform,
+            initial_context={
+                'trigger': initial_data,
+                'variables': {},
+                'errors': [],
+                'execution_id': str(execution.id),
+            },
+        )
+        result = engine.execute(trigger_payload=initial_data)
+
+        execution.context_data = result.context
+        if result.success:
+            execution.status = TenantWorkFormExecutionStatus.COMPLETED
+        else:
+            execution.status = TenantWorkFormExecutionStatus.FAILED
+            execution.error_message = str(result.error or '')
+        execution.completed_at = timezone.now()
+        execution.save(update_fields=['status', 'context_data', 'error_message', 'completed_at'])
+
+        return {'success': result.success, 'execution_id': str(execution.id), 'error': result.error}
+    except Exception as exc:  # noqa: BLE001
+        execution.status = TenantWorkFormExecutionStatus.FAILED
+        execution.error_message = str(exc)
+        execution.completed_at = timezone.now()
+        execution.save(update_fields=['status', 'error_message', 'completed_at'])
+        return {'success': False, 'execution_id': str(execution.id), 'error': str(exc)}
+
+
 @shared_task(name='system.execute_workform_loop_item')
 def execute_workform_loop_item(
     workform_id: str,

--- a/backend/apps/system/workform_views.py
+++ b/backend/apps/system/workform_views.py
@@ -8,6 +8,7 @@ Phase 1.4-1.7 of WF-ENH-2026-Q1
 Created: 2026-02-06
 """
 from django.db import transaction, models
+from django.utils import timezone
 from rest_framework import viewsets, status
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -223,7 +224,76 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
             version=instance.version + 1,
             updated_by=self.request.user
         )
-    
+
+    def _can_manage_workform(self, workform: TenantWorkForm) -> bool:
+        """Only allow delete/execute for superusers, tenant admins, or the creator."""
+        request = self.request
+        user = getattr(request, 'user', None)
+        if not user or not getattr(user, 'is_authenticated', False):
+            return False
+
+        if getattr(user, 'is_superuser', False):
+            return True
+
+        if workform.created_by_id == user.id:
+            return True
+
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return False
+
+        try:
+            from apps.tenants.models import TenantUser
+
+            tenant_user = TenantUser.objects.get(user=user, tenant=tenant, is_active=True)
+            return tenant_user.role in ['owner', 'admin']
+        except Exception:
+            return False
+
+    def destroy(self, request, *args, **kwargs):
+        workform = self.get_object()
+        if not self._can_manage_workform(workform):
+            return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
+        return super().destroy(request, *args, **kwargs)
+
+    @action(detail=True, methods=['post'])
+    def execute(self, request, pk=None):
+        """Execute a TenantWorkForm and create a persisted execution record."""
+        workform = self.get_object()
+        if not self._can_manage_workform(workform):
+            return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
+
+        initial_data = request.data.get('initial_data') if isinstance(request.data, dict) else None
+        initial_data = initial_data if isinstance(initial_data, dict) else {}
+
+        from tenant_apps.workflows.models import TenantWorkFormExecution, TenantWorkFormExecutionStatus
+
+        execution = TenantWorkFormExecution.objects.create(
+            tenant=request.tenant,
+            workform=workform,
+            status=TenantWorkFormExecutionStatus.IN_PROGRESS,
+            initial_data=initial_data,
+            started_by=request.user,
+            started_at=timezone.now(),
+        )
+
+        from apps.system.tasks import execute_workform_execution
+
+        execute_workform_execution.delay(execution_id=str(execution.id), tenant_id=str(request.tenant.id))
+
+        return Response(
+            {
+                'id': str(execution.id),
+                'workform_id': str(workform.id),
+                'workform_name': workform.name,
+                'status': execution.status,
+                'started_at': execution.started_at,
+                'completed_at': None,
+                'error_message': '',
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
+
     @action(detail=True, methods=['post'])
     def clone(self, request, pk=None):
         """

--- a/backend/tenant_apps/workflows/serializers.py
+++ b/backend/tenant_apps/workflows/serializers.py
@@ -396,6 +396,46 @@ class WorkflowExecutionLogSerializer(serializers.ModelSerializer):
 
 
 # =============================================================================
+# WORKFORM EXECUTION SERIALIZERS (TenantWorkForm)
+# =============================================================================
+
+from .models import TenantWorkFormExecution
+
+
+class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
+    """Serializer for TenantWorkFormExecution model."""
+
+    workform_name = serializers.CharField(source='workform.name', read_only=True)
+    started_by_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = TenantWorkFormExecution
+        fields = [
+            'id',
+            'tenant',
+            'workform',
+            'workform_name',
+            'status',
+            'initial_data',
+            'context_data',
+            'audit_trail',
+            'started_by',
+            'started_by_name',
+            'started_at',
+            'completed_at',
+            'error_message',
+            'created_on',
+            'modified_on',
+        ]
+        read_only_fields = fields
+
+    def get_started_by_name(self, obj):
+        if obj.started_by:
+            return obj.started_by.get_full_name() or obj.started_by.username
+        return None
+
+
+# =============================================================================
 # FORM SUBMISSION SERIALIZERS
 # =============================================================================
 

--- a/backend/tenant_apps/workflows/urls.py
+++ b/backend/tenant_apps/workflows/urls.py
@@ -21,6 +21,7 @@ from .views import (
     FieldTemplatesAPIView,
     # Form Submission API Views
     FormSubmissionViewSet, AvailableFormsViewSet, QuickActionsAPIView,
+    TenantWorkFormExecutionViewSet,
     # Entity Options API Views
     EntityOptionsAPIView, QuickCreateEntityAPIView,
     # Form Import/Export API Views
@@ -70,6 +71,7 @@ router.register(r'execution-logs', WorkflowExecutionLogViewSet, basename='workfl
 
 # Form Submissions
 router.register(r'form-submissions', FormSubmissionViewSet, basename='form-submission')
+router.register(r'workform-executions', TenantWorkFormExecutionViewSet, basename='workform-execution')
 router.register(r'available-forms', AvailableFormsViewSet, basename='available-form')
 
 # Wave 3: Step Assignments and Notifications

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 from django.db import IntegrityError, transaction
 from django.db.models import Count, F, Max, Prefetch
 from django.utils import timezone
+from django.utils.dateparse import parse_date
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -1942,7 +1943,49 @@ from .serializers import (
     QuickActionsGetResponseSerializer,
     QuickActionsPutResponseSerializer,
     QuickActionsSerializer,
+    TenantWorkFormExecutionSerializer,
 )
+
+
+class TenantWorkFormExecutionViewSet(viewsets.ReadOnlyModelViewSet):
+    """Read-only list of TenantWorkForm executions.
+
+    Backing model: tenant_apps.workflows.models.TenantWorkFormExecution
+    WorkForm definitions live in apps.system.models.TenantWorkForm.
+    """
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = TenantWorkFormExecutionSerializer
+
+    def get_queryset(self):
+        from .models import TenantWorkFormExecution
+
+        qs = TenantWorkFormExecution.objects.select_related('workform', 'started_by', 'tenant')
+
+        if not self.request.user.is_superuser:
+            qs = qs.filter(tenant=self.request.tenant)
+
+        status_param = self.request.query_params.get('status')
+        if status_param:
+            statuses = [s.strip() for s in status_param.split(',') if s.strip()]
+            if statuses:
+                qs = qs.filter(status__in=statuses)
+
+        search = (self.request.query_params.get('search') or '').strip()
+        if search:
+            qs = qs.filter(workform__name__icontains=search)
+
+        start_date = self.request.query_params.get('start_date')
+        end_date = self.request.query_params.get('end_date')
+
+        sd = parse_date(start_date) if start_date else None
+        ed = parse_date(end_date) if end_date else None
+        if sd:
+            qs = qs.filter(created_on__date__gte=sd)
+        if ed:
+            qs = qs.filter(created_on__date__lte=ed)
+
+        return qs.order_by('-created_on')
 
 
 class FormSubmissionViewSet(viewsets.ModelViewSet):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,6 +96,8 @@ import WorkFormsLayout from './pages/WorkForms';
 import WorkFormsCatalog from './pages/WorkForms/Catalog';
 import WorkFormsInProgress from './pages/WorkForms/InProgress';
 import WorkFormsHistory from './pages/WorkForms/History';
+import ExecuteWorkForm from './pages/WorkForms/Execute';
+import WorkFormExecutionDetails from './pages/WorkForms/ExecutionDetails';
 const WorkFormsEditor = lazy(() => import('./pages/WorkForms/Editor'));
 import WorkFormsMonitoring from './pages/WorkForms/Monitoring';
 
@@ -323,6 +325,8 @@ const App: React.FC = () => {
                   <Route path="monitoring" element={<WorkFormsMonitoring />} />
                   <Route path="catalog" element={<WorkFormsCatalog />} />
                   <Route path="history" element={<WorkFormsHistory />} />
+                  <Route path="execute/:id" element={<ExecuteWorkForm />} />
+                  <Route path="executions/:id" element={<WorkFormExecutionDetails />} />
                   <Route
                     path="editor"
                     element={

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -119,7 +119,7 @@ const Header: React.FC<HeaderProps> = () => {
     }
 
     if (action.type === 'workflow' && action.workflow_id) {
-      navigate(`/workforms/editor/${action.workflow_id}`);
+      navigate(`/workforms/execute/${action.workflow_id}`);
       setShowQuickMenu(false);
     }
   };

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -21,7 +21,7 @@ import { logger } from '@/utils/logger';
 import { showAlert } from '@/utils/uiDialogs';
 
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
 import {
   Plus,
@@ -39,6 +39,7 @@ import {
   Database,
   Play,
   Loader,
+  Trash2,
 } from 'lucide-react';
 import { PageContainer } from '../../components/ui/PageContainer';
 import { Card, CardHeader, CardContent, CardFooter } from '../../components/ui/Card';
@@ -46,6 +47,9 @@ import { Button } from '../../components/ui/Button';
 import { TemplateSelector } from '../../components/FlowEditor/templates/TemplateSelector';
 import { FLOW_TEMPLATES, FlowTemplate } from '../../components/FlowEditor/templates/flowTemplates';
 import { createFormSubmission, getAvailableWorkForms } from '../../services/workformsApi';
+import { deleteWorkflow } from '../../components/FlowEditor/utils/workflowPersistence';
+import { useQuickActions } from '../../contexts/QuickActionsContext';
+import { Popconfirm } from 'antd';
 import { listTenantForms as listLegacyTenantForms } from '../../services/tenantFormService';
 import { useWorkFormPermissions, getUpgradeMessage } from '../../hooks/useWorkFormPermissions';
 
@@ -94,6 +98,35 @@ type Department = 'all' | 'receiving' | 'processing' | 'packaging' | 'quality_co
 
 const Container = styled(PageContainer)`
   /* Additional catalog-specific styling */
+`;
+
+const ActionRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+`;
+
+const IconActionButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-text-primary));
+  font-size: 13px;
+  cursor: pointer;
+
+  &:hover {
+    border-color: rgb(var(--color-primary));
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 `;
 
 const Header = styled.div`
@@ -523,6 +556,23 @@ const FormsFlowsCatalog: React.FC = () => {
 
   // Phase 4.2: Get user permissions
   const { permissions, isLoading: permissionsLoading } = useWorkFormPermissions();
+  const queryClient = useQueryClient();
+  const { refreshQuickActions } = useQuickActions();
+
+  const deleteWorkFormMutation = useMutation({
+    mutationFn: async (workformId: string) => {
+      await deleteWorkflow(workformId);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['workforms-catalog-items'] });
+      await refreshQuickActions();
+      showAlert({ type: 'success', title: 'Deleted', content: 'WorkForm deleted successfully.' });
+    },
+    onError: (error: any) => {
+      const msg = error?.message || 'Failed to delete WorkForm.';
+      showAlert({ type: 'error', title: 'Error', content: msg });
+    },
+  });
 
   // Fetch existing items:
   // - WorkForms: TenantWorkForm (new editor)
@@ -1027,6 +1077,30 @@ const FormsFlowsCatalog: React.FC = () => {
                     </QuickRunButton>
                   </div>
                 )}
+
+                {/* Delete (WorkForms only) */}
+                {typeof form.node_count === 'number' && permissions.can_delete && form.status !== 'active' && (
+                  <ActionRow>
+                    <Popconfirm
+                      title="Delete this WorkForm?"
+                      description="This will permanently delete the WorkForm and any extracted forms."
+                      okText="Delete"
+                      cancelText="Cancel"
+                      okButtonProps={{ danger: true }}
+                      onConfirm={() => deleteWorkFormMutation.mutate(form.id)}
+                    >
+                      <IconActionButton
+                        type="button"
+                        onClick={(e) => e.stopPropagation()}
+                        disabled={deleteWorkFormMutation.isPending}
+                        aria-label={`Delete ${form.name}`}
+                      >
+                        <Trash2 size={14} aria-hidden="true" />
+                        Delete
+                      </IconActionButton>
+                    </Popconfirm>
+                  </ActionRow>
+                )}
               </CardContent>
             </FormCard>
           ))}
@@ -1091,6 +1165,30 @@ const FormsFlowsCatalog: React.FC = () => {
                       )}
                     </QuickRunButton>
                   </div>
+                )}
+
+                {/* Delete (WorkForms only) */}
+                {typeof form.node_count === 'number' && permissions.can_delete && form.status !== 'active' && (
+                  <ActionRow style={{ marginLeft: '4rem' }}>
+                    <Popconfirm
+                      title="Delete this WorkForm?"
+                      description="This will permanently delete the WorkForm and any extracted forms."
+                      okText="Delete"
+                      cancelText="Cancel"
+                      okButtonProps={{ danger: true }}
+                      onConfirm={() => deleteWorkFormMutation.mutate(form.id)}
+                    >
+                      <IconActionButton
+                        type="button"
+                        onClick={(e) => e.stopPropagation()}
+                        disabled={deleteWorkFormMutation.isPending}
+                        aria-label={`Delete ${form.name}`}
+                      >
+                        <Trash2 size={14} aria-hidden="true" />
+                        Delete
+                      </IconActionButton>
+                    </Popconfirm>
+                  </ActionRow>
                 )}
               </CardContent>
             </FormCard>

--- a/frontend/src/pages/WorkForms/Execute.tsx
+++ b/frontend/src/pages/WorkForms/Execute.tsx
@@ -1,0 +1,75 @@
+/**
+ * WorkForm Execute Page
+ *
+ * Starts a TenantWorkForm execution (runtime), then routes the user to
+ * the execution details page.
+ */
+
+import React, { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Skeleton } from 'antd';
+import { apiClient } from '@/services/apiService';
+import { showAlert } from '@/utils/uiDialogs';
+
+interface ExecuteResponse {
+  id: string;
+  workform_id: string;
+  workform_name: string;
+  status: string;
+  started_at?: string;
+  completed_at?: string;
+  error_message?: string;
+}
+
+export const ExecuteWorkForm: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!id) throw new Error('Missing workform id');
+      const response = await apiClient.post<ExecuteResponse>(`/tenant-workforms/${id}/execute/`, {
+        initial_data: {},
+      });
+      return response.data;
+    },
+    onSuccess: async (data) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['workforms-catalog-items'] }),
+        queryClient.invalidateQueries({ queryKey: ['workform-executions', 'active'] }),
+      ]);
+
+      if (data.status === 'failed') {
+        showAlert({
+          type: 'error',
+          title: 'Execution failed',
+          content: data.error_message || 'This workflow failed to execute.',
+        });
+      }
+
+      navigate(`/workforms/executions/${data.id}`, { replace: true });
+    },
+    onError: (err: any) => {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to start workflow.';
+      showAlert({ type: 'error', title: 'Error', content: msg });
+      navigate('/workforms/catalog', { replace: true });
+    },
+  });
+
+  useEffect(() => {
+    if (!mutation.isPending && !mutation.isSuccess) {
+      mutation.mutate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  return (
+    <div>
+      <Skeleton active paragraph={{ rows: 6 }} />
+    </div>
+  );
+};
+
+export default ExecuteWorkForm;

--- a/frontend/src/pages/WorkForms/ExecutionDetails.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.tsx
@@ -1,0 +1,102 @@
+/**
+ * WorkForm Execution Details
+ */
+
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { PageContainer } from '@/components/ui/PageContainer';
+import { workformExecutionService } from '@/services/workformExecutionService';
+
+export const WorkFormExecutionDetails: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const query = useQuery({
+    queryKey: ['workform-execution', id],
+    queryFn: async () => {
+      if (!id) throw new Error('Missing execution id');
+      return workformExecutionService.getExecution(id);
+    },
+    enabled: !!id,
+  });
+
+  const execution = query.data;
+
+  return (
+    <PageContainer title="Workflow Execution">
+      <Card padding="lg">
+        {query.isLoading ? (
+          <div>Loading execution…</div>
+        ) : query.isError || !execution ? (
+          <div>Execution not found.</div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+              <div>
+                <div style={{ fontWeight: 700, fontSize: 16 }}>{execution.workform_name}</div>
+                <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
+                  Status: <span style={{ fontWeight: 600 }}>{execution.status}</span>
+                </div>
+              </div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <Button variant="secondary" onClick={() => navigate('/workforms/history')}>
+                  View History
+                </Button>
+                <Button variant="secondary" onClick={() => navigate('/workforms/catalog')}>
+                  Back to Catalog
+                </Button>
+              </div>
+            </div>
+
+            {execution.error_message ? (
+              <div style={{ color: 'rgb(var(--color-error))' }}>{execution.error_message}</div>
+            ) : null}
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 12 }}>
+              <div>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Context</div>
+                <pre
+                  style={{
+                    background: 'rgb(var(--color-surface))',
+                    border: '1px solid rgb(var(--color-border))',
+                    borderRadius: 8,
+                    padding: 12,
+                    overflow: 'auto',
+                    maxHeight: 360,
+                  }}
+                >
+                  {JSON.stringify(execution.context_data ?? {}, null, 2)}
+                </pre>
+              </div>
+
+              <div>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Audit Trail</div>
+                {Array.isArray(execution.audit_trail) && execution.audit_trail.length > 0 ? (
+                  <pre
+                    style={{
+                      background: 'rgb(var(--color-surface))',
+                      border: '1px solid rgb(var(--color-border))',
+                      borderRadius: 8,
+                      padding: 12,
+                      overflow: 'auto',
+                      maxHeight: 360,
+                    }}
+                  >
+                    {JSON.stringify(execution.audit_trail, null, 2)}
+                  </pre>
+                ) : (
+                  <div style={{ color: 'rgb(var(--color-text-secondary))' }}>No audit entries yet.</div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </Card>
+    </PageContainer>
+  );
+};
+
+export default WorkFormExecutionDetails;

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -25,8 +25,7 @@ import {
   Clock, AlertCircle
 } from 'lucide-react';
 import { businessApi } from '../../services/businessApi';
-import { workflowExecutionService } from '../../services/workflowExecutionService';
-import { WorkflowExecution, WorkflowAuditEntry } from '../../types/workflows';
+import { workformExecutionService, WorkFormExecution } from '@/services/workformExecutionService';
 
 // ============================================================================
 // Types
@@ -490,10 +489,9 @@ const FormsFlowsHistory: React.FC = () => {
   const pageSize = 20;
   
   // Workflow executions state
-  const [workflowExecutions, setWorkflowExecutions] = useState<WorkflowExecution[]>([]);
+  const [workflowExecutions, setWorkflowExecutions] = useState<WorkFormExecution[]>([]);
   const [workflowsLoading, setWorkflowsLoading] = useState(false);
   const [expandedWorkflow, setExpandedWorkflow] = useState<string | null>(null);
-  const [auditTrails, setAuditTrails] = useState<Record<string, WorkflowAuditEntry[]>>({});
   
   // Fetch completed/cancelled submissions
   const fetchSubmissions = async () => {
@@ -550,8 +548,8 @@ const FormsFlowsHistory: React.FC = () => {
       if (startDate) params.start_date = startDate;
       if (endDate) params.end_date = endDate;
       if (searchQuery) params.search = searchQuery;
-      
-      const response = await workflowExecutionService.getExecutions(params as any);
+
+      const response = await workformExecutionService.getExecutions(params as any);
       setWorkflowExecutions(response.results);
       setTotalCount(response.count);
     } catch (error) {
@@ -561,32 +559,10 @@ const FormsFlowsHistory: React.FC = () => {
       setWorkflowsLoading(false);
     }
   };
-  
-  // Fetch workflow audit trail
-  const fetchAuditTrail = async (workflowId: string) => {
-    if (auditTrails[workflowId]) {
-      return; // Already loaded
-    }
-    
-    try {
-      const response = await workflowExecutionService.getAuditTrail(workflowId);
-      setAuditTrails(prev => ({
-        ...prev,
-        [workflowId]: response.audit_trail,
-      }));
-    } catch (error) {
-      console.error('Failed to fetch audit trail:', error);
-    }
-  };
-  
+
   // Toggle workflow expansion
   const toggleWorkflowExpansion = (workflowId: string) => {
-    if (expandedWorkflow === workflowId) {
-      setExpandedWorkflow(null);
-    } else {
-      setExpandedWorkflow(workflowId);
-      fetchAuditTrail(workflowId);
-    }
+    setExpandedWorkflow((cur) => (cur === workflowId ? null : workflowId));
   };
   
   // Fetch data when tab changes
@@ -807,8 +783,7 @@ const FormsFlowsHistory: React.FC = () => {
               <tbody>
                 {workflowExecutions.map((execution) => {
                   const isExpanded = expandedWorkflow === execution.id;
-                  const trail = auditTrails[execution.id] || [];
-                  
+
                   return (
                     <React.Fragment key={execution.id}>
                       <ExpandableRow $expanded={isExpanded}>
@@ -821,7 +796,7 @@ const FormsFlowsHistory: React.FC = () => {
                           </ViewButton>
                         </TableCell>
                         <TableCell>
-                          <FormName>{execution.workflow_name}</FormName>
+                          <FormName>{execution.workform_name}</FormName>
                         </TableCell>
                         <TableCell>
                           <StatusBadge $status={execution.status}>
@@ -831,54 +806,31 @@ const FormsFlowsHistory: React.FC = () => {
                           </StatusBadge>
                         </TableCell>
                         <TableCell>{execution.started_by_name || '-'}</TableCell>
-                        <TableCell>{formatDate(execution.created_at)}</TableCell>
+                        <TableCell>{formatDate(execution.started_at || execution.created_on)}</TableCell>
                         <TableCell>{formatDate(execution.completed_at || '')}</TableCell>
-                        <TableCell>{formatDuration(execution.created_at, execution.completed_at)}</TableCell>
+                        <TableCell>{formatDuration(execution.started_at || execution.created_on, execution.completed_at || undefined)}</TableCell>
                       </ExpandableRow>
                       
                       {isExpanded && (
                         <tr>
                           <ExpandedContent colSpan={7}>
-                            <h4 style={{ marginTop: 0, marginBottom: 16 }}>Execution Timeline</h4>
-                            {trail.length === 0 ? (
-                              <p style={{ color: 'rgb(var(--color-text-tertiary))' }}>
-                                Loading timeline...
-                              </p>
-                            ) : (
-                              <Timeline>
-                                {trail.map((entry) => (
-                                  <TimelineItem key={entry.id}>
-                                    <TimelineDot $status={entry.action} />
-                                    <TimelineContent>
-                                      <TimelineHeader>
-                                        <TimelineTitle>{entry.step_name}</TimelineTitle>
-                                        <TimelineTime>
-                                          {formatDate(entry.timestamp)}
-                                          {entry.duration_seconds && (
-                                            <DurationBadge>
-                                              <Clock size={10} />
-                                              {formatSeconds(entry.duration_seconds)}
-                                            </DurationBadge>
-                                          )}
-                                        </TimelineTime>
-                                      </TimelineHeader>
-                                      <TimelineMeta>
-                                        {entry.action === 'completed' && '✓ Completed'}
-                                        {entry.action === 'started' && '• Started'}
-                                        {entry.action === 'failed' && '✗ Failed'}
-                                        {entry.action === 'skipped' && '○ Skipped'}
-                                        {entry.user_name && ` by ${entry.user_name}`}
-                                      </TimelineMeta>
-                                      {entry.notes && (
-                                        <div style={{ marginTop: 8, fontSize: 13, color: 'rgb(var(--color-text-secondary))' }}>
-                                          {entry.notes}
-                                        </div>
-                                      )}
-                                    </TimelineContent>
-                                  </TimelineItem>
-                                ))}
-                              </Timeline>
-                            )}
+                            <h4 style={{ marginTop: 0, marginBottom: 16 }}>Execution Details</h4>
+                            <pre
+                              style={{
+                                margin: 0,
+                                padding: 12,
+                                background: 'rgb(var(--color-surface))',
+                                border: '1px solid rgb(var(--color-border))',
+                                borderRadius: 8,
+                                overflow: 'auto',
+                                maxHeight: 360,
+                              }}
+                            >
+                              {JSON.stringify({
+                                audit_trail: execution.audit_trail || [],
+                                context_data: execution.context_data || {},
+                              }, null, 2)}
+                            </pre>
                           </ExpandedContent>
                         </tr>
                       )}

--- a/frontend/src/pages/WorkForms/Monitoring.tsx
+++ b/frontend/src/pages/WorkForms/Monitoring.tsx
@@ -11,13 +11,61 @@
 
 import React from 'react';
 
+import { useQuery } from '@tanstack/react-query';
+
 import { ErrorBoundary } from '@/components/common/ErrorBoundary';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { PageContainer } from '@/components/ui/PageContainer';
+import { workformExecutionService } from '@/services/workformExecutionService';
 import ProcessMonitor from '../Cockpit/ProcessMonitor';
 
 export const Monitoring: React.FC = () => {
+  const activeExecutionsQuery = useQuery({
+    queryKey: ['workform-executions', 'active'],
+    queryFn: async () => workformExecutionService.getExecutions({ status: 'pending,in_progress', page_size: 25 }),
+    refetchInterval: 5000,
+  });
+
+  const active = activeExecutionsQuery.data?.results ?? [];
+
   return (
     <ErrorBoundary>
-      <ProcessMonitor />
+      <PageContainer title="Monitoring">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <Card padding="lg">
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+              <div style={{ fontWeight: 700 }}>Active WorkForm Executions</div>
+              <Button
+                variant="secondary"
+                onClick={() => activeExecutionsQuery.refetch()}
+                disabled={activeExecutionsQuery.isFetching}
+              >
+                Refresh
+              </Button>
+            </div>
+
+            {activeExecutionsQuery.isLoading ? (
+              <div style={{ marginTop: 12 }}>Loading…</div>
+            ) : active.length === 0 ? (
+              <div style={{ marginTop: 12, color: 'rgb(var(--color-text-secondary))' }}>No active executions.</div>
+            ) : (
+              <ul style={{ marginTop: 12, paddingLeft: 18 }}>
+                {active.map((ex) => (
+                  <li key={ex.id}>
+                    <a href={`/workforms/executions/${ex.id}`}>
+                      {ex.workform_name} — {ex.status}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+
+          {/* Legacy monitor (FormSubmission-based) */}
+          <ProcessMonitor />
+        </div>
+      </PageContainer>
     </ErrorBoundary>
   );
 };

--- a/frontend/src/services/workformExecutionService.ts
+++ b/frontend/src/services/workformExecutionService.ts
@@ -1,0 +1,70 @@
+/**
+ * WorkForm Execution API Service
+ *
+ * Tracks executions of apps.system.models.TenantWorkForm via
+ * tenant_apps.workflows.models.TenantWorkFormExecution.
+ */
+
+import { businessApi } from './businessApi';
+
+export type WorkFormExecutionStatus = 'pending' | 'in_progress' | 'completed' | 'failed' | 'cancelled';
+
+export interface WorkFormExecution {
+  id: string;
+  tenant: string;
+  workform: string;
+  workform_name: string;
+  status: WorkFormExecutionStatus;
+  initial_data: Record<string, unknown>;
+  context_data: Record<string, unknown>;
+  audit_trail: any[];
+  started_by?: string | null;
+  started_by_name?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  error_message?: string;
+  created_on: string;
+  modified_on: string;
+}
+
+export interface WorkFormExecutionListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: WorkFormExecution[];
+}
+
+export class WorkFormExecutionService {
+  private baseUrl = '/workflows/workform-executions/';
+
+  async getExecutions(params?: {
+    status?: string;
+    search?: string;
+    start_date?: string;
+    end_date?: string;
+    page?: number;
+    page_size?: number;
+  }): Promise<WorkFormExecutionListResponse> {
+    const response = await businessApi.get(this.baseUrl, { params });
+
+    const results = Array.isArray(response.data?.results)
+      ? response.data.results
+      : Array.isArray(response.data)
+        ? response.data
+        : [];
+
+    return {
+      count: response.data?.count ?? results.length,
+      next: response.data?.next ?? null,
+      previous: response.data?.previous ?? null,
+      results,
+    };
+  }
+
+  async getExecution(id: string): Promise<WorkFormExecution> {
+    const response = await businessApi.get(`${this.baseUrl}${id}/`);
+    return response.data;
+  }
+}
+
+export const workformExecutionService = new WorkFormExecutionService();

--- a/frontend/src/services/workformsApi.ts
+++ b/frontend/src/services/workformsApi.ts
@@ -355,15 +355,15 @@ export const listTenantWorkForms = async (params?: {
   status?: 'draft' | 'active' | 'archived';
   search?: string;
 }): Promise<TenantWorkForm[]> => {
-  const response = await apiClient.get('/workflows/workflows/', { params });
-  return response.data;
+  const response = await apiClient.get('/tenant-workforms/', { params });
+  return response.data.results || response.data || [];
 };
 
 /**
  * Get a specific tenant workflow by ID
  */
 export const getTenantWorkForm = async (workformId: string): Promise<TenantWorkForm> => {
-  const response = await apiClient.get(`/workflows/workflows/${workformId}/`);
+  const response = await apiClient.get(`/tenant-workforms/${workformId}/`);
   return response.data;
 };
 
@@ -376,7 +376,7 @@ export const createTenantWorkForm = async (data: {
   status?: 'draft' | 'active' | 'archived';
   workflow_definition: any;
 }): Promise<TenantWorkForm> => {
-  const response = await apiClient.post('/workflows/workflows/', data);
+  const response = await apiClient.post('/tenant-workforms/', data);
   return response.data;
 };
 
@@ -387,7 +387,7 @@ export const updateTenantWorkForm = async (
   workformId: string,
   data: Partial<TenantWorkForm>
 ): Promise<TenantWorkForm> => {
-  const response = await apiClient.put(`/workflows/workflows/${workformId}/`, data);
+  const response = await apiClient.put(`/tenant-workforms/${workformId}/`, data);
   return response.data;
 };
 
@@ -395,7 +395,7 @@ export const updateTenantWorkForm = async (
  * Delete a tenant workflow
  */
 export const deleteTenantWorkForm = async (workformId: string): Promise<void> => {
-  await apiClient.delete(`/workflows/workflows/${workformId}/`);
+  await apiClient.delete(`/tenant-workforms/${workformId}/`);
 };
 
 // ============================================================================
@@ -413,7 +413,7 @@ export const cloneWorkForm = async (
     include_form_references?: boolean;
   }
 ): Promise<TenantWorkForm> => {
-  const response = await apiClient.post(`/workflows/workflows/${workformId}/clone/`, data);
+  const response = await apiClient.post(`/tenant-workforms/${workformId}/clone/`, data);
   return response.data;
 };
 
@@ -434,7 +434,7 @@ export const getWorkFormUsage = async (
   created_at: string;
   updated_at: string;
 }> => {
-  const response = await apiClient.get(`/workflows/workflows/${workformId}/usage/`);
+  const response = await apiClient.get(`/tenant-workforms/${workformId}/usage/`);
   return response.data;
 };
 
@@ -448,7 +448,7 @@ export const validateWorkForm = async (
   missing_forms: string[];
   total_references: number;
 }> => {
-  const response = await apiClient.post(`/workflows/workflows/${workformId}/validate/`);
+  const response = await apiClient.post(`/tenant-workforms/${workformId}/validate/`);
   return response.data;
 };
 
@@ -491,7 +491,7 @@ export interface ContainerDetail {
 export const listWorkFormContainers = async (
   workformId: string
 ): Promise<{ containers: ContainerSummary[] }> => {
-  const response = await apiClient.get(`/workflows/workflows/${workformId}/containers/`);
+  const response = await apiClient.get(`/tenant-workforms/${workformId}/containers/`);
   return response.data;
 };
 
@@ -502,7 +502,7 @@ export const getContainerDetail = async (
   workformId: string,
   containerId: string
 ): Promise<ContainerDetail> => {
-  const response = await apiClient.get(`/workflows/workflows/${workformId}/containers/${containerId}/`);
+  const response = await apiClient.get(`/tenant-workforms/${workformId}/containers/${containerId}/`);
   return response.data;
 };
 
@@ -514,7 +514,7 @@ export const addNodeToContainer = async (
   nodeId: string,
   containerId: string
 ): Promise<{ message: string; node_id: string; container_id: string }> => {
-  const response = await apiClient.post(`/workflows/workflows/${workformId}/containers/add-node/`, {
+  const response = await apiClient.post(`/tenant-workforms/${workformId}/containers/add-node/`, {
     node_id: nodeId,
     container_id: containerId
   });
@@ -528,7 +528,7 @@ export const removeNodeFromContainer = async (
   workformId: string,
   nodeId: string
 ): Promise<{ message: string; node_id: string }> => {
-  const response = await apiClient.post(`/workflows/workflows/${workformId}/containers/remove-node/`, {
+  const response = await apiClient.post(`/tenant-workforms/${workformId}/containers/remove-node/`, {
     node_id: nodeId
   });
   return response.data;


### PR DESCRIPTION
Implements the runtime sprint for WorkForms workflow quick actions:

- Quick Actions: workflow items route to /workforms/execute/:id (not editor)
- Backend: POST /api/v1/tenant-workforms/:id/execute/ creates TenantWorkFormExecution and runs async via Celery
- Backend: add /api/v1/workflows/workform-executions/ read-only list/retrieve
- Frontend: execution details page + Monitoring surfaces active executions
- Catalog: delete WorkForms (draft/archived) with confirmation; refresh quick actions

Tests:
- npm --prefix frontend run type-check
- python backend/manage.py test tenant_apps.workflows apps.system