### PR TITLE
Week0 security: validate X-Tenant-ID post-auth

### DIFF
--- a/backend/apps/core/tests/test_jwt.py
+++ b/backend/apps/core/tests/test_jwt.py
@@ -27,8 +27,8 @@ class JWTConfigurationTestCase(TestCase):
         from django.conf import settings
         auth_classes = settings.REST_FRAMEWORK.get('DEFAULT_AUTHENTICATION_CLASSES', [])
         self.assertIn(
-            'rest_framework_simplejwt.authentication.JWTAuthentication',
-            auth_classes
+            'apps.tenants.authentication.TenantAwareJWTAuthentication',
+            auth_classes,
         )
     
     def test_simple_jwt_settings_exist(self):

--- a/backend/apps/tenants/authentication.py
+++ b/backend/apps/tenants/authentication.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from apps.tenants.models import Tenant, TenantUser
+from apps.tenants.rls import set_current_tenant
+
+logger = logging.getLogger(__name__)
+
+
+class _TenantContextMixin:
+    def _resolve_tenant_for_user(self, request, user):
+        # 1) Explicit tenant selection via header
+        tenant_id = request.headers.get('X-Tenant-ID')
+        if tenant_id:
+            try:
+                tenant = Tenant.objects.get(id=tenant_id, is_active=True)
+            except Tenant.DoesNotExist:
+                raise AuthenticationFailed('Invalid tenant.')
+            except ValueError:
+                raise AuthenticationFailed('Invalid tenant.')
+
+            is_global_admin = user.groups.filter(name='Global System Admins').exists()
+            if not (user.is_superuser or is_global_admin):
+                if not TenantUser.objects.filter(user=user, tenant=tenant, is_active=True).exists():
+                    raise PermissionDenied('You do not have access to this tenant.')
+
+            return tenant
+
+        # 2) If middleware already resolved tenant (domain/subdomain), validate membership
+        tenant = getattr(request, 'tenant', None)
+        if tenant is not None:
+            is_global_admin = user.groups.filter(name='Global System Admins').exists()
+            if not (user.is_superuser or is_global_admin):
+                if not TenantUser.objects.filter(user=user, tenant=tenant, is_active=True).exists():
+                    raise PermissionDenied('You do not have access to this tenant.')
+            return tenant
+
+        # 3) Default tenant from membership
+        membership = (
+            TenantUser.objects.filter(user=user, is_active=True)
+            .select_related('tenant')
+            .order_by('-role')
+            .first()
+        )
+        if membership:
+            return membership.tenant
+
+        # 4) Global admins default to system root (if present)
+        if user.groups.filter(name='Global System Admins').exists():
+            try:
+                return Tenant.objects.get(id='00000000-0000-0000-0000-000000000000')
+            except Tenant.DoesNotExist:
+                return None
+
+        return None
+
+    def _set_tenant_context(self, request, user) -> None:
+        tenant = self._resolve_tenant_for_user(request, user)
+        request.tenant = tenant
+
+        if not tenant:
+            return
+
+        rls = set_current_tenant(str(tenant.id))
+        if rls.ok:
+            request._rls_set = True
+        else:
+            logger.warning('RLS: failed to set session vars for tenant=%s: %s', tenant.id, rls.error)
+
+
+class TenantAwareJWTAuthentication(_TenantContextMixin, JWTAuthentication):
+    def authenticate(self, request):
+        out = super().authenticate(request)
+        if out is None:
+            return None
+        user, token = out
+        self._set_tenant_context(request, user)
+        return (user, token)
+
+
+class TenantAwareTokenAuthentication(_TenantContextMixin, TokenAuthentication):
+    def authenticate(self, request):
+        out = super().authenticate(request)
+        if out is None:
+            return None
+        user, token = out
+        self._set_tenant_context(request, user)
+        return (user, token)

--- a/backend/apps/tenants/middleware.py
+++ b/backend/apps/tenants/middleware.py
@@ -92,11 +92,10 @@ class TenantMiddleware:
         # 1. FIRST: Try to get tenant from X-Tenant-ID header (explicit tenant selection)
         # This takes priority even for Global System Admins so they can switch tenants
         tenant_id = request.headers.get("X-Tenant-ID")
-        # IMPORTANT: Only trust header-based tenant selection when the user is already
-        # authenticated at the Django middleware layer (session auth). For JWT/Token,
-        # DRF authentication happens later; tenant selection + membership validation
-        # must be applied post-auth (see apps.tenants.authentication).
-        if tenant_id and request.user.is_authenticated:
+        # IMPORTANT: Header-based tenant selection is validated post-auth for JWT/Token
+        # requests (see apps.tenants.authentication). Middleware may still resolve
+        # request.tenant for routing and view-layer filtering.
+        if tenant_id:
             try:
                 tenant = Tenant.objects.get(id=tenant_id, is_active=True)
                 resolution_method = "X-Tenant-ID header"

--- a/backend/apps/tenants/middleware.py
+++ b/backend/apps/tenants/middleware.py
@@ -92,7 +92,11 @@ class TenantMiddleware:
         # 1. FIRST: Try to get tenant from X-Tenant-ID header (explicit tenant selection)
         # This takes priority even for Global System Admins so they can switch tenants
         tenant_id = request.headers.get("X-Tenant-ID")
-        if tenant_id:
+        # IMPORTANT: Only trust header-based tenant selection when the user is already
+        # authenticated at the Django middleware layer (session auth). For JWT/Token,
+        # DRF authentication happens later; tenant selection + membership validation
+        # must be applied post-auth (see apps.tenants.authentication).
+        if tenant_id and request.user.is_authenticated:
             try:
                 tenant = Tenant.objects.get(id=tenant_id, is_active=True)
                 resolution_method = "X-Tenant-ID header"
@@ -341,7 +345,7 @@ class TenantMiddleware:
             raise
         finally:
             # Prevent cross-request tenant leakage on pooled DB connections.
-            if rls_set:
+            if rls_set or getattr(request, '_rls_set', False):
                 try:
                     with connection.cursor() as cursor:
                         cursor.execute("RESET app.current_tenant_id")

--- a/backend/apps/tenants/test_isolation_api.py
+++ b/backend/apps/tenants/test_isolation_api.py
@@ -58,7 +58,8 @@ class TenantIsolationApiTests(APITestCase):
         # must still be scoped to the current request tenant context.
         TenantUser.objects.create(tenant=self.tenant_b, user=self.user_a, role='admin', is_active=True)
 
-        self.client.force_authenticate(user=self.user_a)
+        # Use session auth so TenantMiddleware can see an authenticated user and safely honor X-Tenant-ID.
+        self.client.force_login(self.user_a)
         self.tenant_header = {'HTTP_X_TENANT_ID': str(self.tenant_a.id)}
 
     def _assert_only_a(self, resp, a_marker: str, b_marker: str):

--- a/backend/apps/tenants/test_tenant_header_spoofing.py
+++ b/backend/apps/tenants/test_tenant_header_spoofing.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.suppliers.models import Supplier
+
+
+User = get_user_model()
+
+
+class TenantHeaderSpoofingTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+
+        self.tenant_a = Tenant.objects.create(
+            name=f'Tenant A {unique}',
+            slug=f'tenant-a-{unique}',
+            contact_email=f'a-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f'Tenant B {unique}',
+            slug=f'tenant-b-{unique}',
+            contact_email=f'b-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role='admin', is_active=True)
+        Supplier.objects.create(tenant=self.tenant_b, name='B only supplier')
+
+        access = RefreshToken.for_user(self.user).access_token
+        self.token = str(access)
+
+    def test_jwt_cannot_spoof_other_tenant_via_header(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f'Bearer {self.token}',
+            HTTP_X_TENANT_ID=str(self.tenant_b.id),
+        )
+        resp = self.client.get('/api/v1/suppliers/')
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_jwt_can_access_own_tenant(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f'Bearer {self.token}',
+            HTTP_X_TENANT_ID=str(self.tenant_a.id),
+        )
+        resp = self.client.get('/api/v1/suppliers/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)

--- a/backend/projectmeats/settings/base.py
+++ b/backend/projectmeats/settings/base.py
@@ -266,9 +266,9 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         # JWT Authentication (Wave S1: Security Hardening)
         # Short-lived access tokens with refresh token rotation
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "apps.tenants.authentication.TenantAwareJWTAuthentication",
         # Legacy token auth (for backward compatibility during migration)
-        "rest_framework.authentication.TokenAuthentication",
+        "apps.tenants.authentication.TenantAwareTokenAuthentication",
         "rest_framework.authentication.SessionAuthentication",  # For Studio and browsable API
     ],
     "DEFAULT_PERMISSION_CLASSES": [

--- a/backend/tenant_apps/workflows/tests_admin_api.py
+++ b/backend/tenant_apps/workflows/tests_admin_api.py
@@ -111,7 +111,8 @@ class AdminAPITests(APITestCase):
         )
     
     def setUp(self):
-        self.client.force_authenticate(user=self.admin_user)
+        # Use session auth so TenantMiddleware can safely honor X-Tenant-ID.
+        self.client.force_login(self.admin_user)
         self.client.credentials(HTTP_X_TENANT_ID=str(self.tenant.id))
     
     def test_get_available_entities_api(self):
@@ -389,7 +390,8 @@ class FieldConfigAPITests(APITestCase):
         )
     
     def setUp(self):
-        self.client.force_authenticate(user=self.admin_user)
+        # Use session auth so TenantMiddleware can safely honor X-Tenant-ID.
+        self.client.force_login(self.admin_user)
         self.client.credentials(HTTP_X_TENANT_ID=str(self.tenant.id))
     
     def test_get_field_config(self):
@@ -540,7 +542,8 @@ class FormRulesAPITests(APITestCase):
         )
     
     def setUp(self):
-        self.client.force_authenticate(user=self.admin_user)
+        # Use session auth so TenantMiddleware can safely honor X-Tenant-ID.
+        self.client.force_login(self.admin_user)
         self.client.credentials(HTTP_X_TENANT_ID=str(self.tenant.id))
     
     def test_get_form_rules_empty(self):
@@ -735,7 +738,8 @@ class FormStepsAPITests(APITestCase):
         )
     
     def setUp(self):
-        self.client.force_authenticate(user=self.admin_user)
+        # Use session auth so TenantMiddleware can safely honor X-Tenant-ID.
+        self.client.force_login(self.admin_user)
         self.client.credentials(HTTP_X_TENANT_ID=str(self.tenant.id))
     
     def test_get_form_steps(self):


### PR DESCRIPTION
## What
- Adds tenant-aware JWT/Token authentication that resolves tenant context **after** DRF authentication and validates TenantUser membership for `X-Tenant-ID` selection.
- Middleware now only honors `X-Tenant-ID` when user is already authenticated at middleware layer (session auth), preventing pre-auth header spoofing.
- Ensures Postgres RLS session vars are reset even when set during DRF auth.
- Adds regression test: JWT cannot spoof `X-Tenant-ID` for a tenant the user does not belong to.

## Why
Previously, `TenantMiddleware` could trust `X-Tenant-ID` before JWT/Token authentication ran, enabling cross-tenant data access for authenticated API callers.

## Testing
- `python manage.py test apps.tenants.test_isolation_api apps.tenants.test_tenant_header_spoofing --verbosity=2`
- `python manage.py makemigrations --check`

## Risk / Rollback
Medium (auth flow change). Rollback by reverting this PR to restore previous middleware-based header behavior (less secure).,mode:sync,initial_wait:180}