### PR TITLE
Refactor notifications to service layer

### DIFF
--- a/frontend/src/contexts/NotificationsContext.test.tsx
+++ b/frontend/src/contexts/NotificationsContext.test.tsx
@@ -5,11 +5,22 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import React, { ReactNode } from 'react';
 import { vi } from 'vitest';
 import { NotificationsProvider, useNotifications, Notification, ActionItem } from './NotificationsContext';
-import { AuthProvider } from './AuthContext';
 
-// Mock fetch
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+import { notificationsService } from '../services/notificationsService';
+
+vi.mock('../services/notificationsService', () => ({
+  notificationsService: {
+    listNotifications: vi.fn(),
+    getUnreadCount: vi.fn(),
+    markAsRead: vi.fn(),
+    markAllRead: vi.fn(),
+    dismiss: vi.fn(),
+    listActionItems: vi.fn(),
+    getActionItemCounts: vi.fn(),
+    getPreferences: vi.fn(),
+    updatePreferences: vi.fn(),
+  },
+}));
 
 // Mock localStorage
 const mockLocalStorage = {
@@ -138,44 +149,17 @@ const createWrapper = () => {
 describe('NotificationsContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    
-    // Default mock responses
-    mockFetch.mockImplementation((url: string) => {
-      if (url.includes('/notifications/unread-count/')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ count: 1 }),
-        });
-      }
-      if (url.includes('/notifications/') && !url.includes('/read/') && !url.includes('/mark-all-read/')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(mockNotifications),
-        });
-      }
-      if (url.includes('/action-items/counts/')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(mockActionItemCounts),
-        });
-      }
-      if (url.includes('/action-items/')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(mockActionItems),
-        });
-      }
-      if (url.includes('/notification-preferences/')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(mockPreferences),
-        });
-      }
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({}),
-      });
-    });
+
+    vi.mocked(notificationsService.listNotifications).mockResolvedValue(mockNotifications as any);
+    vi.mocked(notificationsService.getUnreadCount).mockResolvedValue(1 as any);
+    vi.mocked(notificationsService.listActionItems).mockResolvedValue(mockActionItems as any);
+    vi.mocked(notificationsService.getActionItemCounts).mockResolvedValue(mockActionItemCounts as any);
+    vi.mocked(notificationsService.getPreferences).mockResolvedValue(mockPreferences as any);
+    vi.mocked(notificationsService.updatePreferences).mockResolvedValue(mockPreferences as any);
+
+    vi.mocked(notificationsService.markAsRead).mockResolvedValue(undefined as any);
+    vi.mocked(notificationsService.markAllRead).mockResolvedValue(1 as any);
+    vi.mocked(notificationsService.dismiss).mockResolvedValue(undefined as any);
   });
 
   describe('useNotifications hook', () => {
@@ -230,49 +214,6 @@ describe('NotificationsContext', () => {
 
   describe('markAsRead', () => {
     it('should mark notification as read', async () => {
-      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
-        if (url.includes('/read/') && options?.method === 'POST') {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ status: 'success' }),
-          });
-        }
-        // Return default responses for other endpoints
-        if (url.includes('/notifications/unread-count/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ count: 1 }),
-          });
-        }
-        if (url.includes('/notifications/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockNotifications),
-          });
-        }
-        if (url.includes('/action-items/counts/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockActionItemCounts),
-          });
-        }
-        if (url.includes('/action-items/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockActionItems),
-          });
-        }
-        if (url.includes('/notification-preferences/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockPreferences),
-          });
-        }
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        });
-      });
 
       const { result } = renderHook(() => useNotifications(), {
         wrapper: createWrapper(),
@@ -293,48 +234,6 @@ describe('NotificationsContext', () => {
 
   describe('markAllAsRead', () => {
     it('should mark all notifications as read', async () => {
-      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
-        if (url.includes('/mark-all-read/') && options?.method === 'POST') {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ status: 'success', count: 1 }),
-          });
-        }
-        if (url.includes('/notifications/unread-count/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ count: 1 }),
-          });
-        }
-        if (url.includes('/notifications/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockNotifications),
-          });
-        }
-        if (url.includes('/action-items/counts/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockActionItemCounts),
-          });
-        }
-        if (url.includes('/action-items/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockActionItems),
-          });
-        }
-        if (url.includes('/notification-preferences/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockPreferences),
-          });
-        }
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        });
-      });
 
       const { result } = renderHook(() => useNotifications(), {
         wrapper: createWrapper(),
@@ -357,48 +256,6 @@ describe('NotificationsContext', () => {
 
   describe('dismissNotification', () => {
     it('should remove notification from list', async () => {
-      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
-        if (url.includes('/notifications/notif-1/') && options?.method === 'DELETE') {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({}),
-          });
-        }
-        if (url.includes('/notifications/unread-count/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ count: 1 }),
-          });
-        }
-        if (url.includes('/notifications/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockNotifications),
-          });
-        }
-        if (url.includes('/action-items/counts/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockActionItemCounts),
-          });
-        }
-        if (url.includes('/action-items/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockActionItems),
-          });
-        }
-        if (url.includes('/notification-preferences/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockPreferences),
-          });
-        }
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        });
-      });
 
       const { result } = renderHook(() => useNotifications(), {
         wrapper: createWrapper(),
@@ -460,49 +317,8 @@ describe('NotificationsContext', () => {
 
     it('should update preferences', async () => {
       const updatedPrefs = { ...mockPreferences, email_enabled: false };
-      
-      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
-        if (url.includes('/notification-preferences/') && options?.method === 'PUT') {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(updatedPrefs),
-          });
-        }
-        if (url.includes('/notifications/unread-count/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ count: 1 }),
-          });
-        }
-        if (url.includes('/notifications/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockNotifications),
-          });
-        }
-        if (url.includes('/action-items/counts/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockActionItemCounts),
-          });
-        }
-        if (url.includes('/action-items/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockActionItems),
-          });
-        }
-        if (url.includes('/notification-preferences/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockPreferences),
-          });
-        }
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        });
-      });
+
+      vi.mocked(notificationsService.updatePreferences).mockResolvedValue(updatedPrefs as any);
 
       const { result } = renderHook(() => useNotifications(), {
         wrapper: createWrapper(),
@@ -532,7 +348,7 @@ describe('NotificationsContext', () => {
 
       // Polling is started automatically when authenticated
       // We can't easily test the interval, but we can verify initial fetch happened
-      expect(mockFetch).toHaveBeenCalled();
+      expect(notificationsService.listNotifications).toHaveBeenCalled();
     });
 
     it('should stop polling when stopPolling is called', async () => {
@@ -555,36 +371,9 @@ describe('NotificationsContext', () => {
 
   describe('error handling', () => {
     it('should handle fetch errors gracefully', async () => {
-      mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/notifications/') && !url.includes('/unread-count/')) {
-          return Promise.resolve({
-            ok: false,
-            status: 500,
-          });
-        }
-        if (url.includes('/notifications/unread-count/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ count: 0 }),
-          });
-        }
-        if (url.includes('/action-items/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve([]),
-          });
-        }
-        if (url.includes('/notification-preferences/')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(mockPreferences),
-          });
-        }
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        });
-      });
+      vi.mocked(notificationsService.listNotifications).mockRejectedValue(new Error('Server error'));
+      vi.mocked(notificationsService.getUnreadCount).mockResolvedValue(0 as any);
+      vi.mocked(notificationsService.listActionItems).mockResolvedValue([] as any);
 
       const { result } = renderHook(() => useNotifications(), {
         wrapper: createWrapper(),

--- a/frontend/src/contexts/NotificationsContext.tsx
+++ b/frontend/src/contexts/NotificationsContext.tsx
@@ -9,7 +9,7 @@
  */
 import React, { createContext, useContext, useEffect, useState, useCallback, ReactNode } from 'react';
 import { useAuth } from './AuthContext';
-import { getAuthHeader } from '../services/jwtService';
+import { notificationsService } from '../services/notificationsService';
 
 // ============================================================================
 // TYPES
@@ -133,107 +133,56 @@ const NotificationsContext = createContext<NotificationsContextType | undefined>
 // API FUNCTIONS
 // ============================================================================
 
-const API_BASE = '/api/v1/workflows';
+// All notifications requests go through the JWT-aware axios apiClient via notificationsService.
 
-const buildApiHeaders = (): Record<string, string> => {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-
-  const authHeader = getAuthHeader();
-  if (authHeader) {
-    headers.Authorization = authHeader;
+const getApiErrorMessage = (error: unknown, fallbackMessage: string): string => {
+  if (error && typeof error === 'object') {
+    const err: any = error as any;
+    return (
+      err.response?.data?.error ||
+      err.response?.data?.detail ||
+      err.response?.data?.message ||
+      err.message ||
+      fallbackMessage
+    );
   }
 
-  const tenantId = localStorage.getItem('tenantId');
-  if (tenantId) {
-    headers['X-Tenant-ID'] = tenantId;
-  }
-
-  return headers;
+  return fallbackMessage;
 };
 
 async function fetchNotificationsAPI(): Promise<Notification[]> {
   try {
-    const authHeader = getAuthHeader();
-    if (!authHeader) return []; // Silently return empty if not authenticated
-
-    const response = await fetch(`${API_BASE}/notifications/`, {
-      headers: buildApiHeaders(),
-    });
-    
-    // Silently return empty array for 401/404 (feature not available)
-    if (response.status === 401 || response.status === 404) return [];
-    if (!response.ok) throw new Error('Failed to fetch notifications');
-    
-    const data = await response.json();
-    // Handle both paginated response {results: []} and bare array
-    return Array.isArray(data) ? data : (data.results || []);
+    return (await notificationsService.listNotifications()) as Notification[];
   } catch (error) {
     console.warn('[NotificationsContext] Notifications API not available:', error);
-    return []; // Graceful degradation
+    return [];
   }
 }
 
 async function fetchUnreadCountAPI(): Promise<number> {
   try {
-    const authHeader = getAuthHeader();
-    if (!authHeader) return 0; // Silently return 0 if not authenticated
-
-    const response = await fetch(`${API_BASE}/notifications/unread-count/`, {
-      headers: buildApiHeaders(),
-    });
-    
-    // Silently return 0 for 401/404 (feature not available)
-    if (response.status === 401 || response.status === 404) return 0;
-    if (!response.ok) throw new Error('Failed to fetch unread count');
-    
-    const data = await response.json();
-    return data.count;
+    return await notificationsService.getUnreadCount();
   } catch (error) {
     console.warn('[NotificationsContext] Unread count API not available:', error);
-    return 0; // Graceful degradation
+    return 0;
   }
 }
 
 async function markAsReadAPI(id: string): Promise<void> {
-  const response = await fetch(`${API_BASE}/notifications/${id}/read/`, {
-    method: 'POST',
-    headers: buildApiHeaders(),
-  });
-  if (!response.ok) throw new Error('Failed to mark notification as read');
+  await notificationsService.markAsRead(id);
 }
 
 async function markAllAsReadAPI(): Promise<number> {
-  const response = await fetch(`${API_BASE}/notifications/mark-all-read/`, {
-    method: 'POST',
-    headers: buildApiHeaders(),
-  });
-  if (!response.ok) throw new Error('Failed to mark all as read');
-  const data = await response.json();
-  return data.count;
+  return notificationsService.markAllRead();
 }
 
 async function dismissNotificationAPI(id: string): Promise<void> {
-  const response = await fetch(`${API_BASE}/notifications/${id}/`, {
-    method: 'DELETE',
-    headers: buildApiHeaders(),
-  });
-  if (!response.ok) throw new Error('Failed to dismiss notification');
+  await notificationsService.dismiss(id);
 }
 
 async function fetchActionItemsAPI(): Promise<ActionItem[]> {
   try {
-    const authHeader = getAuthHeader();
-    if (!authHeader) return [];
-
-    const response = await fetch(`${API_BASE}/action-items/`, {
-      headers: buildApiHeaders(),
-    });
-    
-    if (response.status === 401 || response.status === 404) return [];
-    if (!response.ok) throw new Error('Failed to fetch action items');
-    return response.json();
+    return (await notificationsService.listActionItems()) as ActionItem[];
   } catch (error) {
     console.warn('[NotificationsContext] Action items API not available:', error);
     return [];
@@ -242,34 +191,7 @@ async function fetchActionItemsAPI(): Promise<ActionItem[]> {
 
 async function fetchActionItemCountsAPI(): Promise<ActionItemCounts> {
   try {
-    const authHeader = getAuthHeader();
-    if (!authHeader) {
-      return {
-        total: 0,
-        overdue: 0,
-        due_today: 0,
-        due_this_week: 0,
-        by_priority: {},
-        by_form: [],
-      };
-    }
-
-    const response = await fetch(`${API_BASE}/action-items/counts/`, {
-      headers: buildApiHeaders(),
-    });
-    
-    if (response.status === 401 || response.status === 404) {
-      return {
-        total: 0,
-        overdue: 0,
-        due_today: 0,
-        due_this_week: 0,
-        by_priority: {},
-        by_form: [],
-      };
-    }
-    if (!response.ok) throw new Error('Failed to fetch action item counts');
-    return response.json();
+    return (await notificationsService.getActionItemCounts()) as ActionItemCounts;
   } catch (error) {
     console.warn('[NotificationsContext] Action item counts API not available:', error);
     return {
@@ -285,46 +207,7 @@ async function fetchActionItemCountsAPI(): Promise<ActionItemCounts> {
 
 async function fetchPreferencesAPI(): Promise<NotificationPreferences> {
   try {
-    const authHeader = getAuthHeader();
-    if (!authHeader) {
-      return {
-        id: '',
-        user: 0,
-        notifications_enabled: true,
-        email_enabled: true,
-        sms_enabled: false,
-        push_enabled: false,
-        type_preferences: {} as Record<NotificationType, Array<'email' | 'push' | 'in_app'>>,
-        quiet_hours_enabled: false,
-        quiet_hours_start: null,
-        quiet_hours_end: null,
-        daily_digest_enabled: false,
-        weekly_digest_enabled: false,
-      };
-    }
-
-    const response = await fetch(`${API_BASE}/notification-preferences/`, {
-      headers: buildApiHeaders(),
-    });
-    
-    if (response.status === 401 || response.status === 404) {
-      return {
-        id: '',
-        user: 0,
-        notifications_enabled: true,
-        email_enabled: true,
-        sms_enabled: false,
-        push_enabled: false,
-        type_preferences: {} as Record<NotificationType, Array<'email' | 'push' | 'in_app'>>,
-        quiet_hours_enabled: false,
-        quiet_hours_start: null,
-        quiet_hours_end: null,
-        daily_digest_enabled: false,
-        weekly_digest_enabled: false,
-      };
-    }
-    if (!response.ok) throw new Error('Failed to fetch preferences');
-    return response.json();
+    return (await notificationsService.getPreferences()) as NotificationPreferences;
   } catch (error) {
     console.warn('[NotificationsContext] Preferences API not available:', error);
     return {
@@ -345,13 +228,7 @@ async function fetchPreferencesAPI(): Promise<NotificationPreferences> {
 }
 
 async function updatePreferencesAPI(prefs: Partial<NotificationPreferences>): Promise<NotificationPreferences> {
-  const response = await fetch(`${API_BASE}/notification-preferences/`, {
-    method: 'PUT',
-    headers: buildApiHeaders(),
-    body: JSON.stringify(prefs),
-  });
-  if (!response.ok) throw new Error('Failed to update preferences');
-  return response.json();
+  return (await notificationsService.updatePreferences(prefs as Record<string, unknown>)) as NotificationPreferences;
 }
 
 // ============================================================================
@@ -394,7 +271,7 @@ export const NotificationsProvider: React.FC<NotificationsProviderProps> = ({
       setNotifications(notifs);
       setUnreadCount(count);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch notifications');
+      setError(getApiErrorMessage(err, 'Failed to fetch notifications'));
     } finally {
       setLoading(false);
     }
@@ -409,7 +286,7 @@ export const NotificationsProvider: React.FC<NotificationsProviderProps> = ({
       );
       setUnreadCount(prev => Math.max(0, prev - 1));
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to mark as read');
+      setError(getApiErrorMessage(err, 'Failed to mark as read'));
     }
   }, []);
   
@@ -422,7 +299,7 @@ export const NotificationsProvider: React.FC<NotificationsProviderProps> = ({
       );
       setUnreadCount(0);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to mark all as read');
+      setError(getApiErrorMessage(err, 'Failed to mark all as read'));
     }
   }, []);
   
@@ -436,7 +313,7 @@ export const NotificationsProvider: React.FC<NotificationsProviderProps> = ({
         setUnreadCount(prev => Math.max(0, prev - 1));
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to dismiss notification');
+      setError(getApiErrorMessage(err, 'Failed to dismiss notification'));
     }
   }, [notifications]);
   
@@ -463,7 +340,7 @@ export const NotificationsProvider: React.FC<NotificationsProviderProps> = ({
       const updated = await updatePreferencesAPI(prefs);
       setPreferences(updated);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update preferences');
+      setError(getApiErrorMessage(err, 'Failed to update preferences'));
       throw err;
     }
   }, []);

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -82,6 +82,12 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
         getAvailableWorkForms(),
       ]);
 
+      if (actionsResult.status === 'rejected') {
+        const msg = actionsResult.reason?.message || 'Failed to load quick actions';
+        console.warn('[QuickActions] getQuickActions failed', actionsResult.reason);
+        setError(msg);
+      }
+
       const actionsResponse = actionsResult.status === 'fulfilled' ? actionsResult.value : { items: [] };
       setQuickActions(actionsResponse.items || []);
 

--- a/frontend/src/services/notificationsService.ts
+++ b/frontend/src/services/notificationsService.ts
@@ -1,0 +1,109 @@
+import axios from 'axios';
+
+import { apiClient } from './apiService';
+
+const API_BASE = '/workflows';
+
+const isNotFoundOrUnauthorized = (status?: number) => status === 401 || status === 404;
+
+export const notificationsService = {
+  async listNotifications(): Promise<unknown[]> {
+    try {
+      const response = await apiClient.get(`${API_BASE}/notifications/`);
+      const data: any = response.data;
+      return Array.isArray(data) ? data : (data?.results ?? []);
+    } catch (err) {
+      const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+      if (isNotFoundOrUnauthorized(status)) return [];
+      throw err;
+    }
+  },
+
+  async getUnreadCount(): Promise<number> {
+    try {
+      const response = await apiClient.get(`${API_BASE}/notifications/unread-count/`);
+      const data: any = response.data;
+      return Number(data?.count ?? 0);
+    } catch (err) {
+      const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+      if (isNotFoundOrUnauthorized(status)) return 0;
+      throw err;
+    }
+  },
+
+  async markAsRead(id: string): Promise<void> {
+    await apiClient.post(`${API_BASE}/notifications/${id}/read/`);
+  },
+
+  async markAllRead(): Promise<number> {
+    const response = await apiClient.post(`${API_BASE}/notifications/mark-all-read/`);
+    const data: any = response.data;
+    return Number(data?.count ?? 0);
+  },
+
+  async dismiss(id: string): Promise<void> {
+    await apiClient.delete(`${API_BASE}/notifications/${id}/`);
+  },
+
+  async listActionItems(): Promise<unknown[]> {
+    try {
+      const response = await apiClient.get(`${API_BASE}/action-items/`);
+      return Array.isArray(response.data) ? response.data : [];
+    } catch (err) {
+      const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+      if (isNotFoundOrUnauthorized(status)) return [];
+      throw err;
+    }
+  },
+
+  async getActionItemCounts(): Promise<any> {
+    const empty = {
+      total: 0,
+      overdue: 0,
+      due_today: 0,
+      due_this_week: 0,
+      by_priority: {},
+      by_form: [],
+    };
+
+    try {
+      const response = await apiClient.get(`${API_BASE}/action-items/counts/`);
+      return response.data ?? empty;
+    } catch (err) {
+      const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+      if (isNotFoundOrUnauthorized(status)) return empty;
+      throw err;
+    }
+  },
+
+  async getPreferences(): Promise<any> {
+    const defaults = {
+      id: '',
+      user: 0,
+      notifications_enabled: true,
+      email_enabled: true,
+      sms_enabled: false,
+      push_enabled: false,
+      type_preferences: {},
+      quiet_hours_enabled: false,
+      quiet_hours_start: null,
+      quiet_hours_end: null,
+      daily_digest_enabled: false,
+      weekly_digest_enabled: false,
+    };
+
+    try {
+      const response = await apiClient.get(`${API_BASE}/notification-preferences/`);
+      return response.data ?? defaults;
+    } catch (err) {
+      const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+      if (isNotFoundOrUnauthorized(status)) return defaults;
+      throw err;
+    }
+  },
+
+  async updatePreferences(prefs: Record<string, unknown>): Promise<any> {
+    const response = await apiClient.put(`${API_BASE}/notification-preferences/`, prefs);
+    return response.data;
+  },
+};


### PR DESCRIPTION
### What
- Replace NotificationsContext raw fetch() calls with notificationsService (JWT-aware apiClient).
- Update NotificationsContext tests to mock notificationsService.
- Ensure QuickActionsContext sets an error when getQuickActions fails.

### Why
- Enforces the canonical frontend service layer (token refresh/interceptors).
- Improves test stability by mocking the service boundary.

### Validation
- npm -C frontend run test:ci
- npm -C frontend run type-check
