### PR TITLE
Test: add coverage for Shared select components

### DIFF
--- a/frontend/src/components/Shared/LocalSearchableSelect.test.tsx
+++ b/frontend/src/components/Shared/LocalSearchableSelect.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import LocalSearchableSelect from './LocalSearchableSelect';
+
+describe('LocalSearchableSelect', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('filters options locally with debounce', async () => {
+    vi.useFakeTimers();
+
+    const onChange = vi.fn();
+
+    render(
+      <LocalSearchableSelect
+        label="Customer"
+        value={''}
+        onChange={onChange}
+        options={[
+          { id: 1, name: 'Beef Co' },
+          { id: 2, name: 'Pork LLC' },
+        ]}
+        placeholder="Select Customer"
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.click(input);
+
+    // Type query
+    fireEvent.change(input, { target: { value: 'por' } });
+
+    // Debounce is 180ms
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // With fake timers enabled, avoid waitFor (it uses timers internally).
+    // After advancing the debounce, the filtered list should be updated.
+    expect(screen.queryByText('Beef Co')).not.toBeInTheDocument();
+    expect(screen.getByText('Pork LLC')).toBeInTheDocument();
+  });
+
+  it('selects an item by click and calls onChange', async () => {
+    vi.useFakeTimers();
+
+    const onChange = vi.fn();
+
+    render(
+      <LocalSearchableSelect
+        label="Customer"
+        value={''}
+        onChange={onChange}
+        options={[
+          { id: 1, name: 'Beef Co' },
+          { id: 2, name: 'Pork LLC' },
+        ]}
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.click(input);
+
+    // Initial mount sets a short "Typing..." debounce; advance it so options render.
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    fireEvent.click(screen.getByText('Pork LLC'));
+
+    expect(onChange).toHaveBeenCalledWith(2, expect.objectContaining({ id: 2, name: 'Pork LLC' }));
+  });
+});

--- a/frontend/src/components/Shared/LocalSearchableSelect.tsx
+++ b/frontend/src/components/Shared/LocalSearchableSelect.tsx
@@ -72,16 +72,16 @@ const Required = styled.span`
   margin-left: 0.25rem;
 `;
 
-const InputWrapper = styled.div<{ isOpen: boolean; hasError?: boolean }>`
+const InputWrapper = styled.div<{ $isOpen: boolean; $hasError?: boolean }>`
   position: relative;
   width: 100%;
 `;
 
-const Input = styled.input<{ hasError?: boolean }>`
+const Input = styled.input<{ $hasError?: boolean }>`
   width: 100%;
   padding: 0.75rem 2.5rem 0.75rem 0.75rem;
   background: rgb(var(--color-background));
-  border: 1px solid ${props => props.hasError ? 'rgba(239, 68, 68, 1)' : 'rgb(var(--color-border))'};
+  border: 1px solid ${props => props.$hasError ? 'rgba(239, 68, 68, 1)' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-md);
   color: rgb(var(--color-text-primary));
   font-size: 0.875rem;
@@ -89,7 +89,7 @@ const Input = styled.input<{ hasError?: boolean }>`
   
   &:focus {
     outline: none;
-    border-color: ${props => props.hasError ? 'rgba(239, 68, 68, 1)' : 'rgb(var(--color-primary))'};
+    border-color: ${props => props.$hasError ? 'rgba(239, 68, 68, 1)' : 'rgb(var(--color-primary))'};
   }
   
   &::placeholder {
@@ -102,19 +102,19 @@ const Input = styled.input<{ hasError?: boolean }>`
   }
 `;
 
-const DropdownIcon = styled.div<{ isOpen: boolean }>`
+const DropdownIcon = styled.div<{ $isOpen: boolean }>`
   position: absolute;
   right: 0.75rem;
   top: 50%;
-  transform: translateY(-50%) ${props => props.isOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
+  transform: translateY(-50%) ${props => props.$isOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
   transition: transform 0.2s ease;
   pointer-events: none;
   color: rgb(var(--color-text-secondary));
   font-size: 0.875rem;
 `;
 
-const DropdownList = styled.ul<{ isOpen: boolean }>`
-  display: ${props => props.isOpen ? 'block' : 'none'};
+const DropdownList = styled.ul<{ $isOpen: boolean }>`
+  display: ${props => props.$isOpen ? 'block' : 'none'};
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
@@ -149,14 +149,14 @@ const DropdownList = styled.ul<{ isOpen: boolean }>`
   }
 `;
 
-const DropdownItem = styled.li<{ isSelected: boolean; isFocused: boolean }>`
+const DropdownItem = styled.li<{ $isSelected: boolean; $isFocused: boolean }>`
   padding: 0.75rem;
   cursor: pointer;
   color: rgb(var(--color-text-primary));
   font-size: 0.875rem;
   background: ${props => {
-    if (props.isSelected) return 'rgba(var(--color-primary), 0.1)';
-    if (props.isFocused) return 'rgb(var(--color-surface-hover))';
+    if (props.$isSelected) return 'rgba(var(--color-primary), 0.1)';
+    if (props.$isFocused) return 'rgb(var(--color-surface-hover))';
     return 'transparent';
   }};
   transition: background 0.15s ease;
@@ -165,7 +165,7 @@ const DropdownItem = styled.li<{ isSelected: boolean; isFocused: boolean }>`
     background: rgb(var(--color-surface-hover));
   }
 
-  ${props => props.isSelected && `
+  ${props => props.$isSelected && `
     font-weight: 600;
     color: rgb(var(--color-primary));
   `}
@@ -361,7 +361,7 @@ export const LocalSearchableSelect: React.FC<LocalSearchableSelectProps> = ({
         </Label>
       )}
       
-      <InputWrapper isOpen={isOpen} hasError={!!error}>
+      <InputWrapper $isOpen={isOpen} $hasError={!!error}>
         <Input
           ref={inputRef}
           type="text"
@@ -371,13 +371,13 @@ export const LocalSearchableSelect: React.FC<LocalSearchableSelectProps> = ({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={disabled}
-          hasError={!!error}
+          $hasError={!!error}
           autoComplete="off"
         />
-        <DropdownIcon isOpen={isOpen}>▼</DropdownIcon>
+        <DropdownIcon $isOpen={isOpen}>▼</DropdownIcon>
       </InputWrapper>
 
-      <DropdownList isOpen={isOpen && !disabled}>
+      <DropdownList $isOpen={isOpen && !disabled}>
         {loading ? (
           <LoadingState>
             <Spinner />
@@ -396,8 +396,8 @@ export const LocalSearchableSelect: React.FC<LocalSearchableSelectProps> = ({
           filteredOptions.map((option, index) => (
             <DropdownItem
               key={option.id}
-              isSelected={String(option.id) === String(value)}
-              isFocused={index === focusedIndex}
+              $isSelected={String(option.id) === String(value)}
+              $isFocused={index === focusedIndex}
               onClick={() => handleSelect(option)}
               onMouseEnter={() => setFocusedIndex(index)}
             >

--- a/frontend/src/components/Shared/MultiSelect.test.tsx
+++ b/frontend/src/components/Shared/MultiSelect.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MultiSelect from './MultiSelect';
+
+vi.mock('../../contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        textPrimary: 'rgb(0,0,0)',
+        primary: 'rgb(59,130,246)',
+        danger: 'rgb(239,68,68)',
+      },
+    },
+  }),
+}));
+
+describe('MultiSelect', () => {
+  it('renders selected count and error text', () => {
+    render(
+      <MultiSelect
+        label="Industries"
+        value={['a', 'b']}
+        onChange={() => {}}
+        options={[
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B' },
+        ]}
+        error="Required"
+      />
+    );
+
+    expect(screen.getByText('2 items selected')).toBeInTheDocument();
+    expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Shared/SearchableSelect.test.tsx
+++ b/frontend/src/components/Shared/SearchableSelect.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import SearchableSelect from './SearchableSelect';
+
+const searchOptionsMock = vi.fn();
+
+vi.mock('../../services/quickActionsService', () => ({
+  entityOptionsService: {
+    searchOptions: (...args: any[]) => searchOptionsMock(...args),
+  },
+}));
+
+// Avoid pulling in the real modal implementation in unit tests.
+vi.mock('../FormSubmission/QuickCreateModal', () => ({
+  default: () => null,
+}));
+
+describe('SearchableSelect', () => {
+  beforeEach(() => {
+    searchOptionsMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('selects from provided initialOptions (no API call required)', async () => {
+    const onChange = vi.fn();
+
+    render(
+      <SearchableSelect
+        entityType="customer"
+        value=""
+        onChange={onChange}
+        initialOptions={[
+          { value: '1', label: 'Alpha' },
+          { value: '2', label: 'Beta' },
+        ]}
+        allowCreate={false}
+      />
+    );
+
+    expect(searchOptionsMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await screen.findByRole('listbox');
+    fireEvent.click(screen.getByRole('option', { name: 'Beta' }));
+
+    expect(onChange).toHaveBeenCalledWith('2');
+  });
+
+  it('loads options via API when opened (search mode) and supports debounced search', async () => {
+    const onChange = vi.fn();
+    searchOptionsMock
+      .mockResolvedValueOnce({
+        entity_type: 'customer',
+        entity_label: 'Customer',
+        options: [
+          { value: '1', label: 'Beef Co' },
+          { value: '2', label: 'Pork LLC' },
+        ],
+        count: 2,
+        can_create: true,
+        total_count: 2,
+        has_more: false,
+      })
+      .mockResolvedValueOnce({
+        entity_type: 'customer',
+        entity_label: 'Customer',
+        options: [{ value: '2', label: 'Pork LLC' }],
+        count: 1,
+        can_create: true,
+        total_count: 1,
+        has_more: false,
+      });
+
+    render(
+      <SearchableSelect
+        entityType="customer"
+        value=""
+        onChange={onChange}
+        forceSearch
+        debounceMs={0}
+        allowCreate={false}
+        // Provide an initial option so the component doesn't auto-fetch on mount.
+        initialOptions={[{ value: '0', label: 'Initial' }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // Initial load
+    await waitFor(() => {
+      expect(searchOptionsMock).toHaveBeenCalledWith('customer', '', expect.any(String), undefined);
+    });
+
+    // Search input exists in search mode
+    const search = await screen.findByRole('textbox', { name: 'Search options' });
+    fireEvent.change(search, { target: { value: 'por' } });
+
+    // Immediate debounceMs=0 still schedules via setTimeout(0), so wait for the call.
+    await waitFor(() => {
+      expect(searchOptionsMock).toHaveBeenCalledWith('customer', 'por', expect.any(String), undefined);
+    });
+
+    // Option renders
+    expect(await screen.findByRole('option', { name: 'Pork LLC' })).toBeInTheDocument();
+  });
+
+  it('supports keyboard navigation (ArrowDown + Enter selects highlighted option)', async () => {
+    const onChange = vi.fn();
+
+    render(
+      <SearchableSelect
+        entityType="customer"
+        value=""
+        onChange={onChange}
+        initialOptions={[
+          { value: '1', label: 'Alpha' },
+          { value: '2', label: 'Beta' },
+        ]}
+        allowCreate={false}
+      />
+    );
+
+    const trigger = screen.getByRole('button');
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    await screen.findByRole('listbox');
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith('1');
+  });
+
+  it('closes on outside click and calls onBlur', async () => {
+    const onBlur = vi.fn();
+
+    render(
+      <SearchableSelect
+        entityType="customer"
+        value=""
+        onChange={() => {}}
+        onBlur={onBlur}
+        initialOptions={[{ value: '1', label: 'Alpha' }]}
+        allowCreate={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(await screen.findByRole('option', { name: 'Alpha' })).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('option', { name: 'Alpha' })).not.toBeInTheDocument();
+    });
+
+    expect(onBlur).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds unit tests for Shared select components:
- SearchableSelect (initialOptions, API search mode, keyboard nav, outside click)
- LocalSearchableSelect (debounced filtering, click selection)
- MultiSelect (selected count + error rendering)

Also switches LocalSearchableSelect styled-components to transient props (e.g. ) to avoid React DOM warnings in test output.

Validation:
- npm -C frontend run test:ci -- <3 files>
- npm -C frontend run verify-standards
- npm -C frontend run lint