### PR TITLE
Email integrations: start Gmail connector + OAuth hardening

### DIFF
--- a/backend/apps/email_integration/tests/test_oauth_state_signing.py
+++ b/backend/apps/email_integration/tests/test_oauth_state_signing.py
@@ -1,0 +1,19 @@
+from django.core.signing import BadSignature
+from django.test import TestCase
+
+from apps.email_integration.views.oauth_views import _sign_oauth_state, _unsign_oauth_state
+
+
+class OAuthStateSigningTests(TestCase):
+    def test_signed_state_round_trips(self):
+        state = _sign_oauth_state({'user_id': 123, 'tenant_id': 'tenant-1', 'provider': 'gmail'})
+        payload = _unsign_oauth_state(state)
+        self.assertEqual(payload.get('user_id'), 123)
+        self.assertEqual(payload.get('tenant_id'), 'tenant-1')
+        self.assertEqual(payload.get('provider'), 'gmail')
+
+    def test_signed_state_rejects_tampering(self):
+        state = _sign_oauth_state({'user_id': 123, 'tenant_id': 'tenant-1', 'provider': 'outlook'})
+        tampered = state[:-1] + ('a' if state[-1] != 'a' else 'b')
+        with self.assertRaises(BadSignature):
+            _unsign_oauth_state(tampered)

--- a/backend/apps/email_integration/urls.py
+++ b/backend/apps/email_integration/urls.py
@@ -4,28 +4,36 @@ Email Integration URLs
 Routes for email OAuth flows and webhook notifications.
 """
 from django.urls import path
+from rest_framework.routers import DefaultRouter
+
 from apps.email_integration.views import oauth_views, webhook_views
 
 app_name = 'email_integration'
+
+router = DefaultRouter()
+router.register('email-accounts', oauth_views.EmailAccountViewSet, basename='email-account')
 
 urlpatterns = [
     # Outlook OAuth
     path('email/outlook/auth/init/', oauth_views.outlook_auth_init, name='outlook-auth-init'),
     path('email/outlook/auth/callback/', oauth_views.outlook_auth_callback, name='outlook-auth-callback'),
-    
+
     # Gmail OAuth
     path('email/gmail/auth/init/', oauth_views.gmail_auth_init, name='gmail-auth-init'),
     path('email/gmail/auth/callback/', oauth_views.gmail_auth_callback, name='gmail-auth-callback'),
-    
+
     # Outlook Webhooks
     path('email/outlook/webhook/subscribe/<int:account_id>/', webhook_views.outlook_webhook_subscribe, name='outlook-webhook-subscribe'),
     path('email/outlook/webhook/renew/<int:account_id>/', webhook_views.outlook_webhook_renew, name='outlook-webhook-renew'),
     path('email/outlook/webhook/unsubscribe/<int:account_id>/', webhook_views.outlook_webhook_unsubscribe, name='outlook-webhook-unsubscribe'),
     path('email/outlook/webhook/notifications/', webhook_views.outlook_webhook_notifications, name='outlook-webhook-notifications'),
-    
+
     # Gmail Webhooks
     path('email/gmail/webhook/subscribe/<int:account_id>/', webhook_views.gmail_webhook_subscribe, name='gmail-webhook-subscribe'),
     path('email/gmail/webhook/renew/<int:account_id>/', webhook_views.gmail_webhook_renew, name='gmail-webhook-renew'),
     path('email/gmail/webhook/unsubscribe/<int:account_id>/', webhook_views.gmail_webhook_unsubscribe, name='gmail-webhook-unsubscribe'),
     path('email/gmail/webhook/notifications/', webhook_views.gmail_webhook_notifications, name='gmail-webhook-notifications'),
+
+    # Email account management
+    *router.urls,
 ]

--- a/backend/apps/email_integration/views/oauth_views.py
+++ b/backend/apps/email_integration/views/oauth_views.py
@@ -10,6 +10,8 @@ Created: 2026-02-23 - Email Integration Phase 2
 import logging
 from datetime import timedelta
 from django.conf import settings
+from django.core import signing
+from django.core.signing import BadSignature, SignatureExpired
 from django.shortcuts import redirect
 from django.utils import timezone
 from django.http import JsonResponse
@@ -21,6 +23,17 @@ from rest_framework.response import Response
 from apps.email_integration.models import EmailAccount, EmailLog
 
 logger = logging.getLogger(__name__)
+
+OAUTH_STATE_SALT = 'email_integration.oauth_state'
+OAUTH_STATE_MAX_AGE_SECONDS = 10 * 60
+
+
+def _sign_oauth_state(payload: dict) -> str:
+    return signing.dumps(payload, salt=OAUTH_STATE_SALT)
+
+
+def _unsign_oauth_state(state: str) -> dict:
+    return signing.loads(state, salt=OAUTH_STATE_SALT, max_age=OAUTH_STATE_MAX_AGE_SECONDS)
 
 
 # ============================================================================
@@ -58,8 +71,14 @@ def outlook_auth_init(request):
             "offline_access"
         ]
         
-        # Store user ID in state for callback
-        state = f"{request.user.id}"
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return JsonResponse(
+                {'error': 'Tenant context required', 'code': 'tenant_required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        state = _sign_oauth_state({'user_id': request.user.id, 'tenant_id': str(tenant.id), 'provider': 'outlook'})
         
         auth_url = msal_app.get_authorization_request_url(
             scopes=scopes,
@@ -103,11 +122,30 @@ def outlook_auth_callback(request):
         return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=missing_params")
     
     try:
-        # Get user from state
+        try:
+            payload = _unsign_oauth_state(state)
+        except SignatureExpired:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=state_expired")
+        except BadSignature:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+
+        user_id = payload.get('user_id')
+        tenant_id = payload.get('tenant_id')
+        if not user_id or not tenant_id:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+
         from django.contrib.auth import get_user_model
+        from apps.tenants.models import Tenant, TenantUser
+
         User = get_user_model()
-        user = User.objects.get(id=int(state))
-        
+        user = User.objects.get(id=int(user_id))
+        tenant = Tenant.objects.filter(id=tenant_id, is_active=True).first()
+        if not tenant:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_tenant")
+
+        if not TenantUser.objects.filter(tenant=tenant, user=user, is_active=True).exists():
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=tenant_denied")
+
         # Exchange code for tokens
         client_id = settings.MICROSOFT_CLIENT_ID
         client_secret = settings.MICROSOFT_CLIENT_SECRET
@@ -193,16 +231,37 @@ def gmail_auth_init(request):
     from google_auth_oauthlib.flow import Flow
     
     try:
+        client_id = str(getattr(settings, 'GOOGLE_CLIENT_ID', '') or '').strip()
+        client_secret = str(getattr(settings, 'GOOGLE_CLIENT_SECRET', '') or '').strip()
+        redirect_uri = str(getattr(settings, 'GOOGLE_REDIRECT_URI', '') or '').strip()
+
+        if not client_id or not client_secret or not redirect_uri:
+            return JsonResponse(
+                {
+                    'error': 'Gmail OAuth is not configured',
+                    'code': 'not_configured',
+                    'required': ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'GOOGLE_REDIRECT_URI'],
+                },
+                status=status.HTTP_501_NOT_IMPLEMENTED,
+            )
+
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return JsonResponse(
+                {'error': 'Tenant context required', 'code': 'tenant_required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         client_config = {
             "web": {
-                "client_id": settings.GOOGLE_CLIENT_ID,
-                "client_secret": settings.GOOGLE_CLIENT_SECRET,
-                "redirect_uris": [settings.GOOGLE_REDIRECT_URI],
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uris": [redirect_uri],
                 "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                 "token_uri": "https://oauth2.googleapis.com/token",
             }
         }
-        
+
         flow = Flow.from_client_config(
             client_config,
             scopes=[
@@ -210,11 +269,10 @@ def gmail_auth_init(request):
                 'https://www.googleapis.com/auth/gmail.send',
                 'https://www.googleapis.com/auth/userinfo.email',
             ],
-            redirect_uri=settings.GOOGLE_REDIRECT_URI
+            redirect_uri=redirect_uri
         )
-        
-        # Store user ID in state
-        state = f"{request.user.id}"
+
+        state = _sign_oauth_state({'user_id': request.user.id, 'tenant_id': str(tenant.id), 'provider': 'gmail'})
         
         auth_url, _ = flow.authorization_url(
             access_type='offline',
@@ -258,17 +316,43 @@ def gmail_auth_callback(request):
         return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=missing_params")
     
     try:
-        # Get user from state
+        try:
+            payload = _unsign_oauth_state(state)
+        except SignatureExpired:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=state_expired")
+        except BadSignature:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+
+        user_id = payload.get('user_id')
+        tenant_id = payload.get('tenant_id')
+        if not user_id or not tenant_id:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+
         from django.contrib.auth import get_user_model
+        from apps.tenants.models import Tenant, TenantUser
+
         User = get_user_model()
-        user = User.objects.get(id=int(state))
-        
+        user = User.objects.get(id=int(user_id))
+        tenant = Tenant.objects.filter(id=tenant_id, is_active=True).first()
+        if not tenant:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_tenant")
+
+        if not TenantUser.objects.filter(tenant=tenant, user=user, is_active=True).exists():
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=tenant_denied")
+
+        client_id = str(getattr(settings, 'GOOGLE_CLIENT_ID', '') or '').strip()
+        client_secret = str(getattr(settings, 'GOOGLE_CLIENT_SECRET', '') or '').strip()
+        redirect_uri = str(getattr(settings, 'GOOGLE_REDIRECT_URI', '') or '').strip()
+
+        if not client_id or not client_secret or not redirect_uri:
+            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=not_configured")
+
         # Exchange code for tokens
         client_config = {
             "web": {
-                "client_id": settings.GOOGLE_CLIENT_ID,
-                "client_secret": settings.GOOGLE_CLIENT_SECRET,
-                "redirect_uris": [settings.GOOGLE_REDIRECT_URI],
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uris": [redirect_uri],
                 "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                 "token_uri": "https://oauth2.googleapis.com/token",
             }
@@ -281,7 +365,7 @@ def gmail_auth_callback(request):
                 'https://www.googleapis.com/auth/gmail.send',
                 'https://www.googleapis.com/auth/userinfo.email',
             ],
-            redirect_uri=settings.GOOGLE_REDIRECT_URI,
+            redirect_uri=redirect_uri,
             state=state
         )
         

--- a/docs/features/EMAIL_INTEGRATIONS_PHASE6.md
+++ b/docs/features/EMAIL_INTEGRATIONS_PHASE6.md
@@ -24,3 +24,26 @@ This document tracks the Phase 6 email integration UX + OAuth flow for Microsoft
 
 - Redirect URI is constructed using the request host and `/api/v1/integrations/oauth/callback/microsoft/` to support `dev.meatscentral.com` and other environments consistently.
 - Changes are additive-only and do not break existing workflows.
+
+## Gmail (Starter MVP)
+
+### What ships (backend)
+- `GET /api/v1/workflows/email/email/gmail/auth/init/` (authenticated) returns `{ auth_url, provider }`.
+- `GET /api/v1/workflows/email/email/gmail/auth/callback/` (anonymous) exchanges the auth code and stores tokens in `EmailAccount`.
+- OAuth `state` is now **signed + time-limited** and includes `user_id` + `tenant_id` to prevent tampering.
+
+### What you (user) must configure in Google Cloud (required)
+1. Create/choose a **Google Cloud project**.
+2. Enable **Gmail API**.
+3. Configure **OAuth consent screen** (add test users if not publishing).
+4. Create **OAuth Client ID** → type **Web application**.
+5. Add an authorized redirect URI that matches the backend callback exactly, e.g.:
+   - `https://<YOUR_BACKEND_DOMAIN>/api/v1/workflows/email/email/gmail/auth/callback/`
+6. Provide the following secrets to the target environment:
+   - `GOOGLE_CLIENT_ID`
+   - `GOOGLE_CLIENT_SECRET`
+   - `GOOGLE_REDIRECT_URI` (must match the redirect URI configured in Google)
+
+### Expected behavior
+- If Gmail OAuth secrets are missing, init returns a clear `not_configured` error and lists required keys.
+- On success, the callback redirects back to the frontend with `oauth_success=gmail&email=<address>`.

--- a/frontend/src/components/Widgets/EmailIntegrationWidget.tsx
+++ b/frontend/src/components/Widgets/EmailIntegrationWidget.tsx
@@ -316,7 +316,7 @@ export const EmailIntegrationWidget: React.FC<EmailIntegrationWidgetProps> = ({ 
     try {
       setLoading(true);
       setError(null);
-      const response = await apiClient.get('/workflows/email-accounts/');
+      const response = await apiClient.get('/workflows/email/email-accounts/');
       setAccounts(response.data);
     } catch (err: any) {
       console.error('Failed to fetch email accounts:', err);
@@ -337,13 +337,9 @@ export const EmailIntegrationWidget: React.FC<EmailIntegrationWidgetProps> = ({ 
 
   const handleConnect = async (provider: 'outlook' | 'gmail') => {
     try {
-      const backendProvider = provider === 'outlook' ? 'microsoft' : 'google';
-
       // Use secure apiClient to get the OAuth URL, preserving JWT and Tenant headers.
       // Backend returns JSON { auth_url } (not a redirect) so the SPA can do a top-level navigation.
-      const response = await apiClient.get('/integrations/oauth/authorize/', {
-        params: { provider: backendProvider },
-      });
+      const response = await apiClient.get(`/workflows/email/email/${provider}/auth/init/`);
 
       if (response.data?.auth_url) {
         window.location.href = response.data.auth_url;
@@ -372,7 +368,7 @@ export const EmailIntegrationWidget: React.FC<EmailIntegrationWidgetProps> = ({ 
     if (!confirmed) return;
 
     try {
-      await apiClient.delete(`/workflows/email-accounts/${accountId}/`);
+      await apiClient.delete(`/workflows/email/email-accounts/${accountId}/`);
       setAccounts(accounts.filter(acc => acc.id !== accountId));
     } catch (err: any) {
       console.error('Failed to disconnect account:', err);


### PR DESCRIPTION
## Deliverables
- Gmail + Outlook OAuth `state` is now **signed + time-limited** and encodes `user_id` + `tenant_id` (prevents state tampering).
- Gmail init endpoint returns a clear `not_configured` response when required secrets are missing.
- Exposes `EmailAccountViewSet` under `/api/v1/workflows/email/email-accounts/`.
- Wires `EmailIntegrationWidget` to the email_integration OAuth + account endpoints (previous paths were mismatched).
- Adds unit tests for state signing and documents the required Google Cloud setup steps.

## User action required (Google Cloud)
You must create OAuth web credentials + enable Gmail API and set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` to match the callback URL:
`https://<BACKEND_DOMAIN>/api/v1/workflows/email/email/gmail/auth/callback/`

## Testing
- Frontend: `npm --prefix frontend run verify-standards`
- Backend: CI (Postgres-backed) runs Django tests; locally we verified module compilation with `py_compile`.

## Rollback
Revert this PR to restore prior OAuth state behavior and frontend wiring.
