### PR TITLE
feat(obs): integration readiness signals

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -4,18 +4,24 @@ run-name: >-
   ${{
     github.event_name == 'workflow_dispatch'
       && format(
-        '🛠️ Deploy: {0} — manual (run#{1}) by {2}',
-        inputs.environment,
-        github.run_number,
-        github.actor
+        '🛠️ Deploy: {0} — manual on {1} ({2}) by {3} (run#{4})',
+        inputs.environment == 'development' && 'Dev'
+          || inputs.environment == 'uat' && 'UAT'
+          || inputs.environment == 'production' && 'Prod'
+          || inputs.environment,
+        github.ref_name,
+        github.sha,
+        github.actor,
+        github.run_number
       )
       || format(
-        '🚀 Deploy: {0} — {1} (run#{2})',
+        '🚀 Deploy: {0} — {1} ({2}) (run#{3})',
         github.ref_name == 'development' && 'Dev'
           || github.ref_name == 'uat' && 'UAT'
           || github.ref_name == 'main' && 'Prod'
           || github.ref_name,
-        github.event.head_commit && github.event.head_commit.message || github.sha,
+        github.ref_name,
+        github.sha,
         github.run_number
       )
   }}

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -1282,6 +1282,11 @@ jobs:
             docker logs pm-backend --tail 100
             exit 1
           fi
+
+          echo ""
+          echo "=== Integration diagnostics (non-secret) ==="
+          docker exec pm-backend python -c "import json,urllib.request; data=json.load(urllib.request.urlopen('http://127.0.0.1:8000/api/v1/health/', timeout=10)); summary=data.get('integration_summary',{}); warnings=data.get('integration_warnings',[]); print('integration_summary:'); print(json.dumps(summary, indent=2, sort_keys=True)); print(''); print('integration_warnings:' if warnings else 'No integration warnings.'); [print(f\"- {(w or {}).get('code')}: {(w or {}).get('message')}\") for w in warnings]"
+          echo "=== End integration diagnostics ==="
           
           # Verify EMAIL_HOST_PASSWORD in container
           echo "Verifying EMAIL_HOST_PASSWORD in container..."

--- a/backend/apps/core/tests/test_health.py
+++ b/backend/apps/core/tests/test_health.py
@@ -27,6 +27,15 @@ class HealthCheckTests(TestCase):
         self.assertIsInstance(data['database_status'], dict)
         self.assertIn('service_summary', data)
 
+        # Observability/readiness fields (additive)
+        self.assertIn('integration_summary', data)
+        self.assertIsInstance(data['integration_summary'], dict)
+        self.assertIn('integration_warnings', data)
+        self.assertIsInstance(data['integration_warnings'], list)
+
+        # In test runs we do not have Redis configured, so redis readiness should be false.
+        self.assertIs(data['features'].get('redis'), False)
+
     @patch('projectmeats.health.check_all_services', side_effect=Exception('boom'))
     def test_health_survives_service_check_failure(self, _mock_check):
         resp = self.client.get('/api/v1/health/')

--- a/backend/apps/core/utils/health.py
+++ b/backend/apps/core/utils/health.py
@@ -14,43 +14,64 @@ logger = logging.getLogger(__name__)
 
 
 def check_redis() -> dict:
+    """Report Redis availability (not just cache availability).
+
+    In development/test we often use LocMemCache (which will pass set/get but is
+    *not* Redis). For UAT/Prod readiness we want `available=True` to mean:
+    - REDIS_URL is configured
+    - cache backend is Redis
+    - and Redis is reachable
+
+    Returns additive keys:
+    - configured: bool (REDIS_URL + Redis backend)
+    - is_redis: bool
+    - note: str (when falling back)
     """
-    Test Redis connection using cache ping.
-    
-    Returns:
-        dict: {
-            'available': bool,
-            'backend': str,
-            'error': str (if unavailable)
+
+    import os
+
+    backend = settings.CACHES['default']['BACKEND']
+    is_redis_backend = 'redis' in (backend or '').lower()
+    redis_url = getattr(settings, 'REDIS_URL', None) or os.environ.get('REDIS_URL')
+
+    if not redis_url or not is_redis_backend:
+        return {
+            'available': False,
+            'configured': False,
+            'backend': backend,
+            'is_redis': False,
+            'note': 'Redis not configured; using non-Redis cache backend fallback',
         }
-    """
+
     try:
-        # Attempt to set and get a test key
         cache.set('health_check', '1', timeout=5)
         value = cache.get('health_check')
         cache.delete('health_check')
-        
-        backend = settings.CACHES['default']['BACKEND']
-        is_redis = 'redis' in backend.lower()
-        
-        if value == '1':
+
+        ok = value == '1'
+        if ok:
             return {
                 'available': True,
+                'configured': True,
                 'backend': backend,
-                'is_redis': is_redis,
+                'is_redis': True,
             }
-        else:
-            return {
-                'available': False,
-                'backend': backend,
-                'error': 'Cache write/read mismatch'
-            }
+
+        return {
+            'available': False,
+            'configured': True,
+            'backend': backend,
+            'is_redis': True,
+            'error': 'Cache write/read mismatch',
+        }
     except Exception as e:
         logger.warning(f"Redis health check failed: {e}")
         return {
             'available': False,
-            'backend': settings.CACHES['default']['BACKEND'],
-            'error': str(e)
+            'configured': True,
+            'backend': backend,
+            'is_redis': True,
+            'error': str(e),
         }
 
 

--- a/backend/projectmeats/health.py
+++ b/backend/projectmeats/health.py
@@ -54,13 +54,85 @@ def health_check(request):
             },
         }
 
+    integration_warnings = []
+
+    redis = services.get("redis", {}) if isinstance(services, dict) else {}
+    sentry = services.get("sentry", {}) if isinstance(services, dict) else {}
+    openai = services.get("openai", {}) if isinstance(services, dict) else {}
+    ms = services.get("microsoft_oauth", {}) if isinstance(services, dict) else {}
+
+    if redis.get("configured") and not redis.get("available"):
+        integration_warnings.append(
+            {
+                "code": "redis_unavailable",
+                "message": "REDIS_URL is set but Redis is not reachable; caching/channels may degrade.",
+            }
+        )
+    if not redis.get("configured"):
+        integration_warnings.append(
+            {
+                "code": "redis_not_configured",
+                "message": "Redis not configured (using in-memory fallback). Real-time/caching features are degraded.",
+            }
+        )
+
+    if not openai.get("api_key_set"):
+        integration_warnings.append(
+            {
+                "code": "openai_not_configured",
+                "message": "OpenAI not configured (missing OPENAI_API_KEY). AI features will return AI_NOT_CONFIGURED (503).",
+            }
+        )
+
+    if sentry.get("enabled") and not sentry.get("dsn_set"):
+        integration_warnings.append(
+            {
+                "code": "sentry_misconfigured",
+                "message": "SENTRY_ENABLED is true but SENTRY_DSN is not set; Sentry will not initialize.",
+            }
+        )
+    if sentry.get("dsn_set") and not sentry.get("enabled"):
+        integration_warnings.append(
+            {
+                "code": "sentry_disabled",
+                "message": "SENTRY_DSN is set but SENTRY_ENABLED is false; Sentry is currently disabled.",
+            }
+        )
+
+    if ms.get("client_id_set") and not ms.get("client_secret_set"):
+        integration_warnings.append(
+            {
+                "code": "microsoft_oauth_misconfigured",
+                "message": "MICROSOFT_CLIENT_ID is set but MICROSOFT_CLIENT_SECRET is missing; token exchange will fail.",
+            }
+        )
+
+    integration_summary = {
+        "redis": {
+            "configured": bool(redis.get("configured")),
+            "available": bool(redis.get("available")),
+            "is_redis": bool(redis.get("is_redis")),
+        },
+        "openai": {"configured": bool(openai.get("api_key_set")), "model": openai.get("model")},
+        "sentry": {
+            "enabled": bool(sentry.get("enabled")),
+            "dsn_set": bool(sentry.get("dsn_set")),
+            "sdk_installed": bool(sentry.get("sdk_installed", True)),
+            "environment": sentry.get("environment"),
+        },
+        "microsoft_oauth": {
+            "configured": bool(ms.get("configured")),
+            "tenant_id_set": bool(ms.get("tenant_id_set")),
+        },
+    }
+
     features = {
-        "ai": bool(services.get("openai", {}).get("api_key_set")),
-        "outlook_oauth": bool(services.get("microsoft_oauth", {}).get("configured")),
+        "ai": bool(openai.get("api_key_set")),
+        "outlook_oauth": bool(ms.get("configured")),
         "email_send": bool(services.get("sendgrid", {}).get("configured")),
-        "redis": bool(services.get("redis", {}).get("available")),
+        "redis": bool(redis.get("available")),
         "rag": bool(services.get("pgvector", {}).get("available")),
-        "sentry": bool(services.get("sentry", {}).get("dsn_set")),
+        "sentry": bool(sentry.get("dsn_set")),
     }
 
     service_summary = services.get("summary", {}) if isinstance(services, dict) else {}
@@ -77,6 +149,8 @@ def health_check(request):
             "service_summary": service_summary,
             "debug": settings.DEBUG,
             "features": features,
+            "integration_summary": integration_summary,
+            "integration_warnings": integration_warnings,
             "services": services,
         }
     )

--- a/docs/reference/CONFIGURATION_AND_SECRETS.md
+++ b/docs/reference/CONFIGURATION_AND_SECRETS.md
@@ -9,7 +9,7 @@
 **Single Source of Truth for ProjectMeats Environments**
 
 > **Authority**: This document describes the authoritative configuration system for ProjectMeats.  
-> **Version**: Manifest v3.4 (February 2026) - Environment-Scoped Secrets
+> **Version**: Manifest v5.x (current) - Environment-Scoped Secrets
 
 ---
 
@@ -173,6 +173,16 @@ gh secret set OPENAI_API_KEY --env production-backend --body "$OPENAI_API_KEY"
 python config/manage_env.py audit
 # then trigger the deploy workflow for uat / main
 ```
+
+### 4) Verify integration readiness (non-secret signals)
+
+After deployment, check the backend health payload:
+
+- `GET /api/v1/health/`
+  - `integration_summary` (booleans + models/environments only)
+  - `integration_warnings` (machine-readable codes, safe messages)
+
+This is intentionally designed to surface **misconfiguration vs intentionally-disabled** integrations (e.g. Sentry enabled but missing DSN) without ever exposing secret values.
 
 ---
 


### PR DESCRIPTION
Fork→Upstream sync PR (observability/readiness).

- `/api/v1/health/` adds integration_summary + integration_warnings
- Redis readiness reflects real Redis availability
- Deploy logs print integration diagnostics (non-secret)
- Main pipeline run-name includes ref+sha
- Docs: CONFIGURATION_AND_SECRETS version banner + health readiness guidance

Testing:
- `bash .github/scripts/validate-workflows.sh`
- `cd backend && python manage.py test apps.core.tests.test_health -v 2`