### PR TITLE
Security: harden integrations OAuth (tenant-safe)

### DIFF
--- a/backend/apps/integrations/tests.py
+++ b/backend/apps/integrations/tests.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
+from types import SimpleNamespace
 
 from django.contrib.auth.models import User
+from django.core import signing
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -95,3 +97,84 @@ class IntegrationsOAuthCallbackPublicTests(APITestCase):
     def test_oauth_callback_allows_anonymous(self):
         resp = self.client.get('/api/v1/integrations/oauth/callback/microsoft/?error=access_denied')
         self.assertEqual(resp.status_code, 302)
+
+
+class IntegrationsOAuthSecurityTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='oauth-user', password='pass123')
+        self.tenant = Tenant.objects.create(
+            name='OAuth Tenant',
+            slug='oauth-tenant',
+            contact_email='oauth@example.com',
+            created_by=self.user,
+        )
+
+    def test_oauth_authorize_requires_auth(self):
+        resp = self.client.get('/api/v1/integrations/oauth/authorize/?provider=microsoft')
+        self.assertIn(resp.status_code, {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN})
+
+    def test_oauth_callback_denies_when_user_not_in_tenant(self):
+        state = signing.dumps(
+            {
+                'tenant_id': str(self.tenant.id),
+                'user_id': str(self.user.id),
+                'provider': 'microsoft',
+                'nonce': 'n',
+            },
+            salt='pm.integrations.oauth.state',
+        )
+
+        session = self.client.session
+        session['oauth_state_microsoft'] = state
+        session['oauth_tenant_microsoft'] = str(self.tenant.id)
+        session.save()
+
+        with patch('integrations.views.oauth.MicrosoftGraphProvider') as mocked_provider:
+            resp = self.client.get(
+                f'/api/v1/integrations/oauth/callback/microsoft/?code=abc&state={state}'
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn('error=permission_denied', resp['Location'])
+        self.assertFalse(
+            ExternalAuthProvider.objects.filter(tenant=self.tenant, provider_type='microsoft').exists()
+        )
+        mocked_provider.assert_not_called()
+
+    def test_oauth_callback_persists_tokens_for_member(self):
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner', is_active=True)
+
+        state = signing.dumps(
+            {
+                'tenant_id': str(self.tenant.id),
+                'user_id': str(self.user.id),
+                'provider': 'microsoft',
+                'nonce': 'n',
+            },
+            salt='pm.integrations.oauth.state',
+        )
+
+        session = self.client.session
+        session['oauth_state_microsoft'] = state
+        session['oauth_tenant_microsoft'] = str(self.tenant.id)
+        session.save()
+
+        token_response = SimpleNamespace(access_token='access', refresh_token='refresh', expires_in=3600)
+        user_info = {'email': 'connected@example.com', 'name': 'Connected User'}
+
+        mocked_instance = SimpleNamespace(
+            exchange_code=lambda code, redirect_uri: token_response,
+            get_user_info=lambda access_token: user_info,
+        )
+
+        with patch('integrations.views.oauth.MicrosoftGraphProvider', return_value=mocked_instance):
+            resp = self.client.get(
+                f'/api/v1/integrations/oauth/callback/microsoft/?code=abc&state={state}'
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn('success=connected', resp['Location'])
+
+        provider = ExternalAuthProvider.objects.get(tenant=self.tenant, provider_type='microsoft')
+        self.assertTrue(provider.is_active)
+        self.assertEqual(provider.connected_email, 'connected@example.com')

--- a/backend/apps/integrations/views.py
+++ b/backend/apps/integrations/views.py
@@ -68,7 +68,12 @@ def get_auth_url(request):
     # Generate signed state token (fallback when session cookies are blocked).
     nonce = secrets.token_urlsafe(16)
     state = signing.dumps(
-        {"tenant_id": str(tenant.id), "provider": provider_type, "nonce": nonce},
+        {
+            "tenant_id": str(tenant.id),
+            "user_id": str(request.user.id),
+            "provider": provider_type,
+            "nonce": nonce,
+        },
         salt='integrations.oauth.state',
     )
 
@@ -147,34 +152,43 @@ def oauth_callback(request, provider_type):
     if not code:
         return redirect('/settings?error=no_code')
     
-    # Validate state for CSRF protection
+    # Validate signed state for CSRF protection + identity binding.
     state = request.GET.get('state')
-    expected_state = request.session.get(f'oauth_state_{provider_type}')
 
-    state_payload = None
-    if state and expected_state and state == expected_state:
-        # Session-based validation succeeded
+    try:
+        state_payload = signing.loads(state or '', salt='integrations.oauth.state', max_age=15 * 60)
+    except Exception:
         state_payload = None
-    else:
-        # Fallback: allow signed state when session cookies are not preserved
-        try:
-            state_payload = signing.loads(state or '', salt='integrations.oauth.state', max_age=15 * 60)
-        except Exception:
-            state_payload = None
 
-        if not state_payload or state_payload.get('provider') != provider_type:
-            return redirect('/settings?error=invalid_state')
+    if not state_payload or state_payload.get('provider') != provider_type:
+        return redirect('/settings?error=invalid_state')
 
-    # Get tenant from session or signed payload
+    # Get tenant + initiating user from session or signed payload
     tenant_id = request.session.get(f'oauth_tenant_{provider_type}') or (state_payload or {}).get('tenant_id')
-    if not tenant_id:
-        return redirect('/settings?error=no_tenant')
+    user_id = (state_payload or {}).get('user_id')
+    if not tenant_id or not user_id:
+        return redirect('/settings?error=invalid_state')
     
     try:
-        from apps.tenants.models import Tenant
+        from apps.tenants.models import Tenant, TenantUser
         tenant = Tenant.objects.get(id=tenant_id)
     except Tenant.DoesNotExist:
         return redirect('/settings?error=tenant_not_found')
+
+    # Enforce tenant membership for the initiating user.
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    try:
+        initiating_user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        return redirect('/settings?error=user_not_found')
+
+    if not (
+        getattr(initiating_user, 'is_superuser', False)
+        or TenantUser.objects.filter(tenant=tenant, user=initiating_user, is_active=True).exists()
+    ):
+        return redirect('/settings?error=permission_denied')
 
     # Build redirect URI (must match the one used in get_auth_url)
     callback_path = f'/api/v1/integrations/oauth/callback/{provider_type}/'

--- a/backend/integrations/views/oauth.py
+++ b/backend/integrations/views/oauth.py
@@ -6,11 +6,12 @@ from datetime import timedelta
 from urllib.parse import urlencode, quote
 
 from django.conf import settings
+from django.core import signing
 from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import redirect
 from django.utils import timezone
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
 
 from apps.integrations.microsoft.utils import get_microsoft_redirect_uri
@@ -25,6 +26,7 @@ _OAUTH_COOKIE_PREFIX = 'pm_oauth'
 _OAUTH_COOKIE_MAX_AGE_SECONDS = 15 * 60
 _OAUTH_COOKIE_PATH = '/api/v1/integrations/oauth/'
 _SIGNER = TimestampSigner(salt='pm.integrations.oauth')
+_STATE_SALT = 'pm.integrations.oauth.state'
 
 
 def _oauth_cookie_name(key: str, provider: str) -> str:
@@ -64,15 +66,14 @@ def _clear_oauth_cookies(response, provider: str) -> None:
 
 
 class OAuthAuthorizeView(APIView):
-    """Redirect the user to the provider's OAuth2 authorization page.
+    """Return (or redirect to) the provider's OAuth2 authorization URL.
 
-    IMPORTANT:
-    - This endpoint must work via plain browser navigation (no Authorization header).
-    - We store `state` in the session for CSRF protection and validate it in the callback handler.
+    Security requirements:
+    - Initiation must be tied to an authenticated user.
+    - Callback must validate a signed state containing tenant_id + user_id and enforce membership.
     """
 
-    authentication_classes = []
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request):
         provider = request.query_params.get('provider', 'microsoft')
@@ -128,14 +129,24 @@ class OAuthAuthorizeView(APIView):
         if not tenant:
             return HttpResponse('Tenant not resolved for this request.', status=400, content_type='text/plain')
 
-        # Generate CSRF state.
-        state = secrets.token_urlsafe(32)
+        # Generate signed state tied to the authenticated user + tenant.
+        #
+        # Why signed?
+        # - Callback arrives without Authorization header.
+        # - Session cookie may be blocked on cross-site redirects.
+        # - Signed state provides integrity and lets us enforce tenant membership.
+        nonce = secrets.token_urlsafe(16)
+        state = signing.dumps(
+            {
+                'tenant_id': str(tenant.id),
+                'user_id': str(request.user.id),
+                'provider': provider,
+                'nonce': nonce,
+            },
+            salt=_STATE_SALT,
+        )
 
         # Persist state/tenant for callback verification.
-        #
-        # Why cookies too?
-        # Production uses SESSION_COOKIE_SAMESITE=Strict, which prevents the session cookie
-        # from being sent on cross-site redirects back from Microsoft.
         request.session[f'oauth_state_{provider}'] = state
         request.session[f'oauth_tenant_{provider}'] = str(tenant.id)
 
@@ -248,20 +259,45 @@ class OAuthCallbackView(APIView):
             _clear_oauth_cookies(response, provider)
             return response
 
-        tenant_id = request.session.get(f'oauth_tenant_{provider}') or _get_signed_oauth_cookie(
-            request,
-            name=_oauth_cookie_name('tenant', provider),
-        )
-        if not tenant_id:
-            response = redirect(f'/settings/email-integrations?error=no_tenant&provider={quote(provider)}')
+        # Decode signed state payload (must include tenant_id + user_id).
+        try:
+            state_payload = signing.loads(state, salt=_STATE_SALT, max_age=_OAUTH_COOKIE_MAX_AGE_SECONDS)
+        except Exception:
+            response = redirect(f'/settings/email-integrations?error=invalid_state&provider={quote(provider)}')
             _clear_oauth_cookies(response, provider)
             return response
-        tenant_id = str(tenant_id)
+
+        tenant_id = str(state_payload.get('tenant_id') or '')
+        user_id = str(state_payload.get('user_id') or '')
+        if not tenant_id or not user_id:
+            response = redirect(f'/settings/email-integrations?error=invalid_state&provider={quote(provider)}')
+            _clear_oauth_cookies(response, provider)
+            return response
 
         try:
             tenant = Tenant.objects.get(id=tenant_id)
         except Tenant.DoesNotExist:
             response = redirect(f'/settings/email-integrations?error=tenant_not_found&provider={quote(provider)}')
+            _clear_oauth_cookies(response, provider)
+            return response
+
+        # Enforce tenant membership for the initiating user.
+        from django.contrib.auth import get_user_model
+        from apps.tenants.models import TenantUser
+
+        User = get_user_model()
+        try:
+            initiating_user = User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            response = redirect(f'/settings/email-integrations?error=user_not_found&provider={quote(provider)}')
+            _clear_oauth_cookies(response, provider)
+            return response
+
+        if not (
+            getattr(initiating_user, 'is_superuser', False)
+            or TenantUser.objects.filter(tenant=tenant, user=initiating_user, is_active=True).exists()
+        ):
+            response = redirect(f'/settings/email-integrations?error=permission_denied&provider={quote(provider)}')
             _clear_oauth_cookies(response, provider)
             return response
 


### PR DESCRIPTION
## What
Hardens the /api/v1/integrations/oauth/* flow so OAuth connections are always bound to an authenticated user and a specific tenant membership.

## Changes
- Require authentication to initiate OAuth (authorize URL)
- Use signed state that binds tenant_id + user_id + provider
- Callback enforces tenant membership for the initiating user before persisting tokens
- Add regression tests for authorize auth requirements + callback permission enforcement

## Testing
cd backend && python manage.py test apps.integrations --verbosity=2

## Risk / Rollback
Medium (auth/integration entrypoints). Roll back by reverting this PR.
