### PR TITLE
Fix: Cockpit circuit breaker during backend outages

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -26,6 +26,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-03-31** — Workforms editor: Form Submitted trigger config now lists saved FormProcess nodes via a dynamic dropdown (label: title/display-name + created date). (PR: #4318)
 
+- **2026-03-31** — Cockpit resilience: added circuit breakers to prevent retry/toast spam during 5xx/502 backend outages; show stable "Data unavailable" placeholders. (PR: #4331)
+
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`
 - Stale/Zombie secrets found in GitHub but NOT in `manifests/env.manifest.json` (or legacy `DEV_`/`UAT_`/`PROD_` prefixed):

--- a/frontend/src/cockpit/views/CustomerDetailView.tsx
+++ b/frontend/src/cockpit/views/CustomerDetailView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { EntityFormSurface, ScheduleCallModal } from '@/components/Shared';
@@ -499,6 +499,12 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
   const [defaultCallPurpose, setDefaultCallPurpose] = useState<string | undefined>(undefined);
   const [showInquiryCallModal, setShowInquiryCallModal] = useState(false);
 
+  const queryRetry = useCallback((failureCount: number, err: any) => {
+    const status = err?.response?.status;
+    if (typeof status === 'number' && status >= 500) return false;
+    return failureCount < 1;
+  }, []);
+
   const entityQuery = useQuery({
     queryKey: ['cockpit-entity', canonicalType, entityId],
     enabled: Boolean(canonicalType && entityId),
@@ -508,6 +514,8 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
       const res = await businessApi.get(`/${path}/${entityId}/`);
       return res.data as EntityRecord;
     },
+    retry: queryRetry,
+    refetchOnWindowFocus: false,
   });
 
   const countsQuery = useQuery({
@@ -518,6 +526,8 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
       const res = await businessApi.get(`/entities/${canonicalType}/${entityId}/relationships/?counts=true`);
       return res.data as RelationshipCountsResponse;
     },
+    retry: queryRetry,
+    refetchOnWindowFocus: false,
   });
 
   const locationsQuery = useQuery({
@@ -530,6 +540,8 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
       );
       return (res.data as RelationshipItemsResponse).items ?? [];
     },
+    retry: queryRetry,
+    refetchOnWindowFocus: false,
   });
 
   const productsQuery = useQuery({
@@ -540,6 +552,8 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
       const res = await businessApi.get(`/entities/${canonicalType}/${entityId}/relationships/products/?limit=25`);
       return (res.data as RelationshipItemsResponse).items ?? [];
     },
+    retry: queryRetry,
+    refetchOnWindowFocus: false,
   });
 
   const masterProductsQuery = useQuery({
@@ -551,6 +565,8 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
       const items = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
       return items as Array<{ id: number | string; display_name?: string; item_name?: string; type?: string }>;
     },
+    retry: queryRetry,
+    refetchOnWindowFocus: false,
   });
 
   const tabItemsQuery = useQuery({
@@ -562,7 +578,8 @@ export const CustomerDetailView: React.FC<CustomerDetailViewProps> = ({
       const res = await businessApi.get(`/entities/${canonicalType}/${entityId}/relationships/${rel}/?limit=50`);
       return (res.data as RelationshipItemsResponse).items ?? [];
     },
-    retry: 0,
+    retry: queryRetry,
+    refetchOnWindowFocus: false,
   });
 
   const entity = entityQuery.data;

--- a/frontend/src/components/Cockpit/AIOverviewCard.tsx
+++ b/frontend/src/components/Cockpit/AIOverviewCard.tsx
@@ -159,6 +159,12 @@ export const AIOverviewCard: React.FC<AIOverviewCardProps> = ({ entityType, enti
         return;
       }
 
+      // Backend outage / gateway errors: don't toast-spam, just show a stable placeholder.
+      if (status === 500 || status === 502 || status === 503 || status === 504) {
+        setState({ status: 'unavailable', message: 'AI overview temporarily unavailable (server offline).' });
+        return;
+      }
+
       console.error('[AIOverviewCard] Failed to load AI overview:', err);
       setState({ status: 'error', message: 'AI Summary temporarily unavailable.' });
     }

--- a/frontend/src/components/Cockpit/EntityProfileHeader.tsx
+++ b/frontend/src/components/Cockpit/EntityProfileHeader.tsx
@@ -341,7 +341,15 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
       const resp = await businessApi.get(`/system/entities/${encodeURIComponent(entityType)}/${encodeURIComponent(entityId)}/`);
       setData(resp.data as EntityDetailResponse);
     } catch (err: any) {
+      const status = err?.response?.status;
       console.error('[EntityProfileHeader] Failed to load entity:', err);
+
+      // During backend outages, avoid toast-spam; render a stable placeholder instead.
+      if (status === 500 || status === 502 || status === 503 || status === 504) {
+        setData(null);
+        return;
+      }
+
       message.error('Failed to load record details');
       setData(null);
     } finally {
@@ -388,8 +396,15 @@ export const EntityProfileHeader: React.FC<EntityProfileHeaderProps> = ({
       setData(resp.data as EntityDetailResponse);
       return resp.data as EntityDetailResponse;
     } catch (err: any) {
+      const status = err?.response?.status;
       console.error('[EntityProfileHeader] Failed to update field:', err);
-      message.error(err?.response?.data?.error || 'Failed to update field');
+
+      if (status === 500 || status === 502 || status === 503 || status === 504) {
+        message.error('Server temporarily unavailable. Please try again in a moment.');
+      } else {
+        message.error(err?.response?.data?.error || 'Failed to update field');
+      }
+
       void load();
       throw err;
     }

--- a/frontend/src/hooks/useCockpitStats.ts
+++ b/frontend/src/hooks/useCockpitStats.ts
@@ -89,7 +89,18 @@ export const useCockpitStats = (): UseCockpitStatsReturn => {
       const response = await apiClient.get<CockpitStats>('cockpit/stats/');
       return response.data;
     },
-    refetchInterval: REFETCH_INTERVAL,
+    // Circuit breaker: avoid retry-spam and focus refetch loops during backend outages.
+    retry: (failureCount, err: any) => {
+      const status = err?.response?.status;
+      if (typeof status === 'number' && status >= 500) return false;
+      return failureCount < 1;
+    },
+    refetchOnWindowFocus: false,
+    refetchInterval: (query) => {
+      const status = (query.state.error as any)?.response?.status;
+      if (typeof status === 'number' && status >= 500) return false;
+      return REFETCH_INTERVAL;
+    },
   });
 
   return {


### PR DESCRIPTION
Stops Cockpit from retry-spamming and toast-spamming when the backend is returning 5xx/502.

- useCockpitStats: retry <=1 for non-5xx, no focus refetch, disable interval on 5xx
- AIOverviewCard: treat 500/502/503/504 as unavailable (stable placeholder)
- EntityProfileHeader: avoid toast spam on 5xx load; show stable placeholder; special-case update errors
- CustomerDetailView: apply shared retry policy + disable focus refetch for all queries