### PR TITLE
Test: cover SearchableSelect variants + QuickCreate flow

### DIFF
--- a/frontend/src/components/Shared/SearchableSelect.test.tsx
+++ b/frontend/src/components/Shared/SearchableSelect.test.tsx
@@ -12,13 +12,19 @@ vi.mock('../../services/quickActionsService', () => ({
 }));
 
 // Avoid pulling in the real modal implementation in unit tests.
+const quickCreateModalPropsSpy = vi.fn();
+
 vi.mock('../FormSubmission/QuickCreateModal', () => ({
-  default: () => null,
+  default: (props: any) => {
+    quickCreateModalPropsSpy(props);
+    return null;
+  },
 }));
 
 describe('SearchableSelect', () => {
   beforeEach(() => {
     searchOptionsMock.mockReset();
+    quickCreateModalPropsSpy.mockClear();
   });
 
   afterEach(() => {
@@ -160,5 +166,51 @@ describe('SearchableSelect', () => {
     });
 
     expect(onBlur).toHaveBeenCalled();
+  });
+
+  it('opens QuickCreateModal when selecting the create sentinel and wires onCreated to onChange', async () => {
+    const onChange = vi.fn();
+
+    searchOptionsMock.mockResolvedValue({
+      entity_type: 'customer',
+      entity_label: 'Customer',
+      options: [{ value: '3', label: 'Gamma' }],
+      count: 1,
+      can_create: true,
+      total_count: 1,
+      has_more: false,
+    });
+
+    render(
+      <SearchableSelect
+        entityType="customer"
+        value=""
+        onChange={onChange}
+        initialOptions={[{ value: '1', label: 'Alpha' }]}
+        allowCreate
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const createOption = await screen.findByRole('option', { name: '+ Add new customer' });
+    fireEvent.click(createOption);
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Our QuickCreateModal mock captures props; assert it was opened.
+    expect(quickCreateModalPropsSpy).toHaveBeenCalled();
+    const lastCall = quickCreateModalPropsSpy.mock.calls.at(-1);
+    const modalProps = lastCall?.[0];
+    expect(modalProps?.isOpen).toBe(true);
+
+    // Simulate successful creation (triggers internal state updates)
+    await act(async () => {
+      modalProps.onCreated({ value: '3', label: 'Gamma' });
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('3');
+    });
   });
 });

--- a/frontend/src/components/Shared/SearchableSelectConsolidated.test.tsx
+++ b/frontend/src/components/Shared/SearchableSelectConsolidated.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+import SearchableSelect from './SearchableSelect';
+
+vi.mock('../../contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        textPrimary: 'rgb(0,0,0)',
+        primary: 'rgb(59,130,246)',
+        danger: 'rgb(239,68,68)',
+      },
+    },
+  }),
+}));
+
+describe('SearchableSelect (consolidated variants)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders multi variant via variant prop', () => {
+    render(
+      <SearchableSelect
+        variant="multi"
+        label="Industries"
+        value={['a', 'b']}
+        onChange={() => {}}
+        options={[
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B' },
+        ]}
+        error="Required"
+      />
+    );
+
+    expect(screen.getByText('2 items selected')).toBeInTheDocument();
+    expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+
+  it('renders local variant via variant prop and filters with debounce', async () => {
+    vi.useFakeTimers();
+
+    render(
+      <SearchableSelect
+        variant="local"
+        label="Customer"
+        value={''}
+        onChange={() => {}}
+        options={[
+          { id: 1, name: 'Beef Co' },
+          { id: 2, name: 'Pork LLC' },
+        ]}
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.click(input);
+
+    fireEvent.change(input, { target: { value: 'por' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.queryByText('Beef Co')).not.toBeInTheDocument();
+    expect(screen.getByText('Pork LLC')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adds unit coverage for the new consolidated SearchableSelect surface:
- SearchableSelectConsolidated.test.tsx: asserts variant=multi and variant=local dispatch paths
- SearchableSelect.test.tsx: covers allowCreate sentinel -> QuickCreateModal open and onCreated wiring to onChange

Validation:
- npm -C frontend run test:ci -- src/components/Shared/SearchableSelect.test.tsx src/components/Shared/SearchableSelectConsolidated.test.tsx
- npm -C frontend run verify-standards