### PR TITLE
Integrations: fail-closed webhook task test

### DIFF
--- a/backend/tenant_apps/integrations/tests.py
+++ b/backend/tenant_apps/integrations/tests.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 from apps.tenants.models import Tenant
+from apps.tenants.rls import RlsSetResult
 
 from .models import TenantAPIKey, TenantWebhook, TenantWebhookEventType, generate_api_key
 from .tasks import dispatch_webhook_payload
@@ -85,3 +86,28 @@ class TenantIntegrationsTaskTests(TestCase):
         headers = kwargs['headers']
         self.assertIn('X-PM-Signature', headers)
         self.assertEqual(headers['X-PM-Event'], wh.event_type)
+
+    @patch('tenant_apps.integrations.tasks.requests.post')
+    @patch('apps.tenants.rls.set_current_tenant', return_value=RlsSetResult(ok=False, error='db unavailable'))
+    def test_dispatch_webhook_payload_skips_when_rls_set_fails(self, mock_set_current_tenant, mock_post):
+        wh = TenantWebhook.objects.create(
+            tenant=self.tenant,
+            created_by=self.user,
+            target_url='https://example.com/webhook',
+            event_type=TenantWebhookEventType.PURCHASE_ORDER_CREATED,
+            is_active=True,
+            signing_secret='secret',
+        )
+
+        result = dispatch_webhook_payload.run(
+            webhook_id=wh.id,
+            tenant_id=str(self.tenant.id),
+            event_type=wh.event_type,
+            payload={'hello': 'world'},
+        )
+
+        self.assertFalse(result['success'])
+        self.assertEqual(result['reason'], 'rls_set_failed')
+        self.assertIn('db unavailable', result.get('error', ''))
+        mock_set_current_tenant.assert_called_once_with(str(self.tenant.id))
+        mock_post.assert_not_called()


### PR DESCRIPTION
## What
Add a high-signal regression test to ensure tenant webhooks dispatch fails closed when RLS tenant context cannot be asserted in Celery.

## Changes
- New unit test: if `set_current_tenant()` returns `ok=False`, task returns `rls_set_failed` and does not call `requests.post`.

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test tenant_apps.integrations`

## Why
Celery runs outside request middleware; this guards against accidental cross-tenant/side-effect behavior during DB/RLS failures.