### PR TITLE
Week0 security: workflows + AI docs fail closed without tenant

### DIFF
--- a/backend/tenant_apps/ai_assistant/tests.py
+++ b/backend/tenant_apps/ai_assistant/tests.py
@@ -446,3 +446,67 @@ class SwarmWorkformAndCommsToolsTest(TestCase):
         self.assertEqual(row.tenant, self.tenant)
         self.assertEqual(row.status, CommunicationStatus.DRAFT)
         self.assertEqual(row.to_email, "acme@example.com")
+
+
+class AIDocumentViewSetTenantScopingTests(TestCase):
+    def setUp(self):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        from rest_framework.test import APIRequestFactory, force_authenticate
+
+        from tenant_apps.ai_assistant.models import AIDocument
+
+        unique = uuid.uuid4().hex[:8]
+        self.factory = APIRequestFactory()
+        self._force_authenticate = force_authenticate
+
+        self.user = User.objects.create_user(username=f"aidoc-{unique}", password="pw")
+
+        self.tenant_a = Tenant.objects.create(
+            name=f"Tenant A {unique}",
+            slug=f"tenant-a-{unique}",
+            contact_email=f"a-{unique}@example.com",
+            is_active=True,
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f"Tenant B {unique}",
+            slug=f"tenant-b-{unique}",
+            contact_email=f"b-{unique}@example.com",
+            is_active=True,
+            created_by=self.user,
+        )
+
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role="admin", is_active=True)
+        TenantUser.objects.create(tenant=self.tenant_b, user=self.user, role="admin", is_active=True)
+
+        file_a = SimpleUploadedFile("a.txt", b"hello a", content_type="text/plain")
+        file_b = SimpleUploadedFile("b.txt", b"hello b", content_type="text/plain")
+
+        AIDocument.objects.create(tenant=self.tenant_a, owner=self.user, file=file_a, original_filename="a.txt")
+        AIDocument.objects.create(tenant=self.tenant_b, owner=self.user, file=file_b, original_filename="b.txt")
+
+    def _get(self, tenant):
+        request = self.factory.get("/api/v1/ai-assistant/documents/")
+        self._force_authenticate(request, user=self.user)
+        request.tenant = tenant
+        return request
+
+    def _items(self, response):
+        data = response.data
+        if isinstance(data, dict) and "results" in data:
+            return data["results"]
+        return data
+
+    def test_documents_are_scoped_and_fail_closed(self):
+        from tenant_apps.ai_assistant.views import AIDocumentViewSet
+
+        resp = AIDocumentViewSet.as_view({"get": "list"})(self._get(self.tenant_a))
+        self.assertEqual(resp.status_code, 200)
+        joined = str(self._items(resp))
+        self.assertIn("a.txt", joined)
+        self.assertNotIn("b.txt", joined)
+
+        resp2 = AIDocumentViewSet.as_view({"get": "list"})(self._get(None))
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(len(self._items(resp2)), 0)
+

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -431,9 +431,9 @@ class AIDocumentViewSet(viewsets.ModelViewSet):
         tenant = getattr(self.request, 'tenant', None)
         qs = AIDocument.objects.all().select_related('tenant', 'owner', 'session')
         qs = qs.filter(owner=self.request.user)
-        if tenant:
-            qs = qs.filter(tenant=tenant)
-        return qs
+        if not tenant:
+            return qs.none()
+        return qs.filter(tenant=tenant)
 
     def perform_create(self, serializer):
         from django.db import transaction

--- a/backend/tenant_apps/workflows/tests/test_viewset_tenant_fail_closed.py
+++ b/backend/tenant_apps/workflows/tests/test_viewset_tenant_fail_closed.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.workflows.models import (
+    FormStatusHistory,
+    FormSubmission,
+    FormSubmissionStatus,
+    NotificationType,
+    StepAssignment,
+    TenantForm,
+    TenantFormEntity,
+    UserNotification,
+)
+from tenant_apps.workflows.views import (
+    FormStatusHistoryViewSet,
+    StepAssignmentViewSet,
+    TenantFormEntityViewSet,
+    UserNotificationViewSet,
+)
+
+
+class WorkflowViewSetTenantFailClosedTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        self.factory = APIRequestFactory()
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+
+        self.tenant_a = Tenant.objects.create(
+            name=f'Tenant A {unique}',
+            slug=f'tenant-a-{unique}',
+            contact_email=f'a-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f'Tenant B {unique}',
+            slug=f'tenant-b-{unique}',
+            contact_email=f'b-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role='admin', is_active=True)
+        TenantUser.objects.create(tenant=self.tenant_b, user=self.user, role='admin', is_active=True)
+
+        # Forms + entities in both tenants
+        self.form_a = TenantForm.objects.create(tenant=self.tenant_a, name='Form A', created_by=self.user)
+        self.form_b = TenantForm.objects.create(tenant=self.tenant_b, name='Form B', created_by=self.user)
+
+        self.entity_a = TenantFormEntity.objects.create(form=self.form_a, entity_type='customer', order=0)
+        self.entity_b = TenantFormEntity.objects.create(form=self.form_b, entity_type='customer', order=0)
+
+        # Step assignments in both tenants
+        StepAssignment.objects.create(
+            tenant=self.tenant_a,
+            form=self.form_a,
+            step=self.entity_a,
+            assigned_user=self.user,
+            created_by=self.user,
+        )
+        StepAssignment.objects.create(
+            tenant=self.tenant_b,
+            form=self.form_b,
+            step=self.entity_b,
+            assigned_user=self.user,
+            created_by=self.user,
+        )
+
+        # Form submission + status history in tenant A
+        self.submission_a = FormSubmission.objects.create(
+            tenant=self.tenant_a,
+            form=self.form_a,
+            created_by=self.user,
+            status=FormSubmissionStatus.DRAFT,
+        )
+        FormStatusHistory.objects.create(
+            submission=self.submission_a,
+            from_status='',
+            to_status=FormSubmissionStatus.DRAFT,
+            changed_by=self.user,
+        )
+
+        # Notifications in both tenants
+        UserNotification.objects.create(
+            tenant=self.tenant_a,
+            user=self.user,
+            notification_type=NotificationType.SYSTEM,
+            title='A only',
+            message='Tenant A notification',
+        )
+        UserNotification.objects.create(
+            tenant=self.tenant_b,
+            user=self.user,
+            notification_type=NotificationType.SYSTEM,
+            title='B only',
+            message='Tenant B notification',
+        )
+
+    def _get(self, path: str, tenant):
+        request = self.factory.get(path)
+        force_authenticate(request, user=self.user)
+        request.tenant = tenant
+        return request
+
+    def _items(self, response):
+        data = response.data
+        if isinstance(data, dict) and 'results' in data:
+            return data['results']
+        return data
+
+    def test_tenant_form_entity_list_is_scoped_and_fails_closed(self):
+        # Scoped to tenant
+        resp = TenantFormEntityViewSet.as_view({'get': 'list'})(
+            self._get('/api/v1/workflows/form-entities/', self.tenant_a)
+        )
+        self.assertEqual(resp.status_code, 200)
+        items = self._items(resp)
+        ids = {row.get('id') for row in items}
+        self.assertIn(str(self.entity_a.id), ids)
+        self.assertNotIn(str(self.entity_b.id), ids)
+
+        # Fail closed when tenant missing
+        resp2 = TenantFormEntityViewSet.as_view({'get': 'list'})(self._get('/api/v1/workflows/form-entities/', None))
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(len(self._items(resp2)), 0)
+
+    def test_step_assignments_list_is_scoped_and_fails_closed(self):
+        resp = StepAssignmentViewSet.as_view({'get': 'list'})(
+            self._get('/api/v1/workflows/step-assignments/', self.tenant_a)
+        )
+        self.assertEqual(resp.status_code, 200)
+        joined = str(self._items(resp))
+        self.assertIn(str(self.tenant_a.id), joined)
+        self.assertNotIn(str(self.tenant_b.id), joined)
+
+        resp2 = StepAssignmentViewSet.as_view({'get': 'list'})(self._get('/api/v1/workflows/step-assignments/', None))
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(len(self._items(resp2)), 0)
+
+    def test_notifications_list_is_scoped_and_fails_closed(self):
+        resp = UserNotificationViewSet.as_view({'get': 'list'})(
+            self._get('/api/v1/workflows/notifications/', self.tenant_a)
+        )
+        self.assertEqual(resp.status_code, 200)
+        joined = str(self._items(resp))
+        self.assertIn('A only', joined)
+        self.assertNotIn('B only', joined)
+
+        resp2 = UserNotificationViewSet.as_view({'get': 'list'})(self._get('/api/v1/workflows/notifications/', None))
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(len(self._items(resp2)), 0)
+
+    def test_status_history_is_scoped_and_fails_closed(self):
+        # Scoped to tenant
+        req = self._get(
+            f'/api/v1/workflows/form-submissions/{self.submission_a.id}/history/',
+            self.tenant_a,
+        )
+        resp = FormStatusHistoryViewSet.as_view({'get': 'list'})(req, submission_id=str(self.submission_a.id))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(self._items(resp)), 1)
+
+        # Wrong tenant gets nothing
+        req2 = self._get(
+            f'/api/v1/workflows/form-submissions/{self.submission_a.id}/history/',
+            self.tenant_b,
+        )
+        resp2 = FormStatusHistoryViewSet.as_view({'get': 'list'})(req2, submission_id=str(self.submission_a.id))
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(len(self._items(resp2)), 0)
+
+        # Missing tenant fails closed
+        req3 = self._get(
+            f'/api/v1/workflows/form-submissions/{self.submission_a.id}/history/',
+            None,
+        )
+        resp3 = FormStatusHistoryViewSet.as_view({'get': 'list'})(req3, submission_id=str(self.submission_a.id))
+        self.assertEqual(resp3.status_code, 200)
+        self.assertEqual(len(self._items(resp3)), 0)

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -1378,8 +1378,11 @@ class TenantFormEntityViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            qs = qs.filter(form__tenant=self.request.tenant)
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            return qs.none()
+
+        qs = qs.filter(form__tenant=tenant)
 
         # Filter by form
         form_id = self.request.query_params.get("form")
@@ -1413,8 +1416,11 @@ class TenantFormFieldViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            qs = qs.filter(form_entity__form__tenant=self.request.tenant)
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            return qs.none()
+
+        qs = qs.filter(form_entity__form__tenant=tenant)
 
         # Filter by entity
         entity_id = self.request.query_params.get("entity")
@@ -1442,7 +1448,14 @@ class TenantFormFieldViewSet(viewsets.ModelViewSet):
             404: {"error": "Field not found or cascading not enabled"}
         """
         from tenant_apps.workflows.services.cascading import CascadingFieldService
-        
+
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return Response(
+                {"error": "Tenant context is required (X-Tenant-ID header)"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         field = self.get_object()
         parent_value = request.query_params.get('parent_value')
         
@@ -1462,7 +1475,7 @@ class TenantFormFieldViewSet(viewsets.ModelViewSet):
             options = CascadingFieldService.get_cascaded_options(
                 field=field,
                 parent_value=parent_value,
-                tenant_id=str(request.tenant.id) if request.tenant else None
+                tenant_id=str(tenant.id)
             )
             return Response(options, status=status.HTTP_200_OK)
         except Exception as e:
@@ -1483,8 +1496,11 @@ class TenantFormRuleViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            qs = qs.filter(form__tenant=self.request.tenant)
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            return qs.none()
+
+        qs = qs.filter(form__tenant=tenant)
 
         # Filter by form
         form_id = self.request.query_params.get("form")
@@ -1869,8 +1885,11 @@ class TenantWorkflowConditionViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            qs = qs.filter(workflow__tenant=self.request.tenant)
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            return qs.none()
+
+        qs = qs.filter(workflow__tenant=tenant)
 
         workflow_id = self.request.query_params.get("workflow")
         if workflow_id:
@@ -1890,8 +1909,11 @@ class TenantWorkflowActionViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            qs = qs.filter(workflow__tenant=self.request.tenant)
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            return qs.none()
+
+        qs = qs.filter(workflow__tenant=tenant)
 
         workflow_id = self.request.query_params.get("workflow")
         if workflow_id:
@@ -1913,8 +1935,11 @@ class WorkflowExecutionLogViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            qs = qs.filter(workflow__tenant=self.request.tenant)
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            return qs.none()
+
+        qs = qs.filter(workflow__tenant=tenant)
 
         # Filter by workflow
         workflow_id = self.request.query_params.get("workflow")
@@ -3477,15 +3502,26 @@ class FormStatusHistoryViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, v
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        submission_id = self.kwargs.get("submission_id")
-        return FormStatusHistory.objects.filter(submission_id=submission_id).select_related("changed_by", "submission")
+        tenant = getattr(self.request, 'tenant', None)
+        if not tenant:
+            return FormStatusHistory.objects.none()
+
+        submission_id = self.kwargs.get('submission_id')
+        return (
+            FormStatusHistory.objects.filter(submission_id=submission_id, submission__tenant=tenant)
+            .select_related('changed_by', 'submission')
+        )
 
     def perform_create(self, serializer):
-        submission_id = self.kwargs.get("submission_id")
+        tenant = getattr(self.request, 'tenant', None)
+        if not tenant:
+            raise serializers.ValidationError('Tenant context is required (X-Tenant-ID header).')
+
+        submission_id = self.kwargs.get('submission_id')
         try:
-            submission = FormSubmission.objects.get(pk=submission_id)
+            submission = FormSubmission.objects.get(pk=submission_id, tenant=tenant)
         except FormSubmission.DoesNotExist:
-            raise serializers.ValidationError("Submission not found")
+            raise serializers.ValidationError('Submission not found')
 
         # Get current status before change
         from_status = submission.status
@@ -3517,9 +3553,12 @@ class StepAssignmentViewSet(viewsets.ModelViewSet):
             "tenant", "form", "step", "assigned_user", "escalation_user", "created_by"
         )
 
-        # Filter by tenant
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            queryset = queryset.filter(tenant=self.request.tenant)
+        # Filter by tenant (fail closed)
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            return queryset.none()
+
+        queryset = queryset.filter(tenant=tenant)
 
         # Filter by form
         form_id = self.request.query_params.get("form")
@@ -3562,9 +3601,12 @@ class UserNotificationViewSet(
     def get_queryset(self):
         queryset = UserNotification.objects.filter(user=self.request.user, is_dismissed=False).select_related("tenant")
 
-        # Filter by tenant if available
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            queryset = queryset.filter(tenant=self.request.tenant)
+        # Filter by tenant (fail closed)
+        tenant = getattr(self.request, "tenant", None)
+        if not tenant:
+            return queryset.none()
+
+        queryset = queryset.filter(tenant=tenant)
 
         # Filter by read status
         is_read = self.request.query_params.get("is_read")


### PR DESCRIPTION
## What
- Workflows: multiple endpoints now **fail closed** when tenant context is missing and always scope by `request.tenant` (Form entities/fields/rules, workflow conditions/actions/logs, step assignments, notifications).
- Fixes IDOR risk: `FormStatusHistoryViewSet` now scopes by `submission__tenant` and constrains submission lookups on create.
- AI Assistant: `AIDocumentViewSet` list now fails closed when tenant is missing (owner-only is not sufficient in shared-schema).
- Adds regression tests covering fail-closed + cross-tenant access prevention.

## Why
Shared-schema multi-tenancy must never return unscoped querysets when `request.tenant` is absent. History sub-resource paths are especially prone to IDOR leaks without tenant constraints.

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test tenant_apps.workflows.tests.test_viewset_tenant_fail_closed tenant_apps.ai_assistant.tests --verbosity=2`
- `bash scripts/validate_copilot_squad.sh`

## Risk / Rollback
Low-to-medium (tightening access). Rollback by reverting this PR; behavior returns to previous (less secure) scoping.