### PR TITLE
test(tenancy): extend ViewSet tenant audit coverage

### DIFF
--- a/backend/apps/tenants/test_viewset_tenant_filter_audit.py
+++ b/backend/apps/tenants/test_viewset_tenant_filter_audit.py
@@ -33,6 +33,10 @@ TENANT_APP_URL_MODULES = [
     'tenant_apps.workflows.urls',
     'tenant_apps.bug_reports.urls',
     'tenant_apps.integrations.urls',
+    # Coverage gaps (historical): include apps that register tenant-scoped resources.
+    'tenant_apps.ai_assistant.urls',
+    'tenant_apps.cockpit.urls',
+    'tenant_apps.products.urls',
 ]
 
 


### PR DESCRIPTION
Extends the static tenant-safety guardrail to include additional tenant app routers.

Change:
- Add ai_assistant, cockpit, and products URL modules to apps.tenants.test_viewset_tenant_filter_audit so tenant-scoped ViewSets can’t rely on unsafe default get_queryset.

Validation:
- python backend/manage.py test apps.tenants.test_viewset_tenant_filter_audit