### PR TITLE
ci: show PR title + number in Master Pipeline run-name

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1613,3 +1613,5 @@ Deliverables:
 - **2026-04-16** — Tests: lock Email Sync Now actionable error payloads (not_connected + token_invalid reconnect CTA). (PR: #4392)
 
 - **2026-04-16** — Security: DRF default permission set to IsAuthenticated; explicit allowlist for OAuth callbacks + email webhooks + regression tests. (PR: #4394)
+
+- 2026-04-16 — ci: improve Master Pipeline run-name to show PR title + number instead of SHA — PR: #pending.

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -7,7 +7,7 @@ run-name: >-
       || format(
         '🚀 Deploy: {0} - {1}',
         github.ref_name == 'main' && 'production' || github.ref_name,
-        github.sha
+        github.event.head_commit.message
       )
   }}
 


### PR DESCRIPTION
## Problem
The Master Pipeline actions feed shows the raw SHA, making it hard to tell what deployed:
```
🚀 Deploy: development - a0d4c28b4b34f476edce441045ee26cb09bebc60
```

## Fix
Replace `github.sha` with `github.event.head_commit.message` in the `run-name` format string.

For squash-merged PRs (this repo's standard), the commit message is a **single line** — `PR Title (#4372)` — so no `replace()` is needed and the 0-jobs bug is avoided.

**After:**
```
🚀 Deploy: development - Standardize forms: RHF+Zod InquiryCreateModal entity fields (#4372)
```

## Why not `replace()`?
`replace()` in `run-name` causes the entire workflow to produce 0 jobs (confirmed in PRs #4339/#4341). Using the commit message directly is safe — squash merges guarantee a single-line message.

## Golden Pipeline checklist
- [x] No deployment logic changed — run-name only
- [x] No secrets touched
- [x] `replace()` not used (avoids 0-jobs bug)
- [x] `.github/MASTER_PLAN.md` updated