### PR TITLE
Squad: standardize relay→synthesize orchestration

### DIFF
--- a/.copilot/squad/README.md
+++ b/.copilot/squad/README.md
@@ -48,6 +48,16 @@ copilot
 3) Select a custom agent:
 - Run `/agent` and choose one of the `projectmeats-*` agents
 
+## Collaboration protocol: Relay → Synthesize (MANDATORY)
+Copilot fleet subagents do not directly chat with each other mid-run. We enforce collaboration by a **relay + synthesis** pattern:
+
+1) Run parallel domain agents (fleet) to gather findings.
+2) Relay the key findings (paste summaries) into a **Lead Engineer** follow-up run.
+3) The Lead Engineer produces a single, coherent execution plan: deliverables, acceptance criteria, dependencies, risks, testing, rollback.
+
+**Standard synthesis prompt** (copy/paste):
+> “Synthesize the following squad findings into one patch plan. Resolve conflicts, pick a recommended approach, list risks + mitigations, and specify the smallest test suite that proves correctness. Findings: …”
+
 4) Use a reusable playbook via skills:
 - Run `/skills list`
 - Then invoke the skill (or ask the agent to run it)

--- a/.copilot/squad/roles/lead-engineer.md
+++ b/.copilot/squad/roles/lead-engineer.md
@@ -5,6 +5,7 @@ Own cross-domain technical coherence (backend + frontend + mobile + devops), ens
 
 ## Responsibilities
 - Convert business intent into implementable technical scope.
+- Run the **orchestrator synthesis pass**: consolidate squad findings into one coherent plan (deliverables, acceptance criteria, risks, tests, rollback).
 - Ensure interfaces/contracts between layers are stable (API routes, types, auth, tenant context).
 - Ensure test strategy is appropriate and executed.
 - Ensure PRs are scoped, reviewable, and aligned to `MASTER_PLAN.md` priorities.

--- a/.copilot/squad/tasks/add-backend-endpoint.md
+++ b/.copilot/squad/tasks/add-backend-endpoint.md
@@ -15,6 +15,8 @@ Add a new API endpoint in the backend that is **tenant-isolated**, permissioned,
 - If model changes: safe migrations + RLS policy where required
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - After fleet agents complete, run a Lead Engineer synthesis pass to unify findings into one patch plan.
 1. **Confirm canonical constraints**
    - Read: `docs/architecture/ARCHITECTURE.md`
    - Read: `.github/instructions/backend.instructions.md`

--- a/.copilot/squad/tasks/add-frontend-component.md
+++ b/.copilot/squad/tasks/add-frontend-component.md
@@ -14,6 +14,8 @@ Add a UI component that is **accessible**, **theme-compliant**, and **type-safe*
 - Tests (unit/e2e as appropriate)
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - After fleet agents complete, run a Lead Engineer synthesis pass to unify findings into one patch plan.
 1. **Confirm styling & API constraints**
    - Read: `.github/instructions/frontend.instructions.md`
    - Read: `docs/DESIGN_SYSTEM.md`

--- a/.copilot/squad/tasks/add-mobile-feature.md
+++ b/.copilot/squad/tasks/add-mobile-feature.md
@@ -14,6 +14,8 @@ Add a mobile screen/feature that is **type-safe**, reusable, and consistent with
 - Tests as appropriate
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - After fleet agents complete, run a Lead Engineer synthesis pass to unify findings into one patch plan.
 1. Read: `.github/instructions/mobile.instructions.md`
 2. Implement screen as functional component with typed navigation/route.
 3. Prefer shared utilities/types from `/shared` when applicable.

--- a/.copilot/squad/tasks/add-test-coverage.md
+++ b/.copilot/squad/tasks/add-test-coverage.md
@@ -15,6 +15,8 @@ Add automated tests that prevent regressions without flakiness.
   - mobile: Jest
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - After fleet agents complete, run a Lead Engineer synthesis pass to unify findings into one patch plan.
 1. Write acceptance criteria first (Given/When/Then).
 2. Choose minimal test level that catches regression.
 3. Prefer deterministic assertions.

--- a/.copilot/squad/tasks/ci-cd-workflow-changes.md
+++ b/.copilot/squad/tasks/ci-cd-workflow-changes.md
@@ -12,6 +12,8 @@ Update GitHub Actions workflows without violating ProjectMeats’ **Golden Stand
 - Updated docs if behavior changes
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - After fleet agents complete, run a Lead Engineer synthesis pass to unify findings into one patch plan.
 1. Read constraints:
    - `docs/GOLDEN_PIPELINE.md`
    - `.github/instructions/workflows.instructions.md`

--- a/.copilot/squad/tasks/cross-agent-architectural-review.md
+++ b/.copilot/squad/tasks/cross-agent-architectural-review.md
@@ -17,6 +17,8 @@ Run a structured, cross-functional review before landing risky or cross-cutting 
   - rollback plan
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - Collect domain findings, then run a Lead Engineer synthesis pass to resolve conflicts and produce one go/no-go recommendation.
 1. Architect reviews golden invariant compliance.
 2. Lead Engineer reviews cross-layer cohesion.
 3. Domain leads review within their domain.

--- a/.copilot/squad/tasks/multi-tenant-safe-migration.md
+++ b/.copilot/squad/tasks/multi-tenant-safe-migration.md
@@ -13,6 +13,8 @@ Make schema changes without breaking existing tenants and while preserving defen
 - Verified migration plan + rollback steps
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - After fleet agents complete, run a Lead Engineer synthesis pass to unify findings into one patch plan.
 1. Confirm constraints:
    - Shared schema ONLY (no django-tenants)
    - Additive-only when possible

--- a/.copilot/squad/tasks/update-documentation.md
+++ b/.copilot/squad/tasks/update-documentation.md
@@ -11,6 +11,8 @@ Update documentation while preserving **canonical truth hierarchy**.
 - Updated docs with correct authority labels
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - After fleet agents complete, run a Lead Engineer synthesis pass to unify findings into one patch plan.
 1. Confirm hierarchy:
    - `MASTER_PLAN.md` is canonical.
    - `ROADMAP.md` is reference-only unless explicitly promoted.

--- a/.copilot/squad/tasks/update-golden-files.md
+++ b/.copilot/squad/tasks/update-golden-files.md
@@ -11,6 +11,8 @@ Update authoritative registries so future work stays consistent and discoverable
 - If needed: added enforcement mechanism (validation script/CI gate)
 
 ## Step-by-step execution
+0. **Relay → synthesize (Lead Engineer)**
+   - After fleet agents complete, run a Lead Engineer synthesis pass to unify findings into one patch plan.
 1. Identify the “golden” owner file(s) that must be updated.
 2. Update `manifests/GOLDEN_FILES.md` with:
    - concern

--- a/scripts/validate_copilot_squad.sh
+++ b/scripts/validate_copilot_squad.sh
@@ -24,6 +24,9 @@ require_dir .copilot/squad
 require_dir .copilot/squad/roles
 require_dir .copilot/squad/tasks
 
+require_file .copilot/squad/README.md
+require_heading .copilot/squad/README.md "## Collaboration protocol: Relay → Synthesize (MANDATORY)"
+
 require_file .copilot/squad/squad.json
 python -m json.tool .copilot/squad/squad.json >/dev/null || fail "Invalid JSON: .copilot/squad/squad.json"
 


### PR DESCRIPTION
## What
- Document the mandatory collaboration pattern: **Relay → Synthesize**.
- Add a standard “Lead Engineer synthesis pass” step to all squad playbooks.
- Enforce the protocol via `scripts/validate_copilot_squad.sh` (README heading check).

## Why
Fleet subagents run independently; the reliable way to get true collaboration is to relay findings into an orchestrator pass. This standardizes that practice and prevents regression.

## Testing
- `bash scripts/validate_copilot_squad.sh`

## Rollback
Revert PR (process-only change).
