### PR TITLE
Fix: restore valid Master Pipeline run-name

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1572,3 +1572,5 @@ Deliverables:
 - 2026-04-01 — CI/CD: fix Master Pipeline workflow file issue (run-name + md paths-ignore) — PR: #4339.
 
 - 2026-04-01 — CI/CD: deploy feed run-name flatten + auto-promote token fallback — PR: #4340.
+
+- 2026-04-01 — Hotfix: restore Master Pipeline run-name (fix 0-job failures) — PR: #4341.

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -7,11 +7,7 @@ run-name: >-
       || format(
         '🚀 Deploy: {0} - {1}',
         github.ref_name == 'main' && 'production' || github.ref_name,
-        replace(
-          replace(github.event.head_commit.message, '\n', ' '),
-          '(#',
-          '(PR#:'
-        )
+        github.event.head_commit.message
       )
   }}
 


### PR DESCRIPTION
Master Pipeline runs are failing with 0 jobs due to run-name replace() usage. This PR restores the known-good run-name syntax so deployments resume.