### PR TITLE
Replace inline SVGs with Icon component

### DIFF
--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -17,22 +17,6 @@ interface HeaderProps {
   // No props needed currently
 }
 
-// Search icon SVG component
-const SearchIcon: React.FC = () => (
-  <svg 
-    width="16" 
-    height="16" 
-    viewBox="0 0 24 24" 
-    fill="none" 
-    stroke="currentColor" 
-    strokeWidth="2" 
-    strokeLinecap="round" 
-    strokeLinejoin="round"
-  >
-    <circle cx="11" cy="11" r="8" />
-    <path d="m21 21-4.3-4.3" />
-  </svg>
-);
 
 const Header: React.FC<HeaderProps> = () => {
   const { theme, themeName, toggleTheme } = useTheme();
@@ -175,7 +159,7 @@ const Header: React.FC<HeaderProps> = () => {
       <SearchForm onSubmit={handleSearchSubmit}>
         <SearchInputWrapper $theme={theme}>
           <SearchIconWrapper $theme={theme}>
-            <SearchIcon />
+            <Icon name="search" size={16} />
           </SearchIconWrapper>
           <SearchInput
             ref={searchInputRef}

--- a/frontend/src/components/Navigation/NavigationMenu.tsx
+++ b/frontend/src/components/Navigation/NavigationMenu.tsx
@@ -17,6 +17,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { Theme } from '../../config/theme';
 import { useActionItems, getBadgeValue } from '../../contexts/ActionItemsContext';
 import { useAuth } from '../../contexts/AuthContext';
+import { Icon } from '../ui';
 
 interface NavigationMenuProps {
   items: NavigationItem[];
@@ -24,25 +25,18 @@ interface NavigationMenuProps {
   level?: number;
 }
 
-// Chevron SVG icon component for accordion expand/collapse
+// Chevron icon component for accordion expand/collapse
 const ChevronIcon: React.FC<{ isExpanded: boolean }> = ({ isExpanded }) => (
-  <svg 
-    width="12" 
-    height="12" 
-    viewBox="0 0 24 24" 
-    fill="none" 
-    stroke="currentColor" 
-    strokeWidth="2.5" 
-    strokeLinecap="round" 
-    strokeLinejoin="round"
+  <span
     style={{
+      display: 'inline-flex',
       transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
       transition: 'transform 0.2s ease',
-      flexShrink: 0
+      flexShrink: 0,
     }}
   >
-    <polyline points="9 18 15 12 9 6" />
-  </svg>
+    <Icon name="chevron-right" size={12} />
+  </span>
 );
 
 const NavigationMenu: React.FC<NavigationMenuProps> = ({ items, isExpanded: sidebarExpanded, level = 0 }) => {


### PR DESCRIPTION
### What
- Replace inline SVG icon components with the canonical <Icon /> component:
  - Header search icon
  - NavigationMenu chevron (expand/collapse)

### Why
- Enforces DRY icon rendering and centralized icon behavior/styling.

### Validation
- CI: PR Validation/Frontend Type Check
