### PR TITLE
Docs: update MASTER_PLAN type-check status

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -45,7 +45,7 @@ We are re-validating and completing the last ~25 prompts with **evidence-based a
 ## Reality Snapshot (as of 2026-03-26)
 
 ### What is actively in progress
-- **Type-check hardening:** `pr-golden-sweep-typecheck` (tracked in SQL session todos)
+- **Type-check status:** currently clean (`npm -C frontend run type-check`); keep as a hard gate and only relax with evidence.
 
 ### Recently shipped fixes (evidence)
 - Cockpit Favorites: backend persistence + optimistic UX + RLS policy — PR #4037


### PR DESCRIPTION
Replaces stale type-check hardening note with current verified status (type-check clean) while keeping it as a hard gate.