### PR TITLE
Mobile: Sales Orders usable at 375px

### DIFF
--- a/frontend/e2e/mobile_sales_orders_create.spec.ts
+++ b/frontend/e2e/mobile_sales_orders_create.spec.ts
@@ -1,0 +1,242 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const VIEWPORT = { width: 375, height: 667 }; // iPhone SE logical size
+
+async function login(page: Page) {
+  await page.goto('/');
+
+  // If already authenticated (e.g. reuseExistingServer locally), skip.
+  const password = page.locator('input[type="password"]');
+  if ((await password.count()) === 0) return;
+
+  const testEmail = process.env.TEST_USER_EMAIL || 'admin@meatscentral.com';
+  const testPassword = process.env.TEST_USER_PASSWORD || 'Admin123!';
+
+  await page.fill('input[type="email"], input[type="text"]', testEmail);
+  await page.fill('input[type="password"]', testPassword);
+  await page.click('button:has-text("Login"), button:has-text("Sign In")');
+
+  await page.waitForURL(/\/(dashboard|home|workforms)/i, { timeout: 10000 });
+}
+
+async function assertNoPageHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => {
+    const el = document.documentElement;
+
+    const before = window.scrollX;
+    window.scrollTo(9999, window.scrollY);
+    const after = window.scrollX;
+    window.scrollTo(0, window.scrollY);
+
+    return {
+      before,
+      after,
+      innerWidth: window.innerWidth,
+      clientWidth: el.clientWidth,
+      scrollWidth: el.scrollWidth,
+    };
+  });
+
+  if (metrics.after !== 0) {
+    const offenders = await page.evaluate(() => {
+      const vw = document.documentElement.clientWidth;
+      return Array.from(document.querySelectorAll<HTMLElement>('*'))
+        .map((el) => {
+          const r = el.getBoundingClientRect();
+          return {
+            tag: el.tagName.toLowerCase(),
+            id: el.id || undefined,
+            class: el.className || undefined,
+            right: Math.round(r.right),
+            width: Math.round(r.width),
+          };
+        })
+        .filter((x) => x.right > vw + 1 && x.width > 0)
+        .sort((a, b) => b.right - a.right)
+        .slice(0, 10);
+    });
+
+    throw new Error(
+      `Page is horizontally scrollable at 375px. ${JSON.stringify({ metrics, offenders }, null, 2)}`
+    );
+  }
+
+  expect(metrics.after).toBe(0);
+}
+
+async function assertTableContainerFitsViewport(page: Page) {
+  const ok = await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="sales-orders-table-container"]') as HTMLElement | null;
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    return r.left >= -1 && r.right <= window.innerWidth + 1;
+  });
+
+  expect(ok).toBeTruthy();
+}
+
+async function mockSalesOrdersApis(page: Page) {
+  const now = new Date().toISOString();
+  let created: any = null;
+
+  await page.route(/\/api\/v1\/system\/forms\/schema\/?(\?.*)?$/, async (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') return route.fallback();
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        name: 'New Sales Order',
+        description: 'E2E schema for mobile Sales Orders create test',
+        key_fields: ['customer', 'status', 'order_date', 'total_amount'],
+        fields: [
+          {
+            key: 'customer',
+            label: 'Customer',
+            type: 'select',
+            required: true,
+            choices: [{ value: '1', label: 'E2E Customer' }],
+          },
+          {
+            key: 'status',
+            label: 'Status',
+            type: 'select',
+            required: true,
+            choices: [
+              { value: 'draft', label: 'Draft' },
+              { value: 'confirmed', label: 'Confirmed' },
+              { value: 'processing', label: 'Processing' },
+              { value: 'shipped', label: 'Shipped' },
+              { value: 'delivered', label: 'Delivered' },
+              { value: 'cancelled', label: 'Cancelled' },
+            ],
+          },
+          {
+            key: 'order_date',
+            label: 'Order Date',
+            type: 'date',
+            required: true,
+          },
+          {
+            key: 'total_amount',
+            label: 'Total Amount',
+            type: 'number',
+            required: true,
+          },
+          {
+            key: 'notes',
+            label: 'Notes',
+            type: 'textarea',
+            required: false,
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route(/\/api\/v1\/sales-orders\/?(\?.*)?$/, async (route) => {
+    const req = route.request();
+
+    if (req.method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ results: created ? [created] : [], count: created ? 1 : 0 }),
+      });
+    }
+
+    if (req.method() === 'POST') {
+      const payload = (req.postDataJSON?.() as any) ?? {};
+
+      expect(payload).toMatchObject({
+        customer: '1',
+        status: 'draft',
+        order_date: '2030-01-01',
+      });
+
+      created = {
+        id: 999,
+        tenant: 't1',
+        order_number: 'SO-000999',
+        customer: 1,
+        customer_name: 'E2E Customer',
+        order_date: payload.order_date ?? '2030-01-01',
+        delivery_date: null,
+        status: payload.status ?? 'draft',
+        total_amount: String(payload.total_amount ?? '1'),
+        notes: String(payload.notes ?? ''),
+        created_by: null,
+        created_by_name: 'Admin',
+        created_on: now,
+        updated_on: now,
+      };
+
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(created),
+      });
+    }
+
+    return route.fallback();
+  });
+}
+
+test.describe('Mobile: Sales Orders create is usable at 375px', () => {
+  test.use({ viewport: VIEWPORT });
+
+  test('can open Sales Orders create form and reach primary CTA (no horizontal overflow)', async ({ page }) => {
+    await login(page);
+    await mockSalesOrdersApis(page);
+
+    // Auto-open create modal via query param.
+    await page.goto('/sales-orders?action=create');
+
+    await expect(page.getByRole('heading', { name: /^Sales Orders$/ })).toBeVisible({ timeout: 15000 });
+
+    // Usability: no horizontal overflow at page level.
+    await assertNoPageHorizontalScroll(page);
+
+    // Usability: table container should fit the viewport.
+    await assertTableContainerFitsViewport(page);
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 15000 });
+
+    // Wait for schema-driven fields to render.
+    await expect(dialog.locator('#customer')).toBeVisible({ timeout: 15000 });
+
+    // Fill required fields.
+    await dialog.locator('#customer').click();
+    await page.locator('.ant-select-dropdown:visible').last().getByText('E2E Customer', { exact: true }).click();
+
+    await dialog.locator('#status').click();
+    await page.locator('.ant-select-dropdown:visible').last().getByText('Draft', { exact: true }).click();
+
+    await dialog.locator('input#order_date').fill('2030-01-01');
+    await dialog.locator('input#total_amount').fill('1');
+
+    const submit = dialog.getByRole('button', { name: /^Create$/ });
+
+    // Primary CTA reachable on mobile.
+    await submit.scrollIntoViewIfNeeded();
+    await expect(submit).toBeVisible();
+    await expect(submit).toBeInViewport();
+
+    await Promise.all([
+      page.waitForResponse((resp) =>
+        resp.request().method() === 'POST' &&
+        /\/api\/v1\/sales-orders\/?$/.test(new URL(resp.url()).pathname) &&
+        resp.status() === 201
+      ),
+      submit.click(),
+    ]);
+
+    // Modal should close after successful submit.
+    await expect(dialog).toBeHidden({ timeout: 10000 });
+
+    // Still no horizontal overflow after closing.
+    await assertNoPageHorizontalScroll(page);
+  });
+});

--- a/frontend/src/pages/SalesOrders/SalesOrders.tsx
+++ b/frontend/src/pages/SalesOrders/SalesOrders.tsx
@@ -55,6 +55,11 @@ const PageContainer = styled.div`
   height: 100%;
   padding: 1.5rem;
   background: rgb(var(--color-background));
+  min-width: 0;
+
+  @media (max-width: 520px) {
+    padding: 1rem;
+  }
 `;
 
 const PageHeader = styled.div`
@@ -62,6 +67,8 @@ const PageHeader = styled.div`
   align-items: center;
   justify-content: space-between;
   margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
 `;
 
 const PageTitle = styled.h1`
@@ -69,11 +76,23 @@ const PageTitle = styled.h1`
   font-weight: 700;
   color: rgb(var(--color-text-primary));
   margin: 0;
+
+  @media (max-width: 520px) {
+    font-size: 1.75rem;
+  }
 `;
 
 const HeaderActions = styled.div`
   display: flex;
   gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+
+  @media (max-width: 520px) {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
 const SecondaryButton = styled.button`
@@ -86,6 +105,12 @@ const SecondaryButton = styled.button`
   font-weight: 500;
   cursor: pointer;
   transition: background 0.2s ease;
+  min-height: 44px;
+
+  @media (max-width: 520px) {
+    width: 100%;
+    justify-content: center;
+  }
 
   &:hover {
     background: rgb(var(--color-surface-hover));
@@ -100,13 +125,19 @@ const SecondaryButton = styled.button`
 const PrimaryButton = styled.button`
   padding: 0.75rem 1.5rem;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   border: none;
   border-radius: var(--radius-md);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
   transition: opacity 0.2s ease;
+  min-height: 44px;
+
+  @media (max-width: 520px) {
+    width: 100%;
+    justify-content: center;
+  }
 
   &:hover {
     opacity: 0.9;
@@ -125,6 +156,8 @@ const ContentContainer = styled.div<{ hasSidePanel?: boolean }>`
   height: calc(100vh - 180px);
   overflow: hidden;
   transition: grid-template-columns 0.3s ease;
+  min-width: 0;
+  max-width: 100%;
   
   /* Stack layout on tablets and mobile */
   @media (max-width: 1024px) {
@@ -140,6 +173,7 @@ const MainContent = styled.div`
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-lg);
   overflow: hidden;
+  min-width: 0;
 `;
 
 const FilterBar = styled.div`
@@ -149,10 +183,14 @@ const FilterBar = styled.div`
   background: rgb(var(--color-surface));
   border-bottom: 1px solid rgb(var(--color-border));
   flex-wrap: wrap;
+  min-width: 0;
 `;
 
 const FilterButton = styled.button<{ isActive?: boolean }>`
   padding: 0.5rem 1rem;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
   background: ${props => props.isActive ? 'rgba(var(--color-primary), 0.1)' : 'transparent'};
   color: ${props => props.isActive ? 'rgb(var(--color-primary))' : 'rgb(var(--color-text-secondary))'};
   border: 1px solid ${props => props.isActive ? 'rgb(var(--color-primary))' : 'rgb(var(--color-border))'};
@@ -178,6 +216,13 @@ const SearchBar = styled.input`
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-sm);
   font-size: 0.875rem;
+  min-height: 44px;
+
+  @media (max-width: 520px) {
+    min-width: 0;
+    width: 100%;
+    font-size: 16px; /* prevent iOS Safari zoom-on-focus */
+  }
 
   &:focus {
     outline: none;
@@ -192,6 +237,9 @@ const SearchBar = styled.input`
 const TableContainer = styled.div`
   flex: 1;
   overflow-y: auto;
+  max-width: 100%;
+  min-width: 0;
+  -webkit-overflow-scrolling: touch;
 
   /* Only enable horizontal scroll on small screens when truly needed */
   @media (max-width: 768px) {
@@ -230,6 +278,10 @@ const Table = styled.table`
   @media (max-width: 768px) {
     min-width: 600px;
   }
+
+  @media (max-width: 520px) {
+    min-width: 0;
+  }
 `;
 
 const TableHeader = styled.thead`
@@ -259,6 +311,15 @@ const TableHeaderCell = styled.th`
   text-transform: uppercase;
   letter-spacing: 0.05em;
   white-space: nowrap;
+
+  @media (max-width: 520px) {
+    padding: 0.75rem 1rem;
+
+    &:nth-child(3),
+    &:nth-child(4) {
+      display: none;
+    }
+  }
 `;
 
 const TableCell = styled.td`
@@ -266,6 +327,20 @@ const TableCell = styled.td`
   font-size: 0.875rem;
   color: rgb(var(--color-text-primary));
   white-space: nowrap;
+
+  @media (max-width: 520px) {
+    padding: 0.75rem 1rem;
+
+    &:nth-child(3),
+    &:nth-child(4) {
+      display: none;
+    }
+
+    &:nth-child(2) {
+      white-space: normal;
+      word-break: break-word;
+    }
+  }
 `;
 
 const StatusBadge = styled.span<{ status: OrderStatus }>`
@@ -280,33 +355,33 @@ const StatusBadge = styled.span<{ status: OrderStatus }>`
     switch (props.status) {
       case 'draft':
         return `
-          background: rgba(107, 114, 128, 0.1);
-          color: rgb(107, 114, 128);
+          background: rgba(var(--color-text-secondary), 0.12);
+          color: rgb(var(--color-text-secondary));
         `;
       case 'confirmed':
         return `
-          background: rgba(59, 130, 246, 0.1);
-          color: rgb(59, 130, 246);
+          background: rgba(var(--color-info), 0.12);
+          color: rgb(var(--color-info));
         `;
       case 'processing':
         return `
-          background: rgba(251, 191, 36, 0.1);
-          color: rgb(251, 191, 36);
+          background: rgba(var(--color-warning), 0.12);
+          color: rgb(var(--color-warning));
         `;
       case 'shipped':
         return `
-          background: rgba(139, 92, 246, 0.1);
-          color: rgb(139, 92, 246);
+          background: rgba(var(--color-info), 0.12);
+          color: rgb(var(--color-info));
         `;
       case 'delivered':
         return `
-          background: rgba(34, 197, 94, 0.1);
-          color: rgb(34, 197, 94);
+          background: rgba(var(--color-success), 0.12);
+          color: rgb(var(--color-success));
         `;
       case 'cancelled':
         return `
-          background: rgba(239, 68, 68, 0.1);
-          color: rgb(239, 68, 68);
+          background: rgba(var(--color-danger), 0.12);
+          color: rgb(var(--color-danger));
         `;
       default:
         return '';
@@ -325,10 +400,10 @@ const LoadingState = styled.div`
 
 const ErrorState = styled.div`
   padding: 1rem 1.5rem;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: rgba(var(--color-danger), 0.12);
+  border: 1px solid rgba(var(--color-danger), 0.3);
   border-radius: var(--radius-md);
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-danger));
   font-size: 0.875rem;
   margin: 1rem 1.5rem;
 `;
@@ -378,12 +453,17 @@ const CloseButton = styled.button`
   top: 1rem;
   right: 1rem;
   padding: 0.5rem;
+  min-width: 44px;
+  min-height: 44px;
   background: transparent;
   border: none;
   color: rgb(var(--color-text-secondary));
   cursor: pointer;
   font-size: 1.25rem;
   transition: color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 
   &:hover {
     color: rgb(var(--color-text-primary));
@@ -651,7 +731,7 @@ export const SalesOrdersPage: React.FC = () => {
           {error && <ErrorState>{error}</ErrorState>}
 
           {/* Table */}
-          <TableContainer>
+          <TableContainer data-testid="sales-orders-table-container">
             {loading ? (
               <LoadingState>
                 <Skeleton active paragraph={{ rows: 8 }} />
@@ -703,7 +783,7 @@ export const SalesOrdersPage: React.FC = () => {
         {selectedOrder && (
           <SidePanel>
             <SidePanelHeader>
-              <CloseButton onClick={handleClosePanel}>×</CloseButton>
+              <CloseButton onClick={handleClosePanel} aria-label="Close order details">×</CloseButton>
               <SidePanelTitle>Order Details</SidePanelTitle>
               <SidePanelSubtitle>{selectedOrder.order_number}</SidePanelSubtitle>
             </SidePanelHeader>


### PR DESCRIPTION
Fix Sales Orders mobile usability at 375px (iPhone SE) and add deterministic Playwright coverage.

Changes:
- Stack header actions and mobile-tune filters/search (44px touch targets, iOS-safe 16px input font).
- Contain table overflow and hide low-priority columns on <=520px.
- Tokenize status/error colors.
- Add Playwright E2E for create-flow with mocked UniversalEntityForm schema + sales-orders endpoints.

Tests:
- npm -C frontend run verify-standards
- npm -C frontend run test:e2e -- --project=chromium e2e/mobile_sales_orders_create.spec.ts