### PR TITLE
Chore: validate-workflows cleanup + stricter notifications script

### DIFF
--- a/.github/scripts/deployment-notifications.sh
+++ b/.github/scripts/deployment-notifications.sh
@@ -2,18 +2,26 @@
 # Deployment notification script
 # Usage: deployment-notifications.sh <environment> <status> <component> <message>
 
-ENVIRONMENT=$1
-STATUS=$2
-COMPONENT=$3
-MESSAGE=$4
+set -euo pipefail
+
+ENVIRONMENT="${1:-}"
+STATUS="${2:-}"
+COMPONENT="${3:-}"
+MESSAGE="${4:-}"
+
+if [ -z "$ENVIRONMENT" ] || [ -z "$STATUS" ] || [ -z "$COMPONENT" ] || [ -z "$MESSAGE" ]; then
+  echo "❌ ERROR: Missing required arguments"
+  echo "Usage: $0 <environment> <status> <component> <message>"
+  exit 1
+fi
 
 echo "==================================="
 echo "Deployment Notification"
 echo "==================================="
-echo "Environment: $ENVIRONMENT"
-echo "Status: $STATUS"
-echo "Component: $COMPONENT"
-echo "Message: $MESSAGE"
+echo "Environment: ${ENVIRONMENT}"
+echo "Status: ${STATUS}"
+echo "Component: ${COMPONENT}"
+echo "Message: ${MESSAGE}"
 echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
 echo "==================================="
 

--- a/.github/scripts/validate-workflows.sh
+++ b/.github/scripts/validate-workflows.sh
@@ -179,11 +179,11 @@ check_fetch_depth() {
     local issues=0
     
     for workflow in "${workflows[@]}"; do
-        # Check if using checkout action
-        if grep -q "actions/checkout@v4" "$workflow"; then
-            # Check if fetch-depth is set
-            if ! grep -A 3 "actions/checkout@v4" "$workflow" | grep -q "fetch-depth"; then
-                log_warn "No fetch-depth set in $workflow (will use default full history)"
+        # Check if using checkout action (any version)
+        if grep -qE "actions/checkout@" "$workflow"; then
+            # Check if fetch-depth is set near checkout steps
+            if ! grep -A 6 -E "actions/checkout@" "$workflow" | grep -q "fetch-depth"; then
+                log_warn "No fetch-depth set in $workflow (will use default history depth)"
                 ((issues++))
             fi
         fi
@@ -204,7 +204,7 @@ check_error_handling() {
     
     for script in "${scripts[@]}"; do
         if [[ -f "$script" ]]; then
-            if ! head -5 "$script" | grep -q "set -euo pipefail"; then
+            if ! grep -q "set -euo pipefail" "$script"; then
                 log_warn "Missing 'set -euo pipefail' in $script"
             else
                 log_info "✓ $script has error handling"


### PR DESCRIPTION
Cleanup PR (Part 2 overhaul):
- validate-workflows.sh: check set -euo pipefail anywhere in scripts (reduces false warnings)
- validate-workflows.sh: detect actions/checkout@* (v6) for fetch-depth warnings
- deployment-notifications.sh: add set -euo pipefail + argument validation

Validation:
- bash .github/scripts/validate-workflows.sh
- bash .github/scripts/check_infrastructure.sh