### PR TITLE
Standardize forms: RHF+Zod InquiryCreateModal entity fields

### DIFF
--- a/frontend/src/components/Inquiry/InquiryCreateModal.tsx
+++ b/frontend/src/components/Inquiry/InquiryCreateModal.tsx
@@ -216,6 +216,12 @@ const Muted = styled.div`
   color: rgb(var(--color-text-secondary));
 `;
 
+const FieldError = styled.div`
+  margin-top: 0.5rem;
+  color: rgb(var(--color-error));
+  font-size: 0.8rem;
+`;
+
 const Error = styled.div`
   margin-top: 0.75rem;
   padding: 0.75rem 1rem;
@@ -354,17 +360,24 @@ const newLine = (): LineItem => ({
   notes: '',
 });
 
-const inquiryMetaSchema = z.object({
+const inquiryCreateSchema = z.object({
+  entityType: z.enum(['customer', 'supplier']),
+  entityId: z.string().trim().regex(/^\d+$/, 'Please select a valid customer/supplier'),
   validUntil: z.string().optional().default(''),
   notes: z.string().optional().default(''),
 });
 
-type InquiryMetaValues = z.infer<typeof inquiryMetaSchema>;
+type InquiryCreateValues = z.infer<typeof inquiryCreateSchema>;
 
-const inquiryMetaDefaults: InquiryMetaValues = {
+const buildInquiryCreateDefaults = (opts: {
+  initialEntityType?: EntityType;
+  initialEntityId?: string | number;
+}): InquiryCreateValues => ({
+  entityType: opts.initialEntityType ?? 'customer',
+  entityId: opts.initialEntityId != null ? String(opts.initialEntityId) : '',
   validUntil: '',
   notes: '',
-};
+});
 
 export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
   isOpen,
@@ -375,17 +388,16 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
   enableSupplierPlantSelection = false,
   sourceCallId,
 }) => {
-  const form = useZodForm<InquiryMetaValues>(inquiryMetaSchema, {
-    defaultValues: inquiryMetaDefaults,
+  const form = useZodForm<InquiryCreateValues>(inquiryCreateSchema, {
+    defaultValues: buildInquiryCreateDefaults({ initialEntityType, initialEntityId }),
   });
 
   const submitting = form.formState.isSubmitting;
   const [error, setError] = useState<string | null>(null);
 
-  const [entityType, setEntityType] = useState<EntityType>(initialEntityType ?? 'customer');
-  const [entityId, setEntityId] = useState<string>(
-    initialEntityId != null ? String(initialEntityId) : ''
-  );
+  const entityType = form.watch('entityType');
+  const entityId = form.watch('entityId');
+
   const [entityOptions, setEntityOptions] = useState<EntityOption[]>([]);
   const [loadingEntities, setLoadingEntities] = useState(false);
 
@@ -415,9 +427,8 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
   useEffect(() => {
     if (!isOpen) return;
 
-    if (initialEntityType) setEntityType(initialEntityType);
-    if (initialEntityId != null) setEntityId(String(initialEntityId));
-  }, [initialEntityId, initialEntityType, isOpen]);
+    form.reset(buildInquiryCreateDefaults({ initialEntityType, initialEntityId }));
+  }, [form, initialEntityId, initialEntityType, isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -519,7 +530,7 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
 
   const reset = () => {
     setError(null);
-    form.reset(inquiryMetaDefaults);
+    form.reset(buildInquiryCreateDefaults({ initialEntityType, initialEntityId }));
     setLines([newLine()]);
     setEntityOptions([]);
   };
@@ -581,7 +592,7 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
         }));
 
       const payload: Record<string, unknown> = {
-        entity_type: entityType,
+        entity_type: values.entityType,
         source_type: sourceCallId ? 'scheduled_call' : 'other',
         ...(sourceCallId ? { source_call: Number(sourceCallId) } : {}),
         valid_until: values.validUntil || undefined,
@@ -589,8 +600,8 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
         products,
       };
 
-      if (entityType === 'customer') payload.customer = Number(entityId);
-      if (entityType === 'supplier') payload.supplier = Number(entityId);
+      if (values.entityType === 'customer') payload.customer = Number(values.entityId);
+      if (values.entityType === 'supplier') payload.supplier = Number(values.entityId);
 
       const resp = await businessApi.post('/inquiries/', payload);
       reset();
@@ -615,6 +626,9 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
 
   if (!isOpen) return null;
 
+  const entityTypeField = form.register('entityType');
+  const entityIdField = form.register('entityId');
+
   return (
     <Overlay $open={isOpen} onClick={close}>
       <Modal onClick={(ev) => ev.stopPropagation()}>
@@ -636,10 +650,11 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
                 <Field $span={3}>
                   <Label>Entity Type *</Label>
                   <Select
-                    value={entityType}
+                    {...entityTypeField}
                     onChange={(e) => {
-                      setEntityType(e.target.value as EntityType);
-                      setEntityId('');
+                      entityTypeField.onChange(e);
+                      form.setValue('entityId', '', { shouldValidate: true, shouldDirty: true });
+                      setEntityOptions([]);
                     }}
                     disabled={!canSubmit || Boolean(initialEntityType)}
                   >
@@ -650,8 +665,7 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
                 <Field $span={9}>
                   <Label>{entityType === 'customer' ? 'Customer' : 'Supplier'} *</Label>
                   <Select
-                    value={entityId}
-                    onChange={(e) => setEntityId(e.target.value)}
+                    {...entityIdField}
                     disabled={!canSubmit || loadingEntities || Boolean(initialEntityId)}
                   >
                     <option value="">Select…</option>
@@ -661,6 +675,9 @@ export const InquiryCreateModal: React.FC<InquiryCreateModalProps> = ({
                       </option>
                     ))}
                   </Select>
+                  {form.formState.errors.entityId?.message && (
+                    <FieldError role="alert">{String(form.formState.errors.entityId.message)}</FieldError>
+                  )}
                   {loadingEntities && <Muted>Loading…</Muted>}
                 </Field>
               </Grid>


### PR DESCRIPTION
Next incremental slice of p10-2-3-rhf-standardize.

Changes:
- Move InquiryCreateModal entityType + entityId into canonical useZodForm schema
- Add field-level error display for entityId when not selected
- Keep existing line-item validation + UX unchanged (incremental slice)

Dev deploy will be verified post-merge via Master Pipeline.