### PR TITLE
test(workforms): add WorkForms execution e2e smoke

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1649,3 +1649,4 @@ Deliverables:
 - **2026-04-16** — Mobile: Inquiries page usable at 375px; add E2E coverage; constrain Layout containers to prevent page-level horizontal overflow. (PR: #4399)
 - **2026-04-16** — Mobile: Sales Orders page + create modal usable at 375px; add E2E create-flow coverage (schema mocked). (PR: #4401)
 - **2026-04-16** — CI: Master Pipeline run-name now uses env/branch + SHA + actor (avoid commit message leakage). (PR: #4404)
+- **2026-04-20** — WorkForms E2E: added stable `data-testid` selectors for Catalog/Execute/Execution Details, added execution-details polling for async runs, and added Playwright smoke spec for runtime execute + in-app notification. (PR: #4484)

--- a/frontend/e2e/workforms_execution_smoke.spec.ts
+++ b/frontend/e2e/workforms_execution_smoke.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from '@playwright/test';
+
+const loginViaUI = async (page: any) => {
+  await page.goto('/');
+
+  const testEmail = process.env.TEST_USER_EMAIL || 'admin@meatscentral.com';
+  const testPassword = process.env.TEST_USER_PASSWORD || 'Admin123!';
+
+  await page.fill('input[type="email"], input[type="text"]', testEmail);
+  await page.fill('input[type="password"]', testPassword);
+  await page.click('button:has-text("Login"), button:has-text("Sign In")');
+  await page.waitForURL(/\/(dashboard|home|workforms)/i, { timeout: 10000 });
+};
+
+const getAuthHeadersFromBrowser = async (page: any) => {
+  const { token, scheme, tenantId } = await page.evaluate(() => {
+    const accessToken = localStorage.getItem('accessToken');
+    const legacyToken = localStorage.getItem('authToken');
+    const tenantId = localStorage.getItem('tenantId');
+
+    if (accessToken) {
+      return { token: accessToken, scheme: 'Bearer', tenantId };
+    }
+
+    return { token: legacyToken, scheme: 'Token', tenantId };
+  });
+
+  expect(tenantId, 'tenantId must be present after login').toBeTruthy();
+  expect(token, 'auth token must be present after login').toBeTruthy();
+
+  return {
+    Authorization: `${scheme} ${token}`,
+    'X-Tenant-ID': tenantId,
+  } as Record<string, string>;
+};
+
+test.describe('WorkForms E2E smoke', () => {
+  test('execute WorkForm and create notification', async ({ page, request }) => {
+    await loginViaUI(page);
+
+    const headers = await getAuthHeadersFromBrowser(page);
+
+    // Baseline notifications state (best-effort)
+    await request.post('/api/v1/workflows/notifications/mark-all-read/', { headers });
+
+    const runId = String(Date.now());
+    const workformName = `E2E Smoke WorkForm ${runId}`;
+    const notificationTitle = `E2E Smoke Notification ${runId}`;
+
+    const createRes = await request.post('/api/v1/tenant-workforms/', {
+      headers,
+      data: {
+        name: workformName,
+        description: 'Playwright-created smoke workform',
+        status: 'active',
+        workflow_definition: {
+          nodes: [
+            {
+              id: 'node-start',
+              type: 'triggerManual',
+              position: { x: 100, y: 100 },
+              data: { label: 'Manual Trigger', config: {} },
+            },
+            {
+              id: 'node-notify',
+              type: 'actionNotify',
+              position: { x: 100, y: 220 },
+              data: {
+                label: 'Notify',
+                config: {
+                  title: notificationTitle,
+                  message: 'Smoke test notification from Playwright',
+                },
+              },
+            },
+            {
+              id: 'node-end',
+              type: 'endSuccess',
+              position: { x: 100, y: 340 },
+              data: { label: 'Done', config: {} },
+            },
+          ],
+          edges: [
+            { id: 'e1', source: 'node-start', target: 'node-notify' },
+            { id: 'e2', source: 'node-notify', target: 'node-end' },
+          ],
+        },
+      },
+    });
+
+    expect(createRes.ok(), `WorkForm create failed: ${createRes.status()}`).toBeTruthy();
+    const createdWorkform = await createRes.json();
+    const workformId = String(createdWorkform?.id || '');
+    expect(workformId).not.toEqual('');
+
+    // Prove Catalog renders and the workform is discoverable
+    await page.goto('/workforms/catalog');
+    await expect(page.getByTestId('workforms-catalog-page')).toBeVisible();
+
+    await page.getByTestId('workforms-catalog-search').fill(runId);
+
+    const item = page.locator(`[data-testid="workforms-catalog-item"][data-item-id="${workformId}"]`);
+    await expect(item).toBeVisible({ timeout: 10000 });
+
+    await item.getByTestId('workforms-catalog-item-execute').click();
+
+    await page.waitForURL(/\/workforms\/executions\//, { timeout: 15000 });
+    const executionId = page.url().split('/').pop() || '';
+    expect(executionId).not.toEqual('');
+
+    await expect(page.getByTestId('workform-execution-details-page')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('workform-execution-current-step')).toBeVisible();
+
+    // Poll execution to terminal via API for determinism
+    const finalStatus = await expect.poll(
+      async () => {
+        const res = await request.get(`/api/v1/workflows/workform-executions/${executionId}/`, { headers });
+        if (!res.ok()) return `http_${res.status()}`;
+        const body: any = await res.json();
+        return String(body?.status || 'unknown');
+      },
+      {
+        timeout: 25000,
+        intervals: [500, 1000, 2000],
+      }
+    );
+
+    expect(['completed', 'failed', 'cancelled']).toContain(finalStatus);
+
+    // UI should reflect terminal state (query polling should get it without reload, but reload is safe)
+    await page.reload();
+    await expect(page.getByTestId('workform-execution-status')).toHaveText(new RegExp(finalStatus, 'i'));
+
+    // Verify notification side-effect exists (API deterministic)
+    const hasNotification = await expect.poll(
+      async () => {
+        const res = await request.get('/api/v1/workflows/notifications/', { headers });
+        if (!res.ok()) return false;
+        const body: any = await res.json();
+        const rows = Array.isArray(body) ? body : Array.isArray(body?.results) ? body.results : [];
+        return rows.some((n: any) => String(n?.title || '') === notificationTitle);
+      },
+      { timeout: 15000, intervals: [500, 1000, 2000] }
+    );
+
+    expect(hasNotification).toBeTruthy();
+
+    // Optional UI proof: open notifications panel and find the title
+    await page.getByTestId('notification-bell-button').click();
+    const panel = page.getByTestId('notification-panel');
+    await expect(panel).toBeVisible({ timeout: 5000 });
+    await expect(panel.getByText(notificationTitle)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/src/components/Notifications/NotificationBell.tsx
+++ b/frontend/src/components/Notifications/NotificationBell.tsx
@@ -165,6 +165,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
   return (
     <BellContainer ref={containerRef} className={className}>
       <BellButton
+        data-testid="notification-bell-button"
         onClick={handleToggle}
         $hasUnread={unreadCount > 0}
         $isAnimating={isAnimating}
@@ -174,7 +175,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
       >
         <Bell size={20} />
         {unreadCount > 0 && (
-          <Badge $count={unreadCount} aria-hidden="true">
+          <Badge data-testid="notification-bell-badge" $count={unreadCount} aria-hidden="true">
             {displayCount}
           </Badge>
         )}

--- a/frontend/src/components/Notifications/NotificationPanel.tsx
+++ b/frontend/src/components/Notifications/NotificationPanel.tsx
@@ -400,7 +400,7 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({ onClose }) => {
   };
   
   return (
-    <Panel>
+    <Panel data-testid="notification-panel">
       <Header>
         <Title>
           <Bell size={18} />
@@ -441,6 +441,7 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({ onClose }) => {
                   return (
                     <NotificationItem
                       key={notification.id}
+                      data-testid={`notification-item-${notification.id}`}
                       $isUnread={!notification.is_read}
                       $priority={notification.priority}
                       onClick={() => handleNotificationClick(notification)}

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -833,7 +833,7 @@ const FormsFlowsCatalog: React.FC = () => {
   };
 
   return (
-    <Container>
+    <Container data-testid="workforms-catalog-page">
       <Header>
         <Title>Forms & Flows</Title>
         <HeaderActions>
@@ -842,6 +842,7 @@ const FormsFlowsCatalog: React.FC = () => {
               <Search size={16} />
             </SearchIconWrapper>
             <SearchInput
+              data-testid="workforms-catalog-search"
               type="text"
               placeholder="Search forms..."
               value={searchQuery}
@@ -867,17 +868,25 @@ const FormsFlowsCatalog: React.FC = () => {
 
       {/* Phase 5: Tabbed View - Logic vs Data + Templates (Phase 2.2) */}
       <TabsContainer>
-        <Tab $active={activeTab === 'workflows'} onClick={() => setActiveTab('workflows')}>
+        <Tab
+          data-testid="workforms-catalog-tab-workflows"
+          $active={activeTab === 'workflows'}
+          onClick={() => setActiveTab('workflows')}
+        >
           <Workflow size={18} />
           Workflows (Logic)
           {workflowsCount > 0 && <TabBadge>{workflowsCount}</TabBadge>}
         </Tab>
-        <Tab $active={activeTab === 'forms'} onClick={() => setActiveTab('forms')}>
+        <Tab data-testid="workforms-catalog-tab-forms" $active={activeTab === 'forms'} onClick={() => setActiveTab('forms')}>
           <Database size={18} />
           Forms (Data)
           {formsCount > 0 && <TabBadge>{formsCount}</TabBadge>}
         </Tab>
-        <Tab $active={activeTab === 'templates'} onClick={() => setActiveTab('templates')}>
+        <Tab
+          data-testid="workforms-catalog-tab-templates"
+          $active={activeTab === 'templates'}
+          onClick={() => setActiveTab('templates')}
+        >
           <Boxes size={18} />
           Industry Templates
           <TabBadge style={{ background: 'rgb(var(--color-success))' }}>{FLOW_TEMPLATES.length}</TabBadge>
@@ -1027,110 +1036,28 @@ const FormsFlowsCatalog: React.FC = () => {
         </EmptyState>
       ) : viewMode === 'grid' ? (
         <GridContainer>
-          {filteredForms.map((form) => (
-            <FormCard key={form.id}>
-              <CardContent onClick={() => void handleEditForm(form)} style={{ cursor: 'pointer' }}>
-                <FormCardHeader>
-                  <FormIcon>{form.icon || '📋'}</FormIcon>
-                  <FormInfo>
-                    <FormTitle>{form.name}</FormTitle>
-                    <FormDescription>{form.description || 'No description'}</FormDescription>
-                  </FormInfo>
-                </FormCardHeader>
-                <FormMeta>
-                  <MetaItem>
-                    <Workflow size={14} />
-                    {typeof form.node_count === 'number'
-                      ? form.node_count
-                      : form.entity_count || 0}{' '}
-                    {typeof form.node_count === 'number'
-                      ? form.node_count === 1
-                        ? 'node'
-                        : 'nodes'
-                      : (form.entity_count || 0) === 1
-                        ? 'step'
-                        : 'steps'}
-                  </MetaItem>
-                  <MetaItem>
-                    <Clock size={14} />
-                    {formatDate(form.updated_at)}
-                  </MetaItem>
-                  <StatusBadge $status={form.status}>{form.status}</StatusBadge>
-                </FormMeta>
+          {filteredForms.map((form) => {
+            const isWorkform = form.kind === 'workform' || typeof form.node_count === 'number';
 
-                {/* NEW: Quick Run Button (if workflow supports it) */}
-                {form.can_quick_run && form.status === 'active' && (
-                  <div style={{ marginTop: '1rem' }}>
-                    <QuickRunButton
-                      $isRunning={isQuickRunning === form.id}
-                      onClick={(e) => handleQuickRun(form, e)}
-                      disabled={isQuickRunning === form.id}
-                      title="Start this workflow with one click"
-                    >
-                      {isQuickRunning === form.id ? (
-                        <>
-                          <Loader size={16} />
-                          Starting...
-                        </>
-                      ) : (
-                        <>
-                          <Play size={16} />
-                          Quick Run
-                        </>
-                      )}
-                    </QuickRunButton>
-                  </div>
-                )}
-
-                {/* Delete (WorkForms only) */}
-                {typeof form.node_count === 'number' && permissions.can_delete && form.status !== 'active' && (
-                  <ActionRow>
-                    <Popconfirm
-                      title="Delete this WorkForm?"
-                      description="This will permanently delete the WorkForm and any extracted forms."
-                      okText="Delete"
-                      cancelText="Cancel"
-                      okButtonProps={{ danger: true }}
-                      onConfirm={() => deleteWorkFormMutation.mutate(form.id)}
-                    >
-                      <IconActionButton
-                        type="button"
-                        onClick={(e) => e.stopPropagation()}
-                        disabled={deleteWorkFormMutation.isPending}
-                        aria-label={`Delete ${form.name}`}
-                      >
-                        <Trash2 size={14} aria-hidden="true" />
-                        Delete
-                      </IconActionButton>
-                    </Popconfirm>
-                  </ActionRow>
-                )}
-              </CardContent>
-            </FormCard>
-          ))}
-        </GridContainer>
-      ) : (
-        <ListContainer>
-          {filteredForms.map((form) => (
-            <FormCard key={form.id}>
-              <CardContent
-                onClick={() => {
-                  void handleEditForm(form);
-                }}
-                style={{ cursor: 'pointer' }}
+            return (
+              <FormCard
+                key={form.id}
+                data-testid="workforms-catalog-item"
+                data-item-id={form.id}
+                data-kind={form.kind ?? (isWorkform ? 'workform' : 'form')}
               >
-                <FormCardHeader>
-                  <FormIcon>{form.icon || '📋'}</FormIcon>
-                  <FormInfo>
-                    <FormTitle>{form.name}</FormTitle>
-                    <FormDescription>{form.description || 'No description'}</FormDescription>
-                  </FormInfo>
+                <CardContent onClick={() => void handleEditForm(form)} style={{ cursor: 'pointer' }}>
+                  <FormCardHeader>
+                    <FormIcon>{form.icon || '📋'}</FormIcon>
+                    <FormInfo>
+                      <FormTitle data-testid="workforms-catalog-item-name">{form.name}</FormTitle>
+                      <FormDescription>{form.description || 'No description'}</FormDescription>
+                    </FormInfo>
+                  </FormCardHeader>
                   <FormMeta>
                     <MetaItem>
                       <Workflow size={14} />
-                      {typeof form.node_count === 'number'
-                        ? form.node_count
-                        : form.entity_count || 0}{' '}
+                      {typeof form.node_count === 'number' ? form.node_count : form.entity_count || 0}{' '}
                       {typeof form.node_count === 'number'
                         ? form.node_count === 1
                           ? 'node'
@@ -1145,58 +1072,156 @@ const FormsFlowsCatalog: React.FC = () => {
                     </MetaItem>
                     <StatusBadge $status={form.status}>{form.status}</StatusBadge>
                   </FormMeta>
-                </FormCardHeader>
 
-                {/* NEW: Quick Run Button (if workflow supports it) */}
-                {form.can_quick_run && form.status === 'active' && (
-                  <div style={{ marginTop: '1rem', marginLeft: '4rem' }}>
-                    <QuickRunButton
-                      $isRunning={isQuickRunning === form.id}
-                      onClick={(e) => handleQuickRun(form, e)}
-                      disabled={isQuickRunning === form.id}
-                      title="Start this workflow with one click"
-                    >
-                      {isQuickRunning === form.id ? (
-                        <>
-                          <Loader size={16} />
-                          Starting...
-                        </>
-                      ) : (
-                        <>
-                          <Play size={16} />
-                          Quick Run
-                        </>
-                      )}
-                    </QuickRunButton>
-                  </div>
-                )}
-
-                {/* Delete (WorkForms only) */}
-                {typeof form.node_count === 'number' && permissions.can_delete && form.status !== 'active' && (
-                  <ActionRow style={{ marginLeft: '4rem' }}>
-                    <Popconfirm
-                      title="Delete this WorkForm?"
-                      description="This will permanently delete the WorkForm and any extracted forms."
-                      okText="Delete"
-                      cancelText="Cancel"
-                      okButtonProps={{ danger: true }}
-                      onConfirm={() => deleteWorkFormMutation.mutate(form.id)}
-                    >
-                      <IconActionButton
-                        type="button"
-                        onClick={(e) => e.stopPropagation()}
-                        disabled={deleteWorkFormMutation.isPending}
-                        aria-label={`Delete ${form.name}`}
+                  {/* Execute / Quick Run (WorkForms always show Execute when active; legacy forms gate on can_quick_run) */}
+                  {form.status === 'active' && (form.can_quick_run || isWorkform) && (
+                    <div style={{ marginTop: '1rem' }}>
+                      <QuickRunButton
+                        data-testid="workforms-catalog-item-execute"
+                        $isRunning={isQuickRunning === form.id}
+                        onClick={(e) => handleQuickRun(form, e)}
+                        disabled={isQuickRunning === form.id}
+                        title={isWorkform ? 'Execute this WorkForm' : 'Start this workflow with one click'}
                       >
-                        <Trash2 size={14} aria-hidden="true" />
-                        Delete
-                      </IconActionButton>
-                    </Popconfirm>
-                  </ActionRow>
-                )}
-              </CardContent>
-            </FormCard>
-          ))}
+                        {isQuickRunning === form.id ? (
+                          <>
+                            <Loader size={16} />
+                            Starting...
+                          </>
+                        ) : (
+                          <>
+                            <Play size={16} />
+                            {isWorkform ? 'Execute' : 'Quick Run'}
+                          </>
+                        )}
+                      </QuickRunButton>
+                    </div>
+                  )}
+
+                  {/* Delete (WorkForms only) */}
+                  {isWorkform && permissions.can_delete && form.status !== 'active' && (
+                    <ActionRow>
+                      <Popconfirm
+                        title="Delete this WorkForm?"
+                        description="This will permanently delete the WorkForm and any extracted forms."
+                        okText="Delete"
+                        cancelText="Cancel"
+                        okButtonProps={{ danger: true }}
+                        onConfirm={() => deleteWorkFormMutation.mutate(form.id)}
+                      >
+                        <IconActionButton
+                          type="button"
+                          onClick={(e) => e.stopPropagation()}
+                          disabled={deleteWorkFormMutation.isPending}
+                          aria-label={`Delete ${form.name}`}
+                        >
+                          <Trash2 size={14} aria-hidden="true" />
+                          Delete
+                        </IconActionButton>
+                      </Popconfirm>
+                    </ActionRow>
+                  )}
+                </CardContent>
+              </FormCard>
+            );
+          })}
+        </GridContainer>
+      ) : (
+        <ListContainer>
+          {filteredForms.map((form) => {
+            const isWorkform = form.kind === 'workform' || typeof form.node_count === 'number';
+
+            return (
+              <FormCard
+                key={form.id}
+                data-testid="workforms-catalog-item"
+                data-item-id={form.id}
+                data-kind={form.kind ?? (isWorkform ? 'workform' : 'form')}
+              >
+                <CardContent
+                  onClick={() => {
+                    void handleEditForm(form);
+                  }}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <FormCardHeader>
+                    <FormIcon>{form.icon || '📋'}</FormIcon>
+                    <FormInfo>
+                      <FormTitle data-testid="workforms-catalog-item-name">{form.name}</FormTitle>
+                      <FormDescription>{form.description || 'No description'}</FormDescription>
+                    </FormInfo>
+                    <FormMeta>
+                      <MetaItem>
+                        <Workflow size={14} />
+                        {typeof form.node_count === 'number' ? form.node_count : form.entity_count || 0}{' '}
+                        {typeof form.node_count === 'number'
+                          ? form.node_count === 1
+                            ? 'node'
+                            : 'nodes'
+                          : (form.entity_count || 0) === 1
+                            ? 'step'
+                            : 'steps'}
+                      </MetaItem>
+                      <MetaItem>
+                        <Clock size={14} />
+                        {formatDate(form.updated_at)}
+                      </MetaItem>
+                      <StatusBadge $status={form.status}>{form.status}</StatusBadge>
+                    </FormMeta>
+                  </FormCardHeader>
+
+                  {/* Execute / Quick Run (WorkForms always show Execute when active; legacy forms gate on can_quick_run) */}
+                  {form.status === 'active' && (form.can_quick_run || isWorkform) && (
+                    <div style={{ marginTop: '1rem', marginLeft: '4rem' }}>
+                      <QuickRunButton
+                        data-testid="workforms-catalog-item-execute"
+                        $isRunning={isQuickRunning === form.id}
+                        onClick={(e) => handleQuickRun(form, e)}
+                        disabled={isQuickRunning === form.id}
+                        title={isWorkform ? 'Execute this WorkForm' : 'Start this workflow with one click'}
+                      >
+                        {isQuickRunning === form.id ? (
+                          <>
+                            <Loader size={16} />
+                            Starting...
+                          </>
+                        ) : (
+                          <>
+                            <Play size={16} />
+                            {isWorkform ? 'Execute' : 'Quick Run'}
+                          </>
+                        )}
+                      </QuickRunButton>
+                    </div>
+                  )}
+
+                  {/* Delete (WorkForms only) */}
+                  {isWorkform && permissions.can_delete && form.status !== 'active' && (
+                    <ActionRow style={{ marginLeft: '4rem' }}>
+                      <Popconfirm
+                        title="Delete this WorkForm?"
+                        description="This will permanently delete the WorkForm and any extracted forms."
+                        okText="Delete"
+                        cancelText="Cancel"
+                        okButtonProps={{ danger: true }}
+                        onConfirm={() => deleteWorkFormMutation.mutate(form.id)}
+                      >
+                        <IconActionButton
+                          type="button"
+                          onClick={(e) => e.stopPropagation()}
+                          disabled={deleteWorkFormMutation.isPending}
+                          aria-label={`Delete ${form.name}`}
+                        >
+                          <Trash2 size={14} aria-hidden="true" />
+                          Delete
+                        </IconActionButton>
+                      </Popconfirm>
+                    </ActionRow>
+                  )}
+                </CardContent>
+              </FormCard>
+            );
+          })}
         </ListContainer>
       )}
 

--- a/frontend/src/pages/WorkForms/Execute.tsx
+++ b/frontend/src/pages/WorkForms/Execute.tsx
@@ -96,8 +96,10 @@ export const ExecuteWorkForm: React.FC = () => {
   }, [id]);
 
   return (
-    <div>
-      <Skeleton active paragraph={{ rows: 6 }} />
+    <div data-testid="workforms-execute-page">
+      <div data-testid="workforms-execute-loading">
+        <Skeleton active paragraph={{ rows: 6 }} />
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/WorkForms/ExecutionDetails.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.tsx
@@ -22,6 +22,11 @@ export const WorkFormExecutionDetails: React.FC = () => {
       return workformExecutionService.getExecution(id);
     },
     enabled: !!id,
+    refetchInterval: (q) => {
+      const status = (q.state.data as any)?.status as string | undefined;
+      return status === 'pending' || status === 'in_progress' ? 2000 : false;
+    },
+    refetchIntervalInBackground: true,
   });
 
   const execution = query.data;
@@ -53,15 +58,27 @@ export const WorkFormExecutionDetails: React.FC = () => {
         ) : query.isError || !execution ? (
           <div>Execution not found.</div>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div data-testid="workform-execution-details-page" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
               <div>
-                <div style={{ fontWeight: 700, fontSize: 16 }}>{execution.workform_name}</div>
+                <div data-testid="workform-execution-name" style={{ fontWeight: 700, fontSize: 16 }}>
+                  {execution.workform_name}
+                </div>
                 <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
-                  Status: <span style={{ fontWeight: 600 }}>{execution.status}</span>
+                  Status:{' '}
+                  <span data-testid="workform-execution-status" style={{ fontWeight: 600 }}>
+                    {execution.status}
+                  </span>
                 </div>
               </div>
               <div style={{ display: 'flex', gap: 8 }}>
+                <Button
+                  data-testid="workform-execution-refresh"
+                  variant="secondary"
+                  onClick={() => void query.refetch()}
+                >
+                  Refresh
+                </Button>
                 <Button variant="secondary" onClick={() => navigate('/workforms/history')}>
                   View History
                 </Button>
@@ -72,11 +89,13 @@ export const WorkFormExecutionDetails: React.FC = () => {
             </div>
 
             {execution.error_message ? (
-              <div style={{ color: 'rgb(var(--color-error))' }}>{execution.error_message}</div>
+              <div data-testid="workform-execution-error-message" style={{ color: 'rgb(var(--color-error))' }}>
+                {execution.error_message}
+              </div>
             ) : null}
 
             <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 12 }}>
-              <div>
+              <div data-testid="workform-execution-current-step">
                 <div style={{ fontWeight: 600, marginBottom: 6 }}>Current step</div>
                 {execution.current_node_id ? (
                   <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
@@ -96,7 +115,7 @@ export const WorkFormExecutionDetails: React.FC = () => {
               </div>
 
               {execution.errors && execution.errors.length > 0 ? (
-                <div>
+                <div data-testid="workform-execution-errors">
                   <div style={{ fontWeight: 600, marginBottom: 6 }}>Errors</div>
                   <ul style={{ margin: 0, paddingLeft: 18 }}>
                     {execution.errors.map((e, idx) => (


### PR DESCRIPTION
## What\n- Adds stable WorkForms E2E selectors (catalog/execute/details) and execution-details polling for async runs.\n- Adds notification UI testids (bell + panel + items) for stable assertions.\n- Adds Playwright smoke spec: `frontend/e2e/workforms_execution_smoke.spec.ts` that creates a minimal WorkForm (triggerManual → actionNotify → endSuccess), executes it, and verifies an in-app notification.\n\n## Why\nWorkForms runtime is async (Celery) and previously lacked stable selectors + deterministic waiting. This makes end-to-end execution verifiable and reduces flake.\n\n## Testing\n- ✅ `npm --prefix frontend run verify-standards`\n- (Manual/local) To run the single smoke spec: `cd frontend && npm run test:e2e -- e2e/workforms_execution_smoke.spec.ts --project=chromium` (requires backend + db + celery running).