### PR TITLE
CI: harden ops management workflow secret mapping

### DIFF
--- a/.github/workflows/99-ops-management-command.yml
+++ b/.github/workflows/99-ops-management-command.yml
@@ -91,10 +91,11 @@ jobs:
           DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
           DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
           # Core Django settings
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          # Prefer canonical env.manifest.json names; allow legacy fallback for safety.
+          SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY || secrets.SECRET_KEY }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
-          # Database configuration
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # Database configuration (optional; DB_* vars are the primary interface)
+          DATABASE_URL: ${{ secrets.DATABASE_URL || '' }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_USER: ${{ secrets.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}


### PR DESCRIPTION
Ops workflow hardening:
- Prefer secrets.DJANGO_SECRET_KEY for SECRET_KEY injection (legacy fallback to secrets.SECRET_KEY)
- Make DATABASE_URL optional (DB_* remains primary)

Validation:
- python -c 'import yaml; yaml.safe_load(open(.github/workflows/99-ops-management-command.yml))'
- bash .github/scripts/check_infrastructure.sh