### PR TITLE
fix(quick-actions): include WorkForms in available targets

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1650,3 +1650,4 @@ Deliverables:
 - **2026-04-16** — Mobile: Sales Orders page + create modal usable at 375px; add E2E create-flow coverage (schema mocked). (PR: #4401)
 - **2026-04-16** — CI: Master Pipeline run-name now uses env/branch + SHA + actor (avoid commit message leakage). (PR: #4404)
 - **2026-04-20** — WorkForms E2E: added stable `data-testid` selectors for Catalog/Execute/Execution Details, added execution-details polling for async runs, and added Playwright smoke spec for runtime execute + in-app notification. (PR: #4484)
+- **2026-04-20** — Quick Actions: `/workflows/available-forms/` now treated as the canonical unified list (forms + WorkForms); WorkForms show in Customize Quick Actions and in the header submenu; WorkForms Catalog classifies by `type` and de-dupes to avoid broken execute flows. (PR: #4485)

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -305,14 +305,55 @@ const Header: React.FC<HeaderProps> = () => {
                     </>
                   )}
                   
-                  {availableForms.filter((f) => (f.type ?? 'form') === 'form').length === 0 && (
-                    <SubmenuItem
-                      $theme={theme}
-                      style={{ fontSize: '12px', fontStyle: 'italic', cursor: 'default', opacity: 0.6 }}
-                    >
-                      <span>No published forms yet</span>
-                    </SubmenuItem>
+                  {availableForms.filter((f) => (f.type ?? 'form') === 'workflow').length > 0 && (
+                    <>
+                      <SubmenuDivider />
+                      <SubmenuHeader>Published WorkForms</SubmenuHeader>
+                      {availableForms
+                        .filter((f) => (f.type ?? 'form') === 'workflow')
+                        .slice(0, 5)
+                        .map((wf) => (
+                          <SubmenuItem
+                            key={wf.id}
+                            $theme={theme}
+                            onClick={() => {
+                              navigate(`/workforms/execute/${wf.id}`);
+                              setShowQuickMenu(false);
+                              setShowFormsSubmenu(false);
+                            }}
+                            title={`Execute ${wf.name}`}
+                          >
+                            <span>▶️</span>
+                            <span>{wf.name}</span>
+                          </SubmenuItem>
+                        ))}
+                      {availableForms.filter((f) => (f.type ?? 'form') === 'workflow').length > 5 && (
+                        <SubmenuItem
+                          $theme={theme}
+                          style={{ fontSize: '11px', fontStyle: 'italic' }}
+                          onClick={() => {
+                            navigate('/workforms/catalog');
+                            setShowQuickMenu(false);
+                            setShowFormsSubmenu(false);
+                          }}
+                        >
+                          <span>
+                            +{availableForms.filter((f) => (f.type ?? 'form') === 'workflow').length - 5} more workforms...
+                          </span>
+                        </SubmenuItem>
+                      )}
+                    </>
                   )}
+
+                  {availableForms.filter((f) => (f.type ?? 'form') === 'form').length === 0 &&
+                    availableForms.filter((f) => (f.type ?? 'form') === 'workflow').length === 0 && (
+                      <SubmenuItem
+                        $theme={theme}
+                        style={{ fontSize: '12px', fontStyle: 'italic', cursor: 'default', opacity: 0.6 }}
+                      >
+                        <span>No published forms or workforms yet</span>
+                      </SubmenuItem>
+                    )}
                 </FormsSubmenu>
               )}
               

--- a/frontend/src/components/QuickActions/QuickActionsEditor.tsx
+++ b/frontend/src/components/QuickActions/QuickActionsEditor.tsx
@@ -34,8 +34,9 @@ const QuickActionsEditor: React.FC<QuickActionsEditorProps> = ({ isOpen, onClose
     if (isOpen) {
       setLocalActions([...quickActions]);
       setError(null);
+      void refreshQuickActions();
     }
-  }, [isOpen, quickActions]);
+  }, [isOpen, quickActions, refreshQuickActions]);
 
   if (!isOpen) return null;
 

--- a/frontend/src/contexts/QuickActionsContext.test.tsx
+++ b/frontend/src/contexts/QuickActionsContext.test.tsx
@@ -200,7 +200,7 @@ describe('QuickActionsContext', () => {
       expect(screen.getByTestId('forms-count')).toHaveTextContent('0');
     });
 
-    it('should merge legacy forms + workforms into availableForms with correct typing', async () => {
+    it('should include workflows from available-forms even if tenant-workforms is forbidden', async () => {
       let ctxRef: any;
 
       vi.mocked(quickActionsService.getQuickActions).mockResolvedValue({ items: [] } as any);
@@ -219,7 +219,7 @@ describe('QuickActionsContext', () => {
         {
           id: 'wf-1',
           type: 'workflow',
-          name: 'Should Be Ignored (workflow from legacy list)',
+          name: 'Beta WorkForm',
           description: '',
           icon: 'layers',
           status: 'active',
@@ -230,10 +230,7 @@ describe('QuickActionsContext', () => {
         },
       ] as any);
 
-      vi.mocked(getAvailableWorkForms).mockResolvedValue([
-        { id: 'wf-1', name: 'Beta WorkForm', description: '', status: 'active', node_count: 2, edge_count: 0, updated_at: '' },
-        { id: 'wf-2', name: 'Archived WorkForm', description: '', status: 'archived', node_count: 1, edge_count: 0, updated_at: '' },
-      ] as any);
+      vi.mocked(getAvailableWorkForms).mockRejectedValue({ response: { status: 403 } } as any);
 
       render(
         <QuickActionsProvider>
@@ -250,7 +247,6 @@ describe('QuickActionsContext', () => {
 
       expect(keys).toContain('form:form-a');
       expect(keys).toContain('workflow:wf-1');
-      expect(keys).not.toContain('workflow:wf-2');
     });
 
     it('should handle load error gracefully', async () => {

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -111,20 +111,25 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
       const actionsResponse = actionsResult.status === 'fulfilled' ? actionsResult.value : { items: [] };
       setQuickActions(actionsResponse.items || []);
 
-      const formsResponse = formsResult.status === 'fulfilled' ? formsResult.value : [];
-      const legacyForms = (Array.isArray(formsResponse) ? formsResponse : [])
-        .filter((item) => (item.type ?? 'form') === 'form')
-        .map((item) => ({
-          ...item,
-          type: 'form' as const,
-        }));
+      const availableResponse = formsResult.status === 'fulfilled' ? formsResult.value : [];
+      const availableTargets = (Array.isArray(availableResponse) ? availableResponse : [])
+        .filter((item) => (item.type ?? 'form') === 'form' || item.type === 'workflow')
+        .map((item) => {
+          const isWorkflow = item.type === 'workflow';
+          return {
+            ...item,
+            type: isWorkflow ? ('workflow' as const) : ('form' as const),
+            icon: item.icon || (isWorkflow ? 'layers' : 'file-text'),
+          } as AvailableForm;
+        });
 
       if (formsResult.status === 'rejected') {
-        console.warn('[QuickActions] Legacy available-forms failed; continuing with WorkForms only', formsResult.reason);
+        console.warn('[QuickActions] available-forms failed; continuing with WorkForms enrichment only', formsResult.reason);
       }
 
+      // Optional enrichment from /tenant-workforms/ (may be permission-scoped differently).
       const workformsResponse = workformsResult.status === 'fulfilled' ? workformsResult.value : [];
-      const workforms = (Array.isArray(workformsResponse) ? workformsResponse : [])
+      const workformsEnrichment = (Array.isArray(workformsResponse) ? workformsResponse : [])
         .filter((wf) => wf.status === 'active' || wf.status === 'draft')
         .map((wf) => {
           const anyWf = wf as any;
@@ -133,7 +138,7 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
               ? anyWf.node_count
               : typeof anyWf.step_count === 'number'
                 ? anyWf.step_count
-                : 0;
+                : null;
 
           return {
             id: wf.id,
@@ -146,17 +151,25 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
             is_quick_action_enabled: true,
             step_count: typeof anyWf.step_count === 'number' ? anyWf.step_count : 0,
             node_count: nodeCount,
-          };
+          } as AvailableForm;
         });
 
       if (workformsResult.status === 'rejected') {
-        console.warn('[QuickActions] WorkForms list failed; continuing with legacy forms only', workformsResult.reason);
+        console.warn('[QuickActions] WorkForms list failed; continuing with available-forms only', workformsResult.reason);
       }
 
       const byKey = new Map<string, AvailableForm>();
-      for (const item of [...legacyForms, ...workforms]) {
-        const key = `${item.type ?? 'form'}:${item.id}`;
-        byKey.set(key, item);
+
+      for (const item of availableTargets) {
+        byKey.set(`${item.type ?? 'form'}:${item.id}`, item);
+      }
+
+      // Enrich/override workflow rows with WorkForms list data when available.
+      for (const wf of workformsEnrichment) {
+        byKey.set(`workflow:${wf.id}`, {
+          ...byKey.get(`workflow:${wf.id}`),
+          ...wf,
+        });
       }
 
       const combined = Array.from(byKey.values()).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -586,7 +586,7 @@ const FormsFlowsCatalog: React.FC = () => {
     queryFn: async () => {
       const nowIso = new Date().toISOString();
 
-      const [workformsResult, legacyFormsResult] = await Promise.allSettled([
+      const [workformsResult, targetsResult] = await Promise.allSettled([
         getAvailableWorkForms(),
         quickActionsService.getAvailableForms(),
       ]);
@@ -596,9 +596,9 @@ const FormsFlowsCatalog: React.FC = () => {
         logger.error('[Catalog] Error fetching workforms:', workformsResult.reason);
       }
 
-      const legacyForms = legacyFormsResult.status === 'fulfilled' ? legacyFormsResult.value : [];
-      if (legacyFormsResult.status === 'rejected') {
-        logger.error('[Catalog] Error fetching legacy forms:', legacyFormsResult.reason);
+      const targets = targetsResult.status === 'fulfilled' ? targetsResult.value : [];
+      if (targetsResult.status === 'rejected') {
+        logger.error('[Catalog] Error fetching available targets:', targetsResult.reason);
       }
 
       const mappedWorkforms: CatalogItem[] = (workforms || []).map((wf) => {
@@ -626,26 +626,38 @@ const FormsFlowsCatalog: React.FC = () => {
         };
       });
 
-      const mappedLegacyForms: CatalogItem[] = (Array.isArray(legacyForms) ? legacyForms : []).map((f: any) => {
-        const updated = String(f.updated_at ?? nowIso);
-        const created = String(f.created_at ?? updated);
+      const mappedTargets: CatalogItem[] = (Array.isArray(targets) ? targets : []).map((t: any) => {
+        const updated = String(t.updated_at ?? nowIso);
+        const created = String(t.created_at ?? updated);
+        const isWorkform = t.type === 'workflow';
+
         return {
-          id: String(f.id),
-          kind: 'form',
-          name: String(f.name ?? 'Untitled Form'),
-          description: String(f.description ?? ''),
-          status: (f.status as CatalogItem['status']) ?? 'draft',
-          icon: f.icon || '📋',
-          entity_count: typeof f.entity_count === 'number' ? f.entity_count : 1,
-          is_multi_entity: Boolean(f.is_multi_entity),
-          is_system_template: false,
+          id: String(t.id),
+          kind: isWorkform ? 'workform' : 'form',
+          name: String(t.name ?? (isWorkform ? 'Untitled WorkForm' : 'Untitled Form')),
+          description: String(t.description ?? ''),
+          status: (t.status as CatalogItem['status']) ?? 'draft',
+          icon: t.icon || (isWorkform ? '🧩' : '📋'),
+          entity_count: typeof t.entity_count === 'number' ? t.entity_count : 1,
+          is_multi_entity: Boolean(t.is_multi_entity),
+          is_system_template: Boolean(t.is_system_template),
+          node_count: typeof t.node_count === 'number' ? t.node_count : undefined,
           created_at: created,
           updated_at: updated,
-          flow_data: f.flow_data,
+          flow_data: t.flow_data,
         };
       });
 
-      const combined = [...mappedWorkforms, ...mappedLegacyForms];
+      // De-dupe by kind:id and prefer the richer /tenant-workforms/ payload when available.
+      const byKey = new Map<string, CatalogItem>();
+      for (const item of mappedTargets) {
+        byKey.set(`${item.kind}:${item.id}`, item);
+      }
+      for (const wf of mappedWorkforms) {
+        byKey.set(`workform:${wf.id}`, { ...byKey.get(`workform:${wf.id}`), ...wf });
+      }
+
+      const combined = Array.from(byKey.values());
       combined.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
       return combined;
     },
@@ -775,7 +787,7 @@ const FormsFlowsCatalog: React.FC = () => {
       logger.info('[Catalog] Quick Run initiated:', { id: item.id, kind: item.kind });
 
       // WorkForms: execute via runtime engine
-      if (item.kind === 'workform' || typeof item.node_count === 'number') {
+      if (item.kind === 'workform') {
         navigate(`/workforms/execute/${item.id}`);
         return;
       }
@@ -798,7 +810,7 @@ const FormsFlowsCatalog: React.FC = () => {
   // Open a workform in the editor
   const handleEditForm = async (form: CatalogItem) => {
     // WorkForms: open in editor
-    if (form.kind === 'workform' || typeof form.node_count === 'number') {
+    if (form.kind === 'workform') {
       navigate(`/workforms/editor/${form.id}`);
       return;
     }
@@ -1037,7 +1049,7 @@ const FormsFlowsCatalog: React.FC = () => {
       ) : viewMode === 'grid' ? (
         <GridContainer>
           {filteredForms.map((form) => {
-            const isWorkform = form.kind === 'workform' || typeof form.node_count === 'number';
+            const isWorkform = form.kind === 'workform';
 
             return (
               <FormCard
@@ -1129,7 +1141,7 @@ const FormsFlowsCatalog: React.FC = () => {
       ) : (
         <ListContainer>
           {filteredForms.map((form) => {
-            const isWorkform = form.kind === 'workform' || typeof form.node_count === 'number';
+            const isWorkform = form.kind === 'workform';
 
             return (
               <FormCard


### PR DESCRIPTION
## What\n- Treats /api/v1/workflows/available-forms/ as the canonical unified list (forms + WorkForms) and stops filtering out type=workflow.\n- Keeps /api/v1/tenant-workforms/ as optional enrichment (permission-scoped fallback).\n- Updates WorkForms Catalog to classify items by type (workflow vs form), de-dupes, and routes WorkForms to runtime execute reliably.\n- Header quick actions submenu now lists executable WorkForms in addition to published forms.\n- QuickActionsEditor refreshes data on open.\n\n## Testing\n- ✅ cd frontend && npx vitest run src/contexts/QuickActionsContext.test.tsx src/components/Layout/Header.test.tsx\n- ✅ npm --prefix frontend run verify-standards