### PR TITLE
Feat: SearchableSelect static variant

### DIFF
--- a/frontend/src/components/Shared/SearchableSelectConsolidated.test.tsx
+++ b/frontend/src/components/Shared/SearchableSelectConsolidated.test.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 
 import SearchableSelect from './SearchableSelect';
+
+const searchOptionsMock = vi.fn();
+
+vi.mock('../../services/quickActionsService', () => ({
+  entityOptionsService: {
+    searchOptions: (...args: any[]) => searchOptionsMock(...args),
+  },
+}));
+
+vi.mock('../FormSubmission/QuickCreateModal', () => ({
+  default: () => null,
+}));
 
 vi.mock('../../contexts/ThemeContext', () => ({
   useTheme: () => ({
@@ -19,6 +31,35 @@ vi.mock('../../contexts/ThemeContext', () => ({
 describe('SearchableSelect (consolidated variants)', () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('renders static variant (no API) and selects from options', async () => {
+    const onChange = vi.fn();
+
+    render(
+      <SearchableSelect
+        variant="static"
+        value=""
+        onChange={onChange}
+        options={[
+          { value: '1', label: 'Alpha' },
+          { value: '2', label: 'Beta' },
+        ]}
+        placeholder="Select..."
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(await screen.findByRole('option', { name: 'Beta' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('option', { name: 'Beta' }));
+
+    expect(searchOptionsMock).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith('2');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('option', { name: 'Beta' })).not.toBeInTheDocument();
+    });
   });
 
   it('renders multi variant via variant prop', () => {

--- a/frontend/src/components/Shared/SearchableSelectConsolidated.tsx
+++ b/frontend/src/components/Shared/SearchableSelectConsolidated.tsx
@@ -9,20 +9,51 @@ export type SearchableSelectVariant = 'entity' | 'api' | 'static' | 'local' | 'm
 type EntityVariantProps = SearchableSelectEntityProps & {
   /**
    * Consolidated mode selector.
-   * - entity/api/static: API-backed entity options (existing SearchableSelect behavior)
+   * - entity/api: API-backed entity options (existing SearchableSelect behavior)
+   * - static: static option set (no API)
    * - local: Fuse-based in-memory filtering (existing LocalSearchableSelect behavior)
    * - multi: AntD multi-select for string[] (existing MultiSelect behavior)
    */
-  variant?: 'entity' | 'api' | 'static';
+  variant?: 'entity' | 'api';
+};
+
+export type SearchableSelectStaticOption = {
+  value: string;
+  label: string;
+};
+
+type StaticVariantProps = {
+  variant: 'static';
+  value: string;
+  onChange: (value: string) => void;
+  options: SearchableSelectStaticOption[];
+  placeholder?: string;
+  hasError?: boolean;
+  disabled?: boolean;
+  onBlur?: () => void;
 };
 
 type LocalVariantProps = LocalSearchableSelectProps & { variant: 'local' };
 
 type MultiVariantProps = MultiSelectProps & { variant: 'multi' };
 
-export type SearchableSelectProps = EntityVariantProps | LocalVariantProps | MultiVariantProps;
+export type SearchableSelectProps = EntityVariantProps | StaticVariantProps | LocalVariantProps | MultiVariantProps;
 
 export const SearchableSelectConsolidated: React.FC<SearchableSelectProps> = (props) => {
+  if (props.variant === 'static') {
+    const { variant, options, ...rest } = props;
+
+    return (
+      <SearchableSelectEntity
+        entityType=""
+        initialOptions={options}
+        threshold={Number.POSITIVE_INFINITY}
+        allowCreate={false}
+        {...rest}
+      />
+    );
+  }
+
   if (props.variant === 'local') {
     const { variant, ...rest } = props;
     return <LocalSearchableSelectImpl {...rest} />;


### PR DESCRIPTION
Sprint 2.1: add SearchableSelect variant=static for pure static option sets (no API calls).

Implementation:
- SearchableSelectConsolidated: new static props: options, value, onChange.
- Static variant delegates to SearchableSelectEntity with entityType empty, initialOptions from options, threshold set to Infinity, allowCreate false.

Tests:
- SearchableSelectConsolidated.test.tsx: asserts no API calls and selection works.

Validation:
- npm -C frontend run test:ci -- src/components/Shared/SearchableSelectConsolidated.test.tsx
- npm -C frontend run verify-standards