### PR TITLE
Universal forms: searchable state/province select

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -15,6 +15,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-03-31** — UniversalEntityForm: purged legacy Plant create/edit forms. Suppliers “+ New Plant” and Plants table “Add/Edit” now route through `EntityFormSurface` → `UniversalEntityForm` (supplier prefill via context). Suppliers can still optionally assign plant products post-create. (PR: #4321)
 
+- **2026-03-31** — UniversalEntityForm/DynamicFormEngine: state/province fields now render as a searchable dropdown (search by full name or abbreviation), including inline array sub-fields. (PR: #4322)
+
 - **2026-03-31** — Workforms editor: DynamicConfigPanel now supports `formReference` and `keyValue` schema field types (removes the "Unknown field type" placeholder for real node configs). (PR: #4319)
 - **2026-03-31** — Workforms AI Suggestions: aligned prompt + backend fallback suggestions to canonical node type IDs; added frontend canonicalization + guard to prevent adding unknown suggested nodes. (PR: #4319)
 

--- a/frontend/src/features/system/DynamicFormEngine.tsx
+++ b/frontend/src/features/system/DynamicFormEngine.tsx
@@ -14,6 +14,7 @@ import * as z from 'zod';
 import styled from 'styled-components';
 import { Button } from '../../components/ui/Button';
 import { Select } from '../../components/ui/Select';
+import StateSelect from '../../components/ui/StateSelect';
 import { CountrySelect } from '../../components/ui';
 import { DEFAULT_COUNTRY } from '../../utils/constants/countries';
 import { resolveConfig } from '../../services/configService';
@@ -425,6 +426,17 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     return dynamicOptions[field.key] || [];
   };
 
+  const isStateLikeKey = (normalizedKey: string): boolean => {
+    if (!normalizedKey) return false;
+    if (normalizedKey === 'state') return true;
+    if (normalizedKey.endsWith('_state')) return true;
+    if (normalizedKey === 'province') return true;
+    if (normalizedKey.endsWith('_province')) return true;
+    if (normalizedKey.includes('province')) return true;
+    if (normalizedKey.includes('state')) return true;
+    return false;
+  };
+
   const InlineFormArrayField: React.FC<{ field: FieldDefinition; showRequired: boolean }> = ({
     field,
     showRequired,
@@ -440,6 +452,29 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     const renderItemField = (itemField: FieldDefinition, namePath: string, idx: number) => {
       const itemErr = (errors as any)?.[field.key]?.[idx]?.[itemField.key];
       const hasItemError = Boolean(itemErr);
+
+      const itemNormalizedKey = String(itemField.key).toLowerCase();
+      if (isStateLikeKey(itemNormalizedKey) || itemField.ui?.widget === 'state_select') {
+        return (
+          <FieldGroup key={namePath} style={{ marginBottom: 12 }}>
+            <Label required={formConfig.showRequiredIndicator && itemField.required}>{itemField.label}</Label>
+            <Controller
+              name={namePath as never}
+              control={control}
+              render={({ field: controllerField }) => (
+                <StateSelect
+                  value={String(controllerField.value || '')}
+                  onChange={controllerField.onChange}
+                  placeholder={itemField.placeholder || 'Search state'}
+                  disabled={isSubmitting}
+                  aria-label={itemField.label}
+                />
+              )}
+            />
+            {hasItemError && <ErrorText>{String(itemErr?.message || 'Invalid value')}</ErrorText>}
+          </FieldGroup>
+        );
+      }
 
       if (itemField.ui?.widget === 'tags') {
         return (
@@ -609,6 +644,33 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     }
 
     const normalizedKey = String(field.key).toLowerCase();
+
+    const isStateLikeField = isStateLikeKey(normalizedKey) || field.ui?.widget === 'state_select';
+    if (isStateLikeField) {
+      return (
+        <FieldGroup key={field.key}>
+          <Label htmlFor={field.key} required={showRequired}>
+            {field.label}
+          </Label>
+          <Controller
+            name={field.key}
+            control={control}
+            render={({ field: controllerField }) => (
+              <StateSelect
+                value={String(controllerField.value || '')}
+                onChange={controllerField.onChange}
+                placeholder={field.placeholder || 'Search state'}
+                disabled={isSubmitting}
+                aria-label={field.label}
+              />
+            )}
+          />
+          {formConfig.showHelpText && field.help_text && <HelpText>{field.help_text}</HelpText>}
+          {error && <ErrorText>{error.message as string}</ErrorText>}
+        </FieldGroup>
+      );
+    }
+
     const isIndustryField = normalizedKey === 'industry' || normalizedKey === 'industry_array';
 
     if (isIndustryField && field.type === 'select') {


### PR DESCRIPTION
Upgrade state/province fields rendered by DynamicFormEngine to use searchable StateSelect.

- Applies to keys like state, *_state, province, *_province (and supports schema ui.widget=state_select).
- Also applied to inline_form_array item fields.
- Search works for both full name and abbreviation (e.g. Wisconsin / WI).