### PR TITLE
WorkForms: sanitize FlowEditor shadow state on save

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
@@ -22,6 +22,7 @@ import { DynamicConfigPanel } from './DynamicConfigPanel';
 import { FormProcessConfigPanel } from './FormProcessConfigPanel';
 import { FormNodeConfig } from './nodes/FormNodeConfig';
 import { useNodeShadowState } from '../hooks/useNodeShadowState';
+import { sanitizeNodeConfigForPersistence } from '../utils/nodeDataSanitization';
 import {
   PrimaryButton,
   SecondaryButton,
@@ -200,11 +201,13 @@ export const NodeConfigPanelWithShadow: React.FC<NodeConfigPanelWithShadowProps>
   const handleApply = useCallback(() => {
     if (!node) return;
     
+    const sanitized = (sanitizeNodeConfigForPersistence(shadowConfig) || {}) as Record<string, any>;
+
     // Commit shadow state
     commitShadow();
-    
+
     // Also call the original onUpdate to trigger history
-    onUpdate(node.id, shadowConfig);
+    onUpdate(node.id, sanitized);
   }, [node, commitShadow, onUpdate, shadowConfig]);
   
   // Callbacks for FormProcessConfigPanel

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
@@ -20,6 +20,7 @@ import { Node, Edge } from '@xyflow/react';
 import { AlertCircle } from 'lucide-react';
 import { TabbedConfigPanel } from './TabbedConfigPanel';
 import { useNodeShadowState } from '../hooks/useNodeShadowState';
+import { sanitizeNodeConfigForPersistence } from '../utils/nodeDataSanitization';
 import {
   PrimaryButton,
   SecondaryButton,
@@ -189,11 +190,13 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
   const handleApply = useCallback(() => {
     if (!node) return;
     
+    const sanitized = (sanitizeNodeConfigForPersistence(shadowConfig) || {}) as Record<string, any>;
+
     // Commit shadow state
     commitShadow();
-    
+
     // Also call the original onUpdate to trigger history
-    onUpdate(node.id, shadowConfig);
+    onUpdate(node.id, sanitized);
     
     console.log('[Shadow State] Applied changes to node:', node.id);
   }, [node, commitShadow, onUpdate, shadowConfig]);

--- a/frontend/src/components/FlowEditor/hooks/__tests__/useNodeShadowState.sanitization.test.ts
+++ b/frontend/src/components/FlowEditor/hooks/__tests__/useNodeShadowState.sanitization.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import type { Node } from '@xyflow/react';
+
+import { useNodeShadowState } from '../useNodeShadowState';
+
+function setup(initialNodes: Node[], nodeId: string) {
+  return renderHook(() => {
+    const [nodes, setNodes] = React.useState<Node[]>(initialNodes);
+    const api = useNodeShadowState(nodeId, nodes, setNodes);
+    return { nodes, api };
+  });
+}
+
+describe('useNodeShadowState (sanitization)', () => {
+  it('commits config changes but strips shadow bookkeeping + underscore keys', () => {
+    const initialNodes: Node[] = [
+      {
+        id: 'n1',
+        type: 'actionEmail',
+        position: { x: 0, y: 0 },
+        data: {
+          nodeType: 'actionEmail',
+          subject: 'old',
+          _upstreamVariables: [{ id: 'x' }],
+          shadowConfig: { subject: 'wip', configStatus: 'dirty' },
+          configStatus: 'dirty',
+          config: { subject: 'old' },
+        },
+      } as any,
+    ];
+
+    const { result } = setup(initialNodes, 'n1');
+
+    act(() => {
+      // Simulate panel update that could accidentally include UI-only keys.
+      result.current.api.updateShadow({
+        subject: 'new',
+        shadowConfig: { injected: true },
+        configStatus: 'dirty',
+        _upstreamVariables: [{ id: 'y' }],
+      } as any);
+    });
+
+    act(() => {
+      result.current.api.commitShadow();
+    });
+
+    const committed = result.current.nodes.find((n) => n.id === 'n1')!;
+
+    expect((committed.data as any).subject).toBe('new');
+
+    // UI-only keys should not persist post-commit
+    expect((committed.data as any).shadowConfig).toBeUndefined();
+    expect((committed.data as any).configStatus).toBe('pristine');
+    expect((committed.data as any)._upstreamVariables).toBeUndefined();
+
+    // Config snapshot should be sanitized too
+    expect((committed.data as any).config).toEqual({ subject: 'new', nodeType: 'actionEmail' });
+  });
+});

--- a/frontend/src/components/FlowEditor/hooks/useNodeShadowState.ts
+++ b/frontend/src/components/FlowEditor/hooks/useNodeShadowState.ts
@@ -22,6 +22,8 @@
 import { useCallback, useMemo } from 'react';
 import { Node } from '@xyflow/react';
 
+import { sanitizeNodeConfigForPersistence } from '../utils/nodeDataSanitization';
+
 /**
  * Extended node data interface with shadow state support
  */
@@ -76,14 +78,20 @@ export function useNodeShadowState(
   const shadowConfig = useMemo(() => {
     if (!node) return {};
     const data = node.data as NodeDataWithShadow;
-    
+
     // If shadow config exists, use it (editing in progress)
     if (data.shadowConfig) {
-      return data.shadowConfig;
+      return (sanitizeNodeConfigForPersistence(data.shadowConfig) as Record<string, any>) || {};
     }
-    
-    // Otherwise, return committed config or all data
-    return data.config || { ...data };
+
+    // Otherwise, return the committed config baseline.
+    const { config, shadowConfig, configStatus, ...rest } = data;
+    return (
+      sanitizeNodeConfigForPersistence({
+        ...rest,
+        ...(config || {}),
+      }) as Record<string, any>
+    ) || {};
   }, [node]);
 
   const configStatus = useMemo(() => {
@@ -100,14 +108,17 @@ export function useNodeShadowState(
     const data = node.data as NodeDataWithShadow;
     if (!data.shadowConfig) return false;
 
-    const committedConfig = data.config || (() => {
-      // Avoid comparing against internal shadow bookkeeping keys.
-      const { shadowConfig, configStatus, config, ...rest } = data;
-      return rest;
-    })();
+    const { config, shadowConfig, configStatus, ...rest } = data;
+
+    const committedConfig = sanitizeNodeConfigForPersistence({
+      ...rest,
+      ...(config || {}),
+    });
+
+    const shadow = sanitizeNodeConfigForPersistence(shadowConfig);
 
     try {
-      return JSON.stringify(data.shadowConfig) !== JSON.stringify(committedConfig);
+      return JSON.stringify(shadow) !== JSON.stringify(committedConfig);
     } catch {
       // If serialization fails, fall back to showing Apply/Discard when shadowConfig exists.
       return true;
@@ -126,8 +137,16 @@ export function useNodeShadowState(
         if (n.id !== nodeId) return n;
 
         const currentData = n.data as NodeDataWithShadow;
-        const committedConfig = currentData.config || { ...currentData };
-        const currentShadow = currentData.shadowConfig || committedConfig;
+        const { config, shadowConfig, configStatus, ...rest } = currentData;
+
+        const committedConfig = (sanitizeNodeConfigForPersistence({
+          ...rest,
+          ...(config || {}),
+        }) || {}) as Record<string, any>;
+
+        const currentShadow = (sanitizeNodeConfigForPersistence(
+          shadowConfig || committedConfig,
+        ) || committedConfig) as Record<string, any>;
 
         // Merge changes into shadow config
         const newShadow = {
@@ -135,14 +154,16 @@ export function useNodeShadowState(
           ...changes,
         };
 
+        const sanitizedShadow = (sanitizeNodeConfigForPersistence(newShadow) || {}) as Record<string, any>;
+
         // Check if shadow differs from committed
-        const isDifferent = JSON.stringify(newShadow) !== JSON.stringify(committedConfig);
+        const isDifferent = JSON.stringify(sanitizedShadow) !== JSON.stringify(committedConfig);
 
         return {
           ...n,
           data: {
             ...currentData,
-            shadowConfig: newShadow,
+            shadowConfig: sanitizedShadow,
             configStatus: isDifferent ? ('dirty' as const) : ('pristine' as const),
           },
         };
@@ -166,13 +187,26 @@ export function useNodeShadowState(
 
         if (!shadow) return n; // Nothing to commit
 
-        // Merge shadow into main data and clear shadow
+        const { config, shadowConfig, configStatus, ...rest } = currentData;
+
+        const committedBase = (sanitizeNodeConfigForPersistence({
+          ...rest,
+          ...(config || {}),
+        }) || {}) as Record<string, any>;
+
+        const sanitizedShadow = (sanitizeNodeConfigForPersistence(shadow) || {}) as Record<string, any>;
+        const committed = {
+          ...committedBase,
+          ...sanitizedShadow,
+        };
+
+        // Merge shadow into main data and clear shadow.
+        // Keep top-level keys for compatibility, but never persist UI-only bookkeeping.
         return {
           ...n,
           data: {
-            ...currentData,
-            ...shadow,
-            config: shadow,
+            ...committed,
+            config: committed,
             shadowConfig: undefined,
             configStatus: 'pristine' as const,
           },

--- a/frontend/src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts
+++ b/frontend/src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+
+import { prepareWorkflowForSave } from '../workflowPersistence';
+
+describe('prepareWorkflowForSave (sanitization)', () => {
+  it('removes UI-only node.data keys from the persisted workflow payload', () => {
+    const nodes: Node[] = [
+      {
+        id: 'n1',
+        type: 'actionEmail',
+        position: { x: 0, y: 0 },
+        data: {
+          nodeType: 'actionEmail',
+          subject: 'hello',
+          shadowConfig: { subject: 'draft' },
+          configStatus: 'dirty',
+          hasBreakpoint: true,
+          _upstreamVariables: [{ id: 'v1' }],
+          config: {
+            nodeType: 'actionEmail',
+            subject: 'hello',
+            shadowConfig: { nope: true },
+            configStatus: 'dirty',
+            _upstreamVariables: [{ id: 'v2' }],
+          },
+        },
+      } as any,
+    ];
+
+    const edges: Edge[] = [];
+
+    const prepared = prepareWorkflowForSave(nodes, edges);
+    const preparedNodeData = prepared.nodes[0]!.data as any;
+
+    expect(preparedNodeData.subject).toBe('hello');
+    expect(preparedNodeData.nodeType).toBe('actionEmail');
+
+    expect(preparedNodeData.shadowConfig).toBeUndefined();
+    expect(preparedNodeData.configStatus).toBeUndefined();
+    expect(preparedNodeData.hasBreakpoint).toBeUndefined();
+    expect(preparedNodeData._upstreamVariables).toBeUndefined();
+
+    expect(preparedNodeData.config?.shadowConfig).toBeUndefined();
+    expect(preparedNodeData.config?.configStatus).toBeUndefined();
+    expect(preparedNodeData.config?._upstreamVariables).toBeUndefined();
+  });
+});

--- a/frontend/src/components/FlowEditor/utils/nodeDataSanitization.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeDataSanitization.ts
@@ -1,0 +1,45 @@
+import type { Node } from '@xyflow/react';
+
+const UI_ONLY_KEYS = new Set(['shadowConfig', 'configStatus', '_upstreamVariables', 'hasBreakpoint']);
+
+function sanitizeShallowObject(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (UI_ONLY_KEYS.has(k)) continue;
+    if (typeof v === 'function') continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+export function sanitizeNodeConfigForPersistence(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value;
+  return sanitizeShallowObject(value as Record<string, unknown>);
+}
+
+/**
+ * Shallow sanitizer for persisted node.data.
+ *
+ * Intentionally NOT recursive to avoid breaking user-provided JSON payloads
+ * (e.g. headers/body objects that may contain underscore keys).
+ */
+export function sanitizeNodeDataForPersistence(data: unknown): Record<string, any> {
+  const base = sanitizeNodeConfigForPersistence(data);
+  const out = (base && typeof base === 'object' && !Array.isArray(base))
+    ? (base as Record<string, any>)
+    : {};
+
+  if (out.config && typeof out.config === 'object' && !Array.isArray(out.config)) {
+    out.config = sanitizeNodeConfigForPersistence(out.config) as Record<string, any>;
+  }
+
+  return out;
+}
+
+export function sanitizeNodesForPersistence(nodes: Node[]): Node[] {
+  return nodes.map((n) => ({
+    ...n,
+    data: sanitizeNodeDataForPersistence(n.data),
+  }));
+}

--- a/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
+++ b/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
@@ -15,6 +15,7 @@ import { Node, Edge } from '@xyflow/react';
 import { logger } from '@/utils/logger';
 
 import { sortNodesTopologically } from './nodeSorting';
+import { sanitizeNodeDataForPersistence } from './nodeDataSanitization';
 import { apiClient } from '../../../services/apiService';
 
 // ============================================================================
@@ -153,19 +154,22 @@ export const prepareWorkflowForSave = (
   // Ensure all nodes have proper parentId metadata (React Flow v11+)
   // (This is already set by React Flow, but we verify it's serialized)
   for (const node of sortedNodes) {
+    // Strip UI-only keys before persistence (shadowConfig, dirty flags, debug flags, etc).
+    node.data = sanitizeNodeDataForPersistence(node.data);
+
     if (node.parentId) {
       // Ensure extent is serialized
       if (!node.extent) {
         node.extent = 'parent';
       }
-      
+
       // Ensure expandParent is set for child nodes
       if (node.expandParent === undefined) {
         node.expandParent = true;
       }
     }
   }
-  
+
   return {
     nodes: sortedNodes,
     edges: edgesCopy,


### PR DESCRIPTION
## What
- Add shallow `nodeDataSanitization` utilities to strip UI-only keys from persisted node data (`shadowConfig`, `configStatus`, `_upstreamVariables`, `hasBreakpoint`).
- Sanitize `useNodeShadowState` baselines + commit path so UI-only keys don't leak into committed config.
- Sanitize `prepareWorkflowForSave` so saving mid-edit can't persist shadow bookkeeping.

## Why
Fixes workflows being saved with editor-only state, which can break config panels/runtime and creates schema drift in persisted definitions.

## Tests
- `npm --prefix frontend run test:ci`
- `npm --prefix frontend run verify-standards`

## Risk / Rollback
Low risk: sanitizer is shallow and only removes known UI-only keys. Revert PR to restore prior behavior.