### PR TITLE
WorkForms: fix QuickActions load + catalog/execute for non-admin

### DIFF
--- a/backend/apps/system/workform_views.py
+++ b/backend/apps/system/workform_views.py
@@ -226,7 +226,7 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
         )
 
     def _can_manage_workform(self, workform: TenantWorkForm) -> bool:
-        """Only allow delete/execute for superusers, tenant admins, or the creator."""
+        """Only allow destructive/manage operations for superusers, tenant admins, or the creator."""
         request = self.request
         user = getattr(request, 'user', None)
         if not user or not getattr(user, 'is_authenticated', False):
@@ -250,6 +250,30 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
         except Exception:
             return False
 
+    def _can_execute_workform(self, workform: TenantWorkForm) -> bool:
+        """Allow execution for any active tenant member (plus creator/superuser)."""
+        request = self.request
+        user = getattr(request, 'user', None)
+        if not user or not getattr(user, 'is_authenticated', False):
+            return False
+
+        if getattr(user, 'is_superuser', False):
+            return True
+
+        if workform.created_by_id == user.id:
+            return True
+
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return False
+
+        try:
+            from apps.tenants.models import TenantUser
+
+            return TenantUser.objects.filter(user=user, tenant=tenant, is_active=True).exists()
+        except Exception:
+            return False
+
     def destroy(self, request, *args, **kwargs):
         workform = self.get_object()
         if not self._can_manage_workform(workform):
@@ -260,7 +284,7 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
     def execute(self, request, pk=None):
         """Execute a TenantWorkForm and create a persisted execution record."""
         workform = self.get_object()
-        if not self._can_manage_workform(workform):
+        if not self._can_execute_workform(workform):
             return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
 
         initial_data = request.data.get('initial_data') if isinstance(request.data, dict) else None

--- a/frontend/src/contexts/QuickActionsContext.test.tsx
+++ b/frontend/src/contexts/QuickActionsContext.test.tsx
@@ -177,21 +177,27 @@ describe('QuickActionsContext', () => {
       expect(screen.getByTestId('actions-count')).toHaveTextContent('2');
     });
 
-    it('should not load when not authenticated', async () => {
-      localStorageMock = {}; // No JWT or legacy token
-      
+    it('should treat 401/403 as logged-out state (no error)', async () => {
+      localStorageMock = {}; // No JWT or legacy token (cookie-auth may still exist in real app)
+
+      vi.mocked(quickActionsService.getQuickActions).mockRejectedValue({ response: { status: 401 } } as any);
+      vi.mocked(quickActionsService.getAvailableForms).mockRejectedValue({ response: { status: 401 } } as any);
+      vi.mocked(getAvailableWorkForms).mockRejectedValue({ response: { status: 401 } } as any);
+
       render(
         <QuickActionsProvider>
           <TestConsumer />
         </QuickActionsProvider>
       );
-      
+
       await waitFor(() => {
         expect(screen.getByTestId('loading')).toHaveTextContent('ready');
       });
-      
-      expect(quickActionsService.getQuickActions).not.toHaveBeenCalled();
+
+      expect(quickActionsService.getQuickActions).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('error')).toHaveTextContent('none');
       expect(screen.getByTestId('actions-count')).toHaveTextContent('0');
+      expect(screen.getByTestId('forms-count')).toHaveTextContent('0');
     });
 
     it('should handle load error gracefully', async () => {

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -6,7 +6,6 @@
  */
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import { getAvailableWorkForms } from '@/services/workformsApi';
-import { getAccessToken } from '@/services/jwtService';
 import { showAlert } from '@/utils/uiDialogs';
 import {
   quickActionsService,
@@ -72,15 +71,33 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
 
   // Load quick actions on mount
   const refreshQuickActions = useCallback(async () => {
+    const isAuthError = (err: any) => {
+      const status = err?.response?.status;
+      return status === 401 || status === 403;
+    };
+
     try {
       setIsLoading(true);
       setError(null);
-      
+
       const [actionsResult, formsResult, workformsResult] = await Promise.allSettled([
         quickActionsService.getQuickActions(),
         quickActionsService.getAvailableForms(),
         getAvailableWorkForms(),
       ]);
+
+      const authFailure = [actionsResult, formsResult, workformsResult].some(
+        (r) => r.status === 'rejected' && isAuthError(r.reason)
+      );
+
+      // Important: support cookie-auth sessions (no localStorage token). If the user is not authenticated,
+      // the API will 401/403. Treat that as a normal "logged out" state rather than surfacing an error.
+      if (authFailure) {
+        setQuickActions([]);
+        setAvailableForms([]);
+        setError(null);
+        return;
+      }
 
       if (actionsResult.status === 'rejected') {
         const msg = actionsResult.reason?.message || 'Failed to load quick actions';
@@ -150,13 +167,8 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
   }, []);
 
   useEffect(() => {
-    // Only load if user is authenticated (JWT or legacy token)
-    const token = getAccessToken();
-    if (token) {
-      refreshQuickActions();
-    } else {
-      setIsLoading(false);
-    }
+    // Always attempt to load: supports cookie-auth sessions (no localStorage token).
+    refreshQuickActions();
   }, [refreshQuickActions]);
 
   const updateQuickActions = useCallback(async (items: QuickActionItem[]) => {

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -50,7 +50,7 @@ import { createFormSubmission, getAvailableWorkForms } from '../../services/work
 import { deleteWorkflow } from '../../components/FlowEditor/utils/workflowPersistence';
 import { useQuickActions } from '../../contexts/QuickActionsContext';
 import { Popconfirm } from 'antd';
-import { listTenantForms as listLegacyTenantForms } from '../../services/tenantFormService';
+import { quickActionsService } from '@/services/quickActionsService';
 import { useWorkFormPermissions, getUpgradeMessage } from '../../hooks/useWorkFormPermissions';
 
 // ============================================================================
@@ -588,7 +588,7 @@ const FormsFlowsCatalog: React.FC = () => {
 
       const [workformsResult, legacyFormsResult] = await Promise.allSettled([
         getAvailableWorkForms(),
-        listLegacyTenantForms(),
+        quickActionsService.getAvailableForms(),
       ]);
 
       const workforms = workformsResult.status === 'fulfilled' ? workformsResult.value : [];

--- a/frontend/src/pages/WorkForms/Execute.tsx
+++ b/frontend/src/pages/WorkForms/Execute.tsx
@@ -9,18 +9,8 @@ import React, { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Skeleton } from 'antd';
-import { apiClient } from '@/services/apiService';
 import { showAlert } from '@/utils/uiDialogs';
-
-interface ExecuteResponse {
-  id: string;
-  workform_id: string;
-  workform_name: string;
-  status: string;
-  started_at?: string;
-  completed_at?: string;
-  error_message?: string;
-}
+import { executeTenantWorkForm, type WorkFormExecuteResponse } from '@/services/workformsApi';
 
 export const ExecuteWorkForm: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -30,12 +20,27 @@ export const ExecuteWorkForm: React.FC = () => {
   const mutation = useMutation({
     mutationFn: async () => {
       if (!id) throw new Error('Missing workform id');
-      const response = await apiClient.post<ExecuteResponse>(`/tenant-workforms/${id}/execute/`, {
-        initial_data: {},
-      });
-      return response.data;
+
+      let initialData: Record<string, unknown> = {};
+      try {
+        const raw = sessionStorage.getItem('pm.activeRecordContext');
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          const activeRecord = parsed?.activeRecord;
+          if (activeRecord?.type && activeRecord?.id != null) {
+            initialData = {
+              entity_type: String(activeRecord.type),
+              entity_id: String(activeRecord.id),
+            };
+          }
+        }
+      } catch {
+        // Ignore malformed session payload
+      }
+
+      return executeTenantWorkForm(id, initialData);
     },
-    onSuccess: async (data) => {
+    onSuccess: async (data: WorkFormExecuteResponse) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['workforms-catalog-items'] }),
         queryClient.invalidateQueries({ queryKey: ['workform-executions', 'active'] }),

--- a/frontend/src/services/workformsApi.ts
+++ b/frontend/src/services/workformsApi.ts
@@ -166,6 +166,26 @@ export const createFormSubmission = async (formId: string): Promise<FormSubmissi
   return response.data;
 };
 
+export interface WorkFormExecuteResponse {
+  id: string;
+  workform_id: string;
+  workform_name: string;
+  status: string;
+  started_at?: string;
+  completed_at?: string | null;
+  error_message?: string;
+}
+
+export const executeTenantWorkForm = async (
+  workformId: string,
+  initialData?: Record<string, unknown>
+): Promise<WorkFormExecuteResponse> => {
+  const response = await apiClient.post(`/tenant-workforms/${workformId}/execute/`, {
+    initial_data: initialData ?? {},
+  });
+  return response.data;
+};
+
 // ============================================================================
 // Entity APIs (Phase 1.1-1.3)
 // ============================================================================


### PR DESCRIPTION
- Fix QuickActions to load under cookie-auth (treat 401/403 as logged-out)
- Catalog now uses user-facing available forms endpoint (no admin-only client)
- Execute uses service-layer API + includes active record context in initial_data
- Backend: allow any active tenant member to execute a TenantWorkForm

Testing:
- frontend: npm run verify-standards; npm run test:ci -- QuickActionsContext.test.tsx
- backend: python manage.py makemigrations --check; python manage.py test apps.system
