### PR TITLE
Harden Email Sync Now error responses

### DIFF
--- a/backend/apps/integrations/tests.py
+++ b/backend/apps/integrations/tests.py
@@ -44,7 +44,10 @@ class EmailSyncTests(APITestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(resp.data.get('ok'), False)
         self.assertEqual(resp.data.get('code'), 'sync_exception')
-        self.assertIn('boom', resp.data.get('error', ''))
+
+        # Must not leak raw exception strings to callers (security + UX stability)
+        self.assertNotIn('boom', resp.data.get('error', ''))
+        self.assertEqual(resp.data.get('details', {}).get('type'), 'RuntimeError')
 
     @patch('tenant_apps.integrations.services.email_ingestion.EmailIngestionService.poll_tenant_by_id')
     def test_sync_emails_soft_fails_when_graph_returns_zero_scanned_with_errors(self, poll_tenant_by_id):

--- a/backend/apps/integrations/views.py
+++ b/backend/apps/integrations/views.py
@@ -491,14 +491,12 @@ def sync_emails(request):
 
         # This is a user-triggered action. Prefer a 200 + structured failure payload so the UI
         # can display actionable guidance instead of treating it as a hard outage.
-        # This endpoint is a user-triggered action; include the exception message so callers/tests
-        # can surface a concrete failure reason (while still returning a 200 + structured payload).
-        error_detail = f"Email sync failed. Outlook connection may be expired or misconfigured. ({sync_err})"
+        # IMPORTANT: Never leak raw decryption/token exception strings to the client.
         return Response(
             {
                 "ok": False,
                 "message": "Email sync failed",
-                "error": error_detail,
+                "error": "Email sync failed. Outlook connection may be expired or misconfigured.",
                 "code": "sync_exception",
                 "error_code": "sync_exception",
                 "hint": "If this persists, reconnect Outlook in Settings → Email Integrations and retry.",
@@ -508,6 +506,9 @@ def sync_emails(request):
                 },
                 "tenant_id": tenant_id,
                 "provider_email": provider.connected_email,
+                "details": {
+                    "type": sync_err.__class__.__name__,
+                },
             },
             status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## What\n- Sanitizes Sync Now error responses to avoid leaking raw exception strings\n- Returns stable structured error details (e.g., details.type)\n- Updates tests accordingly\n\n## Why\nImproves security and UX stability for integration sync failures.\n\n## Testing\n- cd backend && python manage.py test apps.integrations.tests.EmailSyncTests