### PR TITLE
Mobile: Inquiries usable at 375px

### DIFF
--- a/frontend/e2e/mobile_inquiries_375.spec.ts
+++ b/frontend/e2e/mobile_inquiries_375.spec.ts
@@ -1,0 +1,258 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const VIEWPORT = { width: 375, height: 667 }; // iPhone SE logical size
+
+async function login(page: Page) {
+  await page.goto('/');
+
+  const password = page.locator('input[type="password"]');
+  if ((await password.count()) === 0) return;
+
+  const testEmail = process.env.TEST_USER_EMAIL || 'admin@meatscentral.com';
+  const testPassword = process.env.TEST_USER_PASSWORD || 'Admin123!';
+
+  await page.fill('input[type="email"], input[type="text"]', testEmail);
+  await page.fill('input[type="password"]', testPassword);
+  await page.click('button:has-text("Login"), button:has-text("Sign In")');
+
+  await page.waitForURL(/\/(dashboard|home|workforms)/i, { timeout: 10000 });
+}
+
+async function mockInquiriesApis(page: Page) {
+  const now = new Date().toISOString();
+
+  // Choices: make required selects deterministic (create modal).
+  await page.route(/\/choices\/?(\?.*)?$/, async (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') return route.fallback();
+
+    const url = new URL(req.url());
+    const choiceType = url.searchParams.get('choice_type');
+
+    const optionsByType: Record<string, Array<{ value: string; label: string }>> = {
+      weight_unit: [
+        { value: 'LBS', label: 'LBS' },
+        { value: 'KG', label: 'KG' },
+      ],
+    };
+
+    const options = (choiceType && optionsByType[choiceType]) || [];
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        choice_type: choiceType,
+        options,
+        count: options.length,
+      }),
+    });
+  });
+
+  // Entities: keep create modal dropdowns stable.
+  await page.route(/\/api\/v1\/customers\/?(\?.*)?$/, async (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') return route.fallback();
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [
+          {
+            id: 1,
+            name: 'E2E Customer',
+            created_at: now,
+            updated_at: now,
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route(/\/api\/v1\/suppliers\/?(\?.*)?$/, async (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') return route.fallback();
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [
+          {
+            id: 1,
+            name: 'E2E Supplier',
+            created_at: now,
+            updated_at: now,
+          },
+        ],
+      }),
+    });
+  });
+
+  // Inquiries list.
+  await page.route(/\/api\/v1\/inquiries\/?(\?.*)?$/, async (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') return route.fallback();
+
+    const results = Array.from({ length: 20 }).map((_, i) => ({
+      id: `inq-${i + 1}`,
+      inquiry_number: `INQ-${String(i + 1).padStart(4, '0')}`,
+      status: 'pending',
+      product_count: 3,
+      total_desired: 1234.56,
+      total_actual: null,
+      valid_until: '2030-12-31',
+      created_on: '2030-01-01',
+      customer_name: 'Acme Foods',
+      supplier_name: null,
+      contact_name: 'Pat',
+      is_expired: false,
+    }));
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ results, count: 42 }),
+    });
+  });
+
+  // Inquiry templates (to render the “From Template” action).
+  await page.route(/\/api\/v1\/inquiry-templates\/?(\?.*)?$/, async (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') return route.fallback();
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [{ id: 'tpl-1', name: 'Weekly Staples', product_count: 12 }],
+        count: 1,
+      }),
+    });
+  });
+}
+
+async function assertNoPageHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => {
+    const el = document.documentElement;
+    const body = document.body;
+
+    const before = window.scrollX;
+    window.scrollTo(9999, window.scrollY);
+    const after = window.scrollX;
+    window.scrollTo(0, window.scrollY);
+
+    const headerEl = document.querySelector('header');
+    const mainEl = document.querySelector('main');
+    const mainAreaEl = headerEl?.parentElement;
+
+    const mainAreaStyle = mainAreaEl ? window.getComputedStyle(mainAreaEl) : null;
+    const headerStyle = headerEl ? window.getComputedStyle(headerEl) : null;
+    const mainStyle = mainEl ? window.getComputedStyle(mainEl) : null;
+
+    const widestBodyChild = Array.from(document.body.children)
+      .map((child) => {
+        const r = child.getBoundingClientRect();
+        return {
+          tag: child.tagName.toLowerCase(),
+          id: child.id || null,
+          class: (child as HTMLElement).className || null,
+          width: Math.round(r.width),
+        };
+      })
+      .sort((a, b) => b.width - a.width)[0] ?? null;
+
+    return {
+      before,
+      after,
+      innerWidth: window.innerWidth,
+      clientWidth: el.clientWidth,
+      scrollWidth: el.scrollWidth,
+      bodyClientWidth: body.clientWidth,
+      bodyScrollWidth: body.scrollWidth,
+      htmlOverflowX: window.getComputedStyle(el).overflowX,
+      bodyOverflowX: window.getComputedStyle(body).overflowX,
+      widestBodyChild,
+      headerWidth: headerEl ? Math.round(headerEl.getBoundingClientRect().width) : null,
+      headerMaxWidth: headerStyle?.maxWidth ?? null,
+      mainWidth: mainEl ? Math.round(mainEl.getBoundingClientRect().width) : null,
+      mainMaxWidth: mainStyle?.maxWidth ?? null,
+      mainAreaWidth: mainAreaEl ? Math.round(mainAreaEl.getBoundingClientRect().width) : null,
+      mainAreaMarginLeft: mainAreaStyle?.marginLeft ?? null,
+      mainAreaTransform: mainAreaStyle?.transform ?? null,
+    };
+  });
+
+  if (metrics.after !== 0) {
+    const offenders = await page.evaluate(() => {
+      const vw = document.documentElement.clientWidth;
+      return Array.from(document.querySelectorAll<HTMLElement>('*'))
+        .map((el) => {
+          const r = el.getBoundingClientRect();
+          return {
+            tag: el.tagName.toLowerCase(),
+            id: el.id || undefined,
+            class: el.className || undefined,
+            right: Math.round(r.right),
+            width: Math.round(r.width),
+          };
+        })
+        .filter((x) => x.right > vw + 1 && x.width > 0)
+        .sort((a, b) => b.right - a.right)
+        .slice(0, 10);
+    });
+
+    throw new Error(
+      `Page is horizontally scrollable at 375px. ${JSON.stringify({ metrics, offenders }, null, 2)}`
+    );
+  }
+
+  expect(metrics.after).toBe(0);
+}
+
+async function assertTableWrapperFitsViewport(page: Page) {
+  const ok = await page.evaluate(() => {
+    const wrapper = document.querySelector('[data-testid="inquiries-table-wrapper"]') as HTMLElement | null;
+    if (!wrapper) return false;
+
+    const r = wrapper.getBoundingClientRect();
+    return r.left >= -1 && r.right <= window.innerWidth + 1;
+  });
+
+  expect(ok).toBeTruthy();
+}
+
+test.describe('Mobile: Inquiries page usable at 375px', () => {
+  test.use({ viewport: VIEWPORT });
+
+  test('no horizontal overflow and create inquiry surface opens', async ({ page }) => {
+    await login(page);
+    await mockInquiriesApis(page);
+
+    await page.goto('/inquiries');
+
+    await expect(page.getByRole('heading', { name: /Inquiries/i })).toBeVisible({ timeout: 15000 });
+
+    // Usability: page must not scroll horizontally at 375px.
+    await assertNoPageHorizontalScroll(page);
+
+    // Header actions should be usable even when templates are present.
+    await expect(page.getByRole('button', { name: /From Template/i })).toBeVisible();
+
+    // Table wrapper should fit within viewport at 375px.
+    await assertTableWrapperFitsViewport(page);
+
+    const newInquiry = page.getByRole('button', { name: /New Inquiry/i });
+    await expect(newInquiry).toBeVisible();
+    await expect(newInquiry).toBeInViewport();
+
+    await newInquiry.click();
+
+    // InquiryCreateModal uses a "New Inquiry" title.
+    const modalTitle = page.getByRole('heading', { name: 'New Inquiry' });
+    await expect(modalTitle).toBeVisible({ timeout: 15000 });
+
+    await assertNoPageHorizontalScroll(page);
+  });
+});

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -70,6 +70,9 @@ const LayoutContainer = styled.div<{ $theme: Theme }>`
   display: flex;
   min-height: 100vh;
   background-color: ${(props) => props.$theme.colors.background};
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
 `;
 
 const MainArea = styled.div<{ $sidebarOpen: boolean; $sidebarHovered: boolean }>`
@@ -80,6 +83,9 @@ const MainArea = styled.div<{ $sidebarOpen: boolean; $sidebarHovered: boolean }>
   flex-direction: column;
   min-height: 100vh;
   will-change: margin-left;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
 
   @media (max-width: 768px) {
     margin-left: 0;
@@ -93,6 +99,9 @@ const Content = styled.main<{ $theme: Theme }>`
   overflow-y: auto;
   display: flex;
   justify-content: center;
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
 
   @media (min-width: 768px) {
     padding: 2rem;
@@ -104,6 +113,7 @@ const CenteredContainer = styled.div`
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 1rem;
+  min-width: 0;
 
   @media (max-width: 768px) {
     padding: 0;

--- a/frontend/src/pages/Inquiries.tsx
+++ b/frontend/src/pages/Inquiries.tsx
@@ -31,6 +31,7 @@ const Container = styled.div`
   padding: 1.5rem;
   max-width: 1400px;
   margin: 0 auto;
+  min-width: 0;
 `;
 
 const Header = styled.div`
@@ -56,6 +57,13 @@ const HeaderActions = styled.div`
   display: flex;
   gap: 0.75rem;
   align-items: center;
+  flex-wrap: wrap;
+
+  @media (max-width: 520px) {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
 const CreateButton = styled.button`
@@ -63,13 +71,19 @@ const CreateButton = styled.button`
   border: none;
   border-radius: var(--radius-md);
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  min-height: 44px;
+
+  @media (max-width: 520px) {
+    width: 100%;
+    justify-content: center;
+  }
   
   &:hover {
     opacity: 0.9;
@@ -88,6 +102,12 @@ const SecondaryButton = styled.button`
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  min-height: 44px;
+
+  @media (max-width: 520px) {
+    width: 100%;
+    justify-content: center;
+  }
   
   &:hover {
     background: rgba(var(--color-primary), 0.05);
@@ -97,6 +117,10 @@ const SecondaryButton = styled.button`
 
 const DropdownContainer = styled.div`
   position: relative;
+
+  @media (max-width: 520px) {
+    width: 100%;
+  }
 `;
 
 const DropdownMenu = styled.div<{ $isOpen: boolean }>`
@@ -108,7 +132,7 @@ const DropdownMenu = styled.div<{ $isOpen: boolean }>`
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-float);
   min-width: 200px;
   max-height: 300px;
   overflow-y: auto;
@@ -145,6 +169,12 @@ const DropdownLabel = styled.div`
   background: rgba(var(--color-primary), 0.05);
 `;
 
+const TemplateMeta = styled.span`
+  font-size: 0.75rem;
+  color: rgb(var(--color-text-secondary));
+  margin-left: 0.5rem;
+`;
+
 const FiltersBar = styled.div`
   display: flex;
   gap: 1rem;
@@ -161,6 +191,13 @@ const SearchInput = styled.input`
   background: rgb(var(--color-surface));
   color: rgb(var(--color-text-primary));
   min-width: 250px;
+  min-height: 44px;
+
+  @media (max-width: 520px) {
+    min-width: 0;
+    width: 100%;
+    font-size: 16px; /* iOS Safari zoom-on-focus prevention */
+  }
   
   &:focus {
     outline: none;
@@ -181,6 +218,13 @@ const FilterSelect = styled.select`
   background: rgb(var(--color-surface));
   color: rgb(var(--color-text-primary));
   cursor: pointer;
+  min-height: 44px;
+
+  @media (max-width: 520px) {
+    min-width: 0;
+    width: 100%;
+    font-size: 16px; /* iOS Safari zoom-on-focus prevention */
+  }
   
   &:focus {
     outline: none;
@@ -188,11 +232,25 @@ const FilterSelect = styled.select`
   }
 `;
 
+const TableWrapper = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
+  min-width: 0;
+  border-radius: var(--radius-lg);
+`;
+
 const Table = styled.div`
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-lg);
   overflow: hidden;
+  min-width: 920px;
+
+  @media (max-width: 520px) {
+    min-width: 0;
+  }
 `;
 
 const TableHeader = styled.div`
@@ -206,6 +264,14 @@ const TableHeader = styled.div`
   color: rgb(var(--color-text-primary));
   text-transform: uppercase;
   letter-spacing: 0.025em;
+
+  @media (max-width: 520px) {
+    grid-template-columns: 120px 1fr 110px;
+
+    > :nth-child(n+4) {
+      display: none;
+    }
+  }
 `;
 
 const TableRow = styled.div`
@@ -217,6 +283,14 @@ const TableRow = styled.div`
   align-items: center;
   cursor: pointer;
   transition: background 0.15s;
+
+  @media (max-width: 520px) {
+    grid-template-columns: 120px 1fr 110px;
+
+    > :nth-child(n+4) {
+      display: none;
+    }
+  }
   
   &:last-child {
     border-bottom: none;
@@ -253,26 +327,26 @@ const StatusBadge = styled.span<{ status: string }>`
   font-weight: 500;
   background: ${props => {
     switch (props.status) {
-      case 'accepted': return 'rgba(34, 197, 94, 0.1)';
-      case 'fulfilled': return 'rgba(34, 197, 94, 0.2)';
-      case 'pending': return 'rgba(234, 179, 8, 0.1)';
-      case 'quoted': return 'rgba(59, 130, 246, 0.1)';
-      case 'rejected': return 'rgba(239, 68, 68, 0.1)';
-      case 'expired': return 'rgba(107, 114, 128, 0.1)';
-      case 'draft': return 'rgba(107, 114, 128, 0.1)';
-      default: return 'rgba(107, 114, 128, 0.1)';
+      case 'accepted': return 'rgba(var(--color-success), 0.12)';
+      case 'fulfilled': return 'rgba(var(--color-success), 0.18)';
+      case 'pending': return 'rgba(var(--color-warning), 0.12)';
+      case 'quoted': return 'rgba(var(--color-info), 0.12)';
+      case 'rejected': return 'rgba(var(--color-danger), 0.12)';
+      case 'expired': return 'rgba(var(--color-text-secondary), 0.12)';
+      case 'draft': return 'rgba(var(--color-text-secondary), 0.12)';
+      default: return 'rgba(var(--color-text-secondary), 0.12)';
     }
   }};
   color: ${props => {
     switch (props.status) {
-      case 'accepted': return 'rgb(22, 163, 74)';
-      case 'fulfilled': return 'rgb(22, 163, 74)';
-      case 'pending': return 'rgb(202, 138, 4)';
-      case 'quoted': return 'rgb(37, 99, 235)';
-      case 'rejected': return 'rgb(220, 38, 38)';
-      case 'expired': return 'rgb(75, 85, 99)';
-      case 'draft': return 'rgb(75, 85, 99)';
-      default: return 'rgb(75, 85, 99)';
+      case 'accepted': return 'rgb(var(--color-success))';
+      case 'fulfilled': return 'rgb(var(--color-success))';
+      case 'pending': return 'rgb(var(--color-warning))';
+      case 'quoted': return 'rgb(var(--color-info))';
+      case 'rejected': return 'rgb(var(--color-danger))';
+      case 'expired': return 'rgb(var(--color-text-secondary))';
+      case 'draft': return 'rgb(var(--color-text-secondary))';
+      default: return 'rgb(var(--color-text-secondary))';
     }
   }};
 `;
@@ -327,16 +401,31 @@ const Pagination = styled.div`
   align-items: center;
   padding: 1rem 1.5rem;
   border-top: 1px solid rgb(var(--color-border));
+  flex-wrap: wrap;
+  gap: 0.75rem;
+
+  @media (max-width: 520px) {
+    align-items: stretch;
+  }
 `;
 
 const PaginationInfo = styled.span`
   font-size: 0.875rem;
   color: rgb(var(--color-text-secondary));
+
+  @media (max-width: 520px) {
+    width: 100%;
+  }
 `;
 
 const PaginationButtons = styled.div`
   display: flex;
   gap: 0.5rem;
+
+  @media (max-width: 520px) {
+    width: 100%;
+    justify-content: space-between;
+  }
 `;
 
 const PaginationButton = styled.button`
@@ -347,6 +436,7 @@ const PaginationButton = styled.button`
   color: rgb(var(--color-text-primary));
   font-size: 0.875rem;
   cursor: pointer;
+  min-height: 44px;
   
   &:hover:not(:disabled) {
     background: rgba(var(--color-primary), 0.05);
@@ -526,9 +616,7 @@ const Inquiries: React.FC = () => {
                     onClick={() => handleCreateFromTemplate(template.id)}
                   >
                     {template.name}
-                    <span style={{ fontSize: '0.75rem', color: 'gray', marginLeft: '8px' }}>
-                      ({template.product_count} products)
-                    </span>
+                    <TemplateMeta>({template.product_count} products)</TemplateMeta>
                   </DropdownItem>
                 ))}
                 <DropdownItem onClick={() => navigate('/inquiries/templates')}>
@@ -584,16 +672,17 @@ const Inquiries: React.FC = () => {
         </FilterSelect>
       </FiltersBar>
 
-      <Table>
-        <TableHeader>
-          <span>Inquiry #</span>
-          <span>Customer/Supplier</span>
-          <span>Status</span>
-          <span>Products</span>
-          <span>Value</span>
-          <span>Valid Until</span>
-          <span>Created</span>
-        </TableHeader>
+      <TableWrapper data-testid="inquiries-table-wrapper">
+        <Table>
+          <TableHeader>
+            <span>Inquiry #</span>
+            <span>Customer/Supplier</span>
+            <span>Status</span>
+            <span>Products</span>
+            <span>Value</span>
+            <span>Valid Until</span>
+            <span>Created</span>
+          </TableHeader>
 
         {loading ? (
           <LoadingState>
@@ -638,7 +727,7 @@ const Inquiries: React.FC = () => {
                 </StatusBadge>
                 <ProductCount>{inquiry.product_count || 0}</ProductCount>
                 <Amount>{formatCurrency(inquiry.total_actual || inquiry.total_desired)}</Amount>
-                <DateCell style={{ color: inquiry.is_expired ? 'rgb(220, 38, 38)' : undefined }}>
+                <DateCell style={{ color: inquiry.is_expired ? 'rgb(var(--color-danger))' : undefined }}>
                   {inquiry.valid_until ? formatDate(inquiry.valid_until) : '-'}
                   {inquiry.is_expired && ' ⚠️'}
                 </DateCell>
@@ -670,6 +759,7 @@ const Inquiries: React.FC = () => {
           </>
         )}
       </Table>
+      </TableWrapper>
 
       {/* Create Inquiry (EntityFormSurface → enhanced inquiry form by default) */}
       <EntityFormSurface


### PR DESCRIPTION
Fixes Inquiries page mobile usability (iPhone SE 375px) and adds deterministic Playwright coverage.

Changes:
- Inquiries: stack header actions on small screens; mobile-friendly filters; responsive list columns; token-compliant status colors.
- Layout: constrain top-level containers to prevent page-level horizontal overflow.
- E2E: add mobile_inquiries_375 spec with API mocking.

Tests:
- npm -C frontend run verify-standards
- npm -C frontend run test:e2e -- --project=chromium e2e/mobile_inquiries_375.spec.ts