### PR TITLE
Fix: Workforms Editor UX polish

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1562,3 +1562,5 @@ Deliverables:
 - 2026-03-31 — Docs: V4.0 enterprise moat sprint (traceability, yield mgmt, enterprise gateway, risk/compliance) — PR: #4317.
 - 2026-03-31 — Frontend: Suppliers/Customers nested contact create uses EntityFormSurface (retire bespoke contact modals) — PR: #4325.
 - 2026-03-31 — Workforms: QuickCreateModal now uses EntityFormSurface → UniversalEntityForm (retire bespoke quick-create fields UI). — PR: #4326.
+
+- [x] FlowEditor UX polish (collapsed config summary + FormProcess drag/collapse fixes) — PR #4336

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -217,6 +217,18 @@ const ConfigPreview = styled.div`
   color: rgb(var(--color-text-secondary));
 `;
 
+const CollapsedConfigPreview = styled.div`
+  padding: 8px 12px;
+  border-top: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-background) / 0.6);
+  font-size: 11px;
+  color: rgb(var(--color-text-secondary));
+
+  strong {
+    color: rgb(var(--color-text-primary));
+  }
+`;
+
 const BreakpointDot = styled.div`
   position: absolute;
   top: -6px;
@@ -606,6 +618,22 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
           </HeaderToggleButton>
         )}
       </NodeHeader>
+
+      {!isExpanded && config && Object.keys(config).length > 0 && (
+        <CollapsedConfigPreview aria-label="Node configuration summary">
+          {Object.entries(config)
+            .slice(0, 2)
+            .map(([key, value]) => {
+              const str = String(value ?? '');
+              const short = str.length > 44 ? `${str.slice(0, 44)}…` : str;
+              return (
+                <div key={key}>
+                  <strong>{key}:</strong> {short}
+                </div>
+              );
+            })}
+        </CollapsedConfigPreview>
+      )}
 
       {/* Body (collapsible) */}
       {isExpanded && (

--- a/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
@@ -141,7 +141,7 @@ const ContainerHeader = styled.div`
   background: rgb(139, 92, 246);
   border-bottom: none;
   border-radius: 10px 10px 0 0;
-  cursor: pointer;
+  cursor: grab;
   user-select: none;
   color: white;
   overflow: hidden; /* Contain header styling within rounded corners */
@@ -149,14 +149,27 @@ const ContainerHeader = styled.div`
   &:hover {
     background: rgb(124, 77, 235); /* Slightly darker on hover */
   }
+
+  &:active {
+    cursor: grabbing;
+  }
 `;
 
-const ExpandIcon = styled.div`
+const ExpandIcon = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
   color: white; /* White icon for solid header */
   transition: transform 0.2s ease;
+  border: none;
+  background: transparent;
+  padding: 4px;
+  border-radius: 6px;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.16);
+  }
 `;
 
 const ContainerIcon = styled.div`
@@ -170,15 +183,15 @@ const ContainerTitle = styled.div`
   h3 {
     margin: 0;
     font-size: 15px;
-    font-weight: 600;
-    color: rgb(var(--color-text-primary));
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.98);
     line-height: 1.3;
   }
   
   p {
     margin: 4px 0 0;
     font-size: 12px;
-    color: rgb(var(--color-text-secondary));
+    color: rgba(255, 255, 255, 0.85);
     line-height: 1.2;
   }
 `;
@@ -204,16 +217,6 @@ const ContainerBody = styled.div<{ isExpanded: boolean }>`
   position: relative;
   overflow: ${props => props.isExpanded ? 'visible' : 'hidden'};
   
-  /* CRITICAL: When expanded, container body must NOT block drop events */
-  /* Drop events need to reach the ReactFlow component's drop zone */
-  ${props => props.isExpanded && `
-    pointer-events: none;
-    
-    /* Re-enable pointer events for buttons and interactive elements */
-    button, a, input, select, textarea {
-      pointer-events: auto;
-    }
-  `}
 `;
 
 /* Phase B: Visual area for child nodes */
@@ -634,16 +637,20 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
           isExpanded={isExpanded}
           className={`pm-node ${selected ? 'selected is-selected' : ''} ${data.isDropTarget ? 'drag-over' : ''}`}
         >
-          <ContainerHeader
-            onClick={(e) => {
-              if (isEditingTitle) {
-                e.stopPropagation();
-                return;
-              }
-              handleHeaderClick(e);
-            }}
-          >
-            <ExpandIcon>
+          <ContainerHeader>
+            <ExpandIcon
+              type="button"
+              className="nodrag"
+              onClick={(e) => {
+                if (isEditingTitle) {
+                  e.stopPropagation();
+                  return;
+                }
+                handleHeaderClick(e);
+              }}
+              aria-label={isExpanded ? 'Collapse container' : 'Expand container'}
+              title={isExpanded ? 'Collapse' : 'Expand'}
+            >
               {isExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
             </ExpandIcon>
             


### PR DESCRIPTION
Improvements to FlowEditor node usability:\n\n- BaseNode: show key config summary even when collapsed\n- FormProcess container: collapse/expand only via chevron (no accidental toggles), restore draggable body, and fix header text contrast\n\nMatches P0 UX notes in MASTER_PLAN.