### PR TITLE
CI: enforce RLS audit on fresh DB

### DIFF
--- a/.github/scripts/validate-migrations.sh
+++ b/.github/scripts/validate-migrations.sh
@@ -143,6 +143,18 @@ if command -v psql &> /dev/null && [ -n "${CI:-}" ]; then
         echo "✅ Migrations applied successfully on fresh database"
     else
         echo "❌ ERROR: Migrations failed on fresh database"
+        PGPASSWORD=postgres psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS test_migration_validation;" 2>/dev/null || true
+        export DATABASE_URL="$ORIGINAL_DB_URL"
+        exit 1
+    fi
+
+    echo ""
+    echo "Step 8: Auditing RLS compliance (fresh database)..."
+    if python manage.py audit_rls_compliance --strict; then
+        echo "✅ RLS compliance audit passed"
+    else
+        echo "❌ ERROR: RLS compliance audit failed"
+        PGPASSWORD=postgres psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS test_migration_validation;" 2>/dev/null || true
         export DATABASE_URL="$ORIGINAL_DB_URL"
         exit 1
     fi

--- a/backend/apps/core/management/commands/audit_rls_compliance.py
+++ b/backend/apps/core/management/commands/audit_rls_compliance.py
@@ -3,7 +3,7 @@ RLS Policy Audit Management Command (Phase 9.3)
 
 Verifies that all tenant-aware models have corresponding PostgreSQL RLS policies.
 """
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 from django.apps import apps
 from apps.core.models import TenantAwareModel
@@ -17,6 +17,11 @@ class Command(BaseCommand):
             '--fix',
             action='store_true',
             help='Automatically create missing RLS policies'
+        )
+        parser.add_argument(
+            '--strict',
+            action='store_true',
+            help='Exit non-zero if any models are not RLS compliant'
         )
     
     def handle(self, *args, **options):
@@ -88,6 +93,9 @@ class Command(BaseCommand):
                 self.stdout.write('Run with --fix to automatically create missing policies')
         
         self.stdout.write(self.style.WARNING('=' * 80))
+
+        if options.get('strict') and compliant_count != len(results):
+            raise CommandError(f"{len(results) - compliant_count} models are not RLS compliant")
     
     def get_tenant_aware_models(self):
         """Get models that MUST have RLS.


### PR DESCRIPTION
## What
- Add `--strict` to `python manage.py audit_rls_compliance` so it can act as a CI gate (non-zero exit on noncompliance).
- Run `audit_rls_compliance --strict` during `.github/scripts/validate-migrations.sh` fresh-DB migration validation.

## Why
We previously had an audit command but it could not fail CI. This change makes missing RLS/policies a hard stop during PR validation using an ephemeral Postgres service (no secrets, no remote DB access).

## Testing
- `python manage.py audit_rls_compliance --help`
- `python manage.py test apps.core.tests.test_audit_rls_compliance --verbosity=2`

## Rollback
Revert this PR (restores warn-only behavior and removes the CI gating step).
