### PR TITLE
FlowEditor: canonicalize FormReference IDs

### DIFF
--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -2504,11 +2504,12 @@ const formReferenceSchema: NodeConfigSchema = {
       defaultExpanded: true,
       fields: [
         {
-          id: 'formId',
-          type: 'text',
-          label: 'Form ID',
-          placeholder: 'Enter form ID to reference...',
+          id: 'tenantFormId',
+          type: 'formReference',
+          label: 'Form',
+          placeholder: 'Select form...',
           required: true,
+          validation: [{ type: 'required', message: 'Form is required' }],
         },
         {
           id: 'passData',

--- a/frontend/src/components/FlowEditor/nodes/FormReferenceNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormReferenceNode.tsx
@@ -18,7 +18,8 @@ import { FileText, ExternalLink, Edit, Eye } from 'lucide-react';
 // ============================================================================
 
 export interface FormReferenceNodeData extends BaseNodeData {
-  formId?: string;
+  tenantFormId?: string;
+  formId?: string; // legacy alias
   formName?: string;
   formDescription?: string;
   fieldCount?: number;
@@ -185,21 +186,24 @@ const Badge = styled.span<{ $type?: 'warning' | 'info' }>`
 // ============================================================================
 
 export const FormReferenceNode = React.memo<NodeProps<Node<FormReferenceNodeData>>>(({ data, selected, id }) => {
-  const hasForm = data.formId && data.formName;
+  const resolvedFormId = data.tenantFormId ?? data.formId;
+  const hasForm = Boolean(resolvedFormId);
   
   const handleEditForm = () => {
-    // TODO: Open form in FormBuilder
-    console.log('Edit form:', data.formId);
+    // TODO: Open form in FormBuilder (needs a canonical route)
+    // Keep as no-op for now.
   };
-  
+
   const handlePreviewForm = () => {
-    // TODO: Open form preview modal
-    console.log('Preview form:', data.formId);
+    // TODO: Open form preview modal (needs a canonical surface)
+    // Keep as no-op for now.
   };
-  
+
   const handleChangeForm = () => {
-    // TODO: Open form selector modal
-    console.log('Change form');
+    // Use the standard config-panel edit flow.
+    if (typeof (data as any)?.onEdit === 'function') {
+      (data as any).onEdit();
+    }
   };
   
   const displayNode = hasForm ? (
@@ -210,7 +214,7 @@ export const FormReferenceNode = React.memo<NodeProps<Node<FormReferenceNodeData
             <FileText size={20} />
           </FormIcon>
           <FormDetails>
-            <FormName>{data.formName}</FormName>
+            <FormName>{data.formName || resolvedFormId || 'Form'}</FormName>
             {data.formDescription && (
               <FormDescription>{data.formDescription}</FormDescription>
             )}

--- a/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
@@ -157,6 +157,29 @@ export function normalizeNodeData(node: Node): Node {
     } as Node;
   }
 
+  // --------------------------------------------------------------------------
+  // FormReference canonicalization: tenantFormId is the canonical key.
+  // Support legacy data.formId by aliasing it to tenantFormId when UUID-like.
+  // --------------------------------------------------------------------------
+  if (next.type === 'formReference') {
+    const data: any = next.data || {};
+    const candidate = data.tenantFormId ?? data.formId;
+    const uuidLike =
+      typeof candidate === 'string' &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(candidate);
+
+    if (uuidLike) {
+      next = {
+        ...next,
+        data: {
+          ...data,
+          tenantFormId: data.tenantFormId ?? candidate,
+          formId: data.formId ?? candidate,
+        },
+      } as Node;
+    }
+  }
+
   // Get node type definition
   const nodeTypeDef = NODE_TYPE_REGISTRY[next.type ?? ''];
 

--- a/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
+++ b/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
@@ -103,8 +103,16 @@ export const extractFormReferences = (nodes: Node[]): string[] => {
     }
 
     // Form Reference node
-    if (node.type === 'formReference' && nodeData.tenantFormId) {
-      formIds.add(nodeData.tenantFormId);
+    if (node.type === 'formReference') {
+      if (nodeData.tenantFormId) {
+        formIds.add(nodeData.tenantFormId);
+      } else if (
+        typeof nodeData.formId === 'string' &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(nodeData.formId)
+      ) {
+        // Back-compat: older workflows stored the reference as formId.
+        formIds.add(nodeData.formId);
+      }
     }
 
     // Form containers


### PR DESCRIPTION
## What
Fix a correctness gap where `formReference` nodes stored `formId` but backend extraction/validation expects `tenantFormId`, causing silent missing form references.

## Changes
- `formReferenceSchema` now uses `tenantFormId` with the existing form selector field type
- Node normalization aliases legacy `data.formId` -> `data.tenantFormId` when UUID-like (backward compatible)
- Form reference extraction falls back to legacy `formId` when `tenantFormId` absent
- Node UI resolves `tenantFormId` first and uses `onEdit()` for “Change”

## Testing
- `bash scripts/validate_copilot_squad.sh`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend run verify-standards`
- `npm --prefix frontend run test:ci`

## Acceptance
- FormReference nodes now persist a `tenantFormId` that backend `extract_form_references()` can detect.
- Existing workflows with only `formId` continue to load safely.