### PR TITLE
Week0 security: scope cockpit + ranked search by tenant

### DIFF
--- a/backend/apps/system/tests/test_ranked_search_tenant_scoping.py
+++ b/backend/apps/system/tests/test_ranked_search_tenant_scoping.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.system.views.search_viewset import RankedSearchViewSet
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.customers.models import Customer
+from tenant_apps.suppliers.models import Supplier
+
+
+class RankedSearchTenantScopingTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+
+        self.tenant_a = Tenant.objects.create(
+            name=f'Tenant A {unique}',
+            slug=f'tenant-a-{unique}',
+            contact_email=f'a-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f'Tenant B {unique}',
+            slug=f'tenant-b-{unique}',
+            contact_email=f'b-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+
+        # User belongs to both tenants; API must still be scoped by request.tenant.
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role='admin', is_active=True)
+        TenantUser.objects.create(tenant=self.tenant_b, user=self.user, role='admin', is_active=True)
+
+        Customer.objects.create(tenant=self.tenant_a, name='Scoped Customer A ONLY')
+        Customer.objects.create(tenant=self.tenant_b, name='Scoped Customer B ONLY')
+
+        Supplier.objects.create(tenant=self.tenant_a, name='Scoped Supplier A ONLY')
+        Supplier.objects.create(tenant=self.tenant_b, name='Scoped Supplier B ONLY')
+
+    def _call(self, tenant):
+        factory = APIRequestFactory()
+        request = factory.get(
+            '/api/v1/system/search/ranked/',
+            {
+                'q': 'Scoped',
+                'entity_types': 'customer,supplier',
+                'limit': 50,
+            },
+        )
+        force_authenticate(request, user=self.user)
+        request.tenant = tenant
+        response = RankedSearchViewSet.as_view({'get': 'list'})(request)
+        return response
+
+    def test_ranked_search_is_scoped_to_request_tenant(self):
+        resp = self._call(self.tenant_a)
+        self.assertEqual(resp.status_code, 200)
+
+        joined = str(resp.data)
+        self.assertIn('Customer A ONLY', joined)
+        self.assertIn('Supplier A ONLY', joined)
+        self.assertNotIn('Customer B ONLY', joined)
+        self.assertNotIn('Supplier B ONLY', joined)
+
+    def test_ranked_search_fails_closed_without_tenant(self):
+        resp = self._call(None)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data.get('total'), 0)
+        self.assertEqual(resp.data.get('results'), [])

--- a/backend/apps/system/views/search_viewset.py
+++ b/backend/apps/system/views/search_viewset.py
@@ -75,7 +75,7 @@ class RankedSearchViewSet(viewsets.ViewSet):
         entity_types_str = request.query_params.get('entity_types', '')
         limit = int(request.query_params.get('limit', 5))
         
-        tenant = request.tenant
+        tenant = getattr(request, 'tenant', None)
         
         # Parse entity types filter
         if entity_types_str:
@@ -97,7 +97,17 @@ class RankedSearchViewSet(viewsets.ViewSet):
                 'counts': counts,
                 'total': 0,
             })
-        
+
+        # Fail closed: ranked search must be scoped to a tenant in shared-schema mode.
+        if not tenant:
+            return Response({
+                'query': query,
+                'date_range': date_range,
+                'results': [],
+                'counts': {},
+                'total': 0,
+            })
+
         # Search customers with intelligent ranking
         if 'customer' in entity_types:
             self._search_customers(query, tenant, limit, results, counts)
@@ -144,13 +154,13 @@ class RankedSearchViewSet(viewsets.ViewSet):
             
             # Build query for all matching customers (for accurate count)
             customers_qs = Customer.objects.filter(
-                Q(name__icontains=query) | 
-                Q(contact_person__icontains=query) |
-                Q(email__icontains=query) |
-                Q(city__icontains=query)
+                tenant=tenant,
+            ).filter(
+                Q(name__icontains=query)
+                | Q(contact_person__icontains=query)
+                | Q(email__icontains=query)
+                | Q(city__icontains=query)
             )
-            if tenant:
-                customers_qs = customers_qs.filter(tenant=tenant)
             
             # Get total count BEFORE limiting
             counts['customer'] = customers_qs.count()
@@ -202,13 +212,13 @@ class RankedSearchViewSet(viewsets.ViewSet):
             from tenant_apps.suppliers.models import Supplier
             
             suppliers_qs = Supplier.objects.filter(
-                Q(name__icontains=query) |
-                Q(contact_person__icontains=query) |
-                Q(email__icontains=query) |
-                Q(city__icontains=query)
+                tenant=tenant,
+            ).filter(
+                Q(name__icontains=query)
+                | Q(contact_person__icontains=query)
+                | Q(email__icontains=query)
+                | Q(city__icontains=query)
             )
-            if tenant:
-                suppliers_qs = suppliers_qs.filter(tenant=tenant)
             
             counts['supplier'] = suppliers_qs.count()
             suppliers = list(suppliers_qs[:limit * 2])
@@ -303,13 +313,13 @@ class RankedSearchViewSet(viewsets.ViewSet):
             from tenant_apps.contacts.models import Contact
             
             contacts_qs = Contact.objects.filter(
-                Q(first_name__icontains=query) |
-                Q(last_name__icontains=query) |
-                Q(email__icontains=query) |
-                Q(phone__icontains=query)
+                tenant=tenant,
+            ).filter(
+                Q(first_name__icontains=query)
+                | Q(last_name__icontains=query)
+                | Q(email__icontains=query)
+                | Q(phone__icontains=query)
             )
-            if tenant:
-                contacts_qs = contacts_qs.filter(tenant=tenant)
             
             counts['contact'] = contacts_qs.count()
             contacts = list(contacts_qs[:limit])
@@ -343,11 +353,10 @@ class RankedSearchViewSet(viewsets.ViewSet):
             from tenant_apps.purchase_orders.models import PurchaseOrder
             
             pos_qs = PurchaseOrder.objects.filter(
-                Q(order_number__icontains=query) |
-                Q(our_purchase_order_num__icontains=query)
+                tenant=tenant,
+            ).filter(
+                Q(order_number__icontains=query) | Q(our_purchase_order_num__icontains=query)
             ).select_related('supplier')
-            if tenant:
-                pos_qs = pos_qs.filter(tenant=tenant)
             
             counts['po'] = pos_qs.count()
             pos = list(pos_qs[:limit])
@@ -378,10 +387,10 @@ class RankedSearchViewSet(viewsets.ViewSet):
             from tenant_apps.sales_orders.models import SalesOrder
             
             sos_qs = SalesOrder.objects.filter(
+                tenant=tenant,
+            ).filter(
                 Q(order_number__icontains=query)
             ).select_related('customer')
-            if tenant:
-                sos_qs = sos_qs.filter(tenant=tenant)
             
             counts['so'] = sos_qs.count()
             sos = list(sos_qs[:limit])

--- a/backend/tenant_apps/cockpit/tests.py
+++ b/backend/tenant_apps/cockpit/tests.py
@@ -53,7 +53,10 @@ class CockpitSearchTestCase(TestCase):
         
         # Authenticate
         self.client.force_authenticate(user=self.user)
-        
+
+        # Tenant context (shared-schema): API tenant isolation is scoped by X-Tenant-ID.
+        self.tenant_header = {'HTTP_X_TENANT_ID': str(self.tenant.id)}
+
         # Create test data with unique identifiers
         self.customer = Customer.objects.create(
             tenant=self.tenant,
@@ -83,7 +86,7 @@ class CockpitSearchTestCase(TestCase):
     
     def test_search_returns_all_types(self):
         """Test that search returns results from all model types."""
-        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'o'})
+        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'o'}, **self.tenant_header)
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
@@ -95,7 +98,7 @@ class CockpitSearchTestCase(TestCase):
     
     def test_search_by_customer_name(self):
         """Test searching for customers by name."""
-        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'Acme'})
+        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'Acme'}, **self.tenant_header)
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
@@ -106,7 +109,7 @@ class CockpitSearchTestCase(TestCase):
     
     def test_search_by_order_number(self):
         """Test searching for orders by order number."""
-        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'PO-2024'})
+        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'PO-2024'}, **self.tenant_header)
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
@@ -117,14 +120,54 @@ class CockpitSearchTestCase(TestCase):
     
     def test_empty_search_returns_empty(self):
         """Test that empty query returns empty results."""
-        response = self.client.get('/api/v1/cockpit/slots/', {'q': ''})
-        
+        response = self.client.get('/api/v1/cockpit/slots/', {'q': ''}, **self.tenant_header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
+
+    def test_search_is_tenant_scoped(self):
+        """Regression guard: matching records in other tenants must not appear."""
+        unique_id = uuid.uuid4().hex[:8]
+        other_tenant = Tenant.objects.create(
+            name=f'Other Cockpit Tenant {unique_id}',
+            slug=f'other-cockpit-{unique_id}',
+            contact_email=f'other-{unique_id}@example.com',
+            is_active=True,
+        )
+
+        # Create matching data in other tenant
+        other_supplier = Supplier.objects.create(
+            tenant=other_tenant,
+            name=f'Global Supplies OTHER {unique_id}',
+            contact_person=f'Jane Smith OTHER {unique_id}',
+            email=f'jane-other-{unique_id}@global.com',
+            phone='555-9999',
+        )
+        PurchaseOrder.objects.create(
+            tenant=other_tenant,
+            order_number=f'PO-OTHER-{unique_id}',
+            our_purchase_order_num=f'INT-OTHER-{unique_id}',
+            supplier=other_supplier,
+            status='pending',
+            order_date='2024-01-01',
+            total_amount='1500.00',
+        )
+        Customer.objects.create(
+            tenant=other_tenant,
+            name=f'Acme Corporation OTHER {unique_id}',
+            contact_person=f'John Doe OTHER {unique_id}',
+            email=f'john-other-{unique_id}@acme.com',
+            phone='555-0000',
+        )
+
+        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'OTHER'}, **self.tenant_header)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
     
     def test_no_results_for_nonexistent_query(self):
         """Test that search with no matches returns empty."""
-        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'ZZZZZZZZZ'})
+        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'ZZZZZZZZZ'}, **self.tenant_header)
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
@@ -132,6 +175,6 @@ class CockpitSearchTestCase(TestCase):
     def test_requires_authentication(self):
         """Test that endpoint requires authentication."""
         self.client.logout()
-        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'test'})
+        response = self.client.get('/api/v1/cockpit/slots/', {'q': 'test'}, **self.tenant_header)
         
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/backend/tenant_apps/cockpit/views.py
+++ b/backend/tenant_apps/cockpit/views.py
@@ -227,28 +227,33 @@ class CockpitSlotViewSet(viewsets.ReadOnlyModelViewSet):
         - Polymorphic list with 'type' field: 'customer', 'supplier', or 'order'
         """
         q = request.query_params.get('q', '').strip()
-        
+
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            # Fail closed: shared-schema search must never return cross-tenant results.
+            return Response([])
+
         results = []
-        
+
         if q:
             # Search customers by name
-            customers = Customer.objects.filter(
+            customers = Customer.objects.filter(tenant=tenant).filter(
                 Q(name__icontains=q) | Q(contact_person__icontains=q)
             )[:10]
             results.extend(CustomerSlotSerializer(customers, many=True).data)
-            
+
             # Search suppliers by name
-            suppliers = Supplier.objects.filter(
+            suppliers = Supplier.objects.filter(tenant=tenant).filter(
                 Q(name__icontains=q) | Q(contact_person__icontains=q)
             )[:10]
             results.extend(SupplierSlotSerializer(suppliers, many=True).data)
-            
+
             # Search orders by order numbers
-            orders = PurchaseOrder.objects.filter(
+            orders = PurchaseOrder.objects.filter(tenant=tenant).filter(
                 Q(order_number__icontains=q) | Q(our_purchase_order_num__icontains=q)
             ).select_related('supplier')[:10]
             results.extend(OrderSlotSerializer(orders, many=True).data)
-        
+
         return Response(results)
 
 


### PR DESCRIPTION
## What
- CockpitSlotViewSet now fails closed when tenant context is missing and always scopes queryset by request.tenant.
- RankedSearchViewSet now fails closed when tenant context is missing and always filters tenant-aware models by tenant (no conditional scoping).
- Adds regression tests for a multi-tenant user to ensure results are scoped to the selected tenant.

## Why
Shared-schema multi-tenancy must never return unscoped data. These endpoints could previously return cross-tenant results when tenant context was absent or only conditionally applied.

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test tenant_apps.cockpit apps.system.tests.test_ranked_search_tenant_scoping --verbosity=2`

## Risk / Rollback
Low risk (tightening filters). Rollback by reverting this PR; behavior returns to previous (less secure) scoping.