### PR TITLE
HOTFIX: stabilize available-forms + parse_document error messaging

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -26,6 +26,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-03-31** — Workforms editor: Form Submitted trigger config now lists saved FormProcess nodes via a dynamic dropdown (label: title/display-name + created date). (PR: #4318)
 
+- **2026-03-31** — **HOTFIX**: Stabilized `AvailableFormsViewSet` (Quick Actions) to avoid ORM/enum edge cases and added explicit “document parsing service unreachable” error return for the AI `parse_document` tool. (PR: TBD)
+
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`
 - Stale/Zombie secrets found in GitHub but NOT in `manifests/env.manifest.json` (or legacy `DEV_`/`UAT_`/`PROD_` prefixed):

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -26,7 +26,7 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-03-31** — Workforms editor: Form Submitted trigger config now lists saved FormProcess nodes via a dynamic dropdown (label: title/display-name + created date). (PR: #4318)
 
-- **2026-03-31** — **HOTFIX**: Stabilized `AvailableFormsViewSet` (Quick Actions) to avoid ORM/enum edge cases and added explicit “document parsing service unreachable” error return for the AI `parse_document` tool. (PR: TBD)
+- **2026-03-31** — **HOTFIX**: Stabilized `AvailableFormsViewSet` (Quick Actions) to avoid ORM/enum edge cases and added explicit “document parsing service unreachable” error return for the AI `parse_document` tool. (PR: #4327)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -844,11 +844,23 @@ class ToolExecutor:
             headers = {
                 'Authorization': f'Bearer {api_key}',
             }
-            resp = requests.post(
-                endpoint,
-                files=files,
-                headers=headers,
-                timeout=60,
+            try:
+                resp = requests.post(
+                    endpoint,
+                    files=files,
+                    headers=headers,
+                    timeout=60,
+                )
+            except requests.exceptions.RequestException:
+                return (
+                    'Error: The document parsing service is currently unreachable. '
+                    'Please inform the user that the server is experiencing issues.'
+                )
+
+        if resp.status_code in (502, 503, 504):
+            return (
+                f'Error: The document parsing service is currently unreachable (HTTP {resp.status_code}). '
+                'Please inform the user that the server is experiencing issues.'
             )
 
         if resp.status_code >= 400:

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2541,16 +2541,22 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = AvailableFormSerializer
 
     def get_queryset(self):
-        # Keep this endpoint extremely stable: Quick Actions depends on it.
+        """Return ONLY TenantForms for Quick Actions.
+
+        This endpoint must never attempt to merge models (no `.union()`), since that has repeatedly
+        caused production issues and is not required for the Quick Actions UX.
+        """
+        tenant = getattr(self.request, 'tenant', None)
+
         queryset = TenantForm.objects.filter(status__in=['active', 'draft'])
 
+        # Superusers may inspect forms across tenants.
         if not self.request.user.is_superuser:
-            tenant = getattr(self.request, 'tenant', None)
             if not tenant:
                 return TenantForm.objects.none()
             queryset = queryset.filter(tenant=tenant)
 
-        return queryset.prefetch_related('entities').order_by('name')
+        return queryset.order_by('-created_at')
 
     @extend_schema(responses={200: AvailableQuickActionTargetSerializer(many=True)})
     def list(self, request, *args, **kwargs):

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2541,11 +2541,14 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = AvailableFormSerializer
 
     def get_queryset(self):
-        # TenantForms: active or draft
-        queryset = TenantForm.objects.filter(status__in=[FormStatus.ACTIVE, FormStatus.DRAFT])
+        # Keep this endpoint extremely stable: Quick Actions depends on it.
+        queryset = TenantForm.objects.filter(status__in=['active', 'draft'])
 
         if not self.request.user.is_superuser:
-            queryset = queryset.filter(tenant=self.request.tenant)
+            tenant = getattr(self.request, 'tenant', None)
+            if not tenant:
+                return TenantForm.objects.none()
+            queryset = queryset.filter(tenant=tenant)
 
         return queryset.prefetch_related('entities').order_by('name')
 


### PR DESCRIPTION
Fixes Quick Actions stability for /api/v1/workflows/available-forms/ and makes Swarm parse_document return a clear 'service unreachable' message when Unstructured is down/timeouts.

- AvailableFormsViewSet: stable status filter + defensive tenant handling
- ToolExecutor._parse_document: catch RequestException + treat 502/503/504 as explicit unreachable

Follow-up: once merged, restart backend to clear any crashed workers.