### PR TITLE
Add clone mode to universal forms

### DIFF
--- a/frontend/src/components/Shared/EntityFormSurface.tsx
+++ b/frontend/src/components/Shared/EntityFormSurface.tsx
@@ -18,7 +18,7 @@ import { getRuntimeConfigBoolean } from '@/config/runtime';
 import UniversalEntityForm from './UniversalEntityForm';
 import { InquiryCreateModal } from '../Inquiry/InquiryCreateModal';
 
-export type EntityFormMode = 'create' | 'edit' | 'view';
+export type EntityFormMode = 'create' | 'edit' | 'view' | 'clone';
 
 export type EntityFormSurfaceVariant = 'modal' | 'inline';
 
@@ -122,7 +122,7 @@ export const EntityFormSurface: React.FC<EntityFormSurfaceProps> = ({
       entityType={entityType}
       mode={mode}
       variant={variant}
-      entityId={mode === 'edit' || mode === 'view' ? entityId : undefined}
+      entityId={mode === 'edit' || mode === 'view' || mode === 'clone' ? entityId : undefined}
       isOpen={isOpen}
       onClose={onClose}
       onSuccess={(result) => onSuccess?.(result)}

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -22,7 +22,7 @@ import DynamicFormEngine from '../../features/system/DynamicFormEngine';
 import EntityOptionsSelect from '../FormSubmission/SearchableSelect';
 import { isValidEmail } from '../../shared/utils';
 
-export type UniversalEntityFormMode = 'create' | 'edit' | 'view';
+export type UniversalEntityFormMode = 'create' | 'edit' | 'view' | 'clone';
 export type UniversalEntityFormVariant = 'modal' | 'inline';
 
 export interface UniversalEntityFormProps {
@@ -208,8 +208,12 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   const [recordValues, setRecordValues] = useState<Record<string, unknown> | null>(null);
 
   const inferredMode: UniversalEntityFormMode = useMemo(() => {
+    const hasId = entityId != null && String(entityId).trim().length > 0;
+
+    if (mode === 'clone') return hasId ? 'clone' : 'create';
     if (mode) return mode;
-    return entityId != null && String(entityId).trim() ? 'edit' : 'create';
+
+    return hasId ? 'edit' : 'create';
   }, [entityId, mode]);
 
   const canSwitchModes = allowModeSwitch ?? inferredMode === 'view';
@@ -742,7 +746,10 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
 
       try {
         setSubmitting(true);
-        const resp = entityId
+        const hasEntityId = entityId != null && String(entityId).trim().length > 0;
+        const isEditSubmit = hasEntityId && activeMode === 'edit';
+
+        const resp = isEditSubmit
           ? await apiClient.patch(`${endpoint}${entityId}/`, payload)
           : await apiClient.post(endpoint, payload);
 
@@ -788,6 +795,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     [
       endpoint,
       entityId,
+      activeMode,
       fkFields,
       fkValues,
       formInitialValues,
@@ -1178,7 +1186,12 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
       footer={null}
       width="min(720px, calc(100vw - 32px))"
       destroyOnClose
-      title={schema?.name || (entityId ? `${entityType} ${entityId}` : `New ${entityType}`)}
+      title={
+        activeMode === 'clone'
+          ? `Clone ${entityType}`
+          : schema?.name ||
+            (entityId ? `${entityType} ${entityId}` : `New ${entityType}`)
+      }
     >
       {content}
     </Modal>


### PR DESCRIPTION
### What
- Add clone mode to the canonical form surface:
  - UniversalEntityForm (create|edit|view|clone)
  - EntityFormSurface (create|edit|view|clone)

### Behavior
- Clone loads an existing record via entityId, seeds initial values, but submits via POST (create) instead of PATCH.
- Submit label: Create copy.

### Why
- Enables duplicate/clone record UX without per-entity custom forms.

### Validation
- CI: PR Validation/Frontend Type Check
