### PR TITLE
Hardening: webhook Celery RLS context

### DIFF
--- a/backend/tenant_apps/integrations/serializers.py
+++ b/backend/tenant_apps/integrations/serializers.py
@@ -34,8 +34,8 @@ class TenantWebhookCreateSerializer(serializers.ModelSerializer):
         ]
 
     def create(self, validated_data):
-        tenant = self.context['tenant']
-        user = self.context.get('user')
+        tenant = validated_data.pop('tenant', None) or self.context['tenant']
+        user = validated_data.pop('created_by', None) or self.context.get('user')
         validated_data.setdefault('signing_secret', generate_webhook_secret())
         return TenantWebhook.objects.create(tenant=tenant, created_by=user, **validated_data)
 
@@ -73,8 +73,8 @@ class TenantAPIKeyCreateSerializer(serializers.ModelSerializer):
         ]
 
     def create(self, validated_data):
-        tenant = self.context['tenant']
-        user = self.context.get('user')
+        tenant = validated_data.pop('tenant', None) or self.context['tenant']
+        user = validated_data.pop('created_by', None) or self.context.get('user')
 
         full_key, prefix, secret_hash = generate_api_key()
         obj = TenantAPIKey.objects.create(

--- a/backend/tenant_apps/integrations/signals.py
+++ b/backend/tenant_apps/integrations/signals.py
@@ -29,7 +29,7 @@ def _enqueue_event(*, tenant_id: str, event_type: str, payload: Dict[str, Any]) 
     )
 
     for webhook in webhooks:
-        dispatch_webhook_payload.delay(webhook.id, event_type, payload)
+        dispatch_webhook_payload.delay(webhook.id, tenant_id, event_type, payload)
 
 
 def _serialize_purchase_order(po: PurchaseOrder) -> Dict[str, Any]:

--- a/backend/tenant_apps/integrations/tasks.py
+++ b/backend/tenant_apps/integrations/tasks.py
@@ -33,7 +33,7 @@ def _sign(secret: str, timestamp: str, body: str) -> str:
     soft_time_limit=20,
     time_limit=30,
 )
-def dispatch_webhook_payload(self, webhook_id: int, event_type: str, payload: Dict[str, Any]):
+def dispatch_webhook_payload(self, webhook_id: int, tenant_id: str, event_type: str, payload: Dict[str, Any]):
     """POST an event payload to a tenant webhook with exponential backoff.
 
     Retries on:
@@ -42,9 +42,19 @@ def dispatch_webhook_payload(self, webhook_id: int, event_type: str, payload: Di
     - HTTP 5xx
     """
 
-    try:
-        webhook = TenantWebhook.objects.select_related('tenant').get(id=webhook_id)
-    except TenantWebhook.DoesNotExist:
+    from apps.tenants.rls import set_current_tenant
+
+    rls = set_current_tenant(str(tenant_id))
+    if not rls.ok:
+        logger.warning('[Webhooks] Skipping webhook=%s (RLS set failed: %s)', webhook_id, rls.error)
+        return {'success': False, 'reason': 'rls_set_failed', 'error': rls.error}
+
+    webhook = (
+        TenantWebhook.objects.select_related('tenant')
+        .filter(id=webhook_id, tenant_id=tenant_id)
+        .first()
+    )
+    if not webhook:
         return {'success': False, 'reason': 'webhook_not_found'}
 
     if not webhook.is_active:

--- a/backend/tenant_apps/integrations/tests.py
+++ b/backend/tenant_apps/integrations/tests.py
@@ -73,7 +73,12 @@ class TenantIntegrationsTaskTests(TestCase):
         )
 
         payload = {'hello': 'world'}
-        result = dispatch_webhook_payload.run(webhook_id=wh.id, event_type=wh.event_type, payload=payload)
+        result = dispatch_webhook_payload.run(
+            webhook_id=wh.id,
+            tenant_id=str(self.tenant.id),
+            event_type=wh.event_type,
+            payload=payload,
+        )
         self.assertTrue(result['success'])
 
         _, kwargs = mock_post.call_args

--- a/backend/tenant_apps/integrations/views.py
+++ b/backend/tenant_apps/integrations/views.py
@@ -62,8 +62,7 @@ class TenantWebhookViewSet(TenantAdminOnlyMixin, viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         self._assert_admin()
-        # Create serializer uses request context to set tenant/user and generate secrets.
-        serializer.save()
+        serializer.save(tenant=self.request.tenant, created_by=self.request.user)
 
     @action(detail=True, methods=['post'])
     def rotate_secret(self, request, pk=None):
@@ -85,8 +84,7 @@ class TenantAPIKeyViewSet(TenantAdminOnlyMixin, viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         self._assert_admin()
-        # Create serializers use request context to set tenant/user and generate secrets.
-        serializer.save()
+        serializer.save(tenant=self.request.tenant, created_by=self.request.user)
 
     def destroy(self, request, *args, **kwargs):
         """Revoke instead of hard delete."""


### PR DESCRIPTION
## What

Ensure webhook deliveries run with the correct tenant RLS context when executed asynchronously via Celery.

## Changes
- Pass `tenant_id` into webhook dispatch task and call `set_current_tenant()` inside the task
- Filter webhook lookup by `(id, tenant_id)` for defense-in-depth
- Align integrations viewsets with explicit `perform_create()` tenant/user assignment
- Update create serializers to accept `tenant`/`created_by` via `serializer.save()` kwargs
- Update unit tests for new task signature

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test tenant_apps.integrations`
- `bash .github/scripts/validate-migrations.sh`

## Risk / Rollback
Low risk (signature change is internal). Roll back by reverting this PR; webhook API surface remains unchanged.