### PR TITLE
feat(workforms): improve execution runtime visibility

### DIFF
--- a/backend/tenant_apps/workflows/serializers.py
+++ b/backend/tenant_apps/workflows/serializers.py
@@ -416,8 +416,12 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
     # WorkForms runtime: surface "where am I" + error summary for UI panels.
     current_node_id = serializers.SerializerMethodField()
     current_node_type = serializers.SerializerMethodField()
+    current_node_label = serializers.SerializerMethodField()
     last_event = serializers.SerializerMethodField()
     errors = serializers.SerializerMethodField()
+
+    # UI helper: map node_id -> label from the underlying WorkForm definition
+    node_labels = serializers.SerializerMethodField()
 
     class Meta:
         model = TenantWorkFormExecution
@@ -431,8 +435,10 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
             'context_data',
             'audit_trail',
             'node_statuses',
+            'node_labels',
             'current_node_id',
             'current_node_type',
+            'current_node_label',
             'last_event',
             'errors',
             'started_by',
@@ -450,6 +456,54 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
             return obj.started_by.get_full_name() or obj.started_by.username
         return None
 
+    def _workflow_definition_nodes(self, obj) -> List[Dict[str, Any]]:
+        definition = getattr(getattr(obj, 'workform', None), 'workflow_definition', None) or {}
+        if not isinstance(definition, dict):
+            return []
+
+        nodes = definition.get('nodes', [])
+        return nodes if isinstance(nodes, list) else []
+
+    def _node_labels_map(self, obj) -> Dict[str, str]:
+        """Map of node_id -> label (best-effort) from workform.workflow_definition."""
+        cache = getattr(self, '_node_labels_cache', None)
+        if cache is None:
+            cache = {}
+            setattr(self, '_node_labels_cache', cache)
+
+        key = str(getattr(obj, 'pk', '') or '')
+        if key in cache:
+            return cache[key]
+
+        mapping: Dict[str, str] = {}
+        for node in self._workflow_definition_nodes(obj):
+            if not isinstance(node, dict):
+                continue
+            node_id = node.get('id')
+            if not node_id:
+                continue
+
+            data = node.get('data') if isinstance(node.get('data'), dict) else {}
+            label = (
+                data.get('label')
+                or data.get('name')
+                or data.get('containerName')
+                or node.get('label')
+                or node.get('name')
+            )
+            if isinstance(label, str):
+                label = label.strip()
+            if label:
+                mapping[str(node_id)] = str(label)
+
+        cache[key] = mapping
+        return mapping
+
+    def _node_label(self, obj, node_id: str | None) -> str | None:
+        if not node_id:
+            return None
+        return self._node_labels_map(obj).get(str(node_id))
+
     def _last_node_event(self, obj):
         trail = obj.audit_trail
         if not isinstance(trail, list):
@@ -461,6 +515,7 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
 
         return None
 
+
     def get_current_node_id(self, obj):
         row = self._last_node_event(obj)
         return row.get('node_id') if isinstance(row, dict) else None
@@ -468,6 +523,14 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
     def get_current_node_type(self, obj):
         row = self._last_node_event(obj)
         return row.get('node_type') if isinstance(row, dict) else None
+
+    def get_current_node_label(self, obj):
+        node_id = self.get_current_node_id(obj)
+        return self._node_label(obj, node_id)
+
+    def get_node_labels(self, obj):
+        return self._node_labels_map(obj)
+
 
     def get_last_event(self, obj):
         row = self._last_node_event(obj)
@@ -479,8 +542,13 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
         Sources:
         - context_data.errors (WorkFormEngine routing payloads)
         - audit_trail action_error events (fallback)
+
+        Additive enrichment:
+        - node_label from workform.workflow_definition.nodes[].data.*
         """
         errors: List[Dict[str, Any]] = []
+
+        labels = self._node_labels_map(obj)
 
         ctx = obj.context_data
         if isinstance(ctx, dict):
@@ -488,7 +556,11 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
             if isinstance(ctx_errors, list):
                 for row in ctx_errors:
                     if isinstance(row, dict) and row.get('error'):
-                        errors.append(row)
+                        cloned = dict(row)
+                        node_id = cloned.get('node_id')
+                        if node_id:
+                            cloned.setdefault('node_label', labels.get(str(node_id)))
+                        errors.append(cloned)
 
         trail = obj.audit_trail
         if isinstance(trail, list):
@@ -499,9 +571,11 @@ class TenantWorkFormExecutionSerializer(serializers.ModelSerializer):
                     continue
                 if not row.get('error'):
                     continue
+                node_id = row.get('node_id')
                 errors.append({
-                    'node_id': row.get('node_id'),
+                    'node_id': node_id,
                     'node_type': row.get('node_type'),
+                    'node_label': labels.get(str(node_id)) if node_id else None,
                     'error': row.get('error'),
                     'routed_to': row.get('routed_to'),
                     'ts': row.get('ts'),
@@ -568,6 +642,8 @@ class TenantWorkFormExecutionRuntimeStateSerializer(serializers.ModelSerializer)
 
     node_statuses = serializers.SerializerMethodField()
     current_node = serializers.SerializerMethodField()
+    current_node_label = serializers.SerializerMethodField()
+    node_labels = serializers.SerializerMethodField()
     errors = serializers.SerializerMethodField()
 
     entity_ref = serializers.SerializerMethodField()
@@ -582,6 +658,8 @@ class TenantWorkFormExecutionRuntimeStateSerializer(serializers.ModelSerializer)
             'entity_ref',
             'node_statuses',
             'current_node',
+            'current_node_label',
+            'node_labels',
             'errors',
             'started_by',
             'started_by_name',
@@ -615,30 +693,36 @@ class TenantWorkFormExecutionRuntimeStateSerializer(serializers.ModelSerializer)
 
         return out
 
+    def _full(self, obj) -> TenantWorkFormExecutionSerializer:
+        return TenantWorkFormExecutionSerializer(obj, context=self.context)
+
     def get_node_statuses(self, obj):
         # Delegate to the full serializer logic.
-        return TenantWorkFormExecutionSerializer(obj, context=self.context).get_node_statuses(obj)
+        return self._full(obj).get_node_statuses(obj)
+
+    def get_node_labels(self, obj):
+        return self._full(obj).get_node_labels(obj)
 
     def get_errors(self, obj):
-        return TenantWorkFormExecutionSerializer(obj, context=self.context).get_errors(obj)
+        return self._full(obj).get_errors(obj)
+
+    def get_current_node_label(self, obj):
+        return self._full(obj).get_current_node_label(obj)
 
     def get_current_node(self, obj):
-        node_id = TenantWorkFormExecutionSerializer(obj, context=self.context).get_current_node_id(obj)
+        node_id = self._full(obj).get_current_node_id(obj)
         if not node_id:
             return None
 
         node_type = None
-        label = None
+        label = self.get_node_labels(obj).get(str(node_id))
 
         definition = getattr(getattr(obj, 'workform', None), 'workflow_definition', None) or {}
         nodes = definition.get('nodes', []) if isinstance(definition, dict) else []
-
         if isinstance(nodes, list):
             for n in nodes:
                 if isinstance(n, dict) and n.get('id') == node_id:
                     node_type = n.get('type')
-                    data = n.get('data') if isinstance(n.get('data'), dict) else {}
-                    label = data.get('label') or data.get('containerName') or data.get('name')
                     break
 
         statuses = self.get_node_statuses(obj)

--- a/backend/tenant_apps/workflows/tests/test_workform_execution_viewset_filters.py
+++ b/backend/tenant_apps/workflows/tests/test_workform_execution_viewset_filters.py
@@ -37,10 +37,18 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
         TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role='admin', is_active=True)
         TenantUser.objects.create(tenant=self.tenant_b, user=self.user, role='admin', is_active=True)
 
+        definition = {
+            'nodes': [
+                {'id': 't1', 'type': 'triggerManual', 'data': {'label': 'Manual Trigger'}},
+                {'id': 'n1', 'type': 'actionEmail', 'data': {'label': 'Send Email'}},
+            ],
+            'edges': [],
+        }
+
         self.workform_a = TenantWorkForm.objects.create(
             tenant=self.tenant_a,
             name='WF A',
-            workflow_definition={'nodes': [{'id': 't1', 'type': 'triggerManual'}], 'edges': []},
+            workflow_definition=definition,
             status='active',
             created_by=self.user,
             updated_by=self.user,
@@ -48,7 +56,7 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
         self.workform_b = TenantWorkForm.objects.create(
             tenant=self.tenant_b,
             name='WF B',
-            workflow_definition={'nodes': [{'id': 't1', 'type': 'triggerManual'}], 'edges': []},
+            workflow_definition=definition,
             status='active',
             created_by=self.user,
             updated_by=self.user,
@@ -77,6 +85,19 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
             workform=self.workform_b,
             status='completed',
             initial_data={'entity_type': 'customer', 'entity_id': '1'},
+            started_by=self.user,
+        )
+
+        self.exec_a_err = TenantWorkFormExecution.objects.create(
+            tenant=self.tenant_a,
+            workform=self.workform_a,
+            status='failed',
+            initial_data={'entity_type': 'customer', 'entity_id': '99'},
+            context_data={
+                'errors': [
+                    {'node_id': 'n1', 'node_type': 'actionEmail', 'error': 'Boom'},
+                ]
+            },
             started_by=self.user,
         )
 
@@ -113,8 +134,27 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
         # Runtime metadata helpers
         self.assertEqual(row.get('current_node_id'), 'n1')
         self.assertEqual(row.get('current_node_type'), 'actionEmail')
+        self.assertEqual(row.get('current_node_label'), 'Send Email')
+        self.assertEqual(row.get('node_labels', {}).get('n1'), 'Send Email')
         self.assertEqual(row.get('last_event'), 'action_success')
         self.assertEqual(row.get('errors'), [])
+
+    def test_errors_include_node_label(self):
+        req = self._get(
+            '/api/v1/workflows/workform-executions/?entity_type=customer&entity_id=99',
+            self.tenant_a,
+        )
+        resp = TenantWorkFormExecutionViewSet.as_view({'get': 'list'})(req)
+        self.assertEqual(resp.status_code, 200)
+
+        rows = self._items(resp)
+        ids = {row.get('id') for row in rows}
+        self.assertIn(str(self.exec_a_err.id), ids)
+        self.assertNotIn(str(self.exec_b_1.id), ids)
+
+        row = next(r for r in rows if r.get('id') == str(self.exec_a_err.id))
+        self.assertEqual(row.get('errors')[0].get('node_id'), 'n1')
+        self.assertEqual(row.get('errors')[0].get('node_label'), 'Send Email')
 
     def test_filters_by_workform_id(self):
         req = self._get(

--- a/frontend/src/components/Entities/EntityWorkflowStatusPanel.test.tsx
+++ b/frontend/src/components/Entities/EntityWorkflowStatusPanel.test.tsx
@@ -49,8 +49,10 @@ describe('EntityWorkflowStatusPanel', () => {
           context_data: {},
           audit_trail: [{ event: 'execution_start', node_id: 'n1', ts: '2026-01-01T00:00:00Z' }],
           node_statuses: { n1: 'completed' },
+          node_labels: { n1: 'Send Email' },
           current_node_id: 'n1',
           current_node_type: 'actionEmail',
+          current_node_label: 'Send Email',
           last_event: 'execution_start',
           errors: [{ node_id: 'n1', error: 'Boom' }],
           started_by: null,
@@ -87,7 +89,7 @@ describe('EntityWorkflowStatusPanel', () => {
     expect(screen.getByText(/1 error/i)).toBeInTheDocument();
     expect(await screen.findByText(/Step status/i)).toBeInTheDocument();
     const pills = screen.getAllByText((_, node) =>
-      (node?.textContent ?? '').replace(/\s+/g, ' ').trim() === 'n1: completed'
+      (node?.textContent ?? '').replace(/\s+/g, ' ').trim() === 'Send Email (n1): completed'
     );
     expect(pills.length).toBeGreaterThan(0);
 

--- a/frontend/src/components/Entities/EntityWorkflowStatusPanel.tsx
+++ b/frontend/src/components/Entities/EntityWorkflowStatusPanel.tsx
@@ -40,27 +40,44 @@ export const EntityWorkflowStatusPanel: React.FC<EntityWorkflowStatusPanelProps>
     const entries = Object.entries(map).filter(([k, v]) => Boolean(k) && Boolean(v));
     if (entries.length === 0) return null;
 
-    entries.sort(([a], [b]) => a.localeCompare(b));
+    const labels = execution.node_labels ?? {};
+
+    entries.sort(([a], [b]) => {
+      const la = labels[a] ?? a;
+      const lb = labels[b] ?? b;
+      return la.localeCompare(lb);
+    });
 
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
         <div style={{ fontWeight: 600 }}>Step status</div>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-          {entries.map(([nodeId, status]) => (
-            <span
-              key={`${execution.id}:node:${nodeId}`}
-              style={{
-                border: '1px solid rgb(var(--color-border))',
-                background: 'rgb(var(--color-surface))',
-                borderRadius: 999,
-                padding: '2px 8px',
-                fontSize: 12,
-                color: 'rgb(var(--color-text-secondary))',
-              }}
-            >
-              {nodeId}: <span style={{ fontWeight: 600 }}>{String(status)}</span>
-            </span>
-          ))}
+          {entries.map(([nodeId, status]) => {
+            const label = labels[nodeId];
+            return (
+              <span
+                key={`${execution.id}:node:${nodeId}`}
+                style={{
+                  border: '1px solid rgb(var(--color-border))',
+                  background: 'rgb(var(--color-surface))',
+                  borderRadius: 999,
+                  padding: '2px 8px',
+                  fontSize: 12,
+                  color: 'rgb(var(--color-text-secondary))',
+                }}
+              >
+                {label ? (
+                  <>
+                    {label}{' '}
+                    <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>({nodeId})</span>
+                  </>
+                ) : (
+                  nodeId
+                )}
+                : <span style={{ fontWeight: 600 }}>{String(status)}</span>
+              </span>
+            );
+          })}
         </div>
       </div>
     );
@@ -121,7 +138,10 @@ export const EntityWorkflowStatusPanel: React.FC<EntityWorkflowStatusPanelProps>
 
                   <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
                     Current step:{' '}
-                    <span style={{ fontWeight: 600 }}>{ex.current_node_id ?? '—'}</span>
+                    <span style={{ fontWeight: 600 }}>{ex.current_node_label ?? ex.current_node_id ?? '—'}</span>
+                    {ex.current_node_label && ex.current_node_id ? (
+                      <span style={{ color: 'rgb(var(--color-text-tertiary))' }}> ({ex.current_node_id})</span>
+                    ) : null}
                     {ex.current_node_type ? <span> • {ex.current_node_type}</span> : null}
                   </div>
 

--- a/frontend/src/pages/WorkForms/ExecutionDetails.test.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -25,10 +26,12 @@ describe('WorkFormExecutionDetails', () => {
       context_data: {},
       audit_trail: [],
       node_statuses: {},
+      node_labels: { n1: 'Send Email' },
       current_node_id: 'n1',
       current_node_type: 'actionEmail',
+      current_node_label: 'Send Email',
       last_event: 'action_error',
-      errors: [{ node_id: 'n1', error: 'Boom' }],
+      errors: [{ node_id: 'n1', node_label: 'Send Email', error: 'Boom' }],
       started_by: null,
       started_by_name: null,
       started_at: null,
@@ -57,14 +60,16 @@ describe('WorkFormExecutionDetails', () => {
     expect(await screen.findByText('My WorkForm')).toBeInTheDocument();
     expect(screen.getByText(/Status:/i)).toBeInTheDocument();
 
-    expect(await screen.findByText(/Current step/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^Current step$/i)).toBeInTheDocument();
     expect(screen.getByText(/Node:/i)).toBeInTheDocument();
-    expect(screen.getAllByText('n1').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Send Email').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/n1/i).length).toBeGreaterThan(0);
 
-    expect(await screen.findByText(/Inputs/i)).toBeInTheDocument();
-    expect(screen.getByText(/entity_type/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^Inputs$/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByText(/View raw inputs/i));
+    expect(await screen.findByText(/entity_type/i)).toBeInTheDocument();
 
-    expect(await screen.findByText(/Errors/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^Errors$/i)).toBeInTheDocument();
     expect(screen.getAllByText('Boom').length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/pages/WorkForms/ExecutionDetails.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.tsx
@@ -9,6 +9,7 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { PageContainer } from '@/components/ui/PageContainer';
 import { workformExecutionService } from '@/services/workformExecutionService';
+import { formSubmissionService } from '@/services/quickActionsService';
 
 export const WorkFormExecutionDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -24,6 +25,25 @@ export const WorkFormExecutionDetails: React.FC = () => {
   });
 
   const execution = query.data;
+
+  const submissionId = React.useMemo(() => {
+    const initial = execution?.initial_data;
+    if (!initial || typeof initial !== 'object') return null;
+
+    const rec = initial as Record<string, unknown>;
+    const raw = (rec.submission_id ?? rec.form_submission_id) as unknown;
+    return typeof raw === 'string' && raw.trim() ? raw : null;
+  }, [execution]);
+
+  const submissionQuery = useQuery({
+    queryKey: ['form-submission', submissionId],
+    queryFn: async () => {
+      if (!submissionId) throw new Error('Missing submission id');
+      return formSubmissionService.get(submissionId);
+    },
+    enabled: Boolean(submissionId),
+    retry: false,
+  });
 
   return (
     <PageContainer title="Workflow Execution">
@@ -60,7 +80,13 @@ export const WorkFormExecutionDetails: React.FC = () => {
                 <div style={{ fontWeight: 600, marginBottom: 6 }}>Current step</div>
                 {execution.current_node_id ? (
                   <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
-                    Node: <span style={{ fontWeight: 600 }}>{execution.current_node_id}</span>
+                    Node:{' '}
+                    <span style={{ fontWeight: 600 }}>
+                      {execution.current_node_label ?? execution.current_node_id}
+                    </span>
+                    {execution.current_node_label ? (
+                      <span style={{ color: 'rgb(var(--color-text-tertiary))' }}> ({execution.current_node_id})</span>
+                    ) : null}
                     {execution.current_node_type ? <span> • {execution.current_node_type}</span> : null}
                     {execution.last_event ? <span> • last: {execution.last_event}</span> : null}
                   </div>
@@ -75,8 +101,13 @@ export const WorkFormExecutionDetails: React.FC = () => {
                   <ul style={{ margin: 0, paddingLeft: 18 }}>
                     {execution.errors.map((e, idx) => (
                       <li key={`${execution.id}:err:${idx}`} style={{ color: 'rgb(var(--color-error))' }}>
-                        {e.node_id ? <span style={{ fontWeight: 600 }}>{e.node_id}</span> : null}
-                        {e.node_id ? <span>: </span> : null}
+                        {e.node_label || e.node_id ? (
+                          <span style={{ fontWeight: 600 }}>{e.node_label ?? e.node_id}</span>
+                        ) : null}
+                        {e.node_label && e.node_id ? (
+                          <span style={{ color: 'rgb(var(--color-text-tertiary))' }}> ({e.node_id})</span>
+                        ) : null}
+                        {e.node_label || e.node_id ? <span>: </span> : null}
                         {e.error}
                       </li>
                     ))}
@@ -84,25 +115,78 @@ export const WorkFormExecutionDetails: React.FC = () => {
                 </div>
               ) : null}
 
+              {submissionId ? (
+                <div>
+                  <div style={{ fontWeight: 600, marginBottom: 6 }}>Form state</div>
+                  {submissionQuery.isLoading ? (
+                    <div style={{ color: 'rgb(var(--color-text-secondary))' }}>Loading form submission…</div>
+                  ) : submissionQuery.isError || !submissionQuery.data ? (
+                    <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
+                      No form submission details found for submission_id={submissionId}.
+                    </div>
+                  ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
+                        Submission status: <span style={{ fontWeight: 600 }}>{submissionQuery.data.status}</span>
+                        {submissionQuery.data.current_step_name ? (
+                          <>
+                            {' '}• Current step: <span style={{ fontWeight: 600 }}>{submissionQuery.data.current_step_name}</span>
+                          </>
+                        ) : null}
+                      </div>
+
+                      {Array.isArray(submissionQuery.data.step_submissions) && submissionQuery.data.step_submissions.length > 0 ? (
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                          {submissionQuery.data.step_submissions
+                            .slice()
+                            .sort((a, b) => (a.step_order ?? 0) - (b.step_order ?? 0))
+                            .map((step) => (
+                              <div key={step.id} style={{ color: 'rgb(var(--color-text-secondary))' }}>
+                                <span style={{ fontWeight: 600 }}>{step.step_name}</span>: {step.status}
+                              </div>
+                            ))}
+                        </div>
+                      ) : null}
+
+                      <details>
+                        <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
+                          View raw submission data
+                        </summary>
+                        <pre
+                          style={{
+                            background: 'rgb(var(--color-surface))',
+                            border: '1px solid rgb(var(--color-border))',
+                            borderRadius: 8,
+                            padding: 12,
+                            overflow: 'auto',
+                            maxHeight: 240,
+                            marginTop: 8,
+                          }}
+                        >
+                          {JSON.stringify(
+                            {
+                              data: submissionQuery.data.data,
+                              step_submissions: submissionQuery.data.step_submissions,
+                            },
+                            null,
+                            2
+                          )}
+                        </pre>
+                      </details>
+                    </div>
+                  )}
+                </div>
+              ) : null}
+
               <div>
                 <div style={{ fontWeight: 600, marginBottom: 6 }}>Inputs</div>
-                <pre
-                  style={{
-                    background: 'rgb(var(--color-surface))',
-                    border: '1px solid rgb(var(--color-border))',
-                    borderRadius: 8,
-                    padding: 12,
-                    overflow: 'auto',
-                    maxHeight: 240,
-                  }}
-                >
-                  {JSON.stringify(execution.initial_data ?? {}, null, 2)}
-                </pre>
-              </div>
-
-              {execution.node_statuses && Object.keys(execution.node_statuses).length > 0 ? (
-                <div>
-                  <div style={{ fontWeight: 600, marginBottom: 6 }}>Step status</div>
+                <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
+                  {execution.initial_data && typeof execution.initial_data === 'object'
+                    ? `${Object.keys(execution.initial_data).length} key(s)`
+                    : 'No inputs captured.'}
+                </div>
+                <details style={{ marginTop: 8 }}>
+                  <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>View raw inputs</summary>
                   <pre
                     style={{
                       background: 'rgb(var(--color-surface))',
@@ -111,32 +195,66 @@ export const WorkFormExecutionDetails: React.FC = () => {
                       padding: 12,
                       overflow: 'auto',
                       maxHeight: 240,
+                      marginTop: 8,
                     }}
                   >
-                    {JSON.stringify(execution.node_statuses, null, 2)}
+                    {JSON.stringify(execution.initial_data ?? {}, null, 2)}
                   </pre>
+                </details>
+              </div>
+
+              {execution.node_statuses && Object.keys(execution.node_statuses).length > 0 ? (
+                <div>
+                  <div style={{ fontWeight: 600, marginBottom: 6 }}>Step status</div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    {Object.entries(execution.node_statuses)
+                      .filter(([k, v]) => Boolean(k) && Boolean(v))
+                      .sort(([a], [b]) => {
+                        const la = execution.node_labels?.[a] ?? a;
+                        const lb = execution.node_labels?.[b] ?? b;
+                        return la.localeCompare(lb);
+                      })
+                      .map(([nodeId, status]) => (
+                        <div key={`${execution.id}:status:${nodeId}`} style={{ color: 'rgb(var(--color-text-secondary))' }}>
+                          <span style={{ fontWeight: 600 }}>{execution.node_labels?.[nodeId] ?? nodeId}</span>
+                          {execution.node_labels?.[nodeId] ? (
+                            <span style={{ color: 'rgb(var(--color-text-tertiary))' }}> ({nodeId})</span>
+                          ) : null}
+                          : <span style={{ fontWeight: 600 }}>{String(status)}</span>
+                        </div>
+                      ))}
+                  </div>
+
+                  <details style={{ marginTop: 8 }}>
+                    <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
+                      View raw status map
+                    </summary>
+                    <pre
+                      style={{
+                        background: 'rgb(var(--color-surface))',
+                        border: '1px solid rgb(var(--color-border))',
+                        borderRadius: 8,
+                        padding: 12,
+                        overflow: 'auto',
+                        maxHeight: 240,
+                        marginTop: 8,
+                      }}
+                    >
+                      {JSON.stringify(execution.node_statuses, null, 2)}
+                    </pre>
+                  </details>
                 </div>
               ) : null}
 
               <div>
                 <div style={{ fontWeight: 600, marginBottom: 6 }}>Context</div>
-                <pre
-                  style={{
-                    background: 'rgb(var(--color-surface))',
-                    border: '1px solid rgb(var(--color-border))',
-                    borderRadius: 8,
-                    padding: 12,
-                    overflow: 'auto',
-                    maxHeight: 360,
-                  }}
-                >
-                  {JSON.stringify(execution.context_data ?? {}, null, 2)}
-                </pre>
-              </div>
-
-              <div>
-                <div style={{ fontWeight: 600, marginBottom: 6 }}>Audit Trail</div>
-                {Array.isArray(execution.audit_trail) && execution.audit_trail.length > 0 ? (
+                <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
+                  Use this for debugging; most UI panels should rely on derived fields (current step, errors, status).
+                </div>
+                <details style={{ marginTop: 8 }}>
+                  <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
+                    View raw context
+                  </summary>
                   <pre
                     style={{
                       background: 'rgb(var(--color-surface))',
@@ -145,10 +263,35 @@ export const WorkFormExecutionDetails: React.FC = () => {
                       padding: 12,
                       overflow: 'auto',
                       maxHeight: 360,
+                      marginTop: 8,
                     }}
                   >
-                    {JSON.stringify(execution.audit_trail, null, 2)}
+                    {JSON.stringify(execution.context_data ?? {}, null, 2)}
                   </pre>
+                </details>
+              </div>
+
+              <div>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Audit Trail</div>
+                {Array.isArray(execution.audit_trail) && execution.audit_trail.length > 0 ? (
+                  <details>
+                    <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
+                      View raw audit trail ({execution.audit_trail.length} event(s))
+                    </summary>
+                    <pre
+                      style={{
+                        background: 'rgb(var(--color-surface))',
+                        border: '1px solid rgb(var(--color-border))',
+                        borderRadius: 8,
+                        padding: 12,
+                        overflow: 'auto',
+                        maxHeight: 360,
+                        marginTop: 8,
+                      }}
+                    >
+                      {JSON.stringify(execution.audit_trail, null, 2)}
+                    </pre>
+                  </details>
                 ) : (
                   <div style={{ color: 'rgb(var(--color-text-secondary))' }}>No audit entries yet.</div>
                 )}

--- a/frontend/src/services/workformExecutionService.ts
+++ b/frontend/src/services/workformExecutionService.ts
@@ -23,12 +23,22 @@ export interface WorkFormExecution {
    * Keys are node IDs, values are statuses like "completed" / "failed" / "in_progress".
    */
   node_statuses?: Record<string, string>;
+  /** Node label map derived from the WorkForm definition (node_id -> label). */
+  node_labels?: Record<string, string>;
   /** Backend-derived "where am I" pointer for UI surfaces. */
   current_node_id?: string | null;
   current_node_type?: string | null;
+  current_node_label?: string | null;
   last_event?: string | null;
   /** Compact list of errors recorded during execution (if any). */
-  errors?: Array<{ node_id?: string; node_type?: string; error: string; routed_to?: string; ts?: string }>;
+  errors?: Array<{
+    node_id?: string;
+    node_type?: string;
+    node_label?: string | null;
+    error: string;
+    routed_to?: string;
+    ts?: string;
+  }>;
   started_by?: string | null;
   started_by_name?: string | null;
   started_at?: string | null;


### PR DESCRIPTION
## Deliverables\n- Backend: add node_labels + current_node_label to TenantWorkFormExecutionSerializer; enrich errors with node_label when possible\n- Frontend: display step labels (not only node IDs) on WorkForms Execution Details + entity workflow panel\n- Frontend: when execution initial_data includes submission_id/form_submission_id, fetch and show related FormSubmission state summary\n- UX: keep raw JSON behind <details> toggles so operators get friendly summaries first\n\n## Testing\n- backend: python manage.py test tenant_apps.workflows.tests.test_workform_execution_viewset_filters\n- frontend: npm test -- --run\n\n## Risk / rollback\nAdditive-only serializer fields + UI fallbacks; revert PR to rollback.