### PR TITLE
WorkForms: fix config panel engine regressions

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
@@ -200,6 +200,20 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
   onChange,
   error
 }) => {
+  const effectiveChildSchema: Omit<NodeConfigSchema, 'nodeType' | 'displayName'> | undefined =
+    field.childSchema ??
+    ((field as any).itemSchema && Array.isArray((field as any).itemSchema.fields)
+      ? {
+          sections: [
+            {
+              id: 'item',
+              title: 'Item',
+              fields: (field as any).itemSchema.fields,
+            },
+          ],
+        }
+      : undefined);
+
   const [expandedChildren, setExpandedChildren] = useState<Set<number>>(
     new Set(value.length === 1 ? [0] : []) // Auto-expand if only one child
   );
@@ -219,7 +233,7 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
   
   // Add new child
   const handleAddChild = useCallback(() => {
-    const newChild = field.childSchema?.sections?.reduce((acc, section) => {
+    const newChild = effectiveChildSchema?.sections?.reduce((acc, section) => {
       section.fields.forEach(f => {
         if (f.defaultValue !== undefined) {
           acc[f.id] = f.defaultValue;
@@ -233,7 +247,7 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
     
     // Auto-expand new child
     setExpandedChildren(prev => new Set([...prev, newValue.length - 1]));
-  }, [field, value, onChange]);
+  }, [effectiveChildSchema, value, onChange]);
   
   // Remove child
   const handleRemoveChild = useCallback((index: number, e: React.MouseEvent) => {
@@ -261,7 +275,7 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
   // Get child title (from first text field or index)
   const getChildTitle = (child: any, index: number): string => {
     // Try to find a title/name/label field
-    const titleField = field.childSchema?.sections?.flatMap(s => s.fields)
+    const titleField = effectiveChildSchema?.sections?.flatMap(s => s.fields)
       .find(f => ['title', 'name', 'label', 'stepTitle'].includes(f.id));
     
     if (titleField && child[titleField.id]) {
@@ -308,7 +322,7 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
                 {isExpanded && (
                   <ChildContent>
                     {/* Render child fields inline without full DynamicConfigPanel */}
-                    {field.childSchema?.sections?.map(section => (
+                    {effectiveChildSchema?.sections?.map(section => (
                       <div key={section.id}>
                         {section.fields.map(childField => (
                           <div key={childField.id} style={{ marginBottom: '12px' }}>

--- a/frontend/src/components/FlowEditor/config/__tests__/configEngine.regression.test.tsx
+++ b/frontend/src/components/FlowEditor/config/__tests__/configEngine.regression.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import type { ConfigField, ConditionalRule } from '../types';
+import { evaluateCondition } from '../conditionalLogic';
+import { validateField } from '../validationEngine';
+import { renderSelectField, renderTextField } from '../fieldRenderers/basicRenderers';
+import { NestedChildrenRenderer } from '../../ConfigPanel/NestedChildrenRenderer';
+
+describe('FlowEditor config engine regressions', () => {
+  it('conditionalLogic supports in / notIn operators', () => {
+    const ruleIn: ConditionalRule = { field: 'status', operator: 'in', value: ['open', 'pending'] };
+    expect(evaluateCondition(ruleIn, { status: 'open' })).toBe(true);
+    expect(evaluateCondition(ruleIn, { status: 'closed' })).toBe(false);
+
+    const ruleNotIn: ConditionalRule = { field: 'status', operator: 'notIn', value: ['closed'] };
+    expect(evaluateCondition(ruleNotIn, { status: 'open' })).toBe(true);
+    expect(evaluateCondition(ruleNotIn, { status: 'closed' })).toBe(false);
+
+    // Arrays should be supported (any-match semantics)
+    const arrayRule: ConditionalRule = { field: 'tags', operator: 'in', value: ['a', 'b'] };
+    expect(evaluateCondition(arrayRule, { tags: ['c', 'b'] })).toBe(true);
+    expect(evaluateCondition(arrayRule, { tags: ['c'] })).toBe(false);
+  });
+
+  it('validationEngine treats pattern as alias of regex', () => {
+    const field: ConfigField = {
+      id: 'sku',
+      label: 'SKU',
+      type: 'text',
+      validation: [
+        {
+          type: 'pattern',
+          value: '^SKU-[0-9]+$',
+          message: 'Invalid SKU',
+        },
+      ],
+    };
+
+    expect(validateField(field, 'SKU-123', {})).toBe(null);
+    expect(validateField(field, 'BAD', {})).toBe('Invalid SKU');
+  });
+
+  it('renderSelectField supports legacy multiSelect alias and emits string[]', () => {
+    const field: ConfigField = {
+      id: 'colors',
+      label: 'Colors',
+      type: 'multiSelect',
+      options: [
+        { value: 'red', label: 'Red' },
+        { value: 'blue', label: 'Blue' },
+      ],
+    };
+
+    const onChange = vi.fn();
+
+    const node = renderSelectField({
+      field,
+      value: ['red'],
+      onChange,
+      error: undefined,
+      disabled: false,
+    });
+
+    render(<>{node}</>);
+
+    const select = screen.getByRole('listbox') as HTMLSelectElement;
+
+    // Simulate selecting both options
+    Array.from(select.options).forEach((opt) => {
+      opt.selected = true;
+    });
+    fireEvent.change(select);
+
+    expect(onChange).toHaveBeenCalledWith(['red', 'blue']);
+  });
+
+  it('renderTextField preserves 0 and parses number inputs to numbers', () => {
+    const field: ConfigField = {
+      id: 'count',
+      label: 'Count',
+      type: 'number',
+    };
+
+    const onChange = vi.fn();
+
+    const node = renderTextField({
+      field,
+      value: 0,
+      onChange,
+      error: undefined,
+      disabled: false,
+    });
+
+    render(<>{node}</>);
+
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('0');
+
+    fireEvent.change(input, { target: { value: '5' } });
+    expect(onChange).toHaveBeenCalledWith(5);
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('NestedChildrenRenderer can render when schema uses itemSchema (no childSchema)', () => {
+    const field: ConfigField = {
+      id: 'options',
+      label: 'Options',
+      type: 'nested-children',
+      itemSchema: {
+        fields: [
+          { id: 'label', label: 'Label', type: 'text', defaultValue: '' },
+          { id: 'value', label: 'Value', type: 'text', defaultValue: '' },
+        ],
+      },
+    };
+
+    const Wrapper: React.FC = () => {
+      const [value, setValue] = React.useState<any[]>([]);
+      return <NestedChildrenRenderer field={field} value={value} onChange={setValue} />;
+    };
+
+    render(<Wrapper />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    // Child fields should render (auto-expanded)
+    expect(screen.getByText('Label')).toBeInTheDocument();
+    expect(screen.getByText('Value')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/FlowEditor/config/conditionalLogic.ts
+++ b/frontend/src/components/FlowEditor/config/conditionalLogic.ts
@@ -85,6 +85,22 @@ function evaluateOperator(
       }
       return true;
 
+    case 'in': {
+      const allowed = Array.isArray(targetValue) ? targetValue : [targetValue];
+      if (Array.isArray(fieldValue)) {
+        return fieldValue.some((v) => allowed.includes(v));
+      }
+      return allowed.includes(fieldValue);
+    }
+
+    case 'notIn': {
+      const blocked = Array.isArray(targetValue) ? targetValue : [targetValue];
+      if (Array.isArray(fieldValue)) {
+        return !fieldValue.some((v) => blocked.includes(v));
+      }
+      return !blocked.includes(fieldValue);
+    }
+
     case 'greaterThan':
       if (typeof fieldValue === 'number' && typeof targetValue === 'number') {
         return fieldValue > targetValue;

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
@@ -29,7 +29,7 @@ import {
  * Render a text input field
  */
 export function renderTextField(
-  props: FieldRendererProps<string>
+  props: FieldRendererProps<string | number | undefined>
 ): React.ReactNode {
   const { field, value, onChange, error } = props;
 
@@ -48,7 +48,7 @@ export function renderTextField(
       </Label>
       {field.type === 'textarea' ? (
         <TextArea
-          value={value || ''}
+          value={value ?? ''}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           disabled={field.disabled || props.disabled}
@@ -63,8 +63,23 @@ export function renderTextField(
             : field.type === 'time' ? 'time'
             : 'text'
           }
-          value={value || ''}
-          onChange={(e) => onChange(e.target.value)}
+          value={value ?? ''}
+          onChange={(e) => {
+            if (field.type === 'number') {
+              const raw = e.target.value;
+              if (raw === '') {
+                onChange(undefined);
+                return;
+              }
+              const parsed = Number(raw);
+              if (!Number.isNaN(parsed)) {
+                onChange(parsed);
+              }
+              return;
+            }
+
+            onChange(e.target.value);
+          }}
           placeholder={placeholder}
           disabled={field.disabled || props.disabled}
         />
@@ -83,9 +98,11 @@ export function renderSelectField(
 ): React.ReactNode {
   const { field, value, onChange, error } = props;
 
+  const isMulti = field.type === 'multiselect' || field.type === 'multiSelect' || field.multiple === true;
+
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (field.type === 'multiselect') {
-      const options = Array.from(e.target.selectedOptions, option => option.value);
+    if (isMulti) {
+      const options = Array.from(e.target.selectedOptions, (option) => option.value);
       onChange(options);
     } else {
       onChange(e.target.value);
@@ -99,12 +116,20 @@ export function renderSelectField(
         {field.required && <span style={{ color: 'rgb(var(--color-error))' }}> *</span>}
       </Label>
       <Select
-        value={value || (field.type === 'multiselect' ? [] : '')}
+        value={
+          isMulti
+            ? Array.isArray(value)
+              ? value
+              : value
+                ? [String(value)]
+                : []
+            : String((value as any) ?? '')
+        }
         onChange={handleChange}
         disabled={field.disabled || props.disabled}
-        multiple={field.type === 'multiselect'}
+        multiple={isMulti}
       >
-        {!field.required && field.type !== 'multiselect' && (
+        {!field.required && !isMulti && (
           <option value="">-- Select --</option>
         )}
         {field.options?.map(option => (

--- a/frontend/src/components/FlowEditor/config/validationEngine.ts
+++ b/frontend/src/components/FlowEditor/config/validationEngine.ts
@@ -92,6 +92,7 @@ function validateRule(
       return null;
 
     case 'regex':
+    case 'pattern':
       if (typeof value === 'string') {
         const regex = rule.value instanceof RegExp ? rule.value : new RegExp(rule.value);
         if (!regex.test(value)) {


### PR DESCRIPTION
## What\nFixes several core schema-driven config panel issues that caused many node panels to appear broken or behave incorrectly.\n\n### Fixes\n- Conditional logic: implement `in` / `notIn` operators\n- Validation: treat `pattern` as alias of `regex` (legacy schemas)\n- Select renderer: support legacy `multiSelect` type + proper string[] handling\n- Nested children renderer: support `itemSchema` (fallback when `childSchema` is missing)\n- Number inputs: preserve 0 and coerce numeric input to numbers (empty => undefined)\n\n## Tests\n- `cd frontend && npm run type-check\n  npm run test -- --run src/components/FlowEditor/config/__tests__/configEngine.regression.test.tsx`\n\n## Risk / Rollback\nLow risk (frontend-only). Roll back by reverting this PR if any panel regression is reported.