### PR TITLE
Fix: deploy feed naming + auto-promote auth

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1570,3 +1570,5 @@ Deliverables:
 - 2026-04-01 — Docs: align README with canonical master plan (remove 100 laims) — PR: #4338.
 
 - 2026-04-01 — CI/CD: fix Master Pipeline workflow file issue (run-name + md paths-ignore) — PR: #4339.
+
+- 2026-04-01 — CI/CD: deploy feed run-name flatten + auto-promote token fallback — PR: #4340.

--- a/.github/workflows/41-auto-promote-dev-to-uat.yml
+++ b/.github/workflows/41-auto-promote-dev-to-uat.yml
@@ -27,20 +27,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Ensure PAT is configured
-        env:
-          PAT: ${{ secrets.PAT }}
-        run: |
-          set -euo pipefail
-          if [ -z "${PAT}" ]; then
-            echo "❌ Missing required secret: PAT"
-            echo "Add a repo secret named PAT with permissions to create pull requests."
-            exit 1
-          fi
-
       - name: Create promotion PR (if missing)
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          # Prefer PAT if configured, otherwise fall back to the workflow GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.PAT || github.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/42-auto-promote-uat-to-main.yml
+++ b/.github/workflows/42-auto-promote-uat-to-main.yml
@@ -27,20 +27,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Ensure PAT is configured
-        env:
-          PAT: ${{ secrets.PAT }}
-        run: |
-          set -euo pipefail
-          if [ -z "${PAT}" ]; then
-            echo "❌ Missing required secret: PAT"
-            echo "Add a repo secret named PAT with permissions to create pull requests."
-            exit 1
-          fi
-
       - name: Create promotion PR (if missing)
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          # Prefer PAT if configured, otherwise fall back to the workflow GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.PAT || github.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -7,7 +7,11 @@ run-name: >-
       || format(
         '🚀 Deploy: {0} - {1}',
         github.ref_name == 'main' && 'production' || github.ref_name,
-        github.event.head_commit.message
+        replace(
+          replace(github.event.head_commit.message, '\n', ' '),
+          '(#',
+          '(PR#:'
+        )
       )
   }}
 


### PR DESCRIPTION
- Master Pipeline run-name now flattens squash commit messages to a single line and rewrites (#1234) → (PR#:1234) for the Actions feed.
- Auto-promote (dev→uat, uat→main) no longer hard-fails without PAT; uses PAT if provided, otherwise falls back to GITHUB_TOKEN.

This addresses remaining CI/CD backlog items called out in MASTER_PLAN.