### PR TITLE
feat(workforms): surface execution runtime metadata

### DIFF
--- a/backend/tenant_apps/workflows/serializers.py
+++ b/backend/tenant_apps/workflows/serializers.py
@@ -4,6 +4,8 @@ Serializers for Tenant Workflows API.
 Bundle Two: System → Tenant Workflows & New Data Entities
 Provides REST API serialization for Forms, Workflows, and Lists.
 """
+from typing import Any, Dict, List
+
 from rest_framework import serializers
 
 from .models import (
@@ -411,6 +413,12 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
     # WorkForms runtime: expose a compact per-node status map derived from audit_trail
     node_statuses = serializers.SerializerMethodField()
 
+    # WorkForms runtime: surface "where am I" + error summary for UI panels.
+    current_node_id = serializers.SerializerMethodField()
+    current_node_type = serializers.SerializerMethodField()
+    last_event = serializers.SerializerMethodField()
+    errors = serializers.SerializerMethodField()
+
     class Meta:
         model = TenantWorkFormExecution
         fields = [
@@ -423,6 +431,10 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
             'context_data',
             'audit_trail',
             'node_statuses',
+            'current_node_id',
+            'current_node_type',
+            'last_event',
+            'errors',
             'started_by',
             'started_by_name',
             'started_at',
@@ -437,6 +449,75 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
         if obj.started_by:
             return obj.started_by.get_full_name() or obj.started_by.username
         return None
+
+    def _last_node_event(self, obj):
+        trail = obj.audit_trail
+        if not isinstance(trail, list):
+            return None
+
+        for row in reversed(trail):
+            if isinstance(row, dict) and row.get('node_id'):
+                return row
+
+        return None
+
+    def get_current_node_id(self, obj):
+        row = self._last_node_event(obj)
+        return row.get('node_id') if isinstance(row, dict) else None
+
+    def get_current_node_type(self, obj):
+        row = self._last_node_event(obj)
+        return row.get('node_type') if isinstance(row, dict) else None
+
+    def get_last_event(self, obj):
+        row = self._last_node_event(obj)
+        return row.get('event') if isinstance(row, dict) else None
+
+    def get_errors(self, obj):
+        """Return a compact list of errors recorded during execution.
+
+        Sources:
+        - context_data.errors (WorkFormEngine routing payloads)
+        - audit_trail action_error events (fallback)
+        """
+        errors: List[Dict[str, Any]] = []
+
+        ctx = obj.context_data
+        if isinstance(ctx, dict):
+            ctx_errors = ctx.get('errors')
+            if isinstance(ctx_errors, list):
+                for row in ctx_errors:
+                    if isinstance(row, dict) and row.get('error'):
+                        errors.append(row)
+
+        trail = obj.audit_trail
+        if isinstance(trail, list):
+            for row in trail:
+                if not isinstance(row, dict):
+                    continue
+                if row.get('event') != 'action_error':
+                    continue
+                if not row.get('error'):
+                    continue
+                errors.append({
+                    'node_id': row.get('node_id'),
+                    'node_type': row.get('node_type'),
+                    'error': row.get('error'),
+                    'routed_to': row.get('routed_to'),
+                    'ts': row.get('ts'),
+                })
+
+        # Dedupe while preserving order
+        seen = set()
+        unique = []
+        for row in errors:
+            key = (row.get('node_id'), row.get('error'), row.get('ts'))
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(row)
+
+        return unique
 
     def get_node_statuses(self, obj):
         """Return a per-node status map derived from the execution audit trail.
@@ -470,6 +551,104 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
                 status_by_node[node_id] = 'in_progress'
 
         return status_by_node
+
+
+class TenantWorkFormExecutionRuntimeStateSerializer(serializers.ModelSerializer):
+    """Slim runtime projection for TenantWorkFormExecution.
+
+    Goal: allow frontend to render runtime state (current node, node statuses,
+    errors) without returning full `context_data` or `audit_trail` blobs.
+
+    This is additive; existing list/retrieve endpoints still use
+    TenantWorkFormExecutionSerializer.
+    """
+
+    workform_name = serializers.CharField(source='workform.name', read_only=True)
+    started_by_name = serializers.SerializerMethodField()
+
+    node_statuses = serializers.SerializerMethodField()
+    current_node = serializers.SerializerMethodField()
+    errors = serializers.SerializerMethodField()
+
+    entity_ref = serializers.SerializerMethodField()
+
+    class Meta:
+        model = TenantWorkFormExecution
+        fields = [
+            'id',
+            'workform',
+            'workform_name',
+            'status',
+            'entity_ref',
+            'node_statuses',
+            'current_node',
+            'errors',
+            'started_by',
+            'started_by_name',
+            'started_at',
+            'completed_at',
+            'error_message',
+            'created_on',
+            'modified_on',
+        ]
+        read_only_fields = fields
+
+    def get_started_by_name(self, obj):
+        if obj.started_by:
+            return obj.started_by.get_full_name() or obj.started_by.username
+        return None
+
+    def get_entity_ref(self, obj):
+        initial = obj.initial_data or {}
+        if not isinstance(initial, dict):
+            return {}
+
+        # Allowlist only.
+        out = {}
+        for key in ('entity_type', 'entity_id', 'submission_id', 'form_submission_id'):
+            if key in initial:
+                out[key] = initial.get(key)
+
+        # Normalize common variants.
+        if 'form_submission_id' in out and 'submission_id' not in out:
+            out['submission_id'] = out['form_submission_id']
+
+        return out
+
+    def get_node_statuses(self, obj):
+        # Delegate to the full serializer logic.
+        return TenantWorkFormExecutionSerializer(obj, context=self.context).get_node_statuses(obj)
+
+    def get_errors(self, obj):
+        return TenantWorkFormExecutionSerializer(obj, context=self.context).get_errors(obj)
+
+    def get_current_node(self, obj):
+        node_id = TenantWorkFormExecutionSerializer(obj, context=self.context).get_current_node_id(obj)
+        if not node_id:
+            return None
+
+        node_type = None
+        label = None
+
+        definition = getattr(getattr(obj, 'workform', None), 'workflow_definition', None) or {}
+        nodes = definition.get('nodes', []) if isinstance(definition, dict) else []
+
+        if isinstance(nodes, list):
+            for n in nodes:
+                if isinstance(n, dict) and n.get('id') == node_id:
+                    node_type = n.get('type')
+                    data = n.get('data') if isinstance(n.get('data'), dict) else {}
+                    label = data.get('label') or data.get('containerName') or data.get('name')
+                    break
+
+        statuses = self.get_node_statuses(obj)
+
+        return {
+            'node_id': node_id,
+            'node_type': node_type,
+            'label': label,
+            'status': statuses.get(node_id),
+        }
 
 
 # =============================================================================

--- a/backend/tenant_apps/workflows/tests/test_workform_execution_viewset_filters.py
+++ b/backend/tenant_apps/workflows/tests/test_workform_execution_viewset_filters.py
@@ -110,6 +110,12 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
         row = next(r for r in rows if r.get('id') == str(self.exec_a_1.id))
         self.assertEqual(row.get('node_statuses', {}).get('n1'), 'completed')
 
+        # Runtime metadata helpers
+        self.assertEqual(row.get('current_node_id'), 'n1')
+        self.assertEqual(row.get('current_node_type'), 'actionEmail')
+        self.assertEqual(row.get('last_event'), 'action_success')
+        self.assertEqual(row.get('errors'), [])
+
     def test_filters_by_workform_id(self):
         req = self._get(
             f'/api/v1/workflows/workform-executions/?workform={self.workform_a.id}',

--- a/frontend/src/components/Entities/EntityWorkflowStatusPanel.test.tsx
+++ b/frontend/src/components/Entities/EntityWorkflowStatusPanel.test.tsx
@@ -49,6 +49,10 @@ describe('EntityWorkflowStatusPanel', () => {
           context_data: {},
           audit_trail: [{ event: 'execution_start', node_id: 'n1', ts: '2026-01-01T00:00:00Z' }],
           node_statuses: { n1: 'completed' },
+          current_node_id: 'n1',
+          current_node_type: 'actionEmail',
+          last_event: 'execution_start',
+          errors: [{ node_id: 'n1', error: 'Boom' }],
           started_by: null,
           started_by_name: 'Tester',
           started_at: '2026-01-01T00:00:00Z',
@@ -79,6 +83,8 @@ describe('EntityWorkflowStatusPanel', () => {
 
     // Expand collapse to show audit
     await userEvent.click(screen.getByText('My WorkForm'));
+    expect(await screen.findByText(/Current step/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 error/i)).toBeInTheDocument();
     expect(await screen.findByText(/Step status/i)).toBeInTheDocument();
     const pills = screen.getAllByText((_, node) =>
       (node?.textContent ?? '').replace(/\s+/g, ' ').trim() === 'n1: completed'

--- a/frontend/src/components/Entities/EntityWorkflowStatusPanel.tsx
+++ b/frontend/src/components/Entities/EntityWorkflowStatusPanel.tsx
@@ -119,6 +119,18 @@ export const EntityWorkflowStatusPanel: React.FC<EntityWorkflowStatusPanelProps>
                     <div style={{ color: 'rgb(var(--color-error))' }}>{ex.error_message}</div>
                   ) : null}
 
+                  <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
+                    Current step:{' '}
+                    <span style={{ fontWeight: 600 }}>{ex.current_node_id ?? '—'}</span>
+                    {ex.current_node_type ? <span> • {ex.current_node_type}</span> : null}
+                  </div>
+
+                  {ex.errors && ex.errors.length > 0 ? (
+                    <div style={{ color: 'rgb(var(--color-error))' }}>
+                      {ex.errors.length} error{ex.errors.length === 1 ? '' : 's'}
+                    </div>
+                  ) : null}
+
                   {renderNodeStatuses(ex)}
 
                   <div>{renderAudit(ex)}</div>

--- a/frontend/src/pages/WorkForms/ExecutionDetails.test.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { WorkFormExecutionDetails } from './ExecutionDetails';
+import { workformExecutionService } from '@/services/workformExecutionService';
+
+vi.mock('@/services/workformExecutionService', () => ({
+  workformExecutionService: {
+    getExecution: vi.fn(),
+  },
+}));
+
+describe('WorkFormExecutionDetails', () => {
+  it('renders current step, inputs, and errors when present', async () => {
+    vi.mocked(workformExecutionService.getExecution).mockResolvedValueOnce({
+      id: 'ex-1',
+      tenant: 't1',
+      workform: 'wf-1',
+      workform_name: 'My WorkForm',
+      status: 'failed',
+      initial_data: { entity_type: 'customer', entity_id: '1' },
+      context_data: {},
+      audit_trail: [],
+      node_statuses: {},
+      current_node_id: 'n1',
+      current_node_type: 'actionEmail',
+      last_event: 'action_error',
+      errors: [{ node_id: 'n1', error: 'Boom' }],
+      started_by: null,
+      started_by_name: null,
+      started_at: null,
+      completed_at: null,
+      error_message: 'Boom',
+      created_on: '2026-01-01T00:00:00Z',
+      modified_on: '2026-01-01T00:00:01Z',
+    } as any);
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/workforms/executions/ex-1']}>
+          <Routes>
+            <Route path="/workforms/executions/:id" element={<WorkFormExecutionDetails />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText('My WorkForm')).toBeInTheDocument();
+    expect(screen.getByText(/Status:/i)).toBeInTheDocument();
+
+    expect(await screen.findByText(/Current step/i)).toBeInTheDocument();
+    expect(screen.getByText(/Node:/i)).toBeInTheDocument();
+    expect(screen.getAllByText('n1').length).toBeGreaterThan(0);
+
+    expect(await screen.findByText(/Inputs/i)).toBeInTheDocument();
+    expect(screen.getByText(/entity_type/i)).toBeInTheDocument();
+
+    expect(await screen.findByText(/Errors/i)).toBeInTheDocument();
+    expect(screen.getAllByText('Boom').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/pages/WorkForms/ExecutionDetails.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.tsx
@@ -56,6 +56,50 @@ export const WorkFormExecutionDetails: React.FC = () => {
             ) : null}
 
             <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 12 }}>
+              <div>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Current step</div>
+                {execution.current_node_id ? (
+                  <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
+                    Node: <span style={{ fontWeight: 600 }}>{execution.current_node_id}</span>
+                    {execution.current_node_type ? <span> • {execution.current_node_type}</span> : null}
+                    {execution.last_event ? <span> • last: {execution.last_event}</span> : null}
+                  </div>
+                ) : (
+                  <div style={{ color: 'rgb(var(--color-text-secondary))' }}>No active node recorded.</div>
+                )}
+              </div>
+
+              {execution.errors && execution.errors.length > 0 ? (
+                <div>
+                  <div style={{ fontWeight: 600, marginBottom: 6 }}>Errors</div>
+                  <ul style={{ margin: 0, paddingLeft: 18 }}>
+                    {execution.errors.map((e, idx) => (
+                      <li key={`${execution.id}:err:${idx}`} style={{ color: 'rgb(var(--color-error))' }}>
+                        {e.node_id ? <span style={{ fontWeight: 600 }}>{e.node_id}</span> : null}
+                        {e.node_id ? <span>: </span> : null}
+                        {e.error}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              <div>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Inputs</div>
+                <pre
+                  style={{
+                    background: 'rgb(var(--color-surface))',
+                    border: '1px solid rgb(var(--color-border))',
+                    borderRadius: 8,
+                    padding: 12,
+                    overflow: 'auto',
+                    maxHeight: 240,
+                  }}
+                >
+                  {JSON.stringify(execution.initial_data ?? {}, null, 2)}
+                </pre>
+              </div>
+
               {execution.node_statuses && Object.keys(execution.node_statuses).length > 0 ? (
                 <div>
                   <div style={{ fontWeight: 600, marginBottom: 6 }}>Step status</div>

--- a/frontend/src/services/workformExecutionService.ts
+++ b/frontend/src/services/workformExecutionService.ts
@@ -23,6 +23,12 @@ export interface WorkFormExecution {
    * Keys are node IDs, values are statuses like "completed" / "failed" / "in_progress".
    */
   node_statuses?: Record<string, string>;
+  /** Backend-derived "where am I" pointer for UI surfaces. */
+  current_node_id?: string | null;
+  current_node_type?: string | null;
+  last_event?: string | null;
+  /** Compact list of errors recorded during execution (if any). */
+  errors?: Array<{ node_id?: string; node_type?: string; error: string; routed_to?: string; ts?: string }>;
   started_by?: string | null;
   started_by_name?: string | null;
   started_at?: string | null;


### PR DESCRIPTION
Improves WorkForms runtime visibility on entity records + execution detail pages.

Backend:
- Add derived execution fields: current_node_id/current_node_type/last_event/errors (from audit_trail + context_data)

Frontend:
- Render Current step + Errors + Inputs in WorkForm Execution Details
- Render Current step + error count in Entity Workflow Status panel

Tests:
- backend: tenant_apps.workflows.tests.test_workform_execution_viewset_filters
- frontend: EntityWorkflowStatusPanel + ExecutionDetails (vitest)
