### PR TITLE
CI: set checkout fetch-depth on workflows

### DIFF
--- a/.github/workflows/98-ops-db-surgery.yml
+++ b/.github/workflows/98-ops-db-surgery.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/99-ops-management-command.yml
+++ b/.github/workflows/99-ops-management-command.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/db-sync-prod-to-uat.yml
+++ b/.github/workflows/db-sync-prod-to-uat.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -146,6 +146,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Adds fetch-depth: 1 to actions/checkout steps in active workflows to reduce checkout time and align with validate-workflows.sh expectations.

Validation:
- bash .github/scripts/validate-workflows.sh
- bash .github/scripts/check_infrastructure.sh