### PR TITLE
ci: pin Trivy action and fix promotion triggers

### DIFF
--- a/.github/scripts/validate-workflows.sh
+++ b/.github/scripts/validate-workflows.sh
@@ -320,6 +320,83 @@ check_concurrency() {
     return 0
 }
 
+# Check for floating action refs (supply chain)
+check_no_floating_action_refs() {
+    log_info "Checking for floating action refs (no @master/@main/@HEAD)..."
+
+    local workflows=(.github/workflows/*.yml .github/workflows/*.yaml)
+    local failed=0
+
+    for workflow in "${workflows[@]}"; do
+        [[ -f "$workflow" ]] || continue
+        if grep -nE "^\s*uses:\s+[^\s]+@(master|main|HEAD)\b" "$workflow" >/dev/null; then
+            log_error "Floating action ref found in $workflow"
+            grep -nE "^\s*uses:\s+[^\s]+@(master|main|HEAD)\b" "$workflow" || true
+            ((failed++))
+        fi
+    done
+
+    if [[ $failed -gt 0 ]]; then
+        log_error "Found $failed workflow(s) with floating action refs"
+        return 1
+    fi
+
+    log_info "✓ No floating action refs detected"
+    return 0
+}
+
+# Check workflow_run targets exist (promotion reliability)
+check_workflow_run_targets_exist() {
+    log_info "Checking workflow_run referenced workflow names exist..."
+
+    if ! python - <<'PY'
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except Exception as e:
+    print(f"ERROR: pyyaml not available: {e}", file=sys.stderr)
+    raise SystemExit(1)
+
+wf_dir = Path('.github/workflows')
+workflow_files = sorted([p for p in wf_dir.glob('*.yml')] + [p for p in wf_dir.glob('*.yaml')])
+
+names = set()
+for p in workflow_files:
+    data = yaml.safe_load(p.read_text(encoding='utf-8', errors='ignore')) or {}
+    name = data.get('name')
+    if isinstance(name, str) and name.strip():
+        names.add(name.strip())
+
+errors = []
+for p in workflow_files:
+    data = yaml.safe_load(p.read_text(encoding='utf-8', errors='ignore')) or {}
+    on = data.get('on') or {}
+    wr = on.get('workflow_run') if isinstance(on, dict) else None
+    if not isinstance(wr, dict):
+        continue
+    targets = wr.get('workflows')
+    if not isinstance(targets, list):
+        continue
+    for t in targets:
+        if isinstance(t, str) and t.strip() and t.strip() not in names:
+            errors.append(f"{p.name}: workflow_run references missing workflow name: {t}")
+
+if errors:
+    for e in errors:
+        print(f"ERROR: {e}", file=sys.stderr)
+    raise SystemExit(1)
+
+print('✓ All workflow_run targets exist')
+PY
+    then
+        return 1
+    fi
+
+    return 0
+}
+
 # Check for environment-specific configurations
 check_env_separation() {
     log_info "Checking environment separation..."
@@ -354,6 +431,8 @@ main() {
     check_retry_logic || ((failed++))
     check_migration_safety || ((failed++))
     check_concurrency || ((failed++))
+    check_no_floating_action_refs || ((failed++))
+    check_workflow_run_targets_exist || ((failed++))
     check_env_separation || ((failed++))
     
     log_info "========================================="

--- a/.github/workflows/41-auto-promote-dev-to-uat.yml
+++ b/.github/workflows/41-auto-promote-dev-to-uat.yml
@@ -9,7 +9,7 @@ run-name: >-
 
 on:
   workflow_run:
-    workflows: ["Master Pipeline"]
+    workflows: ["🚀 Deploy: Dev/UAT/Prod (Frontend + Backend via Golden Pipeline)"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/42-auto-promote-uat-to-main.yml
+++ b/.github/workflows/42-auto-promote-uat-to-main.yml
@@ -9,7 +9,7 @@ run-name: >-
 
 on:
   workflow_run:
-    workflows: ["Master Pipeline"]
+    workflows: ["🚀 Deploy: Dev/UAT/Prod (Frontend + Backend via Golden Pipeline)"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -264,7 +264,7 @@ jobs:
       # Trivy's SARIF mode may include all severities, which can incorrectly fail the job
       # even when CRITICAL/HIGH are 0. We enforce severity thresholds in a separate step.
       - name: Run Trivy vulnerability scanner (SARIF)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
           format: 'sarif'
@@ -279,7 +279,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.DO_ACCESS_TOKEN }}
 
       - name: Enforce Trivy severity gate (CRITICAL,HIGH)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
           format: 'table'
@@ -295,7 +295,7 @@ jobs:
 
       - name: Trivy summary (table)
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
           format: 'table'
@@ -469,7 +469,7 @@ jobs:
     steps:
       # SARIF generation should not gate deployments (see backend scan notes).
       - name: Run Trivy vulnerability scanner (SARIF)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
           format: 'sarif'
@@ -484,7 +484,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.DO_ACCESS_TOKEN }}
 
       - name: Enforce Trivy severity gate (CRITICAL,HIGH)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
           format: 'table'
@@ -500,7 +500,7 @@ jobs:
 
       - name: Trivy summary (table)
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ inputs.environment }}-${{ github.sha }}
           format: 'table'


### PR DESCRIPTION
Supply-chain + promotion reliability hardening.

Changes:
- Pin aquasecurity/trivy-action to immutable SHA (replaces @master)
- Fix auto-promotion workflows to target the real deploy workflow name
- Add workflow validator guardrails:
  - fail on floating refs (@master/@main/@HEAD)
  - fail if workflow_run references a missing workflow name

Validation:
- bash .github/scripts/validate-workflows.sh
- bash scripts/verify_golden_state.sh
