### PR TITLE
Fix main-pipeline workflow file error

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -7,11 +7,7 @@ run-name: >-
       || format(
         '🚀 Deploy: {0} - {1}',
         github.ref_name == 'main' && 'production' || github.ref_name,
-        replace(
-          replace(github.event.head_commit.message, '\n', ' '),
-          '(#',
-          '(PR#:'
-        )
+        github.sha
       )
   }}
 
@@ -45,15 +41,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Cache pip (infra)
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-infra-${{ hashFiles('.github/scripts/check_infrastructure.sh', '.github/scripts/validate-workflows.sh') }}
@@ -87,7 +83,7 @@ jobs:
       trigger_sha: ${{ github.sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 10  # Get recent commits to check for newer ones
       


### PR DESCRIPTION
The development push workflow was failing with "workflow file issue" and creating zero jobs.

Fix:
- Remove unsupported replace() usage from run-name expression
- Use supported action versions (actions/checkout@v4)

Result: main-pipeline.yml should be accepted by GitHub again and create jobs on push to development.