### PR TITLE
CI: add infrastructure drift gate to PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -22,6 +22,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  infrastructure-check:
+    name: Infrastructure Drift Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Verify golden pipeline invariants
+        run: bash .github/scripts/check_infrastructure.sh
+
   validate-migrations:
     name: Validate Migrations
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an Infrastructure Drift Gate job to PR Validation, running the existing Golden drift script (.github/scripts/check_infrastructure.sh) so we fail fast on pipeline/workflow invariant drift.

Local validation:
- bash .github/scripts/check_infrastructure.sh