### PR TITLE
chore(env): add Gmail OAuth secrets to manifest

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -85,6 +85,7 @@ This file is the **append-only PR-referenceable execution log**.
 - **2026-04-18** — Promotion: merged development → uat after checks green (merge commit). (PR: #4389)
 - **2026-04-20** — Docs: add WorkForms E2E completion workstream + runtime gap snapshot to canonical root `MASTER_PLAN.md` for execution tracking. (PR: #4480)
 - **2026-04-20** — WorkForms runtime: implement real in-app notifications (actionNotify -> send_notification) with tenant-safe persistence and preferences respect; add backend tests. (PR: #4481)
+- **2026-04-20** — Env manifest: add optional Gmail OAuth secret keys (GOOGLE_CLIENT_ID/SECRET/REDIRECT_URI) to canonical env manifest. (PR: #4482)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/manifests/env.manifest.json
+++ b/manifests/env.manifest.json
@@ -302,6 +302,27 @@
         "applies_to": ["backend environments"],
         "note": "Use primary domain + /api/v1/... routing for stability (see manifests/GOLDEN_FILES.md)"
       },
+      "GOOGLE_CLIENT_ID": {
+        "description": "Google OAuth client ID for Gmail integration",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "note": "Optional until Gmail integration is enabled. Create a Google Cloud OAuth client and enable Gmail API."
+      },
+      "GOOGLE_CLIENT_SECRET": {
+        "description": "Google OAuth client secret for Gmail integration",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "note": "Optional until Gmail integration is enabled. Store as an environment secret; never commit."
+      },
+      "GOOGLE_REDIRECT_URI": {
+        "description": "Google OAuth redirect/callback URI (must match Google app registration)",
+        "scope": "environment",
+        "required": false,
+        "applies_to": ["backend environments"],
+        "note": "Should match /api/v1/email/gmail/auth/callback/ for the target environment domain."
+      },
       "OAUTH_ENCRYPTION_KEY": {
         "description": "Fernet key for encrypting stored OAuth tokens (ExternalAuthProvider)",
         "scope": "environment",


### PR DESCRIPTION
Adds optional Google OAuth secret keys to the canonical manifests/env.manifest.json so Gmail OAuth can be configured without guessing secret names.

Keys added (optional, backend envs):
- GOOGLE_CLIENT_ID
- GOOGLE_CLIENT_SECRET
- GOOGLE_REDIRECT_URI

Tested:
- JSON validation (python -m json.tool)