### PR TITLE
Frontend: enforce service-layer network usage

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -141,9 +141,9 @@ jobs:
         working-directory: ./frontend
         run: npm ci
 
-      - name: Type check
+      - name: Verify frontend standards
         working-directory: ./frontend
-        run: npm run type-check
+        run: npm run verify-standards
 
   validate-copilot-squad:
     name: Validate Copilot Squad

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -77,4 +77,33 @@ export default [
       'react/self-closing-comp': 'warn',
     },
   },
+  {
+    // Service-layer guardrail: prevent direct network primitives in UI/hook code.
+    files: ['src/**/*.{js,jsx,ts,tsx}'],
+    ignores: ['src/services/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'axios',
+              message: 'Do not import axios directly outside src/services; use the service layer.',
+            },
+          ],
+        },
+      ],
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'fetch',
+          message: 'Do not use fetch() outside src/services; use the service layer.',
+        },
+        {
+          name: 'XMLHttpRequest',
+          message: 'Do not use XMLHttpRequest outside src/services; use the service layer.',
+        },
+      ],
+    },
+  },
 ];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,7 @@
     "serve": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "verify-standards": "npm run type-check && npm run lint:colors && echo '✅ Frontend standards verification passed'"
+    "verify-standards": "npm run type-check && npm run lint && npm run lint:colors && echo '✅ Frontend standards verification passed'"
   },
   "browserslist": {
     "production": [

--- a/frontend/src/pages/Settings/IntegrationSettings.tsx
+++ b/frontend/src/pages/Settings/IntegrationSettings.tsx
@@ -5,24 +5,10 @@ import React, { useState, useEffect } from 'react';
 import { Skeleton } from 'antd';
 import { AlertCircle, CheckCircle, Mail, ExternalLink } from 'lucide-react';
 import { confirmDialog } from '@/utils/uiDialogs';
-import { apiClient as axios } from '../../services/apiService';
-
-interface Connection {
-  provider: string;
-  provider_name: string;
-  connected_email: string;
-  connected_name: string;
-  is_expired: boolean;
-  connected_at: string;
-}
-
-interface ConnectionStatus {
-  connections: Connection[];
-  count: number;
-}
+import { integrationsService, type OAuthConnection } from '@/services/integrationsService';
 
 export const IntegrationSettings: React.FC = () => {
-  const [connections, setConnections] = useState<Connection[]>([]);
+  const [connections, setConnections] = useState<OAuthConnection[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -54,8 +40,8 @@ export const IntegrationSettings: React.FC = () => {
     setError(null);
 
     try {
-      const response = await axios.get<ConnectionStatus>('/integrations/oauth/status/');
-      setConnections(response.data.connections);
+      const data = await integrationsService.getOAuthConnectionStatus();
+      setConnections(data.connections);
     } catch (err: any) {
       setError(err.response?.data?.error || 'Failed to fetch connection status');
     } finally {
@@ -85,7 +71,7 @@ export const IntegrationSettings: React.FC = () => {
     setError(null);
 
     try {
-      await axios.post('/integrations/oauth/disconnect/', { provider });
+      await integrationsService.disconnectOAuth(provider);
       setSuccess('Email account disconnected successfully');
       fetchConnectionStatus();
     } catch (err: any) {
@@ -95,7 +81,7 @@ export const IntegrationSettings: React.FC = () => {
     }
   };
 
-  const getConnectionForProvider = (provider: string): Connection | undefined => {
+  const getConnectionForProvider = (provider: string): OAuthConnection | undefined => {
     return connections.find(conn => conn.provider === provider);
   };
 
@@ -191,7 +177,7 @@ interface EmailProviderCardProps {
   name: string;
   description: string;
   icon: React.ReactNode;
-  connection?: Connection;
+  connection?: OAuthConnection;
   onConnect: () => void;
   onDisconnect: () => void;
   isDisconnecting: boolean;

--- a/frontend/src/services/integrationsService.ts
+++ b/frontend/src/services/integrationsService.ts
@@ -1,0 +1,26 @@
+import { apiClient } from './apiService';
+
+export interface OAuthConnection {
+  provider: string;
+  provider_name: string;
+  connected_email: string;
+  connected_name: string;
+  is_expired: boolean;
+  connected_at: string;
+}
+
+export interface OAuthConnectionStatus {
+  connections: OAuthConnection[];
+  count: number;
+}
+
+export const integrationsService = {
+  async getOAuthConnectionStatus(): Promise<OAuthConnectionStatus> {
+    const response = await apiClient.get<OAuthConnectionStatus>('/integrations/oauth/status/');
+    return response.data;
+  },
+
+  async disconnectOAuth(provider: string): Promise<void> {
+    await apiClient.post('/integrations/oauth/disconnect/', { provider });
+  },
+};


### PR DESCRIPTION
Guardrails:
- ESLint: forbid axios/fetch/XMLHttpRequest outside frontend/src/services
- verify-standards now runs type-check + lint + lint:colors
- PR Validation runs verify-standards

Refactor:
- IntegrationSettings uses new integrationsService (no apiClient alias)

Validation:
- npm --prefix frontend run verify-standards