### PR TITLE
Fix: avoid duplicate create option in FormSubmissionModal

### DIFF
--- a/frontend/src/components/FormSubmission/FormSubmissionModal.tsx
+++ b/frontend/src/components/FormSubmission/FormSubmissionModal.tsx
@@ -1647,6 +1647,9 @@ const FormSubmissionModal: React.FC<FormSubmissionModalProps> = ({
                   hasError={hasError}
                   initialOptions={opts}
                   threshold={50}
+                  // This screen already provides a separate "+ New" button.
+                  // Disable in-dropdown create to avoid duplicate create affordances.
+                  allowCreate={false}
                 />
               </SelectWrapper>
               <QuickAddButton


### PR DESCRIPTION
FormSubmissionModal renders its own "+ New" button for related_entity_type fields.

SearchableSelect defaults allowCreate=true, which also adds a "+ Add new ..." option inside the dropdown. This PR disables allowCreate for this screen to avoid showing two create affordances.