### PR TITLE
Workforms: QuickCreateModal uses UniversalEntityForm

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1521,3 +1521,4 @@ Deliverables:
 - 2026-03-31 — Ops: promote uat → main (pipeline hotfix) — PR: #4312. Verified main deploy run: 23820173539 ✅
 - 2026-03-31 — Docs: V4.0 enterprise moat sprint (traceability, yield mgmt, enterprise gateway, risk/compliance) — PR: #4317.
 - 2026-03-31 — Frontend: Suppliers/Customers nested contact create uses EntityFormSurface (retire bespoke contact modals) — PR: #4325.
+- 2026-03-31 — Workforms: QuickCreateModal now uses EntityFormSurface → UniversalEntityForm (retire bespoke quick-create fields UI). — PR: #4326.

--- a/frontend/src/components/FormSubmission/QuickCreateModal.tsx
+++ b/frontend/src/components/FormSubmission/QuickCreateModal.tsx
@@ -1,266 +1,49 @@
 /**
- * QuickCreateModal Component
- * 
- * Modal for quick-creating entity records from within forms.
- * Shows only the required/essential fields for fast creation.
+ * QuickCreateModal
+ *
+ * Consolidated creation surface for records spawned from within form submissions.
+ *
+ * IMPORTANT:
+ * - Uses EntityFormSurface → UniversalEntityForm so creation stays schema-driven and consistent.
+ * - Keeps the existing QuickCreateModal prop contract so callers don’t need refactors.
  */
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import styled from 'styled-components';
-import { Select, Spin } from 'antd';
-import { CountrySelect } from '../ui';
-import debounce from 'lodash/debounce';
-import {
-  entityOptionsService,
-  QuickCreateField,
-} from '../../services/quickActionsService';
-import { apiClient } from '../../services/apiService';
-import { PROTEIN_TYPE_CHOICES } from '../../utils/constants/choices';
+
+import React, { useMemo } from 'react';
+
+import { EntityFormSurface } from '../Shared';
+import type { EntityFormContext } from '../Shared/EntityFormSurface';
 
 interface QuickCreateModalProps {
   entityType: string;
   isOpen: boolean;
   onClose: () => void;
   onCreated: (entity: { value: string; label: string }) => void;
-  /** Render as inline panel content (no fixed overlay). */
+  /** Render as inline panel content (no modal shell). */
   inline?: boolean;
   /** Optional initial values for context-aware prefill (e.g., customer/supplier FK). */
-  initialValues?: Record<string, any>;
+  initialValues?: Record<string, unknown>;
   /** Context data used to pre-populate and hide fields (e.g., raw UUIDs from Cockpit). */
-  contextData?: Record<string, any>;
+  contextData?: Record<string, unknown>;
 }
 
-const Overlay = styled.div`
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1100;
-  animation: fadeIn 0.2s ease;
+const coerceEntityOption = (entityType: string, result: unknown): { value: string; label: string } | null => {
+  if (!result || typeof result !== 'object') return null;
 
-  @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }
-`;
+  const rec = result as Record<string, unknown>;
+  const id = rec.id ?? rec.pk;
+  if (id == null) return null;
 
-const Modal = styled.div`
-  background: var(--bg-primary, rgb(var(--color-surface)));
-  border-radius: 0.75rem;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  width: 90%;
-  max-width: 500px;
-  max-height: 90vh;
-  overflow: hidden;
-  animation: slideUp 0.3s ease;
+  const label = String(
+    rec.display_name ??
+      rec.effective_name ??
+      rec.name ??
+      rec.title ??
+      rec.label ??
+      `${entityType} ${String(id)}`
+  );
 
-  @keyframes slideUp {
-    from {
-      opacity: 0;
-      transform: translateY(20px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-`;
-
-const ModalHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--border-color, rgb(var(--color-border)));
-  background: var(--bg-secondary, rgb(var(--color-surface)));
-`;
-
-const ModalTitle = styled.h3`
-  margin: 0;
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--text-primary, rgb(var(--color-text-primary)));
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-`;
-
-const CloseButton = styled.button`
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: var(--text-secondary, rgb(var(--color-text-muted)));
-  cursor: pointer;
-  padding: 0.25rem;
-  line-height: 1;
-  transition: color 0.15s ease;
-
-  &:hover {
-    color: var(--text-primary, rgb(var(--color-text-primary)));
-  }
-`;
-
-const ModalBody = styled.div`
-  padding: 1.25rem;
-  overflow-y: auto;
-  max-height: calc(90vh - 140px);
-`;
-
-const FieldGroup = styled.div`
-  margin-bottom: 1rem;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-`;
-
-const Label = styled.label<{ required?: boolean }>`
-  display: block;
-  margin-bottom: 0.375rem;
-  font-weight: 500;
-  font-size: 0.875rem;
-  color: var(--text-primary, rgb(var(--color-text-primary)));
-
-  ${({ required }) => required && `
-    &::after {
-      content: ' *';
-      color: var(--color-error, rgb(var(--color-error)));
-    }
-  `}
-`;
-
-const Input = styled.input`
-  width: 100%;
-  padding: 0.625rem 0.75rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  color: var(--text-primary, rgb(var(--color-text-primary)));
-  background-color: var(--input-bg, rgb(var(--color-surface)));
-  border: 1px solid var(--border-color, rgb(var(--color-border)));
-  border-radius: 0.375rem;
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-
-  &:focus {
-    outline: none;
-    border-color: var(--color-primary, rgb(var(--color-primary)));
-    box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.25);
-  }
-
-  &:disabled {
-    background-color: var(--input-disabled-bg, rgb(var(--color-border)));
-    cursor: not-allowed;
-  }
-
-  &.error {
-    border-color: var(--color-error, rgb(var(--color-error)));
-  }
-`;
-
-const ErrorText = styled.span`
-  display: block;
-  font-size: 0.75rem;
-  color: var(--color-error, rgb(var(--color-error)));
-  margin-top: 0.25rem;
-`;
-
-const ModalFooter = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.75rem;
-  padding: 1rem 1.25rem;
-  border-top: 1px solid var(--border-color, rgb(var(--color-border)));
-  background: var(--bg-secondary, rgb(var(--color-surface)));
-
-  /* Keep the save action visible in embedded mode */
-  position: sticky;
-  bottom: 0;
-  z-index: 5;
-  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.08);
-`;
-
-const Button = styled.button<{ variant?: 'primary' | 'secondary' }>`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  border-radius: 0.375rem;
-  cursor: pointer;
-  transition: all 0.15s ease;
-
-  ${({ variant }) => variant === 'primary' ? `
-    background: var(--color-primary, rgb(var(--color-primary)));
-    color: rgb(var(--color-surface));
-    border: 1px solid var(--color-primary, rgb(var(--color-primary)));
-
-    &:hover:not(:disabled) {
-      background: var(--color-primary-hover, rgb(var(--color-primary)));
-      border-color: var(--color-primary-hover, rgb(var(--color-primary)));
-    }
-  ` : `
-    background: var(--bg-primary, rgb(var(--color-surface)));
-    color: var(--text-primary, rgb(var(--color-text-primary)));
-    border: 1px solid var(--border-color, rgb(var(--color-border)));
-
-    &:hover:not(:disabled) {
-      background: var(--bg-secondary, rgb(var(--color-surface)));
-    }
-  `}
-
-  &:disabled {
-    opacity: 0.65;
-    cursor: not-allowed;
-  }
-`;
-
-const LoadingSpinner = styled.span`
-  display: inline-block;
-  width: 1rem;
-  height: 1rem;
-  border: 2px solid transparent;
-  border-top-color: currentColor;
-  border-radius: 50%;
-  animation: spin 0.75s linear infinite;
-
-  @keyframes spin {
-    to { transform: rotate(360deg); }
-  }
-`;
-
-const LoadingContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
-  gap: 1rem;
-  color: var(--text-secondary, rgb(var(--color-text-muted)));
-`;
-
-const InlineContainer = styled.div`
-  background: rgb(var(--color-surface));
-  border: 1px solid rgb(var(--color-border));
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-`;
-
-const InlineHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid rgb(var(--color-border));
-  background: rgb(var(--color-surface-hover));
-`;
-
-const InlineTitle = styled.div`
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  color: rgb(var(--color-text-primary));
-`;
+  return { value: String(id), label };
+};
 
 const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
   entityType,
@@ -271,608 +54,52 @@ const QuickCreateModal: React.FC<QuickCreateModalProps> = ({
   initialValues,
   contextData,
 }) => {
-  const [fields, setFields] = useState<QuickCreateField[]>([]);
-  const [formData, setFormData] = useState<Record<string, any>>({});
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isLoading, setIsLoading] = useState(true);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [entityLabel, setEntityLabel] = useState('');
-
-  const proteinTypeValue: string[] = useMemo(() => {
-    const raw = formData?.preferred_protein_types;
-    if (!raw) return [];
-    return (Array.isArray(raw) ? raw : [raw]).map((v) => String(v)).filter(Boolean);
-  }, [formData]);
-
-  const [productOptions, setProductOptions] = useState<Array<{ value: string; label: string }>>([]);
-  const [isLoadingProducts, setIsLoadingProducts] = useState(false);
-  const debouncedProductSearchRef = useRef<ReturnType<typeof debounce> | null>(null);
-
   const mergedContext = useMemo(
     () => ({ ...(initialValues || {}), ...(contextData || {}) }),
     [initialValues, contextData]
   );
 
-  useEffect(() => {
-    if (isOpen && entityType) {
-      loadFields();
-    }
-  }, [isOpen, entityType, mergedContext]);
+  const surfaceContext: EntityFormContext | undefined = useMemo(() => {
+    const asId = (value: unknown): string | number | undefined =>
+      typeof value === 'string' || typeof value === 'number' ? value : undefined;
 
-  const loadFields = async () => {
-    setIsLoading(true);
-    setErrors({});
-    try {
-      const response = await entityOptionsService.getQuickCreateFields(entityType);
-      setFields(response.fields);
-      setEntityLabel(response.entity_label);
-      
-      // Initialize form data with empty values (plus optional context prefill)
-      // Use type-appropriate defaults to avoid sending invalid placeholders.
-      const initialData: Record<string, any> = { ...(mergedContext || {}) };
-      response.fields.forEach((f) => {
-        if (initialData[f.key] !== undefined) return;
-        if (f.key === 'country') {
-          initialData[f.key] = 'USA';
-          return;
-        }
-        if (f.type === 'checkbox') {
-          initialData[f.key] = false;
-        } else if (f.type === 'multiselect') {
-          initialData[f.key] = [];
-        } else {
-          initialData[f.key] = '';
-        }
-      });
-      setFormData(initialData);
-    } catch (err) {
-      console.error('Failed to load fields:', err);
-      setErrors({ _general: 'Failed to load form fields' });
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    const customerId = asId(mergedContext.customerId ?? mergedContext.customer);
+    const supplierId = asId(mergedContext.supplierId ?? mergedContext.supplier);
+    const contactId = asId(mergedContext.contactId ?? mergedContext.contact);
+    const sourceCallId = asId(mergedContext.sourceCallId);
 
-  const handleInputChange = useCallback((key: string, value: any) => {
-    setFormData(prev => ({ ...prev, [key]: value }));
-    // Clear error when user starts typing
-    if (errors[key]) {
-      setErrors(prev => {
-        const newErrors = { ...prev };
-        delete newErrors[key];
-        return newErrors;
-      });
-    }
-  }, [errors]);
-
-  const fetchMasterProducts = useCallback(async (search?: string) => {
-    setIsLoadingProducts(true);
-    try {
-      const normalizedProteins = proteinTypeValue
-        .map((t) => String(t).toLowerCase().trim())
-        .filter(Boolean);
-
-      const response = await apiClient.get('/system/products/', {
-        params: {
-          search: search || undefined,
-          is_active: true,
-          // Some environments allow client-set page sizing; some don't.
-          // Include both params for maximum compatibility.
-          page_size: 50,
-          limit: 50,
-          ...(normalizedProteins.length ? { protein: normalizedProteins.join(',') } : {}),
-        },
-      });
-
-      const raw = response.data as any;
-      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
-
-      setProductOptions(
-        data.map((p: any) => ({
-          value: String(p.id),
-          label: `${p.product_code}${p.name ? ` - ${p.name}` : ''}`,
-        }))
-      );
-    } catch (err) {
-      // Silent fail: quick create should still work for basic fields.
-      console.error('[QuickCreateModal] Failed to load master products:', err);
-      setProductOptions([]);
-    } finally {
-      setIsLoadingProducts(false);
-    }
-  }, [proteinTypeValue]);
-
-  useEffect(() => {
-    // Re-load product options whenever protein filters change.
-    if (fields.some((f) => f.key === 'products')) {
-      void fetchMasterProducts();
-    }
-  }, [fetchMasterProducts, fields, proteinTypeValue.join('|')]);
-
-  useEffect(() => {
-    // Setup debounced search handler
-    debouncedProductSearchRef.current = debounce((q: string) => {
-      void fetchMasterProducts(q);
-    }, 300);
-    return () => {
-      debouncedProductSearchRef.current?.cancel();
-      debouncedProductSearchRef.current = null;
+    const ctx: EntityFormContext = {
+      ...(customerId != null ? { customerId } : {}),
+      ...(supplierId != null ? { supplierId } : {}),
+      ...(contactId != null ? { contactId } : {}),
+      ...(sourceCallId != null ? { sourceCallId } : {}),
     };
-  }, [fetchMasterProducts]);
 
-  const validate = (): boolean => {
-    const newErrors: Record<string, string> = {};
+    return Object.keys(ctx).length ? ctx : undefined;
+  }, [mergedContext]);
 
-    fields.forEach((field) => {
-      const raw = formData[field.key];
-
-      if (field.required && !raw) {
-        newErrors[field.key] = `${field.label} is required`;
-        return;
-      }
-
-      if (field.key === 'zip_code' && raw) {
-        const zip = String(raw).trim();
-        if (!/^\d{5}$/.test(zip)) {
-          newErrors[field.key] = 'ZIP code must be 5 digits';
-        }
-      }
-    });
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleSubmit = async () => {
-    if (!validate()) return;
-
-    setIsSubmitting(true);
-    try {
-      // Avoid sending empty-string placeholders; these can break numeric/FK/boolean fields
-      // and cause "Save" to appear non-functional.
-      const payload: Record<string, any> = {};
-
-      // Include context values first (if any)
-      Object.entries(mergedContext || {}).forEach(([k, v]) => {
-        if (v === undefined || v === null) return;
-        if (typeof v === 'string' && v.trim() === '') return;
-        if (Array.isArray(v) && v.length === 0) return;
-        payload[k] = v;
-      });
-
-      fields.forEach((field) => {
-        const raw = formData[field.key];
-
-        // Skip empty values
-        if (raw === undefined || raw === null) return;
-        if (typeof raw === 'string' && raw.trim() === '') return;
-        if (Array.isArray(raw) && raw.filter((x) => String(x).trim() !== '').length === 0) return;
-
-        if (field.type === 'number') {
-          const n = typeof raw === 'number' ? raw : Number(raw);
-          if (!Number.isFinite(n)) return;
-          payload[field.key] = n;
-          return;
-        }
-
-        if (field.type === 'checkbox') {
-          payload[field.key] = Boolean(raw);
-          return;
-        }
-
-        if (field.type === 'multiselect') {
-          payload[field.key] = Array.isArray(raw) ? raw : [raw];
-          return;
-        }
-
-        payload[field.key] = raw;
-      });
-
-      const response = await entityOptionsService.quickCreate(entityType, payload);
-
-      if (!response || response.success !== true || !response.value) {
-        throw new Error('Failed to create record');
-      }
-
-      onCreated({ value: response.value, label: response.label });
-      onClose();
-    } catch (err: any) {
-      console.error('Failed to create entity:', err);
-      const errorMessage = err.response?.data?.error || err.response?.data?.detail || 'Failed to create record';
-      setErrors({ _general: errorMessage });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      onClose();
-    } else if (e.key === 'Enter' && !isSubmitting && !isLoading) {
-      handleSubmit();
-    }
-  };
-
-  if (!isOpen) return null;
-
-  if (inline) {
-    return (
-      <InlineContainer onKeyDown={handleKeyDown}>
-        <InlineHeader>
-          <InlineTitle>➕ Create New {entityLabel}</InlineTitle>
-          <CloseButton onClick={onClose} aria-label="Close">×</CloseButton>
-        </InlineHeader>
-
-        <ModalBody>
-          {isLoading ? (
-            <LoadingContainer>
-              <LoadingSpinner />
-              <span>Loading fields...</span>
-            </LoadingContainer>
-          ) : fields.length === 0 ? (
-            <LoadingContainer>
-              <span>No fields configured for quick creation.</span>
-              <span style={{ fontSize: '0.75rem' }}>
-                Please contact an administrator to configure required fields.
-              </span>
-            </LoadingContainer>
-          ) : (
-            <>
-              {errors._general && (
-                <ErrorText style={{ marginBottom: '1rem', textAlign: 'center' }}>
-                  {errors._general}
-                </ErrorText>
-              )}
-              {fields.map((field) => {
-                // Hide fields that are pre-populated from context
-                if (contextData && contextData[field.key] !== undefined) {
-                  return null;
-                }
-
-                return (
-                  <FieldGroup key={field.key}>
-                    <Label required={field.required} htmlFor={`quick-create-${field.key}`}>
-                      {field.label}
-                    </Label>
-                    {field.key === 'phone_mobile' ? (
-                      <Input
-                        id={`quick-create-${field.key}`}
-                        type="tel"
-                        value={formData[field.key] || ''}
-                        onChange={(e) => handleInputChange(field.key, e.target.value.replace(/\D/g, '').slice(0, 20))}
-                        className={errors[field.key] ? 'error' : ''}
-                        disabled={isSubmitting}
-                        autoFocus={fields.indexOf(field) === 0}
-                        placeholder="(XXX) XXX-XXXX"
-                        inputMode="tel"
-                      />
-                    ) : field.key === 'phone_office' ? (
-                      <Input
-                        id={`quick-create-${field.key}`}
-                        type="tel"
-                        value={formData[field.key] || ''}
-                        onChange={(e) => handleInputChange(field.key, e.target.value.replace(/\D/g, '').slice(0, 20))}
-                        className={errors[field.key] ? 'error' : ''}
-                        disabled={isSubmitting}
-                        autoFocus={fields.indexOf(field) === 0}
-                        placeholder="(XXX) XXX-XXXX"
-                        inputMode="tel"
-                      />
-                    ) : field.key === 'phone_office_extension' ? (
-                      <Input
-                        id={`quick-create-${field.key}`}
-                        type="text"
-                        value={formData[field.key] || ''}
-                        onChange={(e) => handleInputChange(field.key, e.target.value.replace(/\D/g, '').slice(0, 6))}
-                        maxLength={6}
-                        inputMode="numeric"
-                        className={errors[field.key] ? 'error' : ''}
-                        disabled={isSubmitting}
-                        autoFocus={fields.indexOf(field) === 0}
-                        placeholder="e.g., 123"
-                      />
-                    ) : field.key === 'preferred_protein_types' ? (
-                      <Select
-                        mode="multiple"
-                        value={proteinTypeValue}
-                        onChange={(vals) => handleInputChange(field.key, vals)}
-                        options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
-                        placeholder="Search protein types"
-                        disabled={isSubmitting}
-                        showSearch
-                        optionFilterProp="label"
-                        filterOption={(input, option) => {
-                          const q = String(input || '').toLowerCase();
-                          const label = String((option as any)?.label || '').toLowerCase();
-                          const value = String((option as any)?.value || '').toLowerCase();
-                          return label.includes(q) || value.includes(q);
-                        }}
-                        style={{ width: '100%' }}
-                      />
-                    ) : field.key === 'products' && (entityType === 'customer' || entityType === 'supplier') ? (
-                      <Select
-                        mode="multiple"
-                        value={Array.isArray(formData[field.key]) ? formData[field.key] : []}
-                        onChange={(vals) => handleInputChange(field.key, vals)}
-                        options={productOptions}
-                        placeholder={proteinTypeValue.length ? 'Search products (filtered by protein types)...' : 'Search products...'}
-                        showSearch
-                        filterOption={false}
-                        onSearch={(q) => debouncedProductSearchRef.current?.(q)}
-                        notFoundContent={isLoadingProducts ? <Spin size="small" /> : null}
-                        disabled={isSubmitting}
-                        style={{ width: '100%' }}
-                      />
-                    ) : field.key === 'country' ? (
-                      <CountrySelect
-                        value={String(formData[field.key] || '')}
-                        onChange={(val) => handleInputChange(field.key, val)}
-                        placeholder="Search country"
-                        disabled={isSubmitting}
-                        aria-label="Country"
-                      />
-                    ) : field.type === 'checkbox' ? (
-                      <input
-                        id={`quick-create-${field.key}`}
-                        type="checkbox"
-                        checked={Boolean(formData[field.key])}
-                        onChange={(e) => handleInputChange(field.key, e.target.checked)}
-                        disabled={isSubmitting}
-                      />
-                    ) : (
-                      <Input
-                        id={`quick-create-${field.key}`}
-                        type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : field.type === 'date' ? 'date' : 'text'}
-                        value={formData[field.key] || ''}
-                        onChange={(e) => {
-                          const raw = e.target.value;
-                          if (field.key === 'zip_code') {
-                            handleInputChange(field.key, raw.replace(/\D/g, '').slice(0, 5));
-                            return;
-                          }
-                          handleInputChange(field.key, raw);
-                        }}
-                        maxLength={field.key === 'zip_code' ? 5 : undefined}
-                        inputMode={field.key === 'zip_code' ? 'numeric' : undefined}
-                        pattern={field.key === 'zip_code' ? '^\\d{5}$' : undefined}
-                        className={errors[field.key] ? 'error' : ''}
-                        disabled={isSubmitting}
-                        autoFocus={fields.indexOf(field) === 0}
-                      />
-                    )}
-                    {errors[field.key] && <ErrorText>{errors[field.key]}</ErrorText>}
-                  </FieldGroup>
-                );
-              })}
-            </>
-          )}
-        </ModalBody>
-
-        <ModalFooter>
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose();
-            }}
-            disabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            variant="primary"
-            onClick={(e) => {
-              e.stopPropagation();
-              if (isSubmitting) return;
-              void handleSubmit();
-            }}
-            disabled={isLoading || isSubmitting || fields.length === 0}
-          >
-            {isSubmitting ? (
-              <>
-                <LoadingSpinner />
-                Creating...
-              </>
-            ) : (
-              <>💾 Create {entityLabel}</>
-            )}
-          </Button>
-        </ModalFooter>
-      </InlineContainer>
-    );
-  }
+  if (!isOpen || !entityType) return null;
 
   return (
-    <Overlay onClick={onClose}>
-      <Modal onClick={e => e.stopPropagation()} onKeyDown={handleKeyDown}>
-        <ModalHeader>
-          <ModalTitle>
-            ➕ Create New {entityLabel}
-          </ModalTitle>
-          <CloseButton onClick={onClose} aria-label="Close">×</CloseButton>
-        </ModalHeader>
+    <EntityFormSurface
+      entityType={entityType}
+      mode="create"
+      variant={inline ? 'inline' : 'modal'}
+      isOpen={isOpen}
+      onClose={onClose}
+      context={surfaceContext}
+      initialValues={mergedContext}
+      onSuccess={(created) => {
+        const option = coerceEntityOption(entityType, created);
+        if (!option) {
+          onClose();
+          return;
+        }
 
-        <ModalBody>
-          {isLoading ? (
-            <LoadingContainer>
-              <LoadingSpinner />
-              <span>Loading fields...</span>
-            </LoadingContainer>
-          ) : fields.length === 0 ? (
-            <LoadingContainer>
-              <span>No fields configured for quick creation.</span>
-              <span style={{ fontSize: '0.75rem' }}>
-                Please contact an administrator to configure required fields.
-              </span>
-            </LoadingContainer>
-          ) : (
-            <>
-              {errors._general && (
-                <ErrorText style={{ marginBottom: '1rem', textAlign: 'center' }}>
-                  {errors._general}
-                </ErrorText>
-              )}
-              {fields.map((field) => {
-                // Hide fields that are pre-populated from context
-                if (contextData && contextData[field.key] !== undefined) {
-                  return null;
-                }
-
-                return (
-                  <FieldGroup key={field.key}>
-                    <Label required={field.required} htmlFor={`quick-create-${field.key}`}>
-                      {field.label}
-                    </Label>
-                    {field.key === 'phone_mobile' ? (
-                      <Input
-                        id={`quick-create-${field.key}`}
-                        type="tel"
-                        value={formData[field.key] || ''}
-                        onChange={(e) => handleInputChange(field.key, e.target.value.replace(/\D/g, '').slice(0, 20))}
-                        className={errors[field.key] ? 'error' : ''}
-                        disabled={isSubmitting}
-                        autoFocus={fields.indexOf(field) === 0}
-                        placeholder="(XXX) XXX-XXXX"
-                        inputMode="tel"
-                      />
-                    ) : field.key === 'phone_office' ? (
-                      <Input
-                        id={`quick-create-${field.key}`}
-                        type="tel"
-                        value={formData[field.key] || ''}
-                        onChange={(e) => handleInputChange(field.key, e.target.value.replace(/\D/g, '').slice(0, 20))}
-                        className={errors[field.key] ? 'error' : ''}
-                        disabled={isSubmitting}
-                        autoFocus={fields.indexOf(field) === 0}
-                        placeholder="(XXX) XXX-XXXX"
-                        inputMode="tel"
-                      />
-                    ) : field.key === 'phone_office_extension' ? (
-                      <Input
-                        id={`quick-create-${field.key}`}
-                        type="text"
-                        value={formData[field.key] || ''}
-                        onChange={(e) => handleInputChange(field.key, e.target.value.replace(/\D/g, '').slice(0, 6))}
-                        maxLength={6}
-                        inputMode="numeric"
-                        className={errors[field.key] ? 'error' : ''}
-                        disabled={isSubmitting}
-                        autoFocus={fields.indexOf(field) === 0}
-                        placeholder="e.g., 123"
-                      />
-                    ) : field.key === 'preferred_protein_types' ? (
-                      <Select
-                        mode="multiple"
-                        value={proteinTypeValue}
-                        onChange={(vals) => handleInputChange(field.key, vals)}
-                        options={PROTEIN_TYPE_CHOICES.map((o) => ({ value: o.value, label: o.label }))}
-                        placeholder="Search protein types"
-                        disabled={isSubmitting}
-                        showSearch
-                        optionFilterProp="label"
-                        filterOption={(input, option) => {
-                          const q = String(input || '').toLowerCase();
-                          const label = String((option as any)?.label || '').toLowerCase();
-                          const value = String((option as any)?.value || '').toLowerCase();
-                          return label.includes(q) || value.includes(q);
-                        }}
-                        style={{ width: '100%' }}
-                      />
-                    ) : field.key === 'products' && (entityType === 'customer' || entityType === 'supplier') ? (
-                      <Select
-                        mode="multiple"
-                        value={Array.isArray(formData[field.key]) ? formData[field.key] : []}
-                        onChange={(vals) => handleInputChange(field.key, vals)}
-                        options={productOptions}
-                        placeholder={proteinTypeValue.length ? 'Search products (filtered by protein types)...' : 'Search products...'}
-                        showSearch
-                        filterOption={false}
-                        onSearch={(q) => debouncedProductSearchRef.current?.(q)}
-                        notFoundContent={isLoadingProducts ? <Spin size="small" /> : null}
-                        disabled={isSubmitting}
-                        style={{ width: '100%' }}
-                      />
-                    ) : field.key === 'country' ? (
-                      <CountrySelect
-                        value={String(formData[field.key] || '')}
-                        onChange={(val) => handleInputChange(field.key, val)}
-                        placeholder="Search country"
-                        disabled={isSubmitting}
-                        aria-label="Country"
-                      />
-                    ) : field.type === 'checkbox' ? (
-                      <input
-                        id={`quick-create-${field.key}`}
-                        type="checkbox"
-                        checked={Boolean(formData[field.key])}
-                        onChange={(e) => handleInputChange(field.key, e.target.checked)}
-                        disabled={isSubmitting}
-                      />
-                    ) : (
-                      <Input
-                        id={`quick-create-${field.key}`}
-                        type={field.type === 'email' ? 'email' : field.type === 'number' ? 'number' : field.type === 'date' ? 'date' : 'text'}
-                        value={formData[field.key] || ''}
-                        onChange={(e) => {
-                          const raw = e.target.value;
-                          if (field.key === 'zip_code') {
-                            handleInputChange(field.key, raw.replace(/\D/g, '').slice(0, 5));
-                            return;
-                          }
-                          handleInputChange(field.key, raw);
-                        }}
-                        maxLength={field.key === 'zip_code' ? 5 : undefined}
-                        inputMode={field.key === 'zip_code' ? 'numeric' : undefined}
-                        pattern={field.key === 'zip_code' ? '^\\d{5}$' : undefined}
-                        className={errors[field.key] ? 'error' : ''}
-                        disabled={isSubmitting}
-                        autoFocus={fields.indexOf(field) === 0}
-                      />
-                    )}
-                    {errors[field.key] && <ErrorText>{errors[field.key]}</ErrorText>}
-                  </FieldGroup>
-                );
-              })}
-            </>
-          )}
-        </ModalBody>
-
-        <ModalFooter>
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose();
-            }}
-            disabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            variant="primary"
-            onClick={(e) => {
-              e.stopPropagation();
-              if (isSubmitting) return;
-              void handleSubmit();
-            }}
-            disabled={isLoading || isSubmitting || fields.length === 0}
-          >
-            {isSubmitting ? (
-              <>
-                <LoadingSpinner />
-                Creating...
-              </>
-            ) : (
-              <>💾 Create {entityLabel}</>
-            )}
-          </Button>
-        </ModalFooter>
-      </Modal>
-    </Overlay>
+        onClose();
+        onCreated(option);
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
Refactors QuickCreateModal (used from form submissions) to use EntityFormSurface → UniversalEntityForm instead of bespoke field rendering and custom quick-create endpoints.\n\nBenefits:\n- Single schema-driven record creation surface\n- Eliminates duplicated field logic + hardcoded choices\n- Keeps existing QuickCreateModal prop contract (callers unchanged)\n\nVerified: npm --prefix frontend run type-check