### PR TITLE
UniversalEntityForm: enforce Location create

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -17,6 +17,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-03-31** — UniversalEntityForm/DynamicFormEngine: state/province fields now render as a searchable dropdown (search by full name or abbreviation), including inline array sub-fields. (PR: #4322)
 
+- **2026-03-31** — UniversalEntityForm: purged legacy Location create/edit forms. Customers “+ New Location” and Locations table “Add/Edit” now route through `EntityFormSurface` → `UniversalEntityForm` (customer prefill via context). Customers can still optionally assign location products post-create. (PR: #4323)
+
 - **2026-03-31** — Workforms editor: DynamicConfigPanel now supports `formReference` and `keyValue` schema field types (removes the "Unknown field type" placeholder for real node configs). (PR: #4319)
 - **2026-03-31** — Workforms AI Suggestions: aligned prompt + backend fallback suggestions to canonical node type IDs; added frontend canonicalization + guard to prevent adding unknown suggested nodes. (PR: #4319)
 

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -9,7 +9,6 @@ import { apiService, Customer, apiClient } from '../services/apiService';
 import { PhoneInput, Select } from '../components/ui';
 import { MultiSelect } from '../components/Shared';
 import EntityFormSurface from '../components/Shared/EntityFormSurface';
-import { US_STATES } from '../utils/constants/states';
 import { CONTACT_DEPARTMENT_CHOICES, PROTEIN_TYPE_CHOICES } from '../utils/constants/choices';
 
 interface CustomerLocation {
@@ -89,18 +88,6 @@ const Customers: React.FC = () => {
   });
 
   const [showLocationModal, setShowLocationModal] = useState(false);
-  const [locationForm, setLocationForm] = useState({
-    name: '',
-    location_type: 'warehouse',
-    address: '',
-    city: '',
-    state: '',
-    zip_code: '',
-    country: 'USA',
-    contact_name: '',
-    email: '',
-    phone: '',
-  });
   const [locationProductIds, setLocationProductIds] = useState<string[]>([]);
 
   const [productPanel, setProductPanel] = useState<'history' | 'preferences'>('history');
@@ -256,61 +243,16 @@ const Customers: React.FC = () => {
 
   const openCreateLocation = () => {
     if (!selectedCustomerId) return;
-    setLocationForm({
-      name: '',
-      location_type: 'warehouse',
-      address: '',
-      city: '',
-      state: '',
-      zip_code: '',
-      country: 'USA',
-      contact_name: '',
-      email: '',
-      phone: '',
-    });
     setLocationProductIds([]);
     setShowLocationModal(true);
   };
 
-  const submitLocation = async () => {
-    if (!selectedCustomerId) return;
+  const assignLocationProducts = async (locationId: number, productIds: string[]) => {
+    if (!productIds.length) return;
 
-    if (!locationForm.name.trim()) {
-      alert('Location name is required');
-      return;
-    }
-
-    try {
-      const resp = await apiClient.post('locations/', {
-        customer: selectedCustomerId,
-        name: locationForm.name.trim(),
-        location_type: locationForm.location_type,
-        address: locationForm.address,
-        city: locationForm.city,
-        state: locationForm.state,
-        zip_code: locationForm.zip_code,
-        country: locationForm.country,
-        contact_name: locationForm.contact_name,
-        email: locationForm.email,
-        phone: locationForm.phone,
-      });
-
-      const createdLocationId = resp?.data?.id as number | undefined;
-      if (createdLocationId && locationProductIds.length) {
-        await Promise.allSettled(
-          locationProductIds.map((productId) =>
-            apiClient.post(`/locations/${createdLocationId}/available-products/`, { product: productId })
-          )
-        );
-      }
-
-      setShowLocationModal(false);
-      setLocationProductIds([]);
-      await loadCustomerLocations(selectedCustomerId);
-    } catch (error) {
-      console.error('[Customers] Failed to create location:', error);
-      alert('Failed to create location');
-    }
+    await Promise.allSettled(
+      productIds.map((productId) => apiClient.post(`/locations/${locationId}/available-products/`, { product: productId }))
+    );
   };
 
   const openCreateLocationContact = () => {
@@ -488,146 +430,60 @@ const Customers: React.FC = () => {
         />
       )}
 
-      {showLocationModal && (
+      {showLocationModal && selectedCustomerId && (
         <FormOverlay>
-          <FormContainer $theme={theme}>
+          <FormContainer $theme={theme} data-testid="location-create-modal">
             <FormHeader $theme={theme}>
               <FormTitle $theme={theme}>Add New Location</FormTitle>
               <CloseButton $theme={theme} onClick={() => setShowLocationModal(false)}>×</CloseButton>
             </FormHeader>
 
-            <Form onSubmit={(e) => { e.preventDefault(); void submitLocation(); }}>
-              <FormGrid>
-                <FormGroup>
-                  <Label $theme={theme}>Location Name *</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={locationForm.name}
-                    onChange={(e) => setLocationForm((p) => ({ ...p, name: e.target.value }))}
-                    required
-                  />
-                </FormGroup>
+            <FormGrid>
+              <FormGroup $fullWidth>
+                <MultiSelect
+                  value={locationProductIds}
+                  onChange={(values) => setLocationProductIds(values.map(String))}
+                  options={products.map((p) => ({
+                    value: String(p.id),
+                    label: `${p.product_code}${p.name ? ' - ' + p.name : ''}`,
+                  }))}
+                  label="Location Products List"
+                  placeholder="(Optional) Select products this location handles"
+                />
+              </FormGroup>
+            </FormGrid>
 
-                <FormGroup>
-                  <Label $theme={theme}>Type</Label>
-                  <Select
-                    value={locationForm.location_type}
-                    onChange={(value) => setLocationForm((p) => ({ ...p, location_type: value }))}
-                    options={[
-                      { value: 'warehouse', label: 'Warehouse' },
-                      { value: 'store', label: 'Store' },
-                      { value: 'distribution_center', label: 'Distribution Center' },
-                      { value: 'office', label: 'Office' },
-                      { value: 'other', label: 'Other' },
-                    ]}
-                    placeholder="Select type"
-                    aria-label="Location type"
-                  />
-                </FormGroup>
+            <EntityFormSurface
+              entityType="location"
+              mode="create"
+              variant="inline"
+              isOpen={showLocationModal}
+              onClose={() => setShowLocationModal(false)}
+              context={{ customerId: selectedCustomerId }}
+              initialValues={{
+                location_type: 'warehouse',
+                country: 'USA',
+              }}
+              onSuccess={(created) => {
+                const createdId = Number((created as { id?: unknown } | null)?.id);
+                const productIds = [...locationProductIds];
 
-                <FormGroup $fullWidth>
-                  <Label $theme={theme}>Address</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={locationForm.address}
-                    onChange={(e) => setLocationForm((p) => ({ ...p, address: e.target.value }))}
-                  />
-                </FormGroup>
+                void (async () => {
+                  if (Number.isFinite(createdId) && createdId > 0) {
+                    try {
+                      await assignLocationProducts(createdId, productIds);
+                    } catch (error) {
+                      console.error('[Customers] Failed to assign location products:', error);
+                      alert('Location created, but failed to assign products.');
+                    }
+                  }
 
-                <FormGroup>
-                  <Label $theme={theme}>City</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={locationForm.city}
-                    onChange={(e) => setLocationForm((p) => ({ ...p, city: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>State</Label>
-                  <Select
-                    value={locationForm.state}
-                    onChange={(value) => setLocationForm((p) => ({ ...p, state: value }))}
-                    options={US_STATES}
-                    placeholder="Select state"
-                    aria-label="State"
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>ZIP Code</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={locationForm.zip_code}
-                    onChange={(e) => setLocationForm((p) => ({ ...p, zip_code: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Country</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={locationForm.country}
-                    onChange={(e) => setLocationForm((p) => ({ ...p, country: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Contact Name</Label>
-                  <Input
-                    $theme={theme}
-                    type="text"
-                    value={locationForm.contact_name}
-                    onChange={(e) => setLocationForm((p) => ({ ...p, contact_name: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Contact Email</Label>
-                  <Input
-                    $theme={theme}
-                    type="email"
-                    value={locationForm.email}
-                    onChange={(e) => setLocationForm((p) => ({ ...p, email: e.target.value }))}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label $theme={theme}>Contact Phone</Label>
-                  <PhoneInput
-                    value={locationForm.phone}
-                    onChange={(value) => setLocationForm((p) => ({ ...p, phone: value }))}
-                    placeholder="(XXX)XXX-XXXX"
-                    aria-label="Location phone"
-                  />
-                </FormGroup>
-
-                <FormGroup $fullWidth>
-                  <MultiSelect
-                    value={locationProductIds}
-                    onChange={(values) => setLocationProductIds(values.map(String))}
-                    options={products.map((p) => ({
-                      value: String(p.id),
-                      label: `${p.product_code}${p.name ? ' - ' + p.name : ''}`
-                    }))}
-                    label="Location Products List"
-                    placeholder="Select products this location handles"
-                  />
-                </FormGroup>
-              </FormGrid>
-
-              <FormActions>
-                <CancelButton type="button" onClick={() => setShowLocationModal(false)}>
-                  Cancel
-                </CancelButton>
-                <SubmitButton type="submit">Create Location</SubmitButton>
-              </FormActions>
-            </Form>
+                  setShowLocationModal(false);
+                  setLocationProductIds([]);
+                  await loadCustomerLocations(selectedCustomerId);
+                })();
+              }}
+            />
           </FormContainer>
         </FormOverlay>
       )}

--- a/frontend/src/pages/Customers/Locations.tsx
+++ b/frontend/src/pages/Customers/Locations.tsx
@@ -12,10 +12,9 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Table, Input, Button, Modal, Form, Select, message, Tag, Space } from 'antd';
+import { Table, Input, Button, message, Tag, Space } from 'antd';
 import { confirmDialog } from '@/utils/uiDialogs';
-import { CountrySelect } from '../../components/ui';
-import { US_STATES } from '../../utils/constants/states';
+import EntityFormSurface from '../../components/Shared/EntityFormSurface';
 import type { ColumnsType } from 'antd/es/table';
 import { SearchOutlined, PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { apiClient } from '../../services/apiService';
@@ -48,9 +47,6 @@ interface Customer {
   name: string;
 }
 
-interface FormErrors {
-  [key: string]: string[];
-}
 
 // ============================================================================
 // Styled Components (Theme-Compliant)
@@ -185,7 +181,6 @@ const CustomerLocations: React.FC = () => {
   const navigate = useNavigate();
   const { customerId } = useParams<{ customerId?: string }>();
   const [searchParams] = useSearchParams();
-  const [form] = Form.useForm();
   
   // State
   const [locations, setLocations] = useState<Location[]>([]);
@@ -196,7 +191,6 @@ const CustomerLocations: React.FC = () => {
   const [editingLocation, setEditingLocation] = useState<Location | null>(null);
   const [contextCustomerId, setContextCustomerId] = useState<number | null>(null);
   const [searchText, setSearchText] = useState('');
-  const [formErrors, setFormErrors] = useState<FormErrors>({});
 
   // Detect context from URL (preferred) or navigation state (fallback)
   useEffect(() => {
@@ -288,37 +282,11 @@ const CustomerLocations: React.FC = () => {
 
   const handleAdd = () => {
     setEditingLocation(null);
-    setFormErrors({});
-    form.resetFields();
-
-    form.setFieldsValue({ phone_type: 'office', country: 'USA' });
-    
-    // Pre-fill customer if context exists
-    if (contextCustomerId) {
-      form.setFieldsValue({ customer: contextCustomerId });
-    }
-    
     setShowModal(true);
   };
 
   const handleEdit = (loc: Location) => {
     setEditingLocation(loc);
-    setFormErrors({});
-    form.setFieldsValue({
-      name: loc.name,
-      code: loc.code || '',
-      customer: loc.customer,
-      location_type: loc.location_type || 'warehouse',
-      address: loc.address || '',
-      city: loc.city || '',
-      state: loc.state || '',
-      zip_code: loc.zip_code || '',
-      country: loc.country || 'USA',
-      phone_type: loc.phone_type || 'office',
-      phone: loc.phone || '',
-      email: loc.email || '',
-      contact_name: loc.contact_name || '',
-    });
     setShowModal(true);
   };
 
@@ -343,32 +311,7 @@ const CustomerLocations: React.FC = () => {
     }
   };
 
-  const handleSubmit = async () => {
-    try {
-      const values = await form.validateFields();
-      setFormErrors({});
-      
-      if (editingLocation) {
-        await apiClient.patch(`locations/${editingLocation.id}/`, values);
-        message.success('Location updated successfully');
-      } else {
-        await apiClient.post('locations/', values);
-        message.success('Location created successfully');
-      }
-      
-      setShowModal(false);
-      loadLocations(contextCustomerId);
-    } catch (error: any) {
-      if (error.response?.status === 400) {
-        setFormErrors(error.response.data);
-      } else if (error.errorFields) {
-        // Ant Design form validation errors
-        return;
-      } else {
-        message.error('Failed to save location');
-      }
-    }
-  };
+
 
   const handleCustomerClick = (customerId: number) => {
     navigate(`/customers/${customerId}`);
@@ -528,124 +471,28 @@ const CustomerLocations: React.FC = () => {
         scroll={{ x: 'max-content' }}
       />
 
-      {/* Form Modal */}
-      <Modal
-        title={editingLocation ? 'Edit Location' : 'Add New Location'}
-        open={showModal}
-        onOk={handleSubmit}
-        onCancel={() => setShowModal(false)}
-        width={700}
-        okText={editingLocation ? 'Update' : 'Create'}
-      >
-        <Form form={form} layout="vertical">
-          <Form.Item
-            name="name"
-            label={<Label>Name<RequiredMark>*</RequiredMark></Label>}
-            rules={[{ required: true, message: 'Location name is required' }]}
-            validateStatus={formErrors.name ? 'error' : ''}
-            help={formErrors.name && <ErrorMessage>⚠ {formErrors.name[0]}</ErrorMessage>}
-          >
-            <Input placeholder="Location Name" />
-          </Form.Item>
-
-          <Form.Item
-            name="code"
-            label={<Label>Code</Label>}
-            validateStatus={formErrors.code ? 'error' : ''}
-            help={formErrors.code && <ErrorMessage>⚠ {formErrors.code[0]}</ErrorMessage>}
-          >
-            <Input placeholder="Location Code (optional)" />
-          </Form.Item>
-
-          <Form.Item
-            name="customer"
-            label={<Label>Customer</Label>}
-            validateStatus={formErrors.customer ? 'error' : ''}
-            help={formErrors.customer && <ErrorMessage>⚠ {formErrors.customer[0]}</ErrorMessage>}
-          >
-            <Select
-              placeholder="Select Customer"
-              disabled={!!contextCustomerId}
-              allowClear
-              showSearch
-              filterOption={(input, option) =>
-                (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
-              }
-              options={customers.map(c => ({ label: c.name, value: c.id }))}
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="location_type"
-            label={<Label>Location Type</Label>}
-          >
-            <Select placeholder="Select Type">
-              <Select.Option value="warehouse">Warehouse</Select.Option>
-              <Select.Option value="store">Store</Select.Option>
-              <Select.Option value="distribution_center">Distribution Center</Select.Option>
-              <Select.Option value="office">Office</Select.Option>
-            </Select>
-          </Form.Item>
-
-          <Form.Item name="address" label={<Label>Address</Label>}>
-            <Input placeholder="Street Address" />
-          </Form.Item>
-
-          <Form.Item name="city" label={<Label>City</Label>}>
-            <Input placeholder="City" />
-          </Form.Item>
-
-          <Form.Item name="state" label={<Label>State</Label>}>
-            <Select
-              placeholder="Search state"
-              allowClear
-              showSearch
-              optionFilterProp="label"
-              options={US_STATES}
-              filterOption={(input, option) =>
-                String(option?.label || '').toLowerCase().includes(input.toLowerCase())
-                || String(option?.value || '').toLowerCase().includes(input.toLowerCase())
-              }
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="zip_code"
-            label={<Label>ZIP Code</Label>}
-            rules={[{ pattern: /^\d{5}$/, message: 'ZIP Code must be exactly 5 digits' }]}
-            getValueFromEvent={(e) => String(e?.target?.value ?? '').replace(/\D/g, '').slice(0, 5)}
-          >
-            <Input placeholder="12345" maxLength={5} inputMode="numeric" />
-          </Form.Item>
-
-          <Form.Item name="country" label={<Label>Country</Label>}>
-            <CountrySelect placeholder="Search country" aria-label="Country" />
-          </Form.Item>
-
-          <Form.Item name="phone_type" label={<Label>Phone Type</Label>}>
-            <Select placeholder="Select type">
-              <Select.Option value="office">Office</Select.Option>
-              <Select.Option value="mobile">Mobile</Select.Option>
-            </Select>
-          </Form.Item>
-
-          <Form.Item name="phone" label={<Label>Phone</Label>}>
-            <Input placeholder="Phone Number" />
-          </Form.Item>
-
-          <Form.Item
-            name="email"
-            label={<Label>Email</Label>}
-            rules={[{ type: 'email', message: 'Please enter a valid email address' }]}
-          >
-            <Input type="email" placeholder="Email Address" />
-          </Form.Item>
-
-          <Form.Item name="contact_name" label={<Label>Contact Name</Label>}>
-            <Input placeholder="Primary Contact Name" />
-          </Form.Item>
-        </Form>
-      </Modal>
+      {showModal && (
+        <EntityFormSurface
+          entityType="location"
+          mode={editingLocation ? 'edit' : 'create'}
+          entityId={editingLocation?.id}
+          isOpen={showModal}
+          onClose={() => {
+            setShowModal(false);
+            setEditingLocation(null);
+          }}
+          initialValues={{
+            ...(contextCustomerId ? { customer: String(contextCustomerId) } : {}),
+            location_type: 'warehouse',
+            country: 'USA',
+          }}
+          onSuccess={() => {
+            setShowModal(false);
+            setEditingLocation(null);
+            void loadLocations(contextCustomerId);
+          }}
+        />
+      )}
     </PageContainer>
   );
 };


### PR DESCRIPTION
Removes legacy hardcoded Location create/edit forms and routes through EntityFormSurface/UniversalEntityForm.

- Customers page: '+ New Location' now uses UniversalEntityForm (customer prefilled) and assigns selected products post-create.
- Locations table page: Add/Edit now use UniversalEntityForm (with optional customer context prefill).

Non-breaking: UX consolidation; no API changes.