### PR TITLE
Graceful email degradation (reconnect codes)

### DIFF
--- a/backend/tenant_apps/workflows/nodes/outlook_email.py
+++ b/backend/tenant_apps/workflows/nodes/outlook_email.py
@@ -14,6 +14,13 @@ from django.core.exceptions import ValidationError
 logger = logging.getLogger(__name__)
 
 
+def _email_integrations_cta() -> dict:
+    return {
+        'label': 'Open Email Integrations',
+        'url': '/settings/email-integrations',
+    }
+
+
 class OutlookEmailNode:
     """
     Workflow node for sending emails via Microsoft Outlook.
@@ -167,17 +174,71 @@ class OutlookEmailNode:
             except ExternalAuthProvider.DoesNotExist:
                 return {
                     'status': 'error',
-                    'message': 'Microsoft account not connected. Please connect in Settings > Integrations.',
+                    'message': 'Microsoft account not connected.',
+                    'code': 'not_connected',
+                    'error_code': 'not_connected',
+                    'hint': 'Connect Outlook in Settings → Email Integrations, then retry.',
+                    'cta': _email_integrations_cta(),
                     'node_id': self.node_id,
                 }
-            
+
             # Refresh token if needed
             if auth_provider.is_token_expired():
                 logger.info(f"Refreshing expired token for tenant {tenant_id}")
-                auth_provider.refresh_if_needed()
-            
+                try:
+                    auth_provider.refresh_if_needed()
+                except Exception as e:
+                    logger.warning(
+                        'Outlook token refresh failed tenant=%s provider_id=%s: %s',
+                        tenant_id,
+                        getattr(auth_provider, 'id', None),
+                        str(e),
+                        exc_info=True,
+                    )
+                    return {
+                        'status': 'error',
+                        'message': 'Outlook authentication needs to be refreshed.',
+                        'code': 'token_refresh_failed',
+                        'error_code': 'token_refresh_failed',
+                        'hint': 'Reconnect Outlook in Settings → Email Integrations, then retry.',
+                        'cta': _email_integrations_cta(),
+                        'node_id': self.node_id,
+                    }
+
             # Get decrypted access token
-            access_token = auth_provider.get_decrypted_token('access')
+            try:
+                access_token = auth_provider.get_decrypted_token('access')
+            except Exception as e:
+                try:
+                    from cryptography.fernet import InvalidToken
+
+                    is_decrypt = isinstance(e, InvalidToken)
+                except Exception:
+                    is_decrypt = 'decrypt' in str(e).lower() or 'invalidtoken' in str(e).lower()
+
+                if is_decrypt:
+                    return {
+                        'status': 'error',
+                        'message': 'Outlook connection needs to be refreshed for security reasons.',
+                        'code': 'decryption_failed',
+                        'error_code': 'decryption_failed',
+                        'hint': 'Reconnect Outlook in Settings → Email Integrations, then retry.',
+                        'cta': _email_integrations_cta(),
+                        'node_id': self.node_id,
+                    }
+
+                raise
+
+            if not access_token:
+                return {
+                    'status': 'error',
+                    'message': 'No Outlook access token available.',
+                    'code': 'token_missing',
+                    'error_code': 'token_missing',
+                    'hint': 'Reconnect Outlook in Settings → Email Integrations, then retry.',
+                    'cta': _email_integrations_cta(),
+                    'node_id': self.node_id,
+                }
             
             # Render email template with context
             to_addresses = [
@@ -243,15 +304,21 @@ class OutlookEmailNode:
             logger.error(f"Token expired for tenant {tenant_id} in node {self.node_id}")
             return {
                 'status': 'error',
-                'message': 'Email authentication expired. Please reconnect in Settings > Integrations.',
+                'message': 'Outlook authentication expired or is invalid.',
+                'code': 'token_invalid',
+                'error_code': 'token_invalid',
+                'hint': 'Reconnect Outlook in Settings → Email Integrations, then retry.',
+                'cta': _email_integrations_cta(),
                 'node_id': self.node_id,
             }
-        
+
         except ValidationError as e:
             logger.error(f"Email validation error in node {self.node_id}: {str(e)}")
             return {
                 'status': 'error',
                 'message': f'Email validation error: {str(e)}',
+                'code': 'validation_error',
+                'error_code': 'validation_error',
                 'node_id': self.node_id,
             }
         

--- a/backend/tenant_apps/workflows/tests/test_outlook_email_node.py
+++ b/backend/tenant_apps/workflows/tests/test_outlook_email_node.py
@@ -1,0 +1,66 @@
+import uuid
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.integrations.models import ExternalAuthProvider
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.workflows.nodes.outlook_email import OutlookEmailNode
+
+
+class OutlookEmailNodeDegradationTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        unique_id = uuid.uuid4().hex[:8]
+        cls.user = User.objects.create_user(
+            username=f'testuser-{unique_id}',
+            email=f'test-{unique_id}@example.com',
+            password='testpass123',
+        )
+        cls.tenant = Tenant.objects.create(
+            name=f'Test Company {unique_id}',
+            slug=f'test-company-{unique_id}',
+            contact_email=f'admin-{unique_id}@testcompany.com',
+            created_by=cls.user,
+        )
+        TenantUser.objects.create(tenant=cls.tenant, user=cls.user, role='owner')
+
+    def _make_node(self) -> OutlookEmailNode:
+        return OutlookEmailNode(
+            node_id='n1',
+            config={
+                'to': ['buyer@example.com'],
+                'subject': 'Hello',
+                'body': 'Body',
+            },
+        )
+
+    def test_missing_outlook_connection_returns_structured_code(self):
+        node = self._make_node()
+        result = node.execute(context={}, tenant_id=self.tenant.id)
+
+        self.assertEqual(result.get('status'), 'error')
+        self.assertEqual(result.get('error_code'), 'not_connected')
+        self.assertIn('cta', result)
+        self.assertEqual(result.get('cta', {}).get('url'), '/settings/email-integrations')
+
+    def test_decryption_failure_returns_structured_code(self):
+        ExternalAuthProvider.objects.create(
+            tenant=self.tenant,
+            provider_type='microsoft',
+            is_active=True,
+            access_token='not-a-fernet-token',
+            refresh_token=None,
+            token_expiry=timezone.now() + timedelta(days=365),
+            connected_email='connected@example.com',
+            connected_name='Connected User',
+        )
+
+        node = self._make_node()
+        result = node.execute(context={}, tenant_id=self.tenant.id)
+
+        self.assertEqual(result.get('status'), 'error')
+        self.assertEqual(result.get('error_code'), 'decryption_failed')
+        self.assertEqual(result.get('cta', {}).get('url'), '/settings/email-integrations')


### PR DESCRIPTION
### What
- Standardize OutlookEmailNode error payloads with structured error_code + cta for reconnect flows.
- Add tests covering not_connected and decryption_failed scenarios.

### Why
- Enables deterministic Reconnect Outlook UX instead of opaque failures.
- Prevents regressions in common auth/decryption failure modes.

### Validation
- python backend/manage.py test tenant_apps.workflows.tests.test_outlook_email_node --verbosity=2
