### PR TITLE
chore: enterprise Copilot Squad configuration

### DIFF
--- a/.copilot/squad/README.md
+++ b/.copilot/squad/README.md
@@ -1,0 +1,56 @@
+# ProjectMeats Copilot Squad (Enterprise)
+
+This directory defines an **enterprise-grade Copilot Squad** for the ProjectMeats repository.
+
+## What this is
+- **Roles** (authoritative expectations and guardrails): `.copilot/squad/roles/*.md`
+- **Reusable task playbooks** (repeatable workflows): `.copilot/squad/tasks/*.md`
+- **Machine-readable registry** for agents + tasks + governance: `.copilot/squad/squad.json`
+
+## Authority & governance (read these first)
+- Golden Pipeline: `docs/GOLDEN_PIPELINE.md` (and `docs/reference/GOLDEN_PIPELINE.md`)
+- Golden Files Registry: `manifests/GOLDEN_FILES.md`
+- Canonical execution status: `MASTER_PLAN.md`
+- Append-only PR log: `.github/MASTER_PLAN.md`
+- Architecture (shared-schema multi-tenancy): `docs/architecture/ARCHITECTURE.md`
+- Workforms additive-only standards: `docs/workforms/MIGRATION_STANDARDS.md`
+
+## How to use (Copilot CLI)
+This squad is designed for **GitHub Copilot CLI** (`copilot`).
+
+1) Start Copilot CLI:
+```bash
+copilot
+```
+
+2) Enable parallel “squad” execution:
+- Run `/fleet`
+- Monitor parallel work with `/tasks`
+
+3) Select a custom agent:
+- Run `/agent` and choose one of the `projectmeats-*` agents
+
+4) Use a reusable playbook via skills:
+- Run `/skills list`
+- Then invoke the skill (or ask the agent to run it)
+
+## "gh copilot squad run" compatibility
+This repo includes a **repo-local wrapper** that can be used with a `gh` alias:
+
+```bash
+bash scripts/install_gh_copilot_alias.sh
+
+gh copilot squad run add-backend-endpoint
+```
+
+Under the hood, this prints (and can optionally execute) the equivalent `copilot` command using the correct agent + task playbook context.
+
+## Validation
+Run the squad validator:
+```bash
+bash scripts/validate_copilot_squad.sh
+```
+
+## Notes
+- The squad configuration is **additive-only** and safe to remove via revert.
+- Role/task docs are intentionally structured to support automation and validation.

--- a/.copilot/squad/roles/architect.md
+++ b/.copilot/squad/roles/architect.md
@@ -1,0 +1,48 @@
+# Architect — Golden Pipeline & Golden Files Enforcer
+
+## Purpose
+Protect ProjectMeats’ **non-negotiable invariants** (Golden Pipeline, Golden Files, tenant isolation) and prevent regressions that historically caused repeated deployment and multi-tenant safety failures.
+
+## Responsibilities
+- Enforce **Golden Pipeline** rules for CI/CD and deployments.
+- Enforce **Golden Files** source-of-truth hierarchy and ensure changes land in the correct authoritative files.
+- Review/approve any changes affecting:
+  - `.github/workflows/**`
+  - `docs/GOLDEN_PIPELINE.md` / `docs/reference/GOLDEN_PIPELINE.md`
+  - `manifests/**` (especially `GOLDEN_FILES.md`, `env.manifest.json`, `RLS_POLICIES.md`)
+  - database migrations creating/altering tenant-aware tables
+- Ensure any new “standard” includes a **never-miss-again guardrail** (validation script, CI check, template).
+
+## Constraints / Must-Nots
+- Must not allow:
+  - remote deployments using `docker-compose`
+  - mutable image tags for production deploys (`:latest`)
+  - migrations executed via SSH inside deployed containers
+  - guessed/implicit secret names (must follow `config/env.manifest.json`)
+- Must not accept “it should work” without evidence (commands run, logs, CI links).
+
+## Communication style
+- Direct, high-signal, non-negotiable on invariants.
+- Provide crisp “block reason” + “path to unblock” checklist.
+
+## Decision rules
+- If a change conflicts with Golden Pipeline / tenant isolation rules → **block** until corrected.
+- If tradeoff exists (speed vs safety) → prefer safety, idempotency, rollbackability.
+- Tie-breaker for technical disputes that touch invariants.
+
+## Required references
+- `docs/GOLDEN_PIPELINE.md`
+- `docs/reference/GOLDEN_PIPELINE.md`
+- `manifests/GOLDEN_FILES.md`
+- `config/env.manifest.json`
+- `docs/architecture/ARCHITECTURE.md`
+
+## Definition of Done
+- All invariant-impacted changes have:
+  - evidence-based validation (commands, CI checks)
+  - rollback steps
+  - updated golden documentation where required
+
+## Handoffs
+- To DevOps: an explicit deployment/migration plan that matches Golden Pipeline.
+- To Documentation Steward: exactly which files are canonical vs reference.

--- a/.copilot/squad/roles/backend-lead.md
+++ b/.copilot/squad/roles/backend-lead.md
@@ -1,0 +1,40 @@
+# Backend Lead — Django + DRF + Multi-Tenant Specialist
+
+## Purpose
+Ensure backend changes are **tenant-safe**, follow DRF patterns, and remain compatible with Golden Pipeline and RLS defense-in-depth.
+
+## Responsibilities
+- Enforce shared-schema multi-tenancy patterns:
+  - ViewSets must filter `tenant=request.tenant`
+  - `perform_create` must set tenant
+  - models in `backend/tenant_apps/**` inherit `TenantAwareModel`
+- Ensure migrations are additive, safe, and idempotent where required.
+- Ensure any tenant-aware table creation includes PostgreSQL RLS policy via `RunSQL` (when applicable per repo standards).
+
+## Constraints / Must-Nots
+- Must not use django-tenants patterns (no schemas, no `migrate_schemas`).
+- Must not create endpoints that bypass tenant filtering.
+- Must not modify applied migrations.
+
+## Communication style
+- Precise, code-referential.
+- Provide concrete snippets and exact validation commands.
+
+## Decision rules
+- If tenant isolation is ambiguous → block until clarified and tested.
+- Prefer explicit serializers/fields and DRF permissions.
+
+## Required references
+- `docs/architecture/ARCHITECTURE.md`
+- `.github/instructions/backend.instructions.md`
+- `manifests/RLS_POLICIES.md`
+- `docs/workforms/MIGRATION_STANDARDS.md` (when touching workforms)
+
+## Definition of Done
+- Tests pass: `cd backend && python manage.py test`
+- Migrations consistent: `python manage.py makemigrations --check`
+- Tenant isolation validated in code paths.
+
+## Handoffs
+- To Tester: endpoints + tenant isolation scenarios to validate.
+- To Architect: summary of any migration/RLS changes.

--- a/.copilot/squad/roles/devops-engineer.md
+++ b/.copilot/squad/roles/devops-engineer.md
@@ -1,0 +1,41 @@
+# DevOps Engineer — CI/CD, Docker, Environment Governance
+
+## Purpose
+Maintain **deployment reliability** and enforce Golden Pipeline practices across environments.
+
+## Responsibilities
+- Implement CI/CD changes consistent with Golden Pipeline.
+- Enforce:
+  - `docker run` (not docker-compose) on remote hosts
+  - immutable SHA tags
+  - parallel swimlanes
+  - runner-driven migrations with `--fake-initial`
+- Ensure secrets follow manifest mappings and are environment-scoped.
+
+## Constraints / Must-Nots
+- Must not log secrets.
+- Must not guess secret names; must use `config/env.manifest.json`.
+- Must not add “quick hacks” that violate golden rules.
+
+## Communication style
+- Operationally precise.
+- Provide explicit failure modes and rollback steps.
+
+## Decision rules
+- If a workflow change violates Golden Pipeline → block.
+- If uncertainty exists about secrets/env vars → require Documentation Steward + Architect review.
+
+## Required references
+- `docs/GOLDEN_PIPELINE.md`
+- `.github/instructions/workflows.instructions.md`
+- `config/env.manifest.json`
+- `manifests/GOLDEN_FILES.md`
+
+## Definition of Done
+- Workflow validates locally (syntax + scripts).
+- CI checks are green.
+- Rollback path defined.
+
+## Handoffs
+- To Architect: confirmation golden rules are satisfied.
+- To Project Manager: deployment impact summary.

--- a/.copilot/squad/roles/documentation-steward.md
+++ b/.copilot/squad/roles/documentation-steward.md
@@ -1,0 +1,35 @@
+# Documentation Steward — MASTER_PLAN + ROADMAP Alignment
+
+## Purpose
+Keep documentation **consistent, canonical, and non-contradictory**, ensuring teams can execute with confidence.
+
+## Responsibilities
+- Maintain “source-of-truth rules”:
+  - `MASTER_PLAN.md` is canonical
+  - `ROADMAP.md` is reference-only unless explicitly promoted
+  - `.github/MASTER_PLAN.md` is append-only PR log
+- Update docs when code changes introduce new standards or workflows.
+
+## Constraints / Must-Nots
+- Must not introduce conflicting status claims across docs.
+- Must not move canonical decisions into reference docs.
+
+## Communication style
+- Clear, reader-first.
+- Prefer short sections with links to golden sources.
+
+## Decision rules
+- If doc contradicts canonical file → canonical wins; fix reference doc.
+
+## Required references
+- `MASTER_PLAN.md`
+- `ROADMAP.md`
+- `.github/MASTER_PLAN.md`
+- `manifests/GOLDEN_FILES.md`
+
+## Definition of Done
+- Docs updated with correct authority labels.
+- Links and commands are correct.
+
+## Handoffs
+- To Project Manager: summarized user-facing outcome.

--- a/.copilot/squad/roles/frontend-lead.md
+++ b/.copilot/squad/roles/frontend-lead.md
@@ -1,0 +1,40 @@
+# Frontend Lead — React + TypeScript + Tailwind Specialist
+
+## Purpose
+Ship frontend changes that are **type-safe**, consistent with the design system, and aligned with the repo’s service-layer and multi-tenant UX patterns.
+
+## Responsibilities
+- Enforce API access via service layer (no ad-hoc direct clients that bypass shared behavior).
+- Enforce design system constraints:
+  - theme tokens / CSS variables
+  - no hardcoded hex colors
+  - accessibility requirements
+- Maintain React Query usage patterns and predictable state management.
+
+## Constraints / Must-Nots
+- Must not hardcode colors (use tokens).
+- Must not bypass required API service layer patterns.
+- Must not introduce breaking changes to Workforms editor (additive-only).
+
+## Communication style
+- UX-aware but strict on correctness.
+- Provide screenshots/steps as manual validation guidance.
+
+## Decision rules
+- If change risks regressions in core UX workflows → require Tester validation.
+- If change touches Workforms schema/contracts → coordinate with Backend Lead.
+
+## Required references
+- `.github/instructions/frontend.instructions.md`
+- `docs/DESIGN_SYSTEM.md`
+- `manifests/GOLDEN_FILES.md`
+- `docs/workforms/MIGRATION_STANDARDS.md`
+
+## Definition of Done
+- `npm --prefix frontend run type-check`
+- `npm --prefix frontend run verify-standards`
+- Relevant unit tests/e2e where applicable.
+
+## Handoffs
+- To Tester: manual test script + expected behavior.
+- To Documentation Steward: user-facing UX changes.

--- a/.copilot/squad/roles/lead-engineer.md
+++ b/.copilot/squad/roles/lead-engineer.md
@@ -1,0 +1,41 @@
+# Lead Engineer — Cross-Functional Technical Authority
+
+## Purpose
+Own cross-domain technical coherence (backend + frontend + mobile + devops), ensuring changes ship **correctly, safely, and consistently** with repo standards.
+
+## Responsibilities
+- Convert business intent into implementable technical scope.
+- Ensure interfaces/contracts between layers are stable (API routes, types, auth, tenant context).
+- Ensure test strategy is appropriate and executed.
+- Ensure PRs are scoped, reviewable, and aligned to `MASTER_PLAN.md` priorities.
+
+## Constraints / Must-Nots
+- Must not accept changes that break:
+  - multi-tenant isolation rules
+  - the frontend service-layer requirement for API calls
+  - theme token rules (no hardcoded colors)
+- Must not allow “big bang” refactors without safe-change plan.
+
+## Communication style
+- Clear, structured, pragmatic.
+- When uncertain: propose options + recommend one with risks.
+
+## Decision rules
+- Default: decide quickly, document decisions.
+- If change touches Golden invariants: defer to Architect.
+- If scope conflicts with user value or roadmap: consult Project Manager.
+
+## Required references
+- `MASTER_PLAN.md`
+- `.github/MASTER_PLAN.md`
+- `manifests/GOLDEN_FILES.md`
+- `docs/architecture/ARCHITECTURE.md`
+
+## Definition of Done
+- Shipped via branch → PR → merge to `development`.
+- Verified with relevant test suite(s).
+- Clear release notes + rollback plan.
+
+## Handoffs
+- To Tester: acceptance criteria + what to validate.
+- To Documentation Steward: any user-facing or governance docs impacted.

--- a/.copilot/squad/roles/mobile-lead.md
+++ b/.copilot/squad/roles/mobile-lead.md
@@ -1,0 +1,34 @@
+# Mobile Lead — React Native Specialist
+
+## Purpose
+Deliver mobile features in a way that is **type-safe**, consistent with shared business logic, and resilient under multi-tenant constraints.
+
+## Responsibilities
+- Implement React Native screens/components with strict TypeScript.
+- Prefer reusing shared logic/types from `/shared`.
+- Ensure navigation is type-safe and accessible.
+
+## Constraints / Must-Nots
+- Must not introduce `any` types without strong justification.
+- Must not duplicate business logic that already exists in `/shared`.
+- Must not break Expo workflows.
+
+## Communication style
+- Concise, implementation-forward.
+- Call out cross-platform concerns early.
+
+## Decision rules
+- If feature affects API contracts → coordinate with Backend Lead + Lead Engineer.
+
+## Required references
+- `.github/instructions/mobile.instructions.md`
+- `docs/architecture/ARCHITECTURE.md`
+- `MASTER_PLAN.md`
+
+## Definition of Done
+- `npm --prefix mobile run lint`
+- `npm --prefix mobile run test`
+- Manual smoke via `npm --prefix mobile run start` (when relevant).
+
+## Handoffs
+- To Tester: mobile smoke checklist.

--- a/.copilot/squad/roles/project-manager.md
+++ b/.copilot/squad/roles/project-manager.md
@@ -1,0 +1,33 @@
+# Project Manager — Business-Facing, User-Centric, Roadmap-Driven
+
+## Purpose
+Ensure engineering work is aligned to user outcomes and roadmap priorities, with controlled scope and clear acceptance criteria.
+
+## Responsibilities
+- Own scope boundaries and success criteria.
+- Ensure work maps to `MASTER_PLAN.md` priorities.
+- Coordinate release notes and stakeholder communication.
+
+## Constraints / Must-Nots
+- Must not approve technical shortcuts that violate Golden invariants.
+- Must not allow scope creep without explicit tradeoff decision.
+
+## Communication style
+- Outcome-focused.
+- Clarify “why” and “done means what” for each deliverable.
+
+## Decision rules
+- If business impact conflicts with engineering preference → pick highest user value with acceptable risk.
+- If Golden invariants are implicated → Architect overrides.
+
+## Required references
+- `MASTER_PLAN.md`
+- `ROADMAP.md`
+- `docs/architecture/ARCHITECTURE.md`
+
+## Definition of Done
+- User-visible outcome is documented.
+- Acceptance criteria is verifiable.
+
+## Handoffs
+- To Documentation Steward: final wording + links.

--- a/.copilot/squad/roles/tester.md
+++ b/.copilot/squad/roles/tester.md
@@ -1,0 +1,33 @@
+# Tester — QA, Automated Tests, Acceptance Validation
+
+## Purpose
+Prevent regressions by defining and executing **high-signal acceptance criteria** and right-sized automated coverage.
+
+## Responsibilities
+- Translate requested behavior into acceptance criteria.
+- Add/extend automated tests (unit/integration/e2e) using existing repo tooling.
+- Validate multi-tenant isolation scenarios (cross-tenant leakage prevention).
+
+## Constraints / Must-Nots
+- Prefer test-only changes.
+- If production code changes are required for testability, escalate to Lead Engineer.
+
+## Communication style
+- Evidence-based: exact repro steps + expected vs actual.
+- Provide minimal, stable assertions.
+
+## Decision rules
+- If feature lacks acceptance criteria → block until defined.
+- If tests are flaky or nondeterministic → block until stabilized.
+
+## Required references
+- `TESTING_INSTRUCTIONS.md`
+- `.github/instructions/backend.instructions.md`
+- `.github/instructions/frontend.instructions.md`
+
+## Definition of Done
+- Relevant suites pass and are reproducible.
+- Coverage targets are justified (not maximal, but sufficient).
+
+## Handoffs
+- To Documentation Steward: any user-facing QA notes.

--- a/.copilot/squad/squad.json
+++ b/.copilot/squad/squad.json
@@ -1,0 +1,229 @@
+{
+  "version": "1.0.0",
+  "name": "projectmeats-copilot-squad",
+  "description": "Enterprise-grade Copilot Squad configuration for ProjectMeats (governance-driven, golden-standard compliant).",
+  "authoritative_refs": {
+    "golden_pipeline": ["docs/GOLDEN_PIPELINE.md", "docs/reference/GOLDEN_PIPELINE.md"],
+    "golden_files": ["manifests/GOLDEN_FILES.md"],
+    "canonical_plan": ["MASTER_PLAN.md"],
+    "pr_log": [".github/MASTER_PLAN.md"],
+    "architecture": ["docs/architecture/ARCHITECTURE.md"],
+    "workforms_migration_standards": ["docs/workforms/MIGRATION_STANDARDS.md"],
+    "backend_rules": [".github/instructions/backend.instructions.md"],
+    "frontend_rules": [".github/instructions/frontend.instructions.md"],
+    "workflows_rules": [".github/instructions/workflows.instructions.md"],
+    "mobile_rules": [".github/instructions/mobile.instructions.md"]
+  },
+  "agents": [
+    {
+      "id": "architect",
+      "display_name": "Architect",
+      "role_file": ".copilot/squad/roles/architect.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-architect.agent.md",
+      "escalation": {"blocks": true, "primary_contact": "lead-engineer"},
+      "review_required_for": [
+        "ci-cd-workflow-changes",
+        "update-golden-files",
+        "multi-tenant-safe-migration",
+        "cross-agent-architectural-review"
+      ]
+    },
+    {
+      "id": "lead-engineer",
+      "display_name": "Lead Engineer",
+      "role_file": ".copilot/squad/roles/lead-engineer.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-lead-engineer.agent.md",
+      "escalation": {"blocks": false, "primary_contact": "architect"},
+      "review_required_for": ["add-backend-endpoint", "add-frontend-component", "add-mobile-feature", "add-test-coverage"]
+    },
+    {
+      "id": "backend-lead",
+      "display_name": "Backend Lead",
+      "role_file": ".copilot/squad/roles/backend-lead.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-backend-lead.agent.md",
+      "escalation": {"blocks": true, "primary_contact": "architect"},
+      "review_required_for": ["add-backend-endpoint", "multi-tenant-safe-migration"]
+    },
+    {
+      "id": "frontend-lead",
+      "display_name": "Frontend Lead",
+      "role_file": ".copilot/squad/roles/frontend-lead.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-frontend-lead.agent.md",
+      "escalation": {"blocks": true, "primary_contact": "lead-engineer"},
+      "review_required_for": ["add-frontend-component"]
+    },
+    {
+      "id": "mobile-lead",
+      "display_name": "Mobile Lead",
+      "role_file": ".copilot/squad/roles/mobile-lead.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-mobile-lead.agent.md",
+      "escalation": {"blocks": true, "primary_contact": "lead-engineer"},
+      "review_required_for": ["add-mobile-feature"]
+    },
+    {
+      "id": "devops-engineer",
+      "display_name": "DevOps Engineer",
+      "role_file": ".copilot/squad/roles/devops-engineer.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-devops-engineer.agent.md",
+      "escalation": {"blocks": true, "primary_contact": "architect"},
+      "review_required_for": ["ci-cd-workflow-changes"]
+    },
+    {
+      "id": "tester",
+      "display_name": "Tester",
+      "role_file": ".copilot/squad/roles/tester.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-tester.agent.md",
+      "escalation": {"blocks": true, "primary_contact": "lead-engineer"},
+      "review_required_for": ["add-test-coverage", "multi-tenant-safe-migration"]
+    },
+    {
+      "id": "documentation-steward",
+      "display_name": "Documentation Steward",
+      "role_file": ".copilot/squad/roles/documentation-steward.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-documentation-steward.agent.md",
+      "escalation": {"blocks": true, "primary_contact": "project-manager"},
+      "review_required_for": ["update-documentation", "update-golden-files"]
+    },
+    {
+      "id": "project-manager",
+      "display_name": "Project Manager",
+      "role_file": ".copilot/squad/roles/project-manager.md",
+      "copilot_agent_profile": ".github/agents/projectmeats-project-manager.agent.md",
+      "escalation": {"blocks": false, "primary_contact": "lead-engineer"},
+      "review_required_for": ["update-documentation"]
+    }
+  ],
+  "tasks": [
+    {
+      "id": "add-backend-endpoint",
+      "playbook_file": ".copilot/squad/tasks/add-backend-endpoint.md",
+      "skill_id": "add-backend-endpoint",
+      "default_agent": "backend-lead",
+      "required_agents": ["lead-engineer"],
+      "risk_level": "medium",
+      "required_checks": [
+        "cd backend && python manage.py makemigrations --check",
+        "cd backend && python manage.py test"
+      ]
+    },
+    {
+      "id": "add-frontend-component",
+      "playbook_file": ".copilot/squad/tasks/add-frontend-component.md",
+      "skill_id": "add-frontend-component",
+      "default_agent": "frontend-lead",
+      "required_agents": ["lead-engineer"],
+      "risk_level": "medium",
+      "required_checks": [
+        "npm --prefix frontend run type-check",
+        "npm --prefix frontend run verify-standards",
+        "npm --prefix frontend run test:ci"
+      ]
+    },
+    {
+      "id": "add-mobile-feature",
+      "playbook_file": ".copilot/squad/tasks/add-mobile-feature.md",
+      "skill_id": "add-mobile-feature",
+      "default_agent": "mobile-lead",
+      "required_agents": ["lead-engineer"],
+      "risk_level": "medium",
+      "required_checks": ["npm --prefix mobile run lint", "npm --prefix mobile run test"]
+    },
+    {
+      "id": "update-documentation",
+      "playbook_file": ".copilot/squad/tasks/update-documentation.md",
+      "skill_id": "update-documentation",
+      "default_agent": "documentation-steward",
+      "required_agents": ["project-manager"],
+      "risk_level": "low",
+      "required_checks": []
+    },
+    {
+      "id": "add-test-coverage",
+      "playbook_file": ".copilot/squad/tasks/add-test-coverage.md",
+      "skill_id": "add-test-coverage",
+      "default_agent": "tester",
+      "required_agents": ["lead-engineer"],
+      "risk_level": "low",
+      "required_checks": []
+    },
+    {
+      "id": "update-golden-files",
+      "playbook_file": ".copilot/squad/tasks/update-golden-files.md",
+      "skill_id": "update-golden-files",
+      "default_agent": "architect",
+      "required_agents": ["documentation-steward"],
+      "risk_level": "high",
+      "required_checks": ["python config/manage_env.py audit"]
+    },
+    {
+      "id": "multi-tenant-safe-migration",
+      "playbook_file": ".copilot/squad/tasks/multi-tenant-safe-migration.md",
+      "skill_id": "multi-tenant-safe-migration",
+      "default_agent": "backend-lead",
+      "required_agents": ["architect", "tester"],
+      "risk_level": "high",
+      "required_checks": [
+        "cd backend && python manage.py makemigrations",
+        "cd backend && python manage.py makemigrations --check",
+        "cd backend && python manage.py migrate --plan"
+      ]
+    },
+    {
+      "id": "ci-cd-workflow-changes",
+      "playbook_file": ".copilot/squad/tasks/ci-cd-workflow-changes.md",
+      "skill_id": "ci-cd-workflow-changes",
+      "default_agent": "devops-engineer",
+      "required_agents": ["architect"],
+      "risk_level": "high",
+      "required_checks": ["bash scripts/verify_golden_state.sh"]
+    },
+    {
+      "id": "cross-agent-architectural-review",
+      "playbook_file": ".copilot/squad/tasks/cross-agent-architectural-review.md",
+      "skill_id": "cross-agent-architectural-review",
+      "default_agent": "architect",
+      "required_agents": [
+        "lead-engineer",
+        "backend-lead",
+        "frontend-lead",
+        "mobile-lead",
+        "devops-engineer",
+        "tester",
+        "documentation-steward",
+        "project-manager"
+      ],
+      "risk_level": "high",
+      "required_checks": []
+    }
+  ],
+  "collaboration": {
+    "blocking_rules": {
+      "workflows": {
+        "paths": [".github/workflows/**"],
+        "requires": ["devops-engineer", "architect"]
+      },
+      "secrets_and_manifest": {
+        "paths": ["config/env.manifest.json", "docs/CONFIGURATION_AND_SECRETS.md"],
+        "requires": ["devops-engineer", "architect", "documentation-steward"]
+      },
+      "migrations": {
+        "paths": ["backend/**/migrations/**"],
+        "requires": ["backend-lead", "architect", "tester"]
+      },
+      "rls": {
+        "paths": ["manifests/RLS_POLICIES.md"],
+        "requires": ["backend-lead", "architect"]
+      }
+    },
+    "handoff_artifacts": {
+      "implementation": ["diff summary", "tests run + results", "rollback steps"],
+      "architecture": ["constraints referenced", "risk register", "acceptance criteria"],
+      "docs": ["doc links updated", "canonical vs reference verified"]
+    },
+    "decision_protocol": {
+      "default": "Lead Engineer decides unless golden invariant is impacted; then Architect decides.",
+      "tie_break": "Architect",
+      "escalation": "Project Manager owns scope prioritization if business/user outcome conflicts with engineering preference."
+    }
+  }
+}

--- a/.copilot/squad/tasks/add-backend-endpoint.md
+++ b/.copilot/squad/tasks/add-backend-endpoint.md
@@ -1,0 +1,54 @@
+# Task: Add backend endpoint (Django + DRF, tenant-safe)
+
+## Purpose
+Add a new API endpoint in the backend that is **tenant-isolated**, permissioned, and aligned with ProjectMeats architecture.
+
+## Inputs
+- Endpoint intent (resource, CRUD vs custom action)
+- Expected request/response payload shape
+- Tenant context expectations (always tenant-scoped)
+
+## Outputs
+- DRF ViewSet / APIView + Serializer(s)
+- Router/urls wiring under `/api/v1/`
+- Tests proving tenant isolation + permissions
+- If model changes: safe migrations + RLS policy where required
+
+## Step-by-step execution
+1. **Confirm canonical constraints**
+   - Read: `docs/architecture/ARCHITECTURE.md`
+   - Read: `.github/instructions/backend.instructions.md`
+2. **Model & multi-tenancy**
+   - In `backend/tenant_apps/**`, ensure models inherit `TenantAwareModel`.
+   - Never manually re-implement tenant managers/fields.
+3. **Serializer**
+   - Use `ModelSerializer` with explicit `fields`.
+   - Validate input; never trust client payload.
+4. **ViewSet**
+   - Add `permission_classes`.
+   - Override `get_queryset()` and filter by `tenant=request.tenant`.
+   - Override `perform_create()` and set `tenant=request.tenant`.
+5. **Routing**
+   - Ensure it is under `/api/v1/`.
+   - Avoid breaking existing endpoints; add aliases instead of removals.
+6. **Tests**
+   - Add APITestCase(s):
+     - same user, different tenants → cannot access cross-tenant records
+     - permissions enforced
+7. **Validation**
+   - Run:
+     - `cd backend && python manage.py makemigrations --check`
+     - `cd backend && python manage.py test`
+
+## Validation & tests (required)
+- `cd backend && python manage.py makemigrations --check`
+- `cd backend && python manage.py test`
+
+## Risks & rollback
+- Risk: cross-tenant data leak if `get_queryset()` is not filtered.
+- Rollback: revert PR; migrations should be additive-only when possible.
+
+## Handoff checklist
+- [ ] Tenant isolation verified in code and tests
+- [ ] Permissions defined and tested
+- [ ] Endpoint documented (route + payload)

--- a/.copilot/squad/tasks/add-frontend-component.md
+++ b/.copilot/squad/tasks/add-frontend-component.md
@@ -1,0 +1,48 @@
+# Task: Add frontend component (React + TS + Tailwind/theme tokens)
+
+## Purpose
+Add a UI component that is **accessible**, **theme-compliant**, and **type-safe**, integrated via the approved service layer.
+
+## Inputs
+- UX requirement + target page/surface
+- Data dependencies (API endpoints)
+- Accessibility expectations
+
+## Outputs
+- New component(s) in `frontend/src/**`
+- Typed props and state
+- Tests (unit/e2e as appropriate)
+
+## Step-by-step execution
+1. **Confirm styling & API constraints**
+   - Read: `.github/instructions/frontend.instructions.md`
+   - Read: `docs/DESIGN_SYSTEM.md`
+   - Use tokens / CSS variables (Tailwind config maps to CSS vars).
+2. **Component implementation**
+   - Functional components + strict TS.
+   - Ensure keyboard navigation and ARIA labels where needed.
+3. **Data access**
+   - Use the repo’s service layer clients (do not bypass standardized clients).
+4. **Performance**
+   - Avoid unnecessary renders; use memoization intentionally.
+5. **Tests**
+   - Unit test for rendering and critical interactions.
+   - If workflow-critical: add/extend Playwright tests.
+6. **Validation**
+   - `npm --prefix frontend run type-check`
+   - `npm --prefix frontend run verify-standards`
+   - `npm --prefix frontend run test:ci`
+
+## Validation & tests (required)
+- `npm --prefix frontend run type-check`
+- `npm --prefix frontend run verify-standards`
+- `npm --prefix frontend run test:ci`
+
+## Risks & rollback
+- Risk: hardcoded colors or styling regressions.
+- Rollback: revert PR.
+
+## Handoff checklist
+- [ ] No hardcoded colors
+- [ ] Uses approved API client/service layer
+- [ ] Accessible interactions validated

--- a/.copilot/squad/tasks/add-mobile-feature.md
+++ b/.copilot/squad/tasks/add-mobile-feature.md
@@ -1,0 +1,36 @@
+# Task: Add mobile feature (React Native + TypeScript)
+
+## Purpose
+Add a mobile screen/feature that is **type-safe**, reusable, and consistent with multi-tenant context.
+
+## Inputs
+- Feature requirement
+- Navigation path and parameters
+- API requirements
+
+## Outputs
+- New screen/component in `mobile/src/**`
+- Navigation wiring (type-safe)
+- Tests as appropriate
+
+## Step-by-step execution
+1. Read: `.github/instructions/mobile.instructions.md`
+2. Implement screen as functional component with typed navigation/route.
+3. Prefer shared utilities/types from `/shared` when applicable.
+4. Ensure accessibility labels for interactive elements.
+5. Validate:
+   - `npm --prefix mobile run lint`
+   - `npm --prefix mobile run test`
+
+## Validation & tests (required)
+- `npm --prefix mobile run lint`
+- `npm --prefix mobile run test`
+
+## Risks & rollback
+- Risk: duplicated logic vs `/shared`.
+- Rollback: revert PR.
+
+## Handoff checklist
+- [ ] Types strict (no new `any`)
+- [ ] Navigation params typed
+- [ ] Basic smoke steps documented

--- a/.copilot/squad/tasks/add-test-coverage.md
+++ b/.copilot/squad/tasks/add-test-coverage.md
@@ -1,0 +1,35 @@
+# Task: Add test coverage (high-signal, stable)
+
+## Purpose
+Add automated tests that prevent regressions without flakiness.
+
+## Inputs
+- Target behavior and acceptance criteria
+- Where the defect/regression could occur
+
+## Outputs
+- New/updated tests in the relevant layer:
+  - backend: Django/DRF tests
+  - frontend: Vitest + RTL tests
+  - e2e: Playwright
+  - mobile: Jest
+
+## Step-by-step execution
+1. Write acceptance criteria first (Given/When/Then).
+2. Choose minimal test level that catches regression.
+3. Prefer deterministic assertions.
+4. Run relevant suite(s) only; expand if risk is high.
+
+## Validation
+- Backend: `cd backend && python manage.py test`
+- Frontend: `npm --prefix frontend run test:ci`
+- E2E: `npm --prefix frontend run test:e2e`
+- Mobile: `npm --prefix mobile run test`
+
+## Risks & rollback
+- Risk: flaky tests create delivery drag.
+- Rollback: revert test-only changes if necessary.
+
+## Handoff checklist
+- [ ] Tests are deterministic
+- [ ] Repro steps documented

--- a/.copilot/squad/tasks/ci-cd-workflow-changes.md
+++ b/.copilot/squad/tasks/ci-cd-workflow-changes.md
@@ -1,0 +1,38 @@
+# Task: Create CI/CD workflow changes (Golden Pipeline compliant)
+
+## Purpose
+Update GitHub Actions workflows without violating ProjectMeats’ **Golden Standard** deployment reliability.
+
+## Inputs
+- Desired workflow change
+- Target environment lane(s) affected
+
+## Outputs
+- Updated workflow YAML with golden rules preserved
+- Updated docs if behavior changes
+
+## Step-by-step execution
+1. Read constraints:
+   - `docs/GOLDEN_PIPELINE.md`
+   - `.github/instructions/workflows.instructions.md`
+2. Ensure:
+   - remote deploy uses `docker run` (no docker-compose)
+   - SHA-tagged images, no `:latest` in production
+   - parallel frontend/backend swimlanes
+   - migrations are runner-driven and idempotent (`--fake-initial`)
+3. If secrets/env vars change:
+   - update `config/env.manifest.json`
+   - never echo secrets
+4. Validate golden state:
+   - `bash scripts/verify_golden_state.sh`
+
+## Validation & tests (required)
+- `bash scripts/verify_golden_state.sh`
+
+## Risks & rollback
+- Risk: broken deployments.
+- Rollback: revert PR; redeploy last known good SHA.
+
+## Handoff checklist
+- [ ] Golden rules explicitly checked
+- [ ] Rollback steps included

--- a/.copilot/squad/tasks/cross-agent-architectural-review.md
+++ b/.copilot/squad/tasks/cross-agent-architectural-review.md
@@ -1,0 +1,36 @@
+# Task: Cross-agent architectural review (enterprise gate)
+
+## Purpose
+Run a structured, cross-functional review before landing risky or cross-cutting changes.
+
+## Inputs
+- PR diff (or proposed change plan)
+- Affected domains (backend/frontend/mobile/devops)
+
+## Outputs
+- Review report including:
+  - deliverables + expected results
+  - acceptance criteria
+  - dependencies
+  - risk register + mitigations
+  - testing strategy
+  - rollback plan
+
+## Step-by-step execution
+1. Architect reviews golden invariant compliance.
+2. Lead Engineer reviews cross-layer cohesion.
+3. Domain leads review within their domain.
+4. Tester verifies acceptance criteria + test plan.
+5. Documentation Steward confirms canonical docs alignment.
+6. Project Manager confirms scope and user value.
+
+## Validation
+- Ensure all blocking rules are satisfied per `squad.json`.
+
+## Risks & rollback
+- Risk: process overhead.
+- Mitigation: limit to high-risk changes and keep report concise.
+
+## Handoff checklist
+- [ ] All required reviewers provided sign-off
+- [ ] Clear go/no-go decision recorded

--- a/.copilot/squad/tasks/multi-tenant-safe-migration.md
+++ b/.copilot/squad/tasks/multi-tenant-safe-migration.md
@@ -1,0 +1,40 @@
+# Task: Implement multi-tenant-safe migration (Django + RLS)
+
+## Purpose
+Make schema changes without breaking existing tenants and while preserving defense-in-depth isolation.
+
+## Inputs
+- Model/table affected
+- Desired schema evolution (add field/table/index)
+
+## Outputs
+- New migration file(s)
+- RLS policy setup for any new tenant-aware table (when applicable)
+- Verified migration plan + rollback steps
+
+## Step-by-step execution
+1. Confirm constraints:
+   - Shared schema ONLY (no django-tenants)
+   - Additive-only when possible
+2. Create migration:
+   - Add new fields with `null=True` or `default=...` where required.
+   - Never modify already-applied migrations.
+3. If creating a tenant-aware table:
+   - Include `RunSQL` to enable RLS + create policy using `current_setting('app.current_tenant')::uuid`.
+4. Verify:
+   - `cd backend && python manage.py makemigrations`
+   - `cd backend && python manage.py makemigrations --check`
+   - `cd backend && python manage.py migrate --plan`
+
+## Validation & tests (required)
+- `cd backend && python manage.py makemigrations --check`
+- `cd backend && python manage.py migrate --plan`
+
+## Risks & rollback
+- Risk: downtime or broken deploy if migrations are missing.
+- Rollback: `python manage.py migrate <app> <previous>` where safe; otherwise revert PR and redeploy.
+
+## Handoff checklist
+- [ ] Migration files committed
+- [ ] RLS policy added for new tenant-aware tables
+- [ ] Rollback plan documented

--- a/.copilot/squad/tasks/update-documentation.md
+++ b/.copilot/squad/tasks/update-documentation.md
@@ -1,0 +1,33 @@
+# Task: Update documentation (canonical alignment)
+
+## Purpose
+Update documentation while preserving **canonical truth hierarchy**.
+
+## Inputs
+- Change summary
+- Which docs are affected
+
+## Outputs
+- Updated docs with correct authority labels
+
+## Step-by-step execution
+1. Confirm hierarchy:
+   - `MASTER_PLAN.md` is canonical.
+   - `ROADMAP.md` is reference-only unless explicitly promoted.
+   - `.github/MASTER_PLAN.md` is append-only PR log.
+2. Make updates with:
+   - clear headings
+   - minimal duplication
+   - links to authoritative sources
+3. Ensure commands are correct and copy-pastable.
+
+## Validation
+- Spell-check mentally; ensure links/paths exist.
+
+## Risks & rollback
+- Risk: contradictory status claims.
+- Rollback: revert PR.
+
+## Handoff checklist
+- [ ] No contradictions with MASTER_PLAN
+- [ ] Correct authority labels preserved

--- a/.copilot/squad/tasks/update-golden-files.md
+++ b/.copilot/squad/tasks/update-golden-files.md
@@ -1,0 +1,35 @@
+# Task: Update Golden Files (registry + enforcement)
+
+## Purpose
+Update authoritative registries so future work stays consistent and discoverable.
+
+## Inputs
+- What changed (schema, env vars, CI, architecture)
+
+## Outputs
+- Updated `manifests/GOLDEN_FILES.md` and any other golden registries
+- If needed: added enforcement mechanism (validation script/CI gate)
+
+## Step-by-step execution
+1. Identify the “golden” owner file(s) that must be updated.
+2. Update `manifests/GOLDEN_FILES.md` with:
+   - concern
+   - golden file path
+   - authority rationale
+3. If an invariant was added/changed, add an enforcement mechanism:
+   - script under `scripts/`
+   - CI check (only if consistent with Golden Pipeline)
+4. If env vars/secrets changed:
+   - update `config/env.manifest.json` first
+   - run `python config/manage_env.py audit`
+
+## Validation
+- `python config/manage_env.py audit` (when env vars involved)
+
+## Risks & rollback
+- Risk: drift between docs and reality.
+- Rollback: revert PR.
+
+## Handoff checklist
+- [ ] Golden registry updated
+- [ ] Enforcement added where appropriate

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1595,3 +1595,5 @@ Deliverables:
 - 2026-04-01 — CI/CD: fix Master Pipeline workflow file issue (run-name + md paths-ignore) — PR: #4339.
 
 - 2026-04-01 — CI/CD: deploy feed run-name flatten + auto-promote token fallback — PR: #4340.
+
+- **2026-04-16** — Copilot Squad: added enterprise squad roles/tasks/agents/skills + validator and optional gh wrapper (`gh copilot squad run`). (PR: #4374)

--- a/.github/agents/projectmeats-architect.agent.md
+++ b/.github/agents/projectmeats-architect.agent.md
@@ -1,0 +1,27 @@
+---
+name: projectmeats-architect
+description: Enforces Golden Pipeline + Golden Files; blocks unsafe CI/CD, secrets, migration, or tenant isolation changes.
+tools: ["view", "grep", "glob", "bash", "edit"]
+---
+
+You are the **Architect** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/architect.md`.
+
+## Operating rules (non-negotiable)
+- Always consult:
+  - `@docs/GOLDEN_PIPELINE.md`
+  - `@manifests/GOLDEN_FILES.md`
+  - `@MASTER_PLAN.md`
+- If a proposed change violates Golden Pipeline or tenant isolation patterns, you must **block** and provide a precise fix plan.
+
+## What you deliver
+- A short, high-signal compliance assessment:
+  - What golden rules are implicated
+  - Pass/fail per rule
+  - Mitigations + rollback
+- When touching CI/CD: ensure docker run pattern, immutable tags, runner-driven idempotent migrations.
+
+## Collaboration
+- If backend schema/migrations/RLS: require Backend Lead + Tester sign-off.
+- If workflows/secrets: require DevOps + Documentation Steward sign-off.

--- a/.github/agents/projectmeats-backend-lead.agent.md
+++ b/.github/agents/projectmeats-backend-lead.agent.md
@@ -1,0 +1,22 @@
+---
+name: projectmeats-backend-lead
+description: Django/DRF multi-tenant specialist; enforces tenant isolation, serializers, permissions, and migration safety.
+tools: ["view", "grep", "glob", "bash", "edit"]
+---
+
+You are the **Backend Lead** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/backend-lead.md`.
+
+## Non-negotiables
+- Shared-schema multi-tenancy ONLY (no django-tenants).
+- All DRF querysets must be tenant-filtered (`tenant=request.tenant`).
+- `perform_create()` must set tenant.
+- Any new tenant-aware table requires RLS policy SQL (where applicable per repo standards).
+
+## Default workflow
+Use playbook: `@.copilot/squad/tasks/add-backend-endpoint.md`
+
+## Validation
+- `cd backend && python manage.py makemigrations --check`
+- `cd backend && python manage.py test`

--- a/.github/agents/projectmeats-devops-engineer.agent.md
+++ b/.github/agents/projectmeats-devops-engineer.agent.md
@@ -1,0 +1,22 @@
+---
+name: projectmeats-devops-engineer
+description: CI/CD and environment governance; enforces Golden Pipeline deployment/migration patterns and secret manifest correctness.
+tools: ["view", "grep", "glob", "bash", "edit"]
+---
+
+You are the **DevOps Engineer** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/devops-engineer.md`.
+
+## Non-negotiables
+- `docker run` on remote hosts; never docker-compose.
+- Immutable SHA tags.
+- Parallel swimlanes.
+- Runner-driven migrations with `--fake-initial`.
+- Secrets must match `@config/env.manifest.json` (never guess).
+
+## Default workflow
+Use playbook: `@.copilot/squad/tasks/ci-cd-workflow-changes.md`
+
+## Validation
+- `bash scripts/verify_golden_state.sh`

--- a/.github/agents/projectmeats-documentation-steward.agent.md
+++ b/.github/agents/projectmeats-documentation-steward.agent.md
@@ -1,0 +1,17 @@
+---
+name: projectmeats-documentation-steward
+description: Maintains canonical documentation alignment (MASTER_PLAN is truth; ROADMAP is reference; PR log is append-only).
+tools: ["view", "grep", "glob", "edit"]
+---
+
+You are the **Documentation Steward** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/documentation-steward.md`.
+
+## Non-negotiables
+- `MASTER_PLAN.md` is canonical.
+- `ROADMAP.md` is reference-only unless explicitly promoted.
+- `.github/MASTER_PLAN.md` is append-only.
+
+## Default workflow
+Use playbook: `@.copilot/squad/tasks/update-documentation.md`

--- a/.github/agents/projectmeats-frontend-lead.agent.md
+++ b/.github/agents/projectmeats-frontend-lead.agent.md
@@ -1,0 +1,22 @@
+---
+name: projectmeats-frontend-lead
+description: React/TypeScript/Tailwind specialist; enforces design system tokens, accessibility, and service-layer API usage.
+tools: ["view", "grep", "glob", "bash", "edit"]
+---
+
+You are the **Frontend Lead** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/frontend-lead.md`.
+
+## Non-negotiables
+- No hardcoded colors; use theme tokens/CSS variables.
+- Use approved API service layer.
+- Workforms changes must be additive-only.
+
+## Default workflow
+Use playbook: `@.copilot/squad/tasks/add-frontend-component.md`
+
+## Validation
+- `npm --prefix frontend run type-check`
+- `npm --prefix frontend run verify-standards`
+- `npm --prefix frontend run test:ci`

--- a/.github/agents/projectmeats-lead-engineer.agent.md
+++ b/.github/agents/projectmeats-lead-engineer.agent.md
@@ -1,0 +1,26 @@
+---
+name: projectmeats-lead-engineer
+description: Cross-functional technical authority ensuring changes are coherent across backend/frontend/mobile/devops and aligned to MASTER_PLAN.
+tools: ["view", "grep", "glob", "bash", "edit"]
+---
+
+You are the **Lead Engineer** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/lead-engineer.md`.
+
+## Operating rules
+- Always align work to `@MASTER_PLAN.md`.
+- Prefer smallest complete change; maintain backwards compatibility.
+- When golden invariants are involved, defer to `projectmeats-architect`.
+
+## What you deliver
+- A concrete implementation plan (deliverables, acceptance, risks, testing, rollback)
+- A merged PR into `development` when done.
+
+## Collaboration
+- Delegate domain details:
+  - backend: `projectmeats-backend-lead`
+  - frontend: `projectmeats-frontend-lead`
+  - mobile: `projectmeats-mobile-lead`
+  - CI/CD: `projectmeats-devops-engineer`
+  - tests: `projectmeats-tester`

--- a/.github/agents/projectmeats-mobile-lead.agent.md
+++ b/.github/agents/projectmeats-mobile-lead.agent.md
@@ -1,0 +1,16 @@
+---
+name: projectmeats-mobile-lead
+description: React Native/Expo specialist; enforces type-safe navigation, shared logic reuse, and mobile accessibility.
+tools: ["view", "grep", "glob", "bash", "edit"]
+---
+
+You are the **Mobile Lead** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/mobile-lead.md`.
+
+## Default workflow
+Use playbook: `@.copilot/squad/tasks/add-mobile-feature.md`
+
+## Validation
+- `npm --prefix mobile run lint`
+- `npm --prefix mobile run test`

--- a/.github/agents/projectmeats-project-manager.agent.md
+++ b/.github/agents/projectmeats-project-manager.agent.md
@@ -1,0 +1,16 @@
+---
+name: projectmeats-project-manager
+description: Business-facing scope/acceptance owner; aligns work to MASTER_PLAN and user outcomes. No code changes.
+tools: ["view", "grep", "glob"]
+---
+
+You are the **Project Manager** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/project-manager.md`.
+
+## Guardrails
+- Do not modify code. Produce:
+  - acceptance criteria
+  - scope boundaries
+  - user-facing summary
+- If a request conflicts with Golden invariants, defer to Architect.

--- a/.github/agents/projectmeats-tester.agent.md
+++ b/.github/agents/projectmeats-tester.agent.md
@@ -1,0 +1,16 @@
+---
+name: projectmeats-tester
+description: QA/test specialist; defines acceptance criteria and adds stable automated coverage across backend/frontend/e2e/mobile.
+tools: ["view", "grep", "glob", "bash", "edit"]
+---
+
+You are the **Tester** for ProjectMeats.
+
+Your canonical role definition is in `@.copilot/squad/roles/tester.md`.
+
+## Default workflow
+Use playbook: `@.copilot/squad/tasks/add-test-coverage.md`
+
+## Guardrails
+- Prefer test-only changes.
+- Escalate production-code changes for testability to Lead Engineer.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,14 @@ When working in **GitHub Copilot CLI** for this repo, default to a “squad” a
 - Use `/tasks` to monitor/cancel background subagent work
 - Use `/diff` and `/review` before committing or opening PRs
 
+**Squad registry (roles + tasks):**
+- See `.copilot/squad/README.md` and `.copilot/squad/squad.json`
+- Validate setup: `bash scripts/validate_copilot_squad.sh`
+
+**Optional gh wrapper:**
+- Install alias: `bash scripts/install_gh_copilot_alias.sh`
+- Then run tasks: `gh copilot squad run <task-id>`
+
 **Recommended squad split:**
 - *Explore agent*: locate files, map the flow, identify risks
 - *Implementation agent*: make the code changes

--- a/.github/skills/add-backend-endpoint/SKILL.md
+++ b/.github/skills/add-backend-endpoint/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: add-backend-endpoint
+description: Add a tenant-safe Django/DRF endpoint aligned with shared-schema multi-tenancy.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/add-backend-endpoint.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/.github/skills/add-frontend-component/SKILL.md
+++ b/.github/skills/add-frontend-component/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: add-frontend-component
+description: Add a theme-compliant, accessible React+TS component using approved service-layer APIs.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/add-frontend-component.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/.github/skills/add-mobile-feature/SKILL.md
+++ b/.github/skills/add-mobile-feature/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: add-mobile-feature
+description: Add a type-safe React Native feature aligned with shared logic and accessibility requirements.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/add-mobile-feature.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/.github/skills/add-test-coverage/SKILL.md
+++ b/.github/skills/add-test-coverage/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: add-test-coverage
+description: Add high-signal, stable automated tests (backend/frontend/e2e/mobile) for acceptance criteria.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/add-test-coverage.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/.github/skills/ci-cd-workflow-changes/SKILL.md
+++ b/.github/skills/ci-cd-workflow-changes/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ci-cd-workflow-changes
+description: Make Golden Pipeline compliant changes to GitHub Actions workflows and deployment logic.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/ci-cd-workflow-changes.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/.github/skills/cross-agent-architectural-review/SKILL.md
+++ b/.github/skills/cross-agent-architectural-review/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: cross-agent-architectural-review
+description: Run a structured cross-agent review with blocking rules, risks, tests, and rollback.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/cross-agent-architectural-review.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/.github/skills/multi-tenant-safe-migration/SKILL.md
+++ b/.github/skills/multi-tenant-safe-migration/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: multi-tenant-safe-migration
+description: Implement additive, tenant-safe Django migrations including RLS policy where required.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/multi-tenant-safe-migration.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/.github/skills/update-documentation/SKILL.md
+++ b/.github/skills/update-documentation/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: update-documentation
+description: Update canonical documentation (MASTER_PLAN/ROADMAP/PR log) without contradictions.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/update-documentation.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/.github/skills/update-golden-files/SKILL.md
+++ b/.github/skills/update-golden-files/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: update-golden-files
+description: Update Golden Files/registries and add enforcement guardrails where required.
+---
+
+Follow the canonical playbook: @.copilot/squad/tasks/update-golden-files.md
+
+Deliver:
+- Deliverables + expected results
+- Acceptance criteria
+- Dependencies
+- Risk register + mitigations
+- Testing strategy (use existing repo commands)
+- Rollback plan

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -102,6 +102,7 @@ We are re-validating and completing the last ~25 prompts with **evidence-based a
 ### P1 — Operational excellence
 - **Documentation hygiene:** demote/label duplicated roadmaps, remove contradictory “100% complete” claims.
 - **CI automation:** promotion PRs dev→uat and uat→prod/main remain green and observable.
+- **Copilot Squad governance:** repo-local squad roles/tasks/agents/skills under `.copilot/squad/` + `.github/agents/` + `.github/skills/` with validator `bash scripts/validate_copilot_squad.sh`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,8 @@
 
 For current priorities, status, and evidence, see **`MASTER_PLAN.md` (canonical)**.
 
+**Copilot Squad (repo governance):** `.copilot/squad/README.md` documents the enterprise squad roles + reusable tasks for this repo.
+
 ---
 
 ## 📊 Overall Progress (historical; non-canonical)

--- a/scripts/gh-copilot
+++ b/scripts/gh-copilot
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/gh-copilot squad run <task-id> [--agent <agent-id>] [--mode plan|autopilot|interactive] [--execute]
+  scripts/gh-copilot squad list
+  scripts/gh-copilot squad show <task-id>
+
+Notes:
+- This repo uses GitHub Copilot CLI as `copilot`.
+- `gh copilot` is implemented via a gh alias that forwards to this script.
+- By default, this script prints the recommended `copilot` command (safe). Use --execute to run it.
+USAGE
+}
+
+require_repo_root() {
+  git rev-parse --show-toplevel >/dev/null
+}
+
+squad_json() {
+  echo ".copilot/squad/squad.json"
+}
+
+list_tasks() {
+  python - <<'PY'
+import json
+p = '.copilot/squad/squad.json'
+with open(p, 'r', encoding='utf-8') as f:
+  data = json.load(f)
+for t in data.get('tasks', []):
+  print(t['id'])
+PY
+}
+
+show_task() {
+  local task_id="$1"
+  python - <<PY
+import json
+p = '.copilot/squad/squad.json'
+with open(p, 'r', encoding='utf-8') as f:
+  data = json.load(f)
+for t in data.get('tasks', []):
+  if t.get('id') == '${task_id}':
+    print(json.dumps(t, indent=2))
+    raise SystemExit(0)
+raise SystemExit(2)
+PY
+}
+
+infer_default_agent() {
+  local task_id="$1"
+  python - <<PY
+import json
+p = '.copilot/squad/squad.json'
+with open(p, 'r', encoding='utf-8') as f:
+  data = json.load(f)
+for t in data.get('tasks', []):
+  if t.get('id') == '${task_id}':
+    print(t.get('default_agent', 'lead-engineer'))
+    raise SystemExit(0)
+print('lead-engineer')
+PY
+}
+
+agent_profile_for() {
+  local agent_id="$1"
+  python - <<PY
+import json
+p = '.copilot/squad/squad.json'
+with open(p, 'r', encoding='utf-8') as f:
+  data = json.load(f)
+for a in data.get('agents', []):
+  if a.get('id') == '${agent_id}':
+    # map to copilot agent profile name
+    prof = a.get('copilot_agent_profile','')
+    # ID in copilot is derived from filename; ours is `projectmeats-<role>`
+    # return `name` we used in YAML frontmatter, which matches filename.
+    print(prof.split('/')[-1].replace('.agent.md',''))
+    raise SystemExit(0)
+print('projectmeats-lead-engineer')
+PY
+}
+
+playbook_for() {
+  local task_id="$1"
+  python - <<PY
+import json
+p = '.copilot/squad/squad.json'
+with open(p, 'r', encoding='utf-8') as f:
+  data = json.load(f)
+for t in data.get('tasks', []):
+  if t.get('id') == '${task_id}':
+    print(t.get('playbook_file',''))
+    raise SystemExit(0)
+raise SystemExit(2)
+PY
+}
+
+run_task() {
+  local task_id="$1"; shift
+  local agent_override=""
+  local mode="interactive"
+  local execute=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --agent)
+        agent_override="$2"; shift 2 ;;
+      --mode)
+        mode="$2"; shift 2 ;;
+      --execute)
+        execute=1; shift ;;
+      -h|--help)
+        usage; exit 0 ;;
+      *)
+        echo "Unknown arg: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+
+  if ! [ -f "$(squad_json)" ]; then
+    echo "Missing $(squad_json). Run validation." >&2
+    exit 2
+  fi
+
+  local default_agent
+  default_agent=$(infer_default_agent "$task_id")
+  local agent_id
+  agent_id="${agent_override:-$default_agent}"
+  local copilot_agent
+  copilot_agent=$(agent_profile_for "$agent_id")
+  local playbook
+  playbook=$(playbook_for "$task_id")
+
+  if [ -z "$playbook" ] || ! [ -f "$playbook" ]; then
+    echo "Unknown task or missing playbook for: $task_id" >&2
+    echo "Available tasks:" >&2
+    list_tasks >&2
+    exit 2
+  fi
+
+  local prompt
+  prompt=$(cat <<PROMPT
+Follow the ProjectMeats Squad playbook: @$playbook
+
+1) Restate deliverables + acceptance criteria.
+2) Identify dependencies + risks + mitigations.
+3) Implement the change (if requested) following repo governance.
+4) Run the smallest relevant existing validation commands.
+5) Provide rollback steps.
+PROMPT
+)
+
+  local cmd=(copilot --agent="$copilot_agent")
+  case "$mode" in
+    plan)
+      cmd+=(--plan -i "$prompt")
+      ;;
+    autopilot)
+      cmd+=(--autopilot -i "$prompt")
+      ;;
+    interactive)
+      cmd+=(-i "$prompt")
+      ;;
+    *)
+      echo "Invalid mode: $mode (use plan|autopilot|interactive)" >&2
+      exit 2
+      ;;
+  esac
+
+  echo "# Task: $task_id"
+  echo "# Agent: $agent_id (copilot --agent=$copilot_agent)"
+  echo "# Mode: $mode"
+  echo
+  printf '%q ' "${cmd[@]}"; echo
+
+  if [ "$execute" -eq 1 ]; then
+    echo
+    exec "${cmd[@]}"
+  fi
+}
+
+main() {
+  require_repo_root
+
+  if [ $# -lt 1 ]; then
+    usage; exit 2
+  fi
+
+  case "$1" in
+    squad)
+      shift
+      case "${1:-}" in
+        run)
+          shift
+          [ $# -ge 1 ] || { usage; exit 2; }
+          run_task "$@"
+          ;;
+        list)
+          list_tasks
+          ;;
+        show)
+          shift
+          [ $# -ge 1 ] || { usage; exit 2; }
+          show_task "$1"
+          ;;
+        *)
+          usage; exit 2
+          ;;
+      esac
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    *)
+      usage; exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/install_gh_copilot_alias.sh
+++ b/scripts/install_gh_copilot_alias.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This creates a local gh alias so `gh copilot ...` works without a gh extension.
+# It is intentionally opt-in.
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required" >&2
+  exit 2
+fi
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+chmod +x scripts/gh-copilot
+
+gh alias set copilot '!./scripts/gh-copilot'
+
+echo "Installed gh alias: 'gh copilot' -> ./scripts/gh-copilot"
+
+echo "Try: gh copilot squad list"

--- a/scripts/validate_copilot_squad.sh
+++ b/scripts/validate_copilot_squad.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "❌ $*" >&2
+  exit 1
+}
+
+require_file() {
+  [ -f "$1" ] || fail "Missing file: $1"
+}
+
+require_dir() {
+  [ -d "$1" ] || fail "Missing dir: $1"
+}
+
+require_heading() {
+  local file="$1"; local heading="$2"
+  rg -n --fixed-strings "$heading" "$file" >/dev/null || fail "Missing heading '$heading' in $file"
+}
+
+require_dir .copilot/squad
+require_dir .copilot/squad/roles
+require_dir .copilot/squad/tasks
+
+require_file .copilot/squad/squad.json
+python -m json.tool .copilot/squad/squad.json >/dev/null || fail "Invalid JSON: .copilot/squad/squad.json"
+
+# role files
+for f in \
+  architect lead-engineer backend-lead frontend-lead mobile-lead devops-engineer tester documentation-steward project-manager
+do
+  file=".copilot/squad/roles/$f.md"
+  require_file "$file"
+  require_heading "$file" "## Purpose"
+  require_heading "$file" "## Responsibilities"
+  require_heading "$file" "## Constraints / Must-Nots"
+  require_heading "$file" "## Decision rules"
+  require_heading "$file" "## Required references"
+done
+
+# task playbooks
+for f in \
+  add-backend-endpoint add-frontend-component add-mobile-feature update-documentation add-test-coverage update-golden-files multi-tenant-safe-migration ci-cd-workflow-changes cross-agent-architectural-review
+do
+  file=".copilot/squad/tasks/$f.md"
+  require_file "$file"
+  require_heading "$file" "## Purpose"
+  require_heading "$file" "## Inputs"
+  require_heading "$file" "## Outputs"
+  require_heading "$file" "## Step-by-step execution"
+  require_heading "$file" "## Risks & rollback"
+  require_heading "$file" "## Handoff checklist"
+done
+
+# copilot agent profiles
+require_dir .github/agents
+count_agents=$(ls -1 .github/agents/projectmeats-*.agent.md 2>/dev/null | wc -l | tr -d ' ')
+[ "$count_agents" -ge 9 ] || fail "Expected >=9 projectmeats-* agents; found $count_agents"
+
+# skills
+require_dir .github/skills
+count_skills=$(find .github/skills -name SKILL.md | wc -l | tr -d ' ')
+[ "$count_skills" -ge 9 ] || fail "Expected >=9 skills; found $count_skills"
+
+# wrapper script
+require_file scripts/gh-copilot
+require_file scripts/install_gh_copilot_alias.sh
+
+echo "✅ Copilot Squad structure validated"


### PR DESCRIPTION
Adds enterprise Copilot Squad config under .copilot/squad with roles/tasks/squad.json, plus Copilot CLI custom agents (.github/agents) and skills (.github/skills). Includes scripts: validate_copilot_squad.sh and gh-copilot wrapper for optional 'gh copilot squad run'.\n\nValidation: bash scripts/validate_copilot_squad.sh