### PR TITLE
Add missing UI atoms (canonical primitives)

### DIFF
--- a/frontend/src/components/ui/atoms/Badge.tsx
+++ b/frontend/src/components/ui/atoms/Badge.tsx
@@ -1,0 +1,59 @@
+/**
+ * Semantic Badge Atom
+ *
+ * Lightweight status badge using semantic CSS variables.
+ */
+
+import React from 'react';
+import { Tag } from 'antd';
+
+export type BadgeVariant = 'default' | 'success' | 'warning' | 'error' | 'info';
+
+export interface BadgeProps {
+  children: React.ReactNode;
+  variant?: BadgeVariant;
+  className?: string;
+}
+
+const variantStyles: Record<BadgeVariant, React.CSSProperties> = {
+  default: {
+    backgroundColor: 'rgb(var(--color-surface))',
+    borderColor: 'rgb(var(--color-border))',
+    color: 'rgb(var(--color-text-secondary))',
+  },
+  success: {
+    backgroundColor: 'rgba(var(--color-success), 0.15)',
+    borderColor: 'rgba(var(--color-success), 0.35)',
+    color: 'rgb(var(--color-success))',
+  },
+  warning: {
+    backgroundColor: 'rgba(var(--color-warning), 0.15)',
+    borderColor: 'rgba(var(--color-warning), 0.35)',
+    color: 'rgb(var(--color-warning))',
+  },
+  error: {
+    backgroundColor: 'rgba(var(--color-error), 0.15)',
+    borderColor: 'rgba(var(--color-error), 0.35)',
+    color: 'rgb(var(--color-error))',
+  },
+  info: {
+    backgroundColor: 'rgba(var(--color-info), 0.15)',
+    borderColor: 'rgba(var(--color-info), 0.35)',
+    color: 'rgb(var(--color-info))',
+  },
+};
+
+export const Badge: React.FC<BadgeProps> = ({ children, variant = 'default', className }) => {
+  return (
+    <Tag
+      className={className}
+      bordered
+      style={{
+        ...variantStyles[variant],
+        marginInlineEnd: 0,
+      }}
+    >
+      {children}
+    </Tag>
+  );
+};

--- a/frontend/src/components/ui/atoms/Checkbox.tsx
+++ b/frontend/src/components/ui/atoms/Checkbox.tsx
@@ -1,0 +1,15 @@
+/**
+ * Semantic Checkbox Atom
+ */
+
+import React from 'react';
+import { Checkbox as AntCheckbox } from 'antd';
+import type { CheckboxProps as AntCheckboxProps } from 'antd';
+
+export interface CheckboxProps extends Omit<AntCheckboxProps, 'onChange'> {
+  onChange?: (checked: boolean) => void;
+}
+
+export const Checkbox: React.FC<CheckboxProps> = ({ onChange, ...props }) => {
+  return <AntCheckbox onChange={(e) => onChange?.(e.target.checked)} {...props} />;
+};

--- a/frontend/src/components/ui/atoms/Input.tsx
+++ b/frontend/src/components/ui/atoms/Input.tsx
@@ -1,0 +1,35 @@
+/**
+ * Semantic Input Atom
+ *
+ * Wraps Ant Design Input with a small, typed API and optional error display.
+ * Uses CSS variables for colors via global theme.
+ */
+
+import React from 'react';
+import { Input as AntInput, Typography } from 'antd';
+import type { InputProps as AntInputProps } from 'antd';
+
+export interface InputProps extends Omit<AntInputProps, 'value' | 'onChange' | 'size' | 'status'> {
+  value: string;
+  onChange: (value: string) => void;
+  size?: 'sm' | 'md' | 'lg';
+  error?: string;
+}
+
+export const Input: React.FC<InputProps> = ({ value, onChange, size = 'md', error, style, ...props }) => {
+  const antdSize: AntInputProps['size'] = size === 'sm' ? 'small' : size === 'lg' ? 'large' : 'middle';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, width: '100%' }}>
+      <AntInput
+        value={value}
+        size={antdSize}
+        status={error ? 'error' : undefined}
+        style={{ width: '100%', ...style }}
+        onChange={(e) => onChange(e.target.value)}
+        {...props}
+      />
+      {error ? <Typography.Text type="danger">{error}</Typography.Text> : null}
+    </div>
+  );
+};

--- a/frontend/src/components/ui/atoms/Label.tsx
+++ b/frontend/src/components/ui/atoms/Label.tsx
@@ -1,0 +1,33 @@
+/**
+ * Semantic Label Atom
+ */
+
+import React from 'react';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  required?: boolean;
+}
+
+export const Label: React.FC<LabelProps> = ({ children, required = false, style, ...props }) => {
+  return (
+    <label
+      style={{
+        display: 'inline-flex',
+        gap: 4,
+        alignItems: 'center',
+        color: 'rgb(var(--color-text-primary))',
+        fontSize: 13,
+        fontWeight: 500,
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+      {required ? (
+        <span aria-hidden="true" style={{ color: 'rgb(var(--color-danger))' }}>
+          *
+        </span>
+      ) : null}
+    </label>
+  );
+};

--- a/frontend/src/components/ui/atoms/Radio.tsx
+++ b/frontend/src/components/ui/atoms/Radio.tsx
@@ -1,0 +1,50 @@
+/**
+ * Semantic Radio Atom
+ */
+
+import React from 'react';
+import { Radio as AntRadio } from 'antd';
+import type { RadioProps as AntRadioProps } from 'antd';
+
+export interface RadioProps extends Omit<AntRadioProps, 'onChange'> {
+  onChange?: (checked: boolean) => void;
+}
+
+export const Radio: React.FC<RadioProps> = ({ onChange, ...props }) => {
+  return <AntRadio onChange={(e) => onChange?.(e.target.checked)} {...props} />;
+};
+
+export interface RadioOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface RadioGroupProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: RadioOption[];
+  disabled?: boolean;
+  optionType?: 'default' | 'button';
+  buttonStyle?: 'outline' | 'solid';
+}
+
+export const RadioGroup: React.FC<RadioGroupProps> = ({
+  value,
+  onChange,
+  options,
+  disabled = false,
+  optionType = 'default',
+  buttonStyle,
+}) => {
+  return (
+    <AntRadio.Group
+      value={value}
+      onChange={(e) => onChange(String(e.target.value))}
+      options={options}
+      disabled={disabled}
+      optionType={optionType}
+      buttonStyle={buttonStyle}
+    />
+  );
+};

--- a/frontend/src/components/ui/atoms/Textarea.tsx
+++ b/frontend/src/components/ui/atoms/Textarea.tsx
@@ -1,0 +1,30 @@
+/**
+ * Semantic Textarea Atom
+ *
+ * Wraps Ant Design Input.TextArea with typed API and optional error display.
+ */
+
+import React from 'react';
+import { Input as AntInput, Typography } from 'antd';
+import type { TextAreaProps as AntTextAreaProps } from 'antd/es/input';
+
+export interface TextareaProps extends Omit<AntTextAreaProps, 'value' | 'onChange' | 'status'> {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+export const Textarea: React.FC<TextareaProps> = ({ value, onChange, error, style, ...props }) => {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, width: '100%' }}>
+      <AntInput.TextArea
+        value={value}
+        status={error ? 'error' : undefined}
+        style={{ width: '100%', ...style }}
+        onChange={(e) => onChange(e.target.value)}
+        {...props}
+      />
+      {error ? <Typography.Text type="danger">{error}</Typography.Text> : null}
+    </div>
+  );
+};

--- a/frontend/src/components/ui/atoms/index.ts
+++ b/frontend/src/components/ui/atoms/index.ts
@@ -1,0 +1,23 @@
+/**
+ * UI Atoms
+ *
+ * Canonical, reusable primitives built on semantic styling + Ant Design.
+ */
+
+export { Input } from './Input';
+export type { InputProps } from './Input';
+
+export { Textarea } from './Textarea';
+export type { TextareaProps } from './Textarea';
+
+export { Checkbox } from './Checkbox';
+export type { CheckboxProps } from './Checkbox';
+
+export { Radio, RadioGroup } from './Radio';
+export type { RadioProps, RadioGroupProps, RadioOption } from './Radio';
+
+export { Badge } from './Badge';
+export type { BadgeProps, BadgeVariant } from './Badge';
+
+export { Label } from './Label';
+export type { LabelProps } from './Label';

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -15,3 +15,5 @@ export { CountrySelect } from './CountrySelect';
 export { PhoneInput } from './PhoneInput';
 export { default as Icon, AVAILABLE_ICONS, ICON_CATEGORIES } from './Icon';
 export { default as IconPicker } from './IconPicker';
+
+export * from './atoms';


### PR DESCRIPTION
### What
- Add canonical UI atoms under frontend/src/components/ui/atoms:
  - Input, Textarea, Checkbox, Radio (+ RadioGroup), Badge, Label
- Export atoms from frontend/src/components/ui/index.ts

### Why
- Establish a single DRY primitive layer for form/building-block components.
- Standardize semantic styling via existing CSS variables and Ant Design primitives.

### Validation
- CI: PR Validation/Frontend Type Check
