### PR TITLE
feat(workforms): validate runtime support on activate

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -86,6 +86,7 @@ This file is the **append-only PR-referenceable execution log**.
 - **2026-04-20** — Docs: add WorkForms E2E completion workstream + runtime gap snapshot to canonical root `MASTER_PLAN.md` for execution tracking. (PR: #4480)
 - **2026-04-20** — WorkForms runtime: implement real in-app notifications (actionNotify -> send_notification) with tenant-safe persistence and preferences respect; add backend tests. (PR: #4481)
 - **2026-04-20** — Env manifest: add optional Gmail OAuth secret keys (GOOGLE_CLIENT_ID/SECRET/REDIRECT_URI) to canonical env manifest. (PR: #4482)
+- **2026-04-20** — WorkForms runtime: add runtime support validation (unsupported action nodes) + block activation when runtime validation fails; extend validate endpoint to return runtime validation details. (PR: #4483)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/backend/apps/system/models/tenant_workform.py
+++ b/backend/apps/system/models/tenant_workform.py
@@ -268,6 +268,63 @@ class TenantWorkForm(models.Model):
             "missing_forms": missing_forms,
             "total_references": len(form_ids)
         }
+
+    def validate_runtime_support(self) -> dict:
+        """Validate whether this WorkForm is expected to execute reliably at runtime.
+
+        This is intentionally conservative:
+        - We fail activation when the graph contains action nodes the runtime engine cannot execute.
+        - Non-action nodes that are currently traversal-only (forms, notes, etc.) are treated as warnings.
+
+        Returns a JSON-serializable dict safe to return to the frontend.
+        """
+
+        nodes = self.workflow_definition.get('nodes', [])
+        if not isinstance(nodes, list):
+            return {
+                'valid': False,
+                'supported_action_node_types': [],
+                'unsupported_actions': [{'node_id': None, 'node_type': 'invalid_definition', 'label': 'Workflow definition is malformed'}],
+                'warnings': [],
+            }
+
+        supported_action_node_types = {
+            'actionEmail',
+            'actionCreateRecord',
+            'actionUpdateRecord',
+            'actionNotification',  # legacy/alias
+            'actionNotify',        # canonical FlowEditor notification node
+        }
+
+        unsupported_actions = []
+        warnings = []
+
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+
+            node_id = node.get('id')
+            node_type = (node.get('type') or 'unknown')
+            label = ''
+            data = node.get('data')
+            if isinstance(data, dict):
+                label = str(data.get('label') or data.get('title') or '')
+
+            # Hard block: action nodes without runtime handlers.
+            if isinstance(node_type, str) and node_type.startswith('action') and node_type not in supported_action_node_types:
+                unsupported_actions.append({'node_id': node_id, 'node_type': node_type, 'label': label})
+                continue
+
+            # Soft warnings: nodes that currently traverse but do not execute/persist.
+            if node_type in {'form', 'formStep', 'formStepSingle', 'formReference', 'formProcess', 'formBook', 'formProcessGroup', 'formMultiStepContainer', 'smartWorkForm'}:
+                warnings.append({'node_id': node_id, 'node_type': node_type, 'label': label, 'warning': 'form_nodes_not_executed'})
+
+        return {
+            'valid': len(unsupported_actions) == 0,
+            'supported_action_node_types': sorted(supported_action_node_types),
+            'unsupported_actions': unsupported_actions,
+            'warnings': warnings,
+        }
     
     def get_node_count(self):
         """Get total number of nodes in this workflow."""

--- a/backend/apps/system/tests/test_workform_runtime_support_validation.py
+++ b/backend/apps/system/tests/test_workform_runtime_support_validation.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.system.models import TenantWorkForm
+from apps.tenants.models import Tenant, TenantUser
+
+
+User = get_user_model()
+
+
+class WorkFormRuntimeSupportValidationTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+        self.client.force_authenticate(self.user)
+
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        self.workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='WF',
+            description='',
+            status='draft',
+            workflow_definition={
+                'nodes': [
+                    {'id': 't1', 'type': 'triggerManual', 'data': {'label': 'Manual Trigger'}},
+                    {'id': 'bad', 'type': 'actionHttp', 'data': {'label': 'HTTP Request'}},
+                    {'id': 'end', 'type': 'end', 'data': {'label': 'End'}},
+                ],
+                'edges': [
+                    {'id': 'e1', 'source': 't1', 'target': 'bad', 'type': 'default'},
+                    {'id': 'e2', 'source': 'bad', 'target': 'end', 'type': 'default'},
+                ],
+            },
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+    def test_validate_endpoint_reports_runtime_unsupported_actions(self):
+        resp = self.client.post(
+            f'/api/v1/tenant-workforms/{self.workform.id}/validate/',
+            format='json',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+        data = resp.json()
+
+        self.assertIn('runtime_valid', data)
+        self.assertFalse(data['runtime_valid'])
+        self.assertIn('runtime', data)
+
+        unsupported = data['runtime'].get('unsupported_actions') or []
+        self.assertTrue(any(row.get('node_type') == 'actionHttp' for row in unsupported))
+
+    def test_activation_is_blocked_when_runtime_invalid(self):
+        resp = self.client.patch(
+            f'/api/v1/tenant-workforms/{self.workform.id}/',
+            data={'status': 'active'},
+            format='json',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.content)
+        payload = resp.json()
+        self.assertEqual(payload.get('error'), 'workform_validation_failed')
+        self.assertIn('runtime', payload)
+        self.assertFalse(payload['runtime'].get('valid', True))

--- a/backend/apps/system/workform_views.py
+++ b/backend/apps/system/workform_views.py
@@ -277,16 +277,52 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
         except Exception:
             return False
 
+    def _validate_before_activation(self, workform: TenantWorkForm, requested_status: str | None):
+        if requested_status != 'active':
+            return None
+
+        # Backward compatibility: do not block updates to already-active WorkForms.
+        if workform.status == 'active':
+            return None
+
+        refs = workform.validate_form_references()
+        runtime = workform.validate_runtime_support()
+
+        if not refs.get('valid', True) or not runtime.get('valid', True):
+            return Response(
+                {
+                    'error': 'workform_validation_failed',
+                    'detail': 'WorkForm cannot be activated until validation issues are resolved.',
+                    'references': refs,
+                    'runtime': runtime,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return None
+
     def update(self, request, *args, **kwargs):
         workform = self.get_object()
         if not self._can_manage_workform(workform):
             return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
+
+        requested_status = request.data.get('status') if isinstance(request.data, dict) else None
+        gate = self._validate_before_activation(workform, str(requested_status) if requested_status is not None else None)
+        if gate is not None:
+            return gate
+
         return super().update(request, *args, **kwargs)
 
     def partial_update(self, request, *args, **kwargs):
         workform = self.get_object()
         if not self._can_manage_workform(workform):
             return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
+
+        requested_status = request.data.get('status') if isinstance(request.data, dict) else None
+        gate = self._validate_before_activation(workform, str(requested_status) if requested_status is not None else None)
+        if gate is not None:
+            return gate
+
         return super().partial_update(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
@@ -409,9 +445,16 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
         POST /api/v1/tenant-workforms/{id}/validate/
         """
         workform = self.get_object()
-        validation_result = workform.validate_form_references()
-        
-        return Response(validation_result)
+        references = workform.validate_form_references()
+        runtime = workform.validate_runtime_support()
+
+        # Preserve backward compatible keys (valid/missing_forms/total_references)
+        merged = dict(references)
+        merged['runtime_valid'] = bool(runtime.get('valid', False))
+        merged['runtime'] = runtime
+        merged['valid'] = bool(references.get('valid', False)) and bool(runtime.get('valid', False))
+
+        return Response(merged)
     
     @action(detail=True, methods=['get'], url_path='containers')
     def list_containers(self, request, pk=None):


### PR DESCRIPTION
Adds a WorkForms runtime support validator and activation guardrails.

Backend:
- TenantWorkForm.validate_runtime_support reports unsupported action node types + warnings.
- /api/v1/tenant-workforms/:id/validate now returns runtime validation details.
- Activation (status -> active) is blocked with a structured 400 when runtime support or form references are invalid.

Tests:
- apps.system.tests.test_workform_runtime_support_validation

Tested:
- python backend/manage.py test apps.system.tests.test_workform_runtime_support_validation