### PR TITLE
UniversalEntityForm: enforce Plant create

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -13,6 +13,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-03-31** — WorkForms runtime: Quick Actions workflow items now execute via `/workforms/execute/:id` (not editor). Backend adds `POST /api/v1/tenant-workforms/:id/execute/` to create `TenantWorkFormExecution` and run async via Celery; adds `/api/v1/workflows/workform-executions/` and surfaces active executions in WorkForms Monitoring; Catalog supports deleting draft/archived WorkForms with confirmation. (PR: #4320)
 
+- **2026-03-31** — UniversalEntityForm: purged legacy Plant create/edit forms. Suppliers “+ New Plant” and Plants table “Add/Edit” now route through `EntityFormSurface` → `UniversalEntityForm` (supplier prefill via context). Suppliers can still optionally assign plant products post-create. (PR: #4321)
+
 - **2026-03-31** — Workforms editor: DynamicConfigPanel now supports `formReference` and `keyValue` schema field types (removes the "Unknown field type" placeholder for real node configs). (PR: #4319)
 - **2026-03-31** — Workforms AI Suggestions: aligned prompt + backend fallback suggestions to canonical node type IDs; added frontend canonicalization + guard to prevent adding unknown suggested nodes. (PR: #4319)
 

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -6,7 +6,6 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { PhoneInput, Select } from '../components/ui';
 import { MultiSelect } from '../components/Shared';
 import EntityFormSurface from '../components/Shared/EntityFormSurface';
-import { US_STATES } from '../utils/constants/states';
 import { CONTACT_DEPARTMENT_CHOICES, PROTEIN_TYPE_CHOICES } from '../utils/constants/choices';
 import styled from 'styled-components';
 import { apiService, apiClient, Supplier } from '../services/apiService';
@@ -87,20 +86,6 @@ const Suppliers: React.FC = () => {
   });
 
   const [showPlantModal, setShowPlantModal] = useState(false);
-  const [plantForm, setPlantForm] = useState({
-    name: '',
-    code: '',
-    plant_est_num: '',
-    plant_type: 'processing',
-    address: '',
-    city: '',
-    state: '',
-    zip_code: '',
-    country: 'USA',
-    manager: '',
-    email: '',
-    phone: '',
-  });
   const [plantProductIds, setPlantProductIds] = useState<string[]>([]);
 
 
@@ -251,65 +236,16 @@ const Suppliers: React.FC = () => {
 
   const openCreatePlant = () => {
     if (!selectedSupplierId) return;
-    setPlantForm({
-      name: '',
-      code: '',
-      plant_est_num: '',
-      plant_type: 'processing',
-      address: '',
-      city: '',
-      state: '',
-      zip_code: '',
-      country: 'USA',
-      manager: '',
-      email: '',
-      phone: '',
-    });
     setPlantProductIds([]);
     setShowPlantModal(true);
   };
 
-  const submitPlant = async () => {
-    if (!selectedSupplierId) return;
+  const assignPlantProducts = async (plantId: number, productIds: string[]) => {
+    if (!productIds.length) return;
 
-    if (!plantForm.name.trim()) {
-      alert('Plant name is required');
-      return;
-    }
-
-    try {
-      const resp = await apiClient.post('plants/', {
-        supplier: selectedSupplierId,
-        name: plantForm.name.trim(),
-        code: plantForm.code?.trim() || '',
-        plant_est_num: plantForm.plant_est_num?.trim() || '',
-        plant_type: plantForm.plant_type,
-        address: plantForm.address,
-        city: plantForm.city,
-        state: plantForm.state,
-        zip_code: plantForm.zip_code,
-        country: plantForm.country,
-        manager: plantForm.manager,
-        email: plantForm.email,
-        phone: plantForm.phone,
-      });
-
-      const createdPlantId = resp?.data?.id as number | undefined;
-      if (createdPlantId && plantProductIds.length) {
-        await Promise.allSettled(
-          plantProductIds.map((productId) =>
-            apiClient.post(`/plants/${createdPlantId}/available-products/`, { product: productId })
-          )
-        );
-      }
-
-      setShowPlantModal(false);
-      setPlantProductIds([]);
-      await loadSupplierPlants(selectedSupplierId);
-    } catch (error: unknown) {
-      logger.error('[Suppliers] Failed to create plant:', error);
-      alert('Failed to create plant');
-    }
+    await Promise.allSettled(
+      productIds.map((productId) => apiClient.post(`/plants/${plantId}/available-products/`, { product: productId }))
+    );
   };
 
   const openCreatePlantContact = () => {
@@ -476,7 +412,7 @@ const Suppliers: React.FC = () => {
         />
       )}
 
-      {showPlantModal && (
+      {showPlantModal && selectedSupplierId && (
         <FormOverlay>
           <FormContainer $theme={theme} data-testid="plant-create-modal">
             <FormHeader $theme={theme}>
@@ -484,160 +420,52 @@ const Suppliers: React.FC = () => {
               <CloseButton $theme={theme} onClick={() => setShowPlantModal(false)}>×</CloseButton>
             </FormHeader>
 
-            <Form onSubmit={(e) => { e.preventDefault(); void submitPlant(); }}>
-              <FormGrid>
-                <FormGroup>
-                  <Label $theme={theme}>Plant Name *</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={plantForm.name}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, name: e.target.value }))}
-                    required
-                  />
-                </FormGroup>
+            <FormGrid>
+              <FormGroup $fullWidth>
+                <MultiSelect
+                  value={plantProductIds}
+                  onChange={(values) => setPlantProductIds(values.map(String))}
+                  options={Array.isArray(products) ? products.map(p => ({
+                    value: String(p.id),
+                    label: `${p.product_code} - ${p.effective_name || p.product_name || p.name || 'Unknown'}`
+                  })) : []}
+                  label="Plant Products List"
+                  placeholder="(Optional) Select products this plant handles"
+                />
+              </FormGroup>
+            </FormGrid>
 
-                <FormGroup>
-                  <Label $theme={theme}>Plant Est. #</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={plantForm.plant_est_num}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, plant_est_num: e.target.value }))}
-                  />
-                </FormGroup>
+            <EntityFormSurface
+              entityType="plant"
+              mode="create"
+              variant="inline"
+              isOpen={showPlantModal}
+              onClose={() => setShowPlantModal(false)}
+              context={{ supplierId: selectedSupplierId }}
+              initialValues={{
+                plant_type: 'processing',
+                country: 'USA',
+              }}
+              onSuccess={(created) => {
+                const createdId = Number((created as { id?: unknown } | null)?.id);
+                const productIds = [...plantProductIds];
 
-                <FormGroup>
-                  <Label $theme={theme}>Plant Type</Label>
-                  <Select
-                    value={plantForm.plant_type}
-                    onChange={(value) => setPlantForm((p) => ({ ...p, plant_type: value }))}
-                    options={[
-                      { value: 'vertical', label: 'Vertical (Kill to Capture)' },
-                      { value: 'processing', label: 'Processing Plant' },
-                      { value: 'distribution', label: 'Distribution Center' },
-                      { value: 'warehouse', label: 'Warehouse' },
-                      { value: 'retail', label: 'Retail Location' },
-                      { value: 'other', label: 'Other' },
-                    ]}
-                    placeholder="Select plant type"
-                    aria-label="Plant type"
-                  />
-                </FormGroup>
+                void (async () => {
+                  if (Number.isFinite(createdId) && createdId > 0) {
+                    try {
+                      await assignPlantProducts(createdId, productIds);
+                    } catch (error) {
+                      logger.error('[Suppliers] Failed to assign plant products:', error);
+                      alert('Plant created, but failed to assign products.');
+                    }
+                  }
 
-                <FormGroup>
-                  <Label $theme={theme}>Code</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={plantForm.code}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, code: e.target.value }))}
-                    placeholder="Optional (auto-generated if blank)"
-                  />
-                </FormGroup>
-
-                <FormGroup $fullWidth>
-                  <Label $theme={theme}>Plant Address</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={plantForm.address}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, address: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Plant City</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={plantForm.city}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, city: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Plant State</Label>
-                  <Select
-                    value={plantForm.state}
-                    onChange={(value) => setPlantForm((p) => ({ ...p, state: value }))}
-                    options={US_STATES}
-                    placeholder="Select state"
-                    aria-label="Plant state"
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Plant ZIP Code</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={plantForm.zip_code}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, zip_code: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Country</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={plantForm.country}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, country: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Manager</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={plantForm.manager}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, manager: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Email</Label>
-                  <Input
-                    $theme={theme}
-                    type="email"
-                    value={plantForm.email}
-                    onChange={(e) => setPlantForm((p) => ({ ...p, email: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Phone</Label>
-                  <PhoneInput
-                    value={plantForm.phone}
-                    onChange={(value) => setPlantForm((p) => ({ ...p, phone: value }))}
-                    placeholder="(XXX)XXX-XXXX"
-                    aria-label="Plant phone"
-                  />
-                </FormGroup>
-
-                <FormGroup $fullWidth>
-                  <MultiSelect
-                    value={plantProductIds}
-                    onChange={(values) => setPlantProductIds(values.map(String))}
-                    options={Array.isArray(products) ? products.map(p => ({
-                      value: String(p.id),
-                      label: `${p.product_code} - ${p.effective_name || p.product_name || p.name || 'Unknown'}`
-                    })) : []}
-                    label="Plant Products List"
-                    placeholder="Select products this plant handles"
-                  />
-                </FormGroup>
-              </FormGrid>
-
-              <FormActions>
-                <CancelButton type="button" onClick={() => setShowPlantModal(false)}>
-                  Cancel
-                </CancelButton>
-                <SubmitButton type="submit">Create Plant</SubmitButton>
-              </FormActions>
-            </Form>
+                  setShowPlantModal(false);
+                  setPlantProductIds([]);
+                  await loadSupplierPlants(selectedSupplierId);
+                })();
+              }}
+            />
           </FormContainer>
         </FormOverlay>
       )}

--- a/frontend/src/pages/Suppliers/Plants.tsx
+++ b/frontend/src/pages/Suppliers/Plants.tsx
@@ -12,9 +12,8 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Table, Input, Button, Modal, Form, Select, Checkbox, message, Tag, Space } from 'antd';
-import { CountrySelect, PhoneInput } from '../../components/ui';
-import { US_STATES } from '../../utils/constants/states';
+import { Table, Input, Button, message, Tag, Space } from 'antd';
+import EntityFormSurface from '../../components/Shared/EntityFormSurface';
 import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, EditOutlined, DeleteOutlined, AppstoreOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
@@ -53,9 +52,6 @@ interface Supplier {
   name: string;
 }
 
-interface FormErrors {
-  [key: string]: string[];
-}
 
 // ============================================================================
 // Styled Components (Theme-Compliant)
@@ -194,7 +190,6 @@ const Plants: React.FC = () => {
   const navigate = useNavigate();
   const { supplierId } = useParams<{ supplierId?: string }>();
   const [searchParams] = useSearchParams();
-  const [form] = Form.useForm();
   
   // State
   const [plants, setPlants] = useState<Plant[]>([]);
@@ -205,7 +200,6 @@ const Plants: React.FC = () => {
   const [editingPlant, setEditingPlant] = useState<Plant | null>(null);
   const [contextSupplierId, setContextSupplierId] = useState<number | null>(null);
   const [searchText, setSearchText] = useState('');
-  const [formErrors, setFormErrors] = useState<FormErrors>({});
 
   // Detect context from URL (preferred) or navigation state (fallback)
   useEffect(() => {
@@ -285,42 +279,11 @@ const Plants: React.FC = () => {
 
   const handleAdd = () => {
     setEditingPlant(null);
-    setFormErrors({});
-    form.resetFields();
-
-    form.setFieldsValue({ phone_type: 'office', booking_contact_phone_type: 'office', fcfs: false, country: 'USA' });
-    
-    // Pre-fill supplier if context exists
-    if (contextSupplierId) {
-      form.setFieldsValue({ supplier: contextSupplierId });
-    }
-    
     setShowModal(true);
   };
 
   const handleEdit = (plant: Plant) => {
     setEditingPlant(plant);
-    setFormErrors({});
-    form.setFieldsValue({
-      name: plant.name,
-      code: plant.code,
-      supplier: plant.supplier,
-      plant_type: plant.plant_type || 'processing',
-      address: plant.address || '',
-      city: plant.city || '',
-      state: plant.state || '',
-      zip_code: plant.zip_code || '',
-      country: plant.country || 'USA',
-      phone_type: plant.phone_type || 'office',
-      phone: plant.phone || '',
-      email: plant.email || '',
-      booking_contact_email: plant.booking_contact_email || '',
-      fcfs: !!plant.fcfs,
-      booking_contact_phone_type: plant.booking_contact_phone_type || 'office',
-      booking_contact_phone: plant.booking_contact_phone || '',
-      manager: plant.manager || '',
-      capacity: plant.capacity || '',
-    });
     setShowModal(true);
   };
 
@@ -345,40 +308,7 @@ const Plants: React.FC = () => {
     }
   };
 
-  const handleSubmit = async () => {
-    try {
-      const values = await form.validateFields();
-      setFormErrors({});
 
-      const payload: Record<string, unknown> = {
-        ...values,
-      };
-
-      if (typeof values.code === 'string' && values.code.trim() === '') {
-        delete payload.code;
-      }
-      
-      if (editingPlant) {
-        await apiClient.patch(`plants/${editingPlant.id}/`, payload);
-        message.success('Plant updated successfully');
-      } else {
-        await apiClient.post('plants/', payload);
-        message.success('Plant created successfully');
-      }
-      
-      setShowModal(false);
-      loadPlants(contextSupplierId);
-    } catch (error: any) {
-      if (error.response?.status === 400) {
-        setFormErrors(error.response.data);
-      } else if (error.errorFields) {
-        // Ant Design form validation errors
-        return;
-      } else {
-        message.error('Failed to save plant');
-      }
-    }
-  };
 
   const handleSupplierClick = (supplierId: number) => {
     navigate(`/suppliers/${supplierId}`);
@@ -566,151 +496,28 @@ const Plants: React.FC = () => {
         scroll={{ x: 'max-content' }}
       />
 
-      {/* Form Modal */}
-      <Modal
-        title={editingPlant ? 'Edit Plant' : 'Add New Plant'}
-        open={showModal}
-        onOk={handleSubmit}
-        onCancel={() => setShowModal(false)}
-        width={700}
-        okText={editingPlant ? 'Update' : 'Create'}
-      >
-        <Form form={form} layout="vertical">
-          <Form.Item
-            name="name"
-            label={<Label>Name<RequiredMark>*</RequiredMark></Label>}
-            rules={[{ required: true, message: 'Plant name is required' }]}
-            validateStatus={formErrors.name ? 'error' : ''}
-            help={formErrors.name && <ErrorMessage>⚠ {formErrors.name[0]}</ErrorMessage>}
-          >
-            <Input placeholder="Plant Name" />
-          </Form.Item>
-
-          <Form.Item
-            name="code"
-            label={<Label>Code</Label>}
-            validateStatus={formErrors.code ? 'error' : ''}
-            help={formErrors.code && <ErrorMessage>⚠ {formErrors.code[0]}</ErrorMessage>}
-          >
-            <Input placeholder="Plant Code (optional; auto-generated if blank)" />
-          </Form.Item>
-
-          <Form.Item
-            name="supplier"
-            label={<Label>Supplier</Label>}
-            validateStatus={formErrors.supplier ? 'error' : ''}
-            help={formErrors.supplier && <ErrorMessage>⚠ {formErrors.supplier[0]}</ErrorMessage>}
-          >
-            <Select
-              placeholder="Select Supplier"
-              disabled={!!contextSupplierId}
-              allowClear
-              showSearch
-              filterOption={(input, option) =>
-                (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
-              }
-              options={suppliers.map(s => ({ label: s.name, value: s.id }))}
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="plant_type"
-            label={<Label>Plant Type</Label>}
-          >
-            <Select placeholder="Select Type">
-              <Select.Option value="processing">Processing</Select.Option>
-              <Select.Option value="distribution">Distribution</Select.Option>
-              <Select.Option value="storage">Storage</Select.Option>
-              <Select.Option value="mixed">Mixed</Select.Option>
-            </Select>
-          </Form.Item>
-
-          <Form.Item name="address" label={<Label>Address</Label>}>
-            <Input placeholder="Street Address" />
-          </Form.Item>
-
-          <Form.Item name="city" label={<Label>City</Label>}>
-            <Input placeholder="City" />
-          </Form.Item>
-
-          <Form.Item name="state" label={<Label>State</Label>}>
-            <Select
-              placeholder="Search state"
-              allowClear
-              showSearch
-              optionFilterProp="label"
-              options={US_STATES}
-              filterOption={(input, option) =>
-                String(option?.label || '').toLowerCase().includes(input.toLowerCase())
-                || String(option?.value || '').toLowerCase().includes(input.toLowerCase())
-              }
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="zip_code"
-            label={<Label>ZIP Code</Label>}
-            rules={[{ pattern: /^\d{5}$/, message: 'ZIP Code must be exactly 5 digits' }]}
-            getValueFromEvent={(e) => String(e?.target?.value ?? '').replace(/\D/g, '').slice(0, 5)}
-          >
-            <Input placeholder="12345" maxLength={5} inputMode="numeric" />
-          </Form.Item>
-
-          <Form.Item name="country" label={<Label>Country</Label>}>
-            <CountrySelect placeholder="Search country" aria-label="Country" />
-          </Form.Item>
-
-          <Form.Item name="phone_type" label={<Label>Phone Type</Label>}>
-            <Select placeholder="Select type">
-              <Select.Option value="office">Office</Select.Option>
-              <Select.Option value="mobile">Mobile</Select.Option>
-            </Select>
-          </Form.Item>
-
-          <Form.Item name="phone" label={<Label>Phone</Label>}>
-            <Input placeholder="Phone Number" />
-          </Form.Item>
-
-          <Form.Item
-            name="email"
-            label={<Label>Email</Label>}
-            rules={[{ type: 'email', message: 'Please enter a valid email address' }]}
-          >
-            <Input type="email" placeholder="Email Address" />
-          </Form.Item>
-
-          <div style={{ fontWeight: 700, fontSize: 16, marginTop: 8 }}>Booking Contact</div>
-
-          <Form.Item
-            name="booking_contact_email"
-            label={<Label>Booking Email</Label>}
-            rules={[{ type: 'email', message: 'Please enter a valid booking email address' }]}
-          >
-            <Input type="email" placeholder="booking@example.com" />
-          </Form.Item>
-
-          <Form.Item name="fcfs" valuePropName="checked">
-            <Checkbox>FCFS (First Come First Serve)</Checkbox>
-          </Form.Item>
-
-          <Form.Item name="booking_contact_phone_type" label={<Label>Booking Phone Type</Label>}>
-            <Select placeholder="Select type">
-              <Select.Option value="office">Office</Select.Option>
-              <Select.Option value="mobile">Mobile</Select.Option>
-            </Select>
-          </Form.Item>
-
-          <Form.Item name="booking_contact_phone" label={<Label>Booking Phone</Label>}>
-            <PhoneInput aria-label="Booking phone" />
-          </Form.Item>
-
-          <Form.Item name="manager" label={<Label>Manager</Label>}>
-            <Input placeholder="Facility Manager Name" />
-          </Form.Item>
-
-
-        </Form>
-      </Modal>
+      {showModal && (
+        <EntityFormSurface
+          entityType="plant"
+          mode={editingPlant ? 'edit' : 'create'}
+          entityId={editingPlant?.id}
+          isOpen={showModal}
+          onClose={() => {
+            setShowModal(false);
+            setEditingPlant(null);
+          }}
+          initialValues={{
+            ...(contextSupplierId ? { supplier: String(contextSupplierId) } : {}),
+            plant_type: 'processing',
+            country: 'USA',
+          }}
+          onSuccess={() => {
+            setShowModal(false);
+            setEditingPlant(null);
+            void loadPlants(contextSupplierId);
+          }}
+        />
+      )}
     </PageContainer>
   );
 };


### PR DESCRIPTION
Removes legacy hardcoded Plant create forms and routes creation through EntityFormSurface/UniversalEntityForm.

- Suppliers page: '+ New Plant' now opens UniversalEntityForm (supplier prefilled) and then assigns selected products post-create.
- Plants table page: Add/Edit now use UniversalEntityForm (with optional supplier context prefill).

Non-breaking: UX consolidation; no API changes.