### PR TITLE
ci: validate Copilot Squad on PRs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -128,3 +128,14 @@ jobs:
       - name: Type check
         working-directory: ./frontend
         run: npm run type-check
+
+  validate-copilot-squad:
+    name: Validate Copilot Squad
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate squad structure
+        run: bash scripts/validate_copilot_squad.sh

--- a/scripts/validate_copilot_squad.sh
+++ b/scripts/validate_copilot_squad.sh
@@ -16,7 +16,8 @@ require_dir() {
 
 require_heading() {
   local file="$1"; local heading="$2"
-  rg -n --fixed-strings "$heading" "$file" >/dev/null || fail "Missing heading '$heading' in $file"
+  # Use POSIX grep for CI portability (ripgrep isn't guaranteed on runners)
+  grep -Fnq "$heading" "$file" || fail "Missing heading '$heading' in $file"
 }
 
 require_dir .copilot/squad


### PR DESCRIPTION
Adds a PR Validation job that runs: bash scripts/validate_copilot_squad.sh\n\nAlso hardens the validator to use grep (CI portable).