### PR TITLE
Copilot Squad: harden validation + canonical manifest refs

### DIFF
--- a/.copilot/squad/roles/architect.md
+++ b/.copilot/squad/roles/architect.md
@@ -18,7 +18,7 @@ Protect ProjectMeats’ **non-negotiable invariants** (Golden Pipeline, Golden F
   - remote deployments using `docker-compose`
   - mutable image tags for production deploys (`:latest`)
   - migrations executed via SSH inside deployed containers
-  - guessed/implicit secret names (must follow `config/env.manifest.json`)
+  - guessed/implicit secret names (must follow `manifests/env.manifest.json`)
 - Must not accept “it should work” without evidence (commands run, logs, CI links).
 
 ## Communication style
@@ -34,7 +34,7 @@ Protect ProjectMeats’ **non-negotiable invariants** (Golden Pipeline, Golden F
 - `docs/GOLDEN_PIPELINE.md`
 - `docs/reference/GOLDEN_PIPELINE.md`
 - `manifests/GOLDEN_FILES.md`
-- `config/env.manifest.json`
+- `manifests/env.manifest.json`
 - `docs/architecture/ARCHITECTURE.md`
 
 ## Definition of Done

--- a/.copilot/squad/roles/devops-engineer.md
+++ b/.copilot/squad/roles/devops-engineer.md
@@ -14,7 +14,7 @@ Maintain **deployment reliability** and enforce Golden Pipeline practices across
 
 ## Constraints / Must-Nots
 - Must not log secrets.
-- Must not guess secret names; must use `config/env.manifest.json`.
+- Must not guess secret names; must use `manifests/env.manifest.json`.
 - Must not add “quick hacks” that violate golden rules.
 
 ## Communication style
@@ -28,7 +28,7 @@ Maintain **deployment reliability** and enforce Golden Pipeline practices across
 ## Required references
 - `docs/GOLDEN_PIPELINE.md`
 - `.github/instructions/workflows.instructions.md`
-- `config/env.manifest.json`
+- `manifests/env.manifest.json`
 - `manifests/GOLDEN_FILES.md`
 
 ## Definition of Done

--- a/.copilot/squad/squad.json
+++ b/.copilot/squad/squad.json
@@ -203,7 +203,7 @@
         "requires": ["devops-engineer", "architect"]
       },
       "secrets_and_manifest": {
-        "paths": ["config/env.manifest.json", "docs/CONFIGURATION_AND_SECRETS.md"],
+        "paths": ["manifests/env.manifest.json", "docs/CONFIGURATION_AND_SECRETS.md"],
         "requires": ["devops-engineer", "architect", "documentation-steward"]
       },
       "migrations": {

--- a/.copilot/squad/tasks/ci-cd-workflow-changes.md
+++ b/.copilot/squad/tasks/ci-cd-workflow-changes.md
@@ -21,7 +21,7 @@ Update GitHub Actions workflows without violating ProjectMeats’ **Golden Stand
    - parallel frontend/backend swimlanes
    - migrations are runner-driven and idempotent (`--fake-initial`)
 3. If secrets/env vars change:
-   - update `config/env.manifest.json`
+   - update `manifests/env.manifest.json`
    - never echo secrets
 4. Validate golden state:
    - `bash scripts/verify_golden_state.sh`

--- a/.copilot/squad/tasks/update-golden-files.md
+++ b/.copilot/squad/tasks/update-golden-files.md
@@ -20,7 +20,7 @@ Update authoritative registries so future work stays consistent and discoverable
    - script under `scripts/`
    - CI check (only if consistent with Golden Pipeline)
 4. If env vars/secrets changed:
-   - update `config/env.manifest.json` first
+   - update `manifests/env.manifest.json` first
    - run `python config/manage_env.py audit`
 
 ## Validation

--- a/.github/agents/projectmeats-devops-engineer.agent.md
+++ b/.github/agents/projectmeats-devops-engineer.agent.md
@@ -13,7 +13,7 @@ Your canonical role definition is in `@.copilot/squad/roles/devops-engineer.md`.
 - Immutable SHA tags.
 - Parallel swimlanes.
 - Runner-driven migrations with `--fake-initial`.
-- Secrets must match `@config/env.manifest.json` (never guess).
+- Secrets must match `@manifests/env.manifest.json` (never guess).
 
 ## Default workflow
 Use playbook: `@.copilot/squad/tasks/ci-cd-workflow-changes.md`

--- a/scripts/validate_copilot_squad.sh
+++ b/scripts/validate_copilot_squad.sh
@@ -27,8 +27,9 @@ require_dir .copilot/squad/tasks
 require_file .copilot/squad/squad.json
 python -m json.tool .copilot/squad/squad.json >/dev/null || fail "Invalid JSON: .copilot/squad/squad.json"
 
-# Semantic validation: ensure squad.json references are consistent and files exist.
+# Semantic validation: ensure squad.json references are consistent, correctly typed, and paths exist.
 python - <<'PY' || fail "Invalid squad.json references"
+import glob
 import json
 import os
 import re
@@ -46,6 +47,25 @@ def req_path(path: str | None, ctx: str) -> None:
     return
   if not os.path.exists(path):
     errors.append(f"Missing path for {ctx}: {path}")
+
+def list_of_str(value, ctx: str, *, allow_empty: bool = True) -> list[str]:
+  if value is None:
+    return []
+  if not isinstance(value, list):
+    errors.append(f"{ctx} must be an array of strings")
+    return []
+
+  out: list[str] = []
+  for i, item in enumerate(value):
+    if not isinstance(item, str) or not item.strip():
+      errors.append(f"{ctx}[{i}] must be a non-empty string")
+      continue
+    out.append(item)
+
+  if not allow_empty and not out:
+    errors.append(f"{ctx} must be a non-empty array")
+
+  return out
 
 ver = str(data.get('version', ''))
 if not re.match(r'^\d+\.\d+\.\d+$', ver):
@@ -91,6 +111,8 @@ for a in agents:
 if len(agent_ids) != len(set(agent_ids)):
   errors.append('Duplicate agent IDs found in squad.json')
 
+agent_set = set(agent_ids)
+
 task_ids: list[str] = []
 for t in tasks:
   if not isinstance(t, dict):
@@ -104,12 +126,21 @@ for t in tasks:
   req_path(t.get('playbook_file') if isinstance(t.get('playbook_file'), str) else None, f"task.{tid}.playbook_file")
 
   da = t.get('default_agent')
-  if isinstance(da, str) and da and da not in set(agent_ids):
+  if not isinstance(da, str) or not da:
+    errors.append(f"task.{tid}.default_agent must be a non-empty string")
+  elif da not in agent_set:
     errors.append(f"task.{tid}.default_agent references unknown agent: {da}")
 
-  for ra in (t.get('required_agents') or []):
-    if isinstance(ra, str) and ra not in set(agent_ids):
+  required_agents = list_of_str(t.get('required_agents'), f"task.{tid}.required_agents")
+  for ra in required_agents:
+    if ra not in agent_set:
       errors.append(f"task.{tid}.required_agents references unknown agent: {ra}")
+
+  required_checks = list_of_str(t.get('required_checks'), f"task.{tid}.required_checks")
+
+  risk = t.get('risk_level')
+  if risk not in ('low', 'medium', 'high'):
+    errors.append(f"task.{tid}.risk_level must be one of: low, medium, high")
 
   skill_id = t.get('skill_id')
   if isinstance(skill_id, str) and skill_id:
@@ -125,15 +156,52 @@ for a in agents:
   aid = a.get('id')
   if not isinstance(aid, str) or not aid:
     continue
-  for rt in (a.get('review_required_for') or []):
-    if isinstance(rt, str) and rt not in known_tasks:
+
+  review_required_for = list_of_str(a.get('review_required_for'), f"agent.{aid}.review_required_for")
+  for rt in review_required_for:
+    if rt not in known_tasks:
       errors.append(f"agent.{aid}.review_required_for references unknown task: {rt}")
+
+collab = data.get('collaboration') or {}
+if not isinstance(collab, dict):
+  errors.append('collaboration must be an object')
+else:
+  blocking = collab.get('blocking_rules') or {}
+  if not isinstance(blocking, dict):
+    errors.append('collaboration.blocking_rules must be an object')
+  else:
+    for rule_name, rule in blocking.items():
+      if not isinstance(rule, dict):
+        errors.append(f"collaboration.blocking_rules.{rule_name} must be an object")
+        continue
+
+      paths = list_of_str(rule.get('paths'), f"collaboration.blocking_rules.{rule_name}.paths", allow_empty=False)
+      requires = list_of_str(rule.get('requires'), f"collaboration.blocking_rules.{rule_name}.requires", allow_empty=False)
+
+      for req in requires:
+        if req not in agent_set:
+          errors.append(f"collaboration.blocking_rules.{rule_name}.requires references unknown agent: {req}")
+
+      for path in paths:
+        if any(ch in path for ch in ('*', '?', '[')):
+          if not glob.glob(path, recursive=True):
+            errors.append(f"collaboration.blocking_rules.{rule_name}.paths has no matches: {path}")
+        else:
+          if not os.path.exists(path):
+            errors.append(f"collaboration.blocking_rules.{rule_name}.paths missing path: {path}")
 
 if errors:
   for e in errors:
     print(f"ERROR: {e}", file=sys.stderr)
   raise SystemExit(1)
 PY
+
+# Enforce canonical env manifest reference inside squad-owned instructions.
+if [ -f manifests/env.manifest.json ] && [ ! -f config/env.manifest.json ]; then
+  legacy_refs=$(grep -RIn "config/env\.manifest\.json" .copilot/squad .github/agents || true)
+  [ -z "$legacy_refs" ] || fail "Legacy env manifest path referenced (use manifests/env.manifest.json):\n$legacy_refs"
+fi
+
 
 # role files
 for f in \


### PR DESCRIPTION
Strengthens scripts/validate_copilot_squad.sh to catch common config drift (wrong JSON types, invalid collaboration.blocking_rules), and fails if squad-owned docs/agents reference legacy config/env.manifest.json when manifests/env.manifest.json is canonical.

Validation:
- bash scripts/validate_copilot_squad.sh