### PR TITLE
WorkForms: fix action node config panels

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:ci": "vitest run --coverage",
+    "test:ci": "mkdir -p coverage/.tmp && vitest run --coverage", 
     "type-check": "NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit",
     "format": "prettier --write src/**/*.{js,jsx,ts,tsx,json,css,md}",
     "lint": "eslint src/**/*.{js,jsx,ts,tsx}",

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.keyValueModeRecord.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.keyValueModeRecord.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { Edge, Node } from '@xyflow/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { DynamicConfigPanel } from './DynamicConfigPanel';
+import { FormBuilderProvider } from '../../../contexts/FormBuilderContext';
+
+const schema = {
+  nodeType: 'actionHTTP',
+  displayName: 'HTTP Request',
+  version: 'test',
+  sections: [
+    {
+      id: 'http',
+      title: 'HTTP',
+      fields: [
+        {
+          id: 'headers',
+          type: 'keyValue',
+          keyValueMode: 'record',
+          label: 'Headers',
+          placeholder: { key: 'Header name', value: 'Header value' },
+          addButtonText: '+ Add Header',
+          defaultValue: {},
+        },
+      ],
+    },
+  ],
+} as any;
+
+vi.mock('../config', () => ({
+  schemaRegistry: {
+    getSchema: vi.fn(() => schema),
+  },
+}));
+
+vi.mock('../hooks/useUpstreamVariables', () => ({
+  useUpstreamVariables: vi.fn(() => ({ variables: [] })),
+}));
+
+vi.mock('../../../services/schemaService', () => ({
+  useEntityFields: vi.fn(() => ({ data: null })),
+}));
+
+vi.mock('../config/fieldRenderers/basicRenderers', () => ({
+  renderTextField: vi.fn(() => <input />),
+  renderSelectField: vi.fn(() => <select />),
+  renderToggleField: vi.fn(() => <input type="checkbox" />),
+  renderEntityTypeSelect: vi.fn(() => <select />),
+}));
+
+vi.mock('../config/fieldRenderers/complexRenderers', () => ({
+  renderEntitySelector: vi.fn(() => <div />),
+  renderEntityFieldPicker: vi.fn(() => <div />),
+  renderFieldMapping: vi.fn(() => <div />),
+  renderVariablePicker: vi.fn(() => <div />),
+  renderValidationBuilder: vi.fn(() => <div />),
+}));
+
+vi.mock('./NestedChildrenRenderer', () => ({
+  NestedChildrenRenderer: () => <div />,
+}));
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <FormBuilderProvider>{children}</FormBuilderProvider>
+    </QueryClientProvider>
+  );
+
+  return render(ui, { wrapper: Wrapper });
+};
+
+describe('DynamicConfigPanel (keyValueMode=record)', () => {
+  it('emits a record object for keyValueMode=record fields', () => {
+    const node: Node = {
+      id: 'n1',
+      type: 'action',
+      position: { x: 0, y: 0 },
+      data: { nodeType: 'actionHTTP' },
+    };
+
+    const nodes: Node[] = [node];
+    const edges: Edge[] = [];
+    const onUpdateNode = vi.fn();
+
+    renderWithProviders(
+      <DynamicConfigPanel node={node} nodes={nodes} edges={edges} onUpdateNode={onUpdateNode} />,
+    );
+
+    fireEvent.click(screen.getByText('+ Add Header'));
+
+    const keyInput = screen.getByPlaceholderText('Header name');
+    const valueInput = screen.getByPlaceholderText('Header value');
+
+    fireEvent.change(keyInput, { target: { value: 'X-Test' } });
+    fireEvent.change(valueInput, { target: { value: '123' } });
+
+    expect(onUpdateNode).toHaveBeenCalledWith(
+      'n1',
+      expect.objectContaining({
+        headers: { 'X-Test': '123' },
+      }),
+    );
+  });
+});

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -267,28 +267,50 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     );
   }
 
+  const effectiveFormData = useMemo(() => {
+    const next: any = { ...(formData as any) };
+
+    // Additive aliasing for legacy/workflow-safe interoperability.
+    if (next.entityType === undefined && next.entity !== undefined) next.entityType = next.entity;
+    if (next.entity === undefined && next.entityType !== undefined) next.entity = next.entityType;
+
+    if (next.fieldMappings === undefined && next.fields !== undefined) next.fieldMappings = next.fields;
+    if (next.fields === undefined && next.fieldMappings !== undefined) next.fields = next.fieldMappings;
+
+    // Materialize schema defaults for evaluation (visibility/validation).
+    schema.sections.forEach((section) => {
+      section.fields.forEach((field) => {
+        if (field.defaultValue !== undefined && next[field.id] === undefined) {
+          next[field.id] = field.defaultValue;
+        }
+      });
+    });
+
+    return next as Record<string, any>;
+  }, [schema, formData]);
+
   // Calculate which fields should be visible based on conditional rules
   const visibleFields = useMemo(() => {
     const visible = new Set<string>();
-    
-    schema.sections.forEach(section => {
+
+    schema.sections.forEach((section) => {
       // Check section-level conditional (using robust helper)
-      if (!checkIsVisible(section, formData)) {
+      if (!checkIsVisible(section, effectiveFormData)) {
         return; // Hide entire section
       }
 
-      section.fields.forEach(field => {
+      section.fields.forEach((field) => {
         // Check field-level conditional (using robust helper)
-        if (checkIsVisible(field, formData)) {
+        if (checkIsVisible(field, effectiveFormData)) {
           visible.add(field.id);
         }
       });
     });
-    
-    return visible;
-  }, [schema, formData]);
 
-  const entityType = (formData as any)?.entityType as string | undefined;
+    return visible;
+  }, [schema, effectiveFormData]);
+
+  const entityType = (effectiveFormData as any)?.entityType as string | undefined;
 
   const { data: entityFieldsResp } = useEntityFields(entityType, {
     enabled: Boolean(entityType) && (node?.type === 'form' || node?.type === 'formStep' || node?.type === 'formStepSingle'),
@@ -618,7 +640,17 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     const isVisible = visibleFields.has(field.id);
     
     // Always render but with conditional visibility for smooth transitions
-    const value = formData[field.id] ?? field.defaultValue;
+    const rawValue = (effectiveFormData as any)[field.id];
+
+    // Additive aliasing for legacy/workflow-safe interoperability.
+    // (Do not mutate formData here; just compute the displayed value.)
+    const value =
+      rawValue ??
+      (field.id === 'entityType' ? (formData as any).entity : undefined) ??
+      (field.id === 'fields' ? (formData as any).fieldMappings : undefined) ??
+      (field.id === 'fieldMappings' ? (formData as any).fields : undefined) ??
+      field.defaultValue;
+
     const error = errors[field.id];
 
     const commonProps = {
@@ -751,37 +783,82 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       }
 
       case 'keyValue': {
-        const pairs: Array<{ key: string; value: string }> = Array.isArray(value)
-          ? value
-          : Array.isArray(field.defaultValue)
-            ? (field.defaultValue as any)
-            : [];
+        const mode = (field as any).keyValueMode === 'record' ? 'record' : 'array';
+
+        const coercePairs = (input: unknown): Array<{ key: string; value: string }> => {
+          if (Array.isArray(input)) return input as any;
+          if (input && typeof input === 'object') {
+            return Object.entries(input as Record<string, any>).map(([k, v]) => ({
+              key: String(k),
+              value: v === undefined || v === null ? '' : String(v),
+            }));
+          }
+          return [];
+        };
+
+        const pairs: Array<{ key: string; value: string }> =
+          mode === 'record'
+            ? coercePairs(value ?? field.defaultValue)
+            : Array.isArray(value)
+              ? (value as any)
+              : Array.isArray(field.defaultValue)
+                ? (field.defaultValue as any)
+                : [];
 
         const placeholderKey = (field.placeholder as any)?.key || 'Key';
         const placeholderValue = (field.placeholder as any)?.value || 'Value';
         const addText = (field as any).addButtonText || '+ Add';
 
+        const emit = (nextPairs: Array<{ key: string; value: string }>) => {
+          if (mode === 'record') {
+            const out: Record<string, string> = {};
+            nextPairs.forEach((p) => {
+              const k = String(p?.key ?? '').trim();
+              if (!k) return;
+              out[k] = String(p?.value ?? '');
+            });
+            commonProps.onChange(out);
+            return;
+          }
+
+          commonProps.onChange(nextPairs);
+        };
+
         const updatePair = (idx: number, patch: Partial<{ key: string; value: string }>) => {
           const next = pairs.map((p, i) => (i === idx ? { ...p, ...patch } : p));
-          commonProps.onChange(next);
+
+          // In record mode, allow a draft row with an empty key to exist long enough
+          // for the user to type a key (otherwise the row disappears immediately).
+          if (mode === 'record' && next.some((p) => !String(p?.key ?? '').trim())) {
+            commonProps.onChange(next);
+            return;
+          }
+
+          emit(next);
         };
 
         const removePair = (idx: number) => {
           const next = pairs.filter((_, i) => i != idx);
-          commonProps.onChange(next);
+          emit(next);
         };
 
         const addPair = () => {
-          commonProps.onChange([...(pairs || []), { key: '', value: '' }]);
+          const next = [...(pairs || []), { key: '', value: '' }];
+
+          // Draft rows in record mode must persist until the key is filled.
+          if (mode === 'record') {
+            commonProps.onChange(next);
+            return;
+          }
+
+          emit(next);
         };
 
         renderedField = (
           <FormField key={field.id}>
             <Label>{field.label}</Label>
             <KeyValueList>
-              {pairs.length === 0 && (
-                <KeyValueEmpty>None configured yet.</KeyValueEmpty>
-              )}
+              {pairs.length === 0 && <KeyValueEmpty>None configured yet.</KeyValueEmpty>}
               {pairs.map((p, idx) => (
                 <KeyValueRow key={`${field.id}-${idx}`}>
                   <Input
@@ -966,7 +1043,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
   // Render a section
   const renderSection = (section: ConfigSection) => {
     // Check section-level conditional (using robust helper)
-    if (!checkIsVisible(section, formData)) {
+    if (!checkIsVisible(section, effectiveFormData)) {
       return null;
     }
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.visibilityDefaults.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.visibilityDefaults.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { Edge, Node } from '@xyflow/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { DynamicConfigPanel } from './DynamicConfigPanel';
+import { FormBuilderProvider } from '../../../contexts/FormBuilderContext';
+
+// Minimal schema for conditional visibility based on a defaulted field.
+const httpSchema = {
+  nodeType: 'actionHTTP',
+  displayName: 'HTTP Request',
+  version: 'test',
+  sections: [
+    {
+      id: 'http',
+      title: 'HTTP Request',
+      fields: [
+        {
+          id: 'method',
+          type: 'select',
+          label: 'HTTP Method',
+          defaultValue: 'GET',
+          options: [
+            { value: 'GET', label: 'GET' },
+            { value: 'POST', label: 'POST' },
+          ],
+        },
+        {
+          id: 'body',
+          type: 'textarea',
+          label: 'Request Body',
+          conditional: { field: 'method', operator: 'equals', value: 'POST' },
+        },
+      ],
+    },
+  ],
+} as any;
+
+vi.mock('../config', () => ({
+  schemaRegistry: {
+    getSchema: vi.fn(() => httpSchema),
+  },
+}));
+
+vi.mock('../hooks/useUpstreamVariables', () => ({
+  useUpstreamVariables: vi.fn(() => ({ variables: [] })),
+}));
+
+vi.mock('../../../services/schemaService', () => ({
+  useEntityFields: vi.fn(() => ({ data: null })),
+}));
+
+vi.mock('../config/fieldRenderers/basicRenderers', () => ({
+  renderTextField: vi.fn(({ field, value, onChange }) => (
+    <input
+      data-testid={`field-${field.id}`}
+      value={value ?? ''}
+      onChange={(e: any) => onChange(e.target.value)}
+    />
+  )),
+  renderSelectField: vi.fn(({ field, value, onChange }) => (
+    <select
+      data-testid={`field-${field.id}`}
+      value={value ?? ''}
+      onChange={(e: any) => onChange(e.target.value)}
+    >
+      {(field.options ?? []).map((o: any) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  )),
+  renderToggleField: vi.fn(() => <input type="checkbox" />),
+  renderEntityTypeSelect: vi.fn(() => <select />),
+}));
+
+vi.mock('../config/fieldRenderers/complexRenderers', () => ({
+  renderEntitySelector: vi.fn(() => <div />),
+  renderEntityFieldPicker: vi.fn(() => <div />),
+  renderFieldMapping: vi.fn(() => <div />),
+  renderVariablePicker: vi.fn(() => <div />),
+  renderValidationBuilder: vi.fn(() => <div />),
+}));
+
+vi.mock('./NestedChildrenRenderer', () => ({
+  NestedChildrenRenderer: () => <div />,
+}));
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <FormBuilderProvider>{children}</FormBuilderProvider>
+    </QueryClientProvider>
+  );
+
+  return render(ui, { wrapper: Wrapper });
+};
+
+describe('DynamicConfigPanel (visibility + defaults)', () => {
+  it('hides conditional fields when defaultValue does not satisfy condition', () => {
+    const node: Node = {
+      id: 'n1',
+      type: 'action',
+      position: { x: 0, y: 0 },
+      data: { nodeType: 'actionHTTP' },
+    };
+
+    const nodes: Node[] = [node];
+    const edges: Edge[] = [];
+
+    renderWithProviders(
+      <DynamicConfigPanel node={node} nodes={nodes} edges={edges} onUpdateNode={vi.fn()} />,
+    );
+
+    const body = screen.getByTestId('field-body');
+
+    // FieldTransitionWrapper should collapse when not visible.
+    const wrapper = body.parentElement as HTMLElement;
+    expect(wrapper).toHaveStyle({ maxHeight: '0' });
+    expect(wrapper).toHaveStyle({ opacity: '0' });
+  });
+});

--- a/frontend/src/components/FlowEditor/config/__tests__/schemaRegistry.actionSchemas.test.ts
+++ b/frontend/src/components/FlowEditor/config/__tests__/schemaRegistry.actionSchemas.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+import { schemaRegistry } from '../schemaRegistry';
+
+// Side-effect: registers all schemas into the singleton registry.
+import '../nodeConfigSchemas';
+
+describe('schemaRegistry action schemas', () => {
+  it('registers actionHTTP schema (no fallback)', () => {
+    const schema = schemaRegistry.getSchema('actionHTTP');
+
+    const fieldIds = new Set(
+      schema.sections.flatMap((s) => (s.fields ?? []).map((f) => f.id)),
+    );
+
+    // Fallback schemas only include name/description/notes.
+    expect(fieldIds.has('url')).toBe(true);
+    expect(fieldIds.has('method')).toBe(true);
+  });
+
+  it('registers CRUD action schemas with entity + mapping fields', () => {
+    const createSchema = schemaRegistry.getSchema('actionCreateRecord');
+    const updateSchema = schemaRegistry.getSchema('actionUpdateRecord');
+
+    const createFieldIds = new Set(createSchema.sections.flatMap((s) => s.fields.map((f) => f.id)));
+    const updateFieldIds = new Set(updateSchema.sections.flatMap((s) => s.fields.map((f) => f.id)));
+
+    expect(createFieldIds.has('entityType')).toBe(true);
+    expect(createFieldIds.has('fieldMappings')).toBe(true);
+
+    expect(updateFieldIds.has('entityType')).toBe(true);
+    expect(updateFieldIds.has('recordId')).toBe(true);
+    expect(updateFieldIds.has('fieldMappings')).toBe(true);
+  });
+});

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/complexRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/complexRenderers.tsx
@@ -128,34 +128,51 @@ export function renderEntitySelector(props: FieldRenderProps): React.ReactElemen
  */
 export function renderFieldMapping(props: FieldRenderProps): React.ReactElement {
   const { field, value, onChange, error, data } = props;
-  
-  // FieldMappingPanel expects entity, upstreamVariables, mappings, onMappingsChange
-  const mappings = value || {};
-  const entityType = data?.entityType as string | undefined;
-  
+
+  // IMPORTANT:
+  // - Schemas may store the "selected entity" under different keys (e.g., entityType vs entity).
+  // - Schemas may specify the source key via field.entityFieldId.
+  // - FieldMappingPanel expects (mappings: FieldMapping[], formFields, targetEntity, onChange).
+  const entityFieldId = (field as any).entityFieldId as string | undefined;
+
+  const entityType = (
+    (entityFieldId ? (data as any)?.[entityFieldId] : undefined) ??
+    (data as any)?.entityType ??
+    (data as any)?.eventEntity ??
+    (data as any)?.entity
+  ) as string | undefined;
+
   if (!entityType) {
     return (
       <FieldContainer>
-        <EmptyState>
-          ℹ️ Select an entity type first to configure field mappings
-        </EmptyState>
+        <EmptyState>ℹ️ Select an entity type first to configure field mappings</EmptyState>
       </FieldContainer>
     );
   }
-  
-  const handleMappingsChange = (newMappings: Record<string, any>) => {
-    onChange(newMappings);
-  };
-  
-  const MappingPanel = FieldMappingPanel as any;
+
+  // Build source field list from upstream variables (best-effort).
+  const upstream = ((data as any)?._upstreamVariables as any[] | undefined) ?? [];
+  const formFields = upstream.map((v) => ({
+    id: String(v.template ?? `${v.nodeId}.${v.fieldName}`),
+    label: String(v.fieldLabel ?? v.fieldName ?? ''),
+    type: String(v.fieldType ?? 'string'),
+  }));
+
+  // Coerce mappings to the array shape expected by FieldMappingPanel.
+  const mappings = Array.isArray(value)
+    ? value
+    : Array.isArray(field.defaultValue)
+      ? (field.defaultValue as any)
+      : [];
 
   return (
     <FieldContainer>
-      <MappingPanel
-        entity={entityType}
-        upstreamVariables={data?._upstreamVariables || []}
-        mappings={mappings}
-        onMappingsChange={handleMappingsChange}
+      <FieldMappingPanel
+        mappings={mappings as any}
+        formFields={formFields}
+        targetEntity={entityType}
+        onChange={(newMappings) => onChange(newMappings)}
+        availableSteps={[]}
       />
       {error && <ErrorMessage>{error}</ErrorMessage>}
     </FieldContainer>
@@ -173,7 +190,6 @@ export function renderFieldMapping(props: FieldRenderProps): React.ReactElement 
 export function renderVariablePicker(props: FieldRenderProps): React.ReactElement {
   const { field, value, onChange, error, data } = props;
 
-  const selectedTemplate = value as string | undefined;
   const upstream = (data as any)?._upstreamVariables as any[] | undefined;
 
   const variables: VariableOption[] = (upstream || []).map((v) => ({
@@ -189,9 +205,19 @@ export function renderVariablePicker(props: FieldRenderProps): React.ReactElemen
     sampleValue: undefined,
   }));
 
-  const selectedVariables = selectedTemplate
-    ? variables.filter((v) => v.path === selectedTemplate)
-    : undefined;
+  const isMulti = field.multiple === true;
+
+  const selectedTemplates: string[] = isMulti
+    ? Array.isArray(value)
+      ? value.map(String)
+      : value
+        ? [String(value)]
+        : []
+    : typeof value === 'string'
+      ? [value]
+      : [];
+
+  const selectedVariables = variables.filter((v) => selectedTemplates.includes(v.path));
 
   const placeholder =
     typeof field.placeholder === 'string'
@@ -203,7 +229,20 @@ export function renderVariablePicker(props: FieldRenderProps): React.ReactElemen
       <VariablePicker
         variables={variables}
         selectedVariables={selectedVariables}
-        onSelect={(variable) => onChange(variable.path)}
+        onSelect={(variable) => {
+          if (!isMulti) {
+            onChange(variable.path);
+            return;
+          }
+
+          // Toggle selection in multi mode.
+          const exists = selectedTemplates.includes(variable.path);
+          const next = exists
+            ? selectedTemplates.filter((t) => t !== variable.path)
+            : [...selectedTemplates, variable.path];
+
+          onChange(next);
+        }}
         placeholder={placeholder}
         showSearch
       />

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -1030,28 +1030,10 @@ export const formStepSingleSchema = formSchema;
 // Registry initialization
 // ============================================================================
 
-// NOTE: Registry initialization is deferred until end-of-module to avoid TDZ
-// errors from schema constants declared later in this file.
-
-// CRITICAL HOTFIX (2026-03-18): Defer all registry calls to bypass Vite/Rollup ES Module TDZ
-// When index.ts re-exports cause evaluation order issues, schemaRegistry may not be
-// instantiated yet. setTimeout pushes execution to next macro-task after all modules link.
-setTimeout(() => {
-  if (typeof schemaRegistry !== 'undefined') {
-    // Phase E Fix (2026-02-19): Register backward compatibility aliases
-    // formStepSingle nodes should use the same schema as 'form' nodes
-    schemaRegistry.register({
-      ...formSchema,
-      nodeType: 'formStepSingle',
-      displayName: 'Form (Legacy)',
-      description: '[DEPRECATED] Use the "Form" node instead. This exists for backward compatibility only.',
-    }, true); // Allow overwrite
-
-    logger.debug('[Schema Registry] Registered backward compatibility: formStepSingle → formSchema');
-  } else {
-    console.error('[Schema Registry] CRITICAL: schemaRegistry still undefined after deferral at line 1013');
-  }
-}, 0);
+// NOTE:
+// Schema registry initialization (including backward-compat aliases) is performed
+// synchronously at end-of-module (see bottom of file) to avoid any runtime race
+// where DynamicConfigPanel resolves fallback schemas.
 
 // ============================================================================
 // Phase 2: Trigger Node Schema (Unified Entry Point)
@@ -3099,12 +3081,13 @@ const actionHTTPSchema: NodeConfigSchema = {
         {
           id: 'headers',
           type: 'keyValue',
+          keyValueMode: 'record',
           label: 'Headers',
           helpText: 'HTTP headers to send with the request',
           placeholder: { key: 'Header name', value: 'Header value' },
-          defaultValue: [
-            { key: 'Content-Type', value: 'application/json' }
-          ],
+          defaultValue: {
+            'Content-Type': 'application/json',
+          },
           addButtonText: '+ Add Header',
         },
         {
@@ -3226,6 +3209,7 @@ const actionHTTPSchema: NodeConfigSchema = {
         {
           id: 'extractFields',
           type: 'keyValue',
+          keyValueMode: 'record',
           label: 'Extract Specific Fields',
           helpText: 'JSONPath expressions to extract data (e.g., $.data.id)',
           placeholder: { key: 'Field name', value: 'JSONPath expression' },
@@ -3310,18 +3294,42 @@ const actionNotifySchema: NodeConfigSchema = {
       defaultExpanded: true,
       fields: [
         {
+          id: 'userId',
+          type: 'text',
+          label: 'Recipient User ID',
+          placeholder: 'e.g., {{trigger.userId}}',
+          helpText: 'User identifier to receive the notification (supports variables)',
+          required: true,
+          validation: [{ type: 'required', message: 'Recipient user is required' }],
+        },
+        {
           id: 'title',
           type: 'text',
           label: 'Title',
           placeholder: 'Notification title...',
-          required: true,
+          helpText: 'Short notification title',
+          required: false,
         },
         {
           id: 'message',
           type: 'textarea',
           label: 'Message',
           placeholder: 'Notification message...',
+          helpText: 'Notification body (supports variables)',
           required: true,
+          validation: [{ type: 'required', message: 'Message is required' }],
+        },
+        {
+          id: 'priority',
+          type: 'select',
+          label: 'Priority',
+          defaultValue: 'normal',
+          options: [
+            { value: 'low', label: 'Low' },
+            { value: 'normal', label: 'Normal' },
+            { value: 'high', label: 'High' },
+          ],
+          helpText: 'Higher priority may surface more prominently',
         },
       ]
     }
@@ -3344,11 +3352,23 @@ const actionScriptSchema: NodeConfigSchema = {
       defaultExpanded: true,
       fields: [
         {
+          id: 'language',
+          type: 'select',
+          label: 'Language',
+          defaultValue: 'javascript',
+          options: [
+            { value: 'javascript', label: 'JavaScript' },
+            { value: 'python', label: 'Python' },
+          ],
+          helpText: 'Execution runtime (if supported by the engine)',
+        },
+        {
           id: 'code',
           type: 'textarea',
-          label: 'JavaScript Code',
+          label: 'Code',
           placeholder: '// Your code here...',
           required: true,
+          validation: [{ type: 'required', message: 'Code is required' }],
         },
       ]
     }
@@ -3372,10 +3392,20 @@ const actionCreateRecordSchema: NodeConfigSchema = {
       fields: [
         {
           id: 'entityType',
-          type: 'text',
+          type: 'entityType',
           label: 'Entity Type',
-          placeholder: 'e.g., PurchaseOrder',
+          placeholder: 'Select an entity...',
+          helpText: 'Choose which entity type to create',
           required: true,
+          validation: [{ type: 'required', message: 'Entity type is required' }],
+        },
+        {
+          id: 'fieldMappings',
+          type: 'field-mapping',
+          label: 'Field Mappings',
+          helpText: 'Map upstream variables to entity fields',
+          entityFieldId: 'entityType',
+          showAutoSuggest: true,
         },
       ]
     }
@@ -3399,17 +3429,29 @@ const actionUpdateRecordSchema: NodeConfigSchema = {
       fields: [
         {
           id: 'entityType',
-          type: 'text',
+          type: 'entityType',
           label: 'Entity Type',
-          placeholder: 'e.g., PurchaseOrder',
+          placeholder: 'Select an entity...',
+          helpText: 'Choose which entity type to update',
           required: true,
+          validation: [{ type: 'required', message: 'Entity type is required' }],
         },
         {
           id: 'recordId',
           type: 'text',
           label: 'Record ID',
-          placeholder: 'ID of record to update',
+          placeholder: 'ID of record to update (supports {{variables}})',
+          helpText: 'Identifier of the record to update',
           required: true,
+          validation: [{ type: 'required', message: 'Record ID is required' }],
+        },
+        {
+          id: 'fieldMappings',
+          type: 'field-mapping',
+          label: 'Field Updates',
+          helpText: 'Map upstream variables to entity fields to update',
+          entityFieldId: 'entityType',
+          showAutoSuggest: true,
         },
       ]
     }
@@ -3433,17 +3475,21 @@ const actionDeleteRecordSchema: NodeConfigSchema = {
       fields: [
         {
           id: 'entityType',
-          type: 'text',
+          type: 'entityType',
           label: 'Entity Type',
-          placeholder: 'e.g., PurchaseOrder',
+          placeholder: 'Select an entity...',
+          helpText: 'Choose which entity type to delete from',
           required: true,
+          validation: [{ type: 'required', message: 'Entity type is required' }],
         },
         {
           id: 'recordId',
           type: 'text',
           label: 'Record ID',
-          placeholder: 'ID of record to delete',
+          placeholder: 'ID of record to delete (supports {{variables}})',
+          helpText: 'Identifier of the record to delete',
           required: true,
+          validation: [{ type: 'required', message: 'Record ID is required' }],
         },
       ]
     }
@@ -4318,14 +4364,21 @@ export const subWorkflowSchema: NodeConfigSchema = {
 // Build + initialize schemas at end-of-module to avoid TDZ errors.
 export const allSchemas: NodeConfigSchema[] = buildAllSchemas();
 
-// CRITICAL HOTFIX (2026-03-18): Defer initialization to bypass Vite/Rollup ES Module TDZ
-setTimeout(() => {
-  if (typeof schemaRegistry !== 'undefined') {
-    schemaRegistry.initialize(allSchemas);
-    logger.debug(`[Schema Registry] Complete config coverage: ${allSchemas.length} node schemas registered`);
-  } else {
-    console.error('[Schema Registry] CRITICAL: schemaRegistry still undefined after deferral at line 4171');
-  }
-}, 0);
+// Initialize synchronously so config panels never race into fallback schemas.
+// Registry init is idempotent (it no-ops if already initialized).
+schemaRegistry.initialize(allSchemas);
+
+// Phase E Fix: Register backward compatibility aliases.
+schemaRegistry.register(
+  {
+    ...formSchema,
+    nodeType: 'formStepSingle',
+    displayName: 'Form (Legacy)',
+    description: '[DEPRECATED] Use the "Form" node instead. This exists for backward compatibility only.',
+  },
+  true,
+);
+
+logger.debug(`[Schema Registry] Complete config coverage: ${allSchemas.length} node schemas registered`);
 
 // Cache bust: 1771875847

--- a/frontend/src/components/FlowEditor/config/types.ts
+++ b/frontend/src/components/FlowEditor/config/types.ts
@@ -269,6 +269,9 @@ export interface ConfigField {
   /** Key-value field: label for add button */
   addButtonText?: string;
 
+  /** Key-value fields: persistence shape (default: array pairs) */
+  keyValueMode?: 'array' | 'record';
+
   /** Entity-field picker: pre-selected field id */
   entityFieldId?: string;
 

--- a/frontend/src/components/FlowEditor/nodes/ActionNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ActionNode.tsx
@@ -137,10 +137,18 @@ function getActionDetails(data: ActionNodeData): { mainItems: ActionDetailItem[]
     case 'createRecord':
     case 'updateRecord':
     case 'deleteRecord': {
+      const fieldsValue = (data.fields ?? (data as any).fieldMappings) as any;
+
+      const fieldSummary = Array.isArray(fieldsValue)
+        ? `${fieldsValue.length} mapping(s)`
+        : fieldsValue && typeof fieldsValue === 'object'
+          ? Object.keys(fieldsValue).join(', ')
+          : undefined;
+
       const mainItems = [
-        { label: 'Entity', value: data.entity },
+        { label: 'Entity', value: (data.entity ?? (data as any).entityType) as any },
         { label: 'Record ID', value: data.recordId },
-        { label: 'Fields', value: data.fields ? Object.keys(data.fields).join(', ') : undefined },
+        { label: 'Fields', value: fieldSummary },
       ];
       return { mainItems, extraItems: [] };
     }


### PR DESCRIPTION
## What
Fix broken WorkForms action-node config panels by hardening the DynamicConfigPanel + config schema plumbing.

- Make schema registry initialization synchronous (remove setTimeout race → no fallback schemas).
- Add effectiveFormData (defaults + legacy aliases) so conditional visibility evaluates correctly.
- Fix complex renderers:
  - FieldMappingPanel wiring respects `entityFieldId` and correct prop shape.
  - VariablePicker supports `multiple: true` (string[] toggle semantics).
- Harden keyValue fields with `keyValueMode: 'record'` for HTTP headers/extractFields (backward compatible with array-pairs).
- Improve ActionNode record summary with legacy key aliases.
- Stabilize Vitest coverage output by creating `coverage/.tmp` in `test:ci`.

## Why
Several action panels rendered generic/fallback fields or failed to persist config due to registry init races, schema↔data mismatches, and renderer prop/shape issues.

## Tests
- `npm --prefix frontend run verify-standards`
- `npm --prefix frontend run test:ci`

## Rollback
Revert PR.
