### PR TITLE
Tenants API: enforce request tenant scope

### DIFF
--- a/backend/apps/tenants/test_isolation_api.py
+++ b/backend/apps/tenants/test_isolation_api.py
@@ -15,7 +15,8 @@ from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from apps.tenants.models import Tenant, TenantUser
+from apps.tenants.activity_models import ActivityLog
+from apps.tenants.models import Tenant, TenantConfiguration, TenantUser
 from tenant_apps.carriers.models import Carrier
 from tenant_apps.contacts.models import Contact
 from tenant_apps.customers.models import Customer
@@ -53,6 +54,9 @@ class TenantIsolationApiTests(APITestCase):
 
         TenantUser.objects.create(tenant=self.tenant_a, user=self.user_a, role='owner', is_active=True)
         TenantUser.objects.create(tenant=self.tenant_b, user=self.user_b, role='owner', is_active=True)
+        # Cross-tenant regression guard: user_a is admin in both tenants, but API responses
+        # must still be scoped to the current request tenant context.
+        TenantUser.objects.create(tenant=self.tenant_b, user=self.user_a, role='admin', is_active=True)
 
         self.client.force_authenticate(user=self.user_a)
         self.tenant_header = {'HTTP_X_TENANT_ID': str(self.tenant_a.id)}
@@ -135,3 +139,57 @@ class TenantIsolationApiTests(APITestCase):
         # Minimal smoke for workflows endpoint filtering behavior (no fixtures required).
         resp = self.client.get('/api/v1/workflows/workflows/', **self.tenant_header)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_tenant_users_list_is_tenant_scoped(self):
+        resp = self.client.get('/api/v1/tenant-users/', **self.tenant_header)
+        self._assert_only_a(resp, 'user_a', 'user_b')
+
+    def test_activity_logs_list_is_tenant_scoped(self):
+        ActivityLog.log_activity(
+            tenant=self.tenant_a,
+            user=self.user_a,
+            action='test.log',
+            description='LOG-A-ONLY',
+            entity_type='Test',
+            entity_id=None,
+            metadata={},
+            ip_address='127.0.0.1',
+        )
+        ActivityLog.log_activity(
+            tenant=self.tenant_b,
+            user=self.user_b,
+            action='test.log',
+            description='LOG-B-ONLY',
+            entity_type='Test',
+            entity_id=None,
+            metadata={},
+            ip_address='127.0.0.1',
+        )
+
+        resp = self.client.get('/api/v1/activity-logs/', **self.tenant_header)
+        self._assert_only_a(resp, 'LOG-A-ONLY', 'LOG-B-ONLY')
+
+    def test_configurations_list_is_tenant_scoped(self):
+        TenantConfiguration.objects.create(
+            tenant=self.tenant_a,
+            category='general',
+            key='cfg_a',
+            display_name='CFG-A-ONLY',
+            description='cfg',
+            value='1',
+            data_type='string',
+            updated_by=self.user_a,
+        )
+        TenantConfiguration.objects.create(
+            tenant=self.tenant_b,
+            category='general',
+            key='cfg_b',
+            display_name='CFG-B-ONLY',
+            description='cfg',
+            value='1',
+            data_type='string',
+            updated_by=self.user_b,
+        )
+
+        resp = self.client.get('/api/v1/configurations/', **self.tenant_header)
+        self._assert_only_a(resp, 'CFG-A-ONLY', 'CFG-B-ONLY')

--- a/backend/apps/tenants/views.py
+++ b/backend/apps/tenants/views.py
@@ -439,39 +439,54 @@ class TenantUserViewSet(viewsets.ModelViewSet):
     ordering = ["-created_at"]
 
     def get_queryset(self):
-        """Filter based on user permissions."""
+        """Filter associations to the current tenant context.
+
+        In shared-schema multi-tenancy, API access should be scoped to request.tenant.
+        """
         user = self.request.user
+        tenant = getattr(self.request, 'tenant', None)
+
+        if not tenant:
+            return TenantUser.objects.none()
+
         if user.is_superuser:
-            return TenantUser.objects.select_related("user", "tenant")
+            return TenantUser.objects.filter(tenant=tenant).select_related('user', 'tenant')
 
-        # Users can only see associations for tenants they have admin access to
-        admin_tenant_ids = TenantUser.objects.filter(
-            user=user, role__in=["owner", "admin"], is_active=True
-        ).values_list("tenant_id", flat=True)
+        is_admin = TenantUser.objects.filter(
+            tenant=tenant,
+            user=user,
+            role__in=['owner', 'admin'],
+            is_active=True,
+        ).exists()
+        if not is_admin:
+            return TenantUser.objects.none()
 
-        return TenantUser.objects.filter(tenant_id__in=admin_tenant_ids).select_related(
-            "user", "tenant"
-        )
+        return TenantUser.objects.filter(tenant=tenant).select_related('user', 'tenant')
 
     def perform_create(self, serializer):
-        """Ensure user has permission to create associations."""
-        tenant = serializer.validated_data["tenant"]
+        """Ensure user has permission to create associations.
+
+        Tenant is enforced from request.tenant (TenantMiddleware), not from client input.
+        """
+        from rest_framework.exceptions import ValidationError
+
+        tenant = getattr(self.request, 'tenant', None)
+        if not tenant:
+            raise ValidationError({'tenant': 'Tenant context required'})
 
         # Check if user has admin access to the tenant
         if (
             not TenantUser.objects.filter(
                 tenant=tenant,
                 user=self.request.user,
-                role__in=["owner", "admin"],
+                role__in=['owner', 'admin'],
                 is_active=True,
             ).exists()
             and not self.request.user.is_superuser
         ):
-            raise permissions.PermissionDenied(
-                "You don't have permission to manage users for this tenant."
-            )
+            raise permissions.PermissionDenied("You don't have permission to manage users for this tenant.")
 
-        instance = serializer.save()
+        instance = serializer.save(tenant=tenant)
 
         try:
             ActivityLog.log_activity(
@@ -759,22 +774,26 @@ class ActivityLogViewSet(viewsets.ReadOnlyModelViewSet):
     ordering = ["-created_at"]
     
     def get_queryset(self):
-        """Filter activity logs based on user permissions."""
+        """Filter activity logs to the current tenant context."""
         user = self.request.user
-        
+        tenant = getattr(self.request, 'tenant', None)
+
+        if not tenant:
+            return ActivityLog.objects.none()
+
         if user.is_superuser:
-            return ActivityLog.objects.select_related("user", "tenant")
-        
-        # Get tenants where user is admin or owner
-        admin_tenant_ids = TenantUser.objects.filter(
+            return ActivityLog.objects.filter(tenant=tenant).select_related('user', 'tenant')
+
+        is_admin = TenantUser.objects.filter(
+            tenant=tenant,
             user=user,
-            role__in=["owner", "admin"],
-            is_active=True
-        ).values_list("tenant_id", flat=True)
-        
-        return ActivityLog.objects.filter(
-            tenant_id__in=admin_tenant_ids
-        ).select_related("user", "tenant")
+            role__in=['owner', 'admin'],
+            is_active=True,
+        ).exists()
+        if not is_admin:
+            return ActivityLog.objects.none()
+
+        return ActivityLog.objects.filter(tenant=tenant).select_related('user', 'tenant')
     
     @action(detail=False, methods=["get"])
     def export(self, request):
@@ -844,42 +863,37 @@ class TenantConfigurationViewSet(viewsets.ModelViewSet):
     ordering = ["category", "key"]
     
     def get_queryset(self):
-        """Filter configurations for user's tenant."""
+        """Filter configurations to the current tenant context."""
         user = self.request.user
-        
+        tenant = getattr(self.request, 'tenant', None)
+
+        if not tenant:
+            return TenantConfiguration.objects.none()
+
         if user.is_superuser:
-            return TenantConfiguration.objects.select_related("tenant", "updated_by")
-        
-        # Get tenants where user is admin or owner
-        admin_tenant_ids = TenantUser.objects.filter(
+            return TenantConfiguration.objects.filter(tenant=tenant).select_related('tenant', 'updated_by')
+
+        # Permission class enforces admin/owner; keep a defense-in-depth check here.
+        is_admin = TenantUser.objects.filter(
+            tenant=tenant,
             user=user,
-            role__in=["owner", "admin"],
-            is_active=True
-        ).values_list("tenant_id", flat=True)
-        
-        return TenantConfiguration.objects.filter(
-            tenant_id__in=admin_tenant_ids
-        ).select_related("tenant", "updated_by")
+            role__in=['owner', 'admin'],
+            is_active=True,
+        ).exists()
+        if not is_admin:
+            return TenantConfiguration.objects.none()
+
+        return TenantConfiguration.objects.filter(tenant=tenant).select_related('tenant', 'updated_by')
     
     def perform_create(self, serializer):
         """Set tenant and updated_by on creation."""
-        # Use tenant from request (set by TenantMiddleware)
-        tenant_id = self.request.headers.get('X-Tenant-ID')
-        if tenant_id:
-            tenant = Tenant.objects.get(id=tenant_id)
-            instance = serializer.save(tenant=tenant, updated_by=self.request.user)
-        else:
-            # Fallback: Use first tenant where user is admin
-            tenant_user = TenantUser.objects.filter(
-                user=self.request.user,
-                role__in=["owner", "admin"],
-                is_active=True
-            ).first()
+        from rest_framework.exceptions import ValidationError
 
-            if not tenant_user:
-                raise permissions.PermissionDenied("User is not an admin of any tenant")
+        tenant = getattr(self.request, 'tenant', None)
+        if not tenant:
+            raise ValidationError({'tenant': 'Tenant context required'})
 
-            instance = serializer.save(tenant=tenant_user.tenant, updated_by=self.request.user)
+        instance = serializer.save(tenant=tenant, updated_by=self.request.user)
 
         try:
             ActivityLog.log_activity(


### PR DESCRIPTION
## What
Tighten shared-schema tenant isolation for core multi-tenancy endpoints by scoping them strictly to `request.tenant` (not “all admin tenants”).

## Changes
- TenantUserViewSet, ActivityLogViewSet, TenantConfigurationViewSet now fail closed when tenant context is missing and always filter by the current tenant
- Remove header-based tenant selection + unsafe fallback in TenantConfigurationViewSet.create
- Add API isolation tests proving tenant scoping holds even when a user is a member of multiple tenants

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test apps.tenants`

## Why
Prevents cross-tenant responses when a user belongs to multiple tenants and enforces the repo’s canonical tenant isolation pattern (`tenant=request.tenant`).