### PR TITLE
Suppliers Plants UI polish (modal + detail view)

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -36,7 +36,7 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-04-01** — Plants: removed legacy Plant fields (`code`, `manager`, `phone`, `email`), updated Vertical plant type label to “Vertical (Kill to Fabrication)”, fixed contact phone inputs, added Department column in contact lists, and implemented strict drill-down routing + breadcrumbs (Suppliers→Plants→Contacts, Customers→Locations→Contacts). (PR: #4332)
 
-- **2026-04-06** — Suppliers/Plants UX polish: fixed UniversalEntityForm “pushed left / distorted” modal rendering by making AntD modal width responsive (`min(720px, calc(100vw - 32px))`), hardening container sizing (`max-width: 100%`, `box-sizing: border-box`, `overflow-x: hidden`), and ensuring AntD `<Select>` dropdowns mount inside the active modal/drawer container via `getPopupContainer`. Plant detail view now uses Record Pivot standard (`EntityProfileHeader` + Contacts tab) instead of a full read-only UniversalEntityForm wall. (PR: TBD)
+- **2026-04-06** — Suppliers/Plants UX polish: fixed UniversalEntityForm “pushed left / distorted” modal rendering by making AntD modal width responsive (`min(720px, calc(100vw - 32px))`), hardening container sizing (`max-width: 100%`, `box-sizing: border-box`, `overflow-x: hidden`), and ensuring AntD `<Select>` dropdowns mount inside the active modal/drawer container via `getPopupContainer`. Plant detail view now uses Record Pivot standard (`EntityProfileHeader` + Contacts tab) instead of a full read-only UniversalEntityForm wall. (PR: #4344)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -36,7 +36,7 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-04-01** — Plants: removed legacy Plant fields (`code`, `manager`, `phone`, `email`), updated Vertical plant type label to “Vertical (Kill to Fabrication)”, fixed contact phone inputs, added Department column in contact lists, and implemented strict drill-down routing + breadcrumbs (Suppliers→Plants→Contacts, Customers→Locations→Contacts). (PR: #4332)
 
-- **2026-04-06** — UniversalEntityForm modal layout: made AntD modal width responsive (`min(720px, calc(100vw - 32px))`), added container `max-width: 100%` + `box-sizing: border-box` + `overflow-x: hidden` to prevent “pushed left / distorted” rendering on smaller viewports and when embedded in modal/drawer contexts. (PR: TBD)
+- **2026-04-06** — Suppliers/Plants UX polish: fixed UniversalEntityForm “pushed left / distorted” modal rendering by making AntD modal width responsive (`min(720px, calc(100vw - 32px))`), hardening container sizing (`max-width: 100%`, `box-sizing: border-box`, `overflow-x: hidden`), and ensuring AntD `<Select>` dropdowns mount inside the active modal/drawer container via `getPopupContainer`. Plant detail view now uses Record Pivot standard (`EntityProfileHeader` + Contacts tab) instead of a full read-only UniversalEntityForm wall. (PR: TBD)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -36,6 +36,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-04-01** — Plants: removed legacy Plant fields (`code`, `manager`, `phone`, `email`), updated Vertical plant type label to “Vertical (Kill to Fabrication)”, fixed contact phone inputs, added Department column in contact lists, and implemented strict drill-down routing + breadcrumbs (Suppliers→Plants→Contacts, Customers→Locations→Contacts). (PR: #4332)
 
+- **2026-04-06** — UniversalEntityForm modal layout: made AntD modal width responsive (`min(720px, calc(100vw - 32px))`), added container `max-width: 100%` + `box-sizing: border-box` + `overflow-x: hidden` to prevent “pushed left / distorted” rendering on smaller viewports and when embedded in modal/drawer contexts. (PR: TBD)
+
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`
 - Stale/Zombie secrets found in GitHub but NOT in `manifests/env.manifest.json` (or legacy `DEV_`/`UAT_`/`PROD_` prefixed):

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -82,9 +82,12 @@ type BackendSchema = {
   key_fields?: string[];
 };
 
-const Container = styled.div`
+const Container = styled.div<{ $variant: UniversalEntityFormVariant }>`
   width: 100%;
-  min-height: 520px;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow-x: hidden;
+  min-height: ${(p) => (p.$variant === 'modal' ? '520px' : 'auto')};
 `;
 
 const normalizeEntityKey = (entityType: string): string => {
@@ -917,7 +920,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     );
 
   const content = (
-    <Container>
+    <Container $variant={variant}>
       {loading ? (
         <div style={{ padding: 16 }}>
           <Skeleton active paragraph={{ rows: 6 }} />
@@ -1153,6 +1156,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   return (
     <Modal
       open={isOpen}
+      centered
       onCancel={() => {
         if (submitting) return;
         onClose();
@@ -1160,7 +1164,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
       maskClosable={!submitting}
       keyboard={!submitting}
       footer={null}
-      width={720}
+      width="min(720px, calc(100vw - 32px))"
       destroyOnClose
       title={schema?.name || (entityId ? `${entityType} ${entityId}` : `New ${entityType}`)}
     >

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -230,6 +230,16 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   const schemaEntityKey = useMemo(() => normalizeEntityKey(entityType), [entityType]);
   const endpoint = useMemo(() => normalizeEntityEndpoint(entityType), [entityType]);
 
+  const getSelectPopupContainer = useCallback((triggerNode: HTMLElement) => {
+    const modalBody = (triggerNode?.closest?.('.ant-modal-body') as HTMLElement | null) ?? null;
+    if (modalBody) return modalBody;
+
+    const drawerBody = (triggerNode?.closest?.('.ant-drawer-body') as HTMLElement | null) ?? null;
+    if (drawerBody) return drawerBody;
+
+    return document.body;
+  }, []);
+
   const loadSchema = useCallback(async () => {
     // 1) Preferred: metadata endpoint (tenant-safe)
     try {
@@ -1002,6 +1012,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
                         value={value || undefined}
                         onChange={(next) => setFkValues((prev) => ({ ...prev, [f.key]: String(next) }))}
                         notFoundContent={loadingProducts[f.key] ? <Spin size="small" /> : null}
+                        getPopupContainer={getSelectPopupContainer}
                         style={{ width: '100%' }}
                         placeholder="Search products…"
                       />
@@ -1054,6 +1065,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
                       options={options.map((o) => ({ value: String(o.id), label: o.name }))}
                       value={value || undefined}
                       onChange={(next) => setFkValues((prev) => ({ ...prev, [f.key]: String(next) }))}
+                      getPopupContainer={getSelectPopupContainer}
                       style={{ width: '100%' }}
                       placeholder={`Select ${f.label || f.key}`}
                       filterOption={(input, option) =>

--- a/frontend/src/pages/Suppliers/PlantDetail.tsx
+++ b/frontend/src/pages/Suppliers/PlantDetail.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Breadcrumb, Button, Card, Empty, Spin, Table } from 'antd';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Breadcrumb, Button, Card, Empty, Spin, Table, Tabs } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
+import { EntityProfileHeader } from '@/components/Cockpit';
 import { EntityFormSurface } from '@/components/Shared';
 import { apiClient } from '@/services/apiService';
 
@@ -35,6 +36,9 @@ export const PlantDetail: React.FC = () => {
 
   const sid = String(supplierId || '').trim();
   const pid = String(plantId || '').trim();
+
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [showEditModal, setShowEditModal] = useState(false);
 
   const [loading, setLoading] = useState(true);
   const [supplier, setSupplier] = useState<SupplierRow | null>(null);
@@ -70,7 +74,7 @@ export const PlantDetail: React.FC = () => {
     return () => {
       mounted = false;
     };
-  }, [pid, sid]);
+  }, [pid, refreshKey, sid]);
 
   useEffect(() => {
     if (!pid) return;
@@ -103,6 +107,42 @@ export const PlantDetail: React.FC = () => {
     const name = String(plant?.name || '').trim();
     return name || (pid ? `Plant #${pid}` : 'Plant');
   }, [pid, plant?.name]);
+
+  const handleNavigateToEntity = useCallback(
+    (entityType: string, entityId: string, _label: string) => {
+      const t = String(entityType || '').trim().toLowerCase();
+      const id = String(entityId || '').trim();
+      if (!t || !id) return;
+
+      if (t === 'supplier') {
+        navigate(`/suppliers/${id}`);
+        return;
+      }
+
+      if (t === 'plant') {
+        navigate(sid ? `/suppliers/${sid}/plants/${id}` : `/plants/${id}`);
+        return;
+      }
+
+      if (t === 'contact') {
+        navigate(sid && pid ? `/suppliers/${sid}/plants/${pid}/contacts/${id}` : `/contacts?contact=${id}`);
+        return;
+      }
+
+      if (t === 'customer') {
+        navigate(`/customers/${id}`);
+        return;
+      }
+
+      if (t === 'location') {
+        navigate(`/locations/${id}`);
+        return;
+      }
+
+      navigate(`/${t}/${id}`);
+    },
+    [navigate, pid, sid]
+  );
 
   const columns: ColumnsType<ContactRow> = useMemo(
     () => [
@@ -145,7 +185,15 @@ export const PlantDetail: React.FC = () => {
 
   return (
     <div style={{ padding: 16 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
           <Button onClick={() => navigate(-1)}>Back</Button>
           <Breadcrumb
@@ -170,7 +218,27 @@ export const PlantDetail: React.FC = () => {
             ]}
           />
         </div>
+
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Button type="primary" onClick={() => setShowEditModal(true)} disabled={!pid || loading}>
+            Edit Plant
+          </Button>
+        </div>
       </div>
+
+      {showEditModal && pid && (
+        <EntityFormSurface
+          entityType="plant"
+          mode="edit"
+          entityId={pid}
+          isOpen={showEditModal}
+          onClose={() => setShowEditModal(false)}
+          onSuccess={() => {
+            setShowEditModal(false);
+            setRefreshKey((k) => k + 1);
+          }}
+        />
+      )}
 
       <div style={{ marginTop: 12 }}>
         {loading ? (
@@ -178,37 +246,47 @@ export const PlantDetail: React.FC = () => {
             <Spin />
           </Card>
         ) : (
-          <EntityFormSurface
+          <EntityProfileHeader
+            key={`${pid}-${refreshKey}`}
             entityType="plant"
-            mode="view"
-            variant="inline"
-            isOpen={true}
             entityId={pid}
-            onClose={() => navigate('/suppliers')}
+            variant="full"
+            onNavigateToEntity={handleNavigateToEntity}
           />
         )}
       </div>
 
-      <Card style={{ marginTop: 16 }} title="Contacts">
-        {loadingContacts ? (
-          <div style={{ padding: 12 }}>
-            <Spin />
-          </div>
-        ) : contacts.length === 0 ? (
-          <Empty description="No contacts for this plant" />
-        ) : (
-          <Table
-            columns={columns}
-            dataSource={contacts}
-            rowKey={(r) => String(r.id)}
-            pagination={false}
-            onRow={(record) => ({
-              onClick: () => navigate(`/suppliers/${sid}/plants/${pid}/contacts/${record.id}`),
-              style: { cursor: 'pointer' },
-            })}
-          />
-        )}
-      </Card>
+      <Tabs
+        style={{ marginTop: 12 }}
+        items={[
+          {
+            key: 'contacts',
+            label: `Contacts (${contacts.length})`,
+            children: (
+              <Card title="Contacts">
+                {loadingContacts ? (
+                  <div style={{ padding: 12 }}>
+                    <Spin />
+                  </div>
+                ) : contacts.length === 0 ? (
+                  <Empty description="No contacts for this plant" />
+                ) : (
+                  <Table
+                    columns={columns}
+                    dataSource={contacts}
+                    rowKey={(r) => String(r.id)}
+                    pagination={false}
+                    onRow={(record) => ({
+                      onClick: () => navigate(`/suppliers/${sid}/plants/${pid}/contacts/${record.id}`),
+                      style: { cursor: 'pointer' },
+                    })}
+                  />
+                )}
+              </Card>
+            ),
+          },
+        ]}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Fixes Suppliers plant UX regressions:

- UniversalEntityForm: responsive modal width + hardened container sizing
- UniversalEntityForm: Select dropdowns mount inside modal/drawer via getPopupContainer
- Suppliers/PlantDetail: replace inline view-form wall with EntityProfileHeader + Contacts tab; Edit opens overlay form

Verification:
- npm -C frontend run type-check
- npm -C frontend run lint (warnings only)