### PR TITLE
Entity pages: show WorkForm execution history

### DIFF
--- a/backend/tenant_apps/workflows/tests/test_workform_execution_viewset_filters.py
+++ b/backend/tenant_apps/workflows/tests/test_workform_execution_viewset_filters.py
@@ -73,6 +73,14 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
             ],
             started_by=self.user,
         )
+        # Ensure entity_id filtering works even when the JSON payload persisted a number.
+        self.exec_a_1_int = TenantWorkFormExecution.objects.create(
+            tenant=self.tenant_a,
+            workform=self.workform_a,
+            status='completed',
+            initial_data={'entity_type': 'customer', 'entity_id': 1},
+            started_by=self.user,
+        )
         self.exec_a_2 = TenantWorkFormExecution.objects.create(
             tenant=self.tenant_a,
             workform=self.workform_a,
@@ -85,6 +93,13 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
             workform=self.workform_b,
             status='completed',
             initial_data={'entity_type': 'customer', 'entity_id': '1'},
+            started_by=self.user,
+        )
+        self.exec_b_1_int = TenantWorkFormExecution.objects.create(
+            tenant=self.tenant_b,
+            workform=self.workform_b,
+            status='completed',
+            initial_data={'entity_type': 'customer', 'entity_id': 1},
             started_by=self.user,
         )
 
@@ -124,8 +139,10 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
         rows = self._items(resp)
         ids = {row.get('id') for row in rows}
         self.assertIn(str(self.exec_a_1.id), ids)
+        self.assertIn(str(self.exec_a_1_int.id), ids)
         self.assertNotIn(str(self.exec_a_2.id), ids)
         self.assertNotIn(str(self.exec_b_1.id), ids)
+        self.assertNotIn(str(self.exec_b_1_int.id), ids)
 
         # Serializer exposes per-node statuses derived from audit_trail
         row = next(r for r in rows if r.get('id') == str(self.exec_a_1.id))
@@ -151,6 +168,7 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
         ids = {row.get('id') for row in rows}
         self.assertIn(str(self.exec_a_err.id), ids)
         self.assertNotIn(str(self.exec_b_1.id), ids)
+        self.assertNotIn(str(self.exec_b_1_int.id), ids)
 
         row = next(r for r in rows if r.get('id') == str(self.exec_a_err.id))
         self.assertEqual(row.get('errors')[0].get('node_id'), 'n1')
@@ -166,8 +184,10 @@ class TenantWorkFormExecutionViewSetFilterTests(TestCase):
 
         ids = {row.get('id') for row in self._items(resp)}
         self.assertIn(str(self.exec_a_1.id), ids)
+        self.assertIn(str(self.exec_a_1_int.id), ids)
         self.assertIn(str(self.exec_a_2.id), ids)
         self.assertNotIn(str(self.exec_b_1.id), ids)
+        self.assertNotIn(str(self.exec_b_1_int.id), ids)
 
     def test_missing_tenant_fails_closed(self):
         req = self._get('/api/v1/workflows/workform-executions/', None)

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2110,7 +2110,15 @@ class TenantWorkFormExecutionViewSet(viewsets.ReadOnlyModelViewSet):
 
         entity_id = (self.request.query_params.get('entity_id') or '').strip()
         if entity_id:
-            qs = qs.filter(initial_data__entity_id=str(entity_id))
+            # initial_data is a JSONField; entity_id may be persisted as either a JSON string
+            # ("1") or a JSON number (1) depending on the caller payload.
+            entity_id_str = str(entity_id)
+            entity_id_filter = Q(initial_data__entity_id=entity_id_str)
+            try:
+                entity_id_filter |= Q(initial_data__entity_id=int(entity_id_str))
+            except (TypeError, ValueError):
+                pass
+            qs = qs.filter(entity_id_filter)
 
         status_param = self.request.query_params.get('status')
         if status_param:

--- a/frontend/src/pages/Customers/LocationDetail.tsx
+++ b/frontend/src/pages/Customers/LocationDetail.tsx
@@ -4,6 +4,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { EntityProfileHeader } from '@/components/Cockpit';
+import { EntityWorkflowStatusPanel } from '@/components/Entities/EntityWorkflowStatusPanel';
 import { ActivityFeed, EntityFormSurface } from '@/components/Shared';
 import { apiClient } from '@/services/apiService';
 
@@ -293,6 +294,11 @@ export const LocationDetail: React.FC = () => {
             ),
           },
           {
+            key: 'workflows',
+            label: 'Automation',
+            children: lid ? <EntityWorkflowStatusPanel entityType="location" entityId={lid} /> : <Empty description="Automation unavailable" />,
+          },
+          {
             key: 'activity',
             label: 'Activity',
             children:
@@ -302,6 +308,7 @@ export const LocationDetail: React.FC = () => {
                 <Empty description="Activity unavailable" />
               ),
           },
+
         ]}
       />
     </div>

--- a/frontend/src/pages/Customers/LocationDetail.workflows.test.tsx
+++ b/frontend/src/pages/Customers/LocationDetail.workflows.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { LocationDetail } from './LocationDetail';
+
+vi.mock('@/components/Cockpit', () => ({
+  EntityProfileHeader: () => <div data-testid="entity-profile-header" />,
+}));
+
+vi.mock('@/components/Entities/EntityWorkflowStatusPanel', () => ({
+  EntityWorkflowStatusPanel: ({ entityType, entityId }: { entityType: string; entityId: string }) => (
+    <div data-testid="entity-workflow-status-panel">
+      {entityType}:{entityId}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/Shared', () => ({
+  ActivityFeed: () => <div data-testid="activity-feed" />,
+  EntityFormSurface: () => null,
+}));
+
+const apiGet = vi.fn(async (url: string) => {
+  if (url.startsWith('customers/')) return { data: { id: 1, name: 'ACME' } };
+  if (url.startsWith('locations/')) return { data: { id: 2, name: 'Dock' } };
+  if (url === 'contacts/') return { data: { results: [] } };
+  return { data: {} };
+});
+
+vi.mock('@/services/apiService', () => ({
+  apiClient: {
+    get: (url: string, _config?: unknown) => apiGet(url),
+  },
+}));
+
+describe('LocationDetail workflows tab', () => {
+  it('renders an Automation tab that shows the entity workflow status panel', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/customers/1/locations/2']}>
+        <Routes>
+          <Route path="/customers/:customerId/locations/:locationId" element={<LocationDetail />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const automationTab = await screen.findByRole('tab', { name: /automation/i });
+    await user.click(automationTab);
+
+    expect(await screen.findByTestId('entity-workflow-status-panel')).toHaveTextContent('location:2');
+  });
+});

--- a/frontend/src/pages/Suppliers/PlantDetail.tsx
+++ b/frontend/src/pages/Suppliers/PlantDetail.tsx
@@ -4,6 +4,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { EntityProfileHeader } from '@/components/Cockpit';
+import { EntityWorkflowStatusPanel } from '@/components/Entities/EntityWorkflowStatusPanel';
 import { ActivityFeed, EntityFormSurface } from '@/components/Shared';
 import { apiClient } from '@/services/apiService';
 
@@ -293,6 +294,11 @@ export const PlantDetail: React.FC = () => {
             ),
           },
           {
+            key: 'workflows',
+            label: 'Automation',
+            children: pid ? <EntityWorkflowStatusPanel entityType="plant" entityId={pid} /> : <Empty description="Automation unavailable" />,
+          },
+          {
             key: 'activity',
             label: 'Activity',
             children:
@@ -302,6 +308,7 @@ export const PlantDetail: React.FC = () => {
                 <Empty description="Activity unavailable" />
               ),
           },
+
         ]}
       />
     </div>

--- a/frontend/src/pages/Suppliers/PlantDetail.workflows.test.tsx
+++ b/frontend/src/pages/Suppliers/PlantDetail.workflows.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { PlantDetail } from './PlantDetail';
+
+vi.mock('@/components/Cockpit', () => ({
+  EntityProfileHeader: () => <div data-testid="entity-profile-header" />,
+}));
+
+vi.mock('@/components/Entities/EntityWorkflowStatusPanel', () => ({
+  EntityWorkflowStatusPanel: ({ entityType, entityId }: { entityType: string; entityId: string }) => (
+    <div data-testid="entity-workflow-status-panel">
+      {entityType}:{entityId}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/Shared', () => ({
+  ActivityFeed: () => <div data-testid="activity-feed" />,
+  EntityFormSurface: () => null,
+}));
+
+const apiGet = vi.fn(async (url: string) => {
+  if (url.startsWith('suppliers/')) return { data: { id: 1, name: 'Supplier' } };
+  if (url.startsWith('plants/')) return { data: { id: 2, name: 'Plant' } };
+  if (url === 'contacts/') return { data: { results: [] } };
+  return { data: {} };
+});
+
+vi.mock('@/services/apiService', () => ({
+  apiClient: {
+    get: (url: string, _config?: unknown) => apiGet(url),
+  },
+}));
+
+describe('PlantDetail workflows tab', () => {
+  it('renders an Automation tab that shows the entity workflow status panel', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/suppliers/1/plants/2']}>
+        <Routes>
+          <Route path="/suppliers/:supplierId/plants/:plantId" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const automationTab = await screen.findByRole('tab', { name: /automation/i });
+    await user.click(automationTab);
+
+    expect(await screen.findByTestId('entity-workflow-status-panel')).toHaveTextContent('plant:2');
+  });
+});


### PR DESCRIPTION
## Deliverables
- Adds an **Automation** tab to Plant + Location detail pages, surfacing record-scoped WorkForm executions (same data used by the universal record pivot).
- Fixes backend entity execution filtering to match initial_data.entity_id stored as either JSON string ("1") or JSON number (1).
- Adds focused Vitest coverage for the new tab wiring.

## Why
Users frequently land on legacy detail pages (PlantDetail/LocationDetail). Without this tab, record-scoped automation history is effectively hidden even though the underlying panel + API exist.

## Testing
- frontend: npm run type-check
- frontend: vitest run (focused specs for the new tabs + existing panel unit tests)
- backend: updated tenant_apps.workflows.tests.test_workform_execution_viewset_filters (full run requires Postgres-backed test DB)

## Risk / Rollback
Low-risk additive UI + query widening. Revert PR to roll back.
