### PR TITLE
FlowEditor: dual-model form fields (fields + formFields)

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -38,6 +38,7 @@ import {
 } from '../utils/scheduleCron';
 import { evaluateCondition } from '../config/conditionalLogic';
 import { validateField } from '../config/validationEngine';
+import { toFormFieldsFromSelectedFields } from '../utils/formFieldsDualModel';
 
 // Field renderers
 import { 
@@ -387,7 +388,11 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     }
 
     const defaults = buildSmartDefaults(entityFieldsResp.fields);
-    const next = { ...(formData as any), fields: defaults };
+    const next = {
+      ...(formData as any),
+      fields: defaults,
+      formFields: toFormFieldsFromSelectedFields(defaults as any),
+    };
     setFormData(next);
     onUpdateNode(node.id, next);
     pendingAutoDefaultsRef.current = null;
@@ -411,7 +416,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
         (node.type === 'form' || node.type === 'formStep' || node.type === 'formStepSingle')
       ) {
         pendingAutoDefaultsRef.current = value as string;
-        const next = { ...prev, entityType: value, fields: [] };
+        const next = { ...prev, entityType: value, fields: [], formFields: [] };
         onUpdateNode(node.id, next);
         return next;
       }
@@ -513,6 +518,16 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
           }));
         }
 
+        return next;
+      }
+
+      if (fieldId === 'fields' && field?.type === 'entity-field-picker') {
+        const next = {
+          ...prev,
+          fields: value,
+          formFields: Array.isArray(value) ? toFormFieldsFromSelectedFields(value as any) : [],
+        };
+        onUpdateNode(node.id, next);
         return next;
       }
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
@@ -229,6 +229,7 @@ export const NodeConfigPanelWithShadow: React.FC<NodeConfigPanelWithShadowProps>
         name: `Step ${nodes.filter(n => n.parentId === node.id).length + 1}`,
         entityType: '',
         fields: [],
+        formFields: [],
       },
       parentId: node.id,
     };

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
@@ -21,6 +21,7 @@ import { VisualFormBuilderPanel } from './VisualFormBuilderPanel';
 import { LiveFormPreview } from './LiveFormPreview';
 import DeveloperJsonEditor from './DeveloperJsonEditor';
 import { FormField } from '../../form-builder/types';
+import { getResolvedFormFields } from '../utils/formFieldsDualModel';
 
 // ============================================================================
 // Types
@@ -191,9 +192,10 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
                 transition={{ duration: 0.2 }}
               >
                 <VisualFormBuilderPanel
-                  fields={(node.data?.fields as FormField[]) || []}
+                  fields={getResolvedFormFields(node.data)}
                   onChange={(newFields) => {
-                    onUpdateNode(node.id, { fields: newFields });
+                    // Dual-model: persist form-builder fields separately from config-time entity picker selections.
+                    onUpdateNode(node.id, { formFields: newFields });
                   }}
                 />
               </TabPanel>

--- a/frontend/src/components/FlowEditor/ConfigPanel/nodes/FormNodeConfig.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/nodes/FormNodeConfig.tsx
@@ -4,6 +4,7 @@ import { Node, Edge } from '@xyflow/react';
 import EntityFieldPicker, { type SelectedField } from '../EntityFieldPicker';
 import { useEntityList } from '../../../../services/schemaService';
 import { useUpstreamVariables } from '../../hooks/useUpstreamVariables';
+import { getResolvedSelectedFields, toFormFieldsFromSelectedFields } from '../../utils/formFieldsDualModel';
 
 import styled from 'styled-components';
 
@@ -67,7 +68,7 @@ export const FormNodeConfig: React.FC<FormNodeConfigProps> = ({
   }, [node.id, node.data]);
 
   const entityType = (formData.entityType as string) || '';
-  const selectedFields = (formData.fields as SelectedField[]) || [];
+  const selectedFields = getResolvedSelectedFields(formData);
 
   const { data: entities = [] } = useEntityList();
 
@@ -122,7 +123,7 @@ export const FormNodeConfig: React.FC<FormNodeConfigProps> = ({
           onChange={(e) => {
             const nextEntityType = e.target.value;
             // Critical: reset selected fields when switching entity.
-            update({ entityType: nextEntityType, fields: [] });
+            update({ entityType: nextEntityType, fields: [], formFields: [] });
           }}
         >
           <option value="">Select an entity…</option>
@@ -139,7 +140,9 @@ export const FormNodeConfig: React.FC<FormNodeConfigProps> = ({
         <Label>Fields</Label>
         <EntityFieldPicker
           selectedFields={selectedFields}
-          onFieldsChange={(fields) => update({ fields })}
+          onFieldsChange={(fields) =>
+            update({ fields, formFields: toFormFieldsFromSelectedFields(fields) })
+          }
           upstreamVariables={upstreamVariables}
           entityType={entityType}
           hideEntitySelector

--- a/frontend/src/components/FlowEditor/ConfigPanel/nodes/__tests__/FormNodeConfig.dualModel.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/nodes/__tests__/FormNodeConfig.dualModel.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { FormNodeConfig } from '../FormNodeConfig';
+
+vi.mock('../../EntityFieldPicker', () => {
+  return {
+    default: (props: any) => {
+      return (
+        <div>
+          <div data-testid="selected-count">{props.selectedFields?.length ?? 0}</div>
+          <button
+            onClick={() =>
+              props.onFieldsChange([
+                {
+                  name: 'email',
+                  label: 'Email',
+                  type: 'EmailField',
+                  required: true,
+                  fieldId: 'sf-123',
+                },
+              ])
+            }
+          >
+            set-fields
+          </button>
+        </div>
+      );
+    },
+  };
+});
+
+vi.mock('@/services/schemaService', () => ({
+  useEntityList: () => ({ data: [] }),
+}));
+
+vi.mock('../../hooks/useUpstreamVariables', () => ({
+  useUpstreamVariables: () => ({ variables: [] }),
+}));
+
+vi.mock('../hooks/useUpstreamVariables', () => ({
+  useUpstreamVariables: () => ({ variables: [] }),
+}));
+
+describe('FormNodeConfig dual-model', () => {
+  it('preselects fields when node.data.formFields is FormField[]', () => {
+    render(
+      <FormNodeConfig
+        node={{
+          id: 'n1',
+          type: 'form',
+          position: { x: 0, y: 0 },
+          data: {
+            entityType: 'supplier',
+            formFields: [
+              { id: 'email', type: 'email', label: 'Email', required: true, validation: [] },
+            ],
+          },
+        } as any}
+        nodes={[] as any}
+        edges={[] as any}
+        onUpdateNode={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('selected-count')).toHaveTextContent('1');
+  });
+
+  it('writes formFields when picker changes selection', () => {
+    const onUpdateNode = vi.fn();
+
+    render(
+      <FormNodeConfig
+        node={{
+          id: 'n1',
+          type: 'form',
+          position: { x: 0, y: 0 },
+          data: {
+            entityType: 'supplier',
+            fields: [],
+          },
+        } as any}
+        nodes={[] as any}
+        edges={[] as any}
+        onUpdateNode={onUpdateNode}
+      />
+    );
+
+    fireEvent.click(screen.getByText('set-fields'));
+
+    const last = onUpdateNode.mock.calls.at(-1);
+    expect(last?.[0]).toBe('n1');
+
+    const nextData = last?.[1];
+    expect(nextData.fields).toHaveLength(1);
+    expect(nextData.formFields).toHaveLength(1);
+    expect(nextData.formFields[0]).toMatchObject({ id: 'email', type: 'email' });
+  });
+});

--- a/frontend/src/components/FlowEditor/Modals/FlowPreviewModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FlowPreviewModal.tsx
@@ -19,6 +19,7 @@ import styled from 'styled-components';
 import { X, Play, Pause, RotateCcw, FastForward, CheckCircle, AlertCircle, Clock } from 'lucide-react';
 import { Node, Edge, useReactFlow } from '@xyflow/react';
 import { FormField } from '@/components/form-builder/types';
+import { getResolvedFormFields } from '../utils/formFieldsDualModel';
 
 /**
  * Props for FlowPreviewModal
@@ -398,7 +399,7 @@ export const FlowPreviewModal: React.FC<FlowPreviewModalProps> = React.memo(({
     
     if (node.type?.includes('form')) {
       // Generate mock form data
-      const fields = ((node.data as any)?.fields as FormField[] | undefined) || [];
+      const fields = getResolvedFormFields(node.data);
       fields.forEach((field) => {
         mockData[field.id] = `Mock ${field.type} value`;
       });

--- a/frontend/src/components/FlowEditor/NodeContextMenu.tsx
+++ b/frontend/src/components/FlowEditor/NodeContextMenu.tsx
@@ -316,6 +316,7 @@ export const NodeContextMenu: React.FC<ContextMenuProps> = ({ node, x, y, onClos
         label: `Step ${childNodes.length + 1}`,
         status: 'draft',
         fields: [],
+        formFields: [],
       },
       draggable: true,
     };

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -3718,6 +3718,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             label: `Page ${index + 1}`,
             status: 'draft',
             fields: [],
+            formFields: [],
             ...getDefaultNodeData('form'),
           },
           selected: index === 0,
@@ -4545,6 +4546,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             label: `Page ${index + 1}`,
             status: 'draft',
             fields: [],
+            formFields: [],
             ...getDefaultNodeData('form'),
           },
         });
@@ -6820,6 +6822,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             stepTitle: `Page ${newPageNumber}`,
             label: `Page ${newPageNumber}`,
             fields: [],
+            formFields: [],
             order: insertIndex,
           },
           parentId: containerId,

--- a/frontend/src/components/FlowEditor/hooks/useFormDataMapping.ts
+++ b/frontend/src/components/FlowEditor/hooks/useFormDataMapping.ts
@@ -16,6 +16,7 @@
 import { useCallback, useMemo } from 'react';
 import { Node, Edge, useReactFlow } from '@xyflow/react';
 import { FormField } from '@/components/form-builder/types';
+import { getResolvedFormFields } from '../utils/formFieldsDualModel';
 
 /**
  * Data mapping between form field and workflow node
@@ -96,7 +97,7 @@ export const useFormDataMapping = (): UseFormDataMappingReturn => {
       // Get child nodes with form fields
       const childNodes = getNodes().filter(n => n.parentId === node.id);
       childNodes.forEach((child, stepIndex) => {
-        const fields = child.data?.fields as FormField[] || [];
+        const fields = getResolvedFormFields(child.data);
         fields.forEach((field: FormField, fieldIndex: number) => {
           outputs.push({
             id: field.id,
@@ -108,9 +109,9 @@ export const useFormDataMapping = (): UseFormDataMappingReturn => {
           });
         });
       });
-    } else if (node.type === 'formStepSingle') {
+    } else if (node.type === 'formStepSingle' || node.type === 'form' || node.type === 'formStep') {
       // Single step form - get fields directly
-      const fields = data?.fields as FormField[] || [];
+      const fields = getResolvedFormFields(data);
       fields.forEach((field: FormField, index: number) => {
         outputs.push({
           id: field.id,
@@ -201,7 +202,12 @@ export const useFormDataMapping = (): UseFormDataMappingReturn => {
 
       incomingEdges.forEach((edge) => {
         const sourceNode = nodes.find((n) => n.id === edge.source);
-        if (sourceNode && ['formBook', 'formProcessGroup', 'formReference', 'formStepSingle'].includes(sourceNode.type || '')) {
+        if (
+          sourceNode &&
+          ['formBook', 'formProcessGroup', 'formReference', 'formStepSingle', 'form', 'formStep'].includes(
+            sourceNode.type || ''
+          )
+        ) {
           const fields = generateFormOutputs(sourceNode);
           upstreamFields.push(...fields);
         }

--- a/frontend/src/components/FlowEditor/utils/__tests__/formFieldsDualModel.test.ts
+++ b/frontend/src/components/FlowEditor/utils/__tests__/formFieldsDualModel.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  getResolvedFormFields,
+  getResolvedSelectedFields,
+  toFormFieldsFromSelectedFields,
+  toSelectedFieldsFromFormFields,
+} from '../formFieldsDualModel';
+
+describe('formFieldsDualModel', () => {
+  it('converts SelectedField[] to FormField[] (id + label + type + required)', () => {
+    const selected = [
+      {
+        name: 'email',
+        label: 'Email',
+        type: 'EmailField',
+        required: true,
+        fieldId: 'sf-123',
+        customLabel: 'Work Email',
+        cascadeFrom: '{{trigger.email}}',
+      },
+    ] as any;
+
+    const out = toFormFieldsFromSelectedFields(selected);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      id: 'email',
+      label: 'Work Email',
+      type: 'email',
+      required: true,
+      validation: [],
+    });
+  });
+
+  it('converts FormField[] to SelectedField[] for EntityFieldPicker', () => {
+    const fields = [
+      {
+        id: 'email',
+        type: 'email',
+        label: 'Email',
+        required: true,
+        validation: [],
+      },
+    ] as any;
+
+    const out = toSelectedFieldsFromFormFields(fields);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'email',
+      label: 'Email',
+      type: 'email',
+      required: true,
+      fieldId: 'email',
+    });
+  });
+
+  it('resolves formFields first, then fields as FormField[], then fields as SelectedField[]', () => {
+    const asFormFields = [
+      { id: 'a', type: 'text', label: 'A', required: false, validation: [] },
+    ] as any;
+
+    const asSelected = [{ name: 'b', label: 'B', type: 'text', required: false, fieldId: 'x' }] as any;
+
+    expect(getResolvedFormFields({ formFields: asFormFields, fields: asSelected })[0]!.id).toBe('a');
+    expect(getResolvedFormFields({ fields: asFormFields })[0]!.id).toBe('a');
+    expect(getResolvedFormFields({ fields: asSelected })[0]!.id).toBe('b');
+
+    expect(getResolvedSelectedFields({ fields: asSelected })[0]!.name).toBe('b');
+    expect(getResolvedSelectedFields({ formFields: asFormFields })[0]!.name).toBe('a');
+  });
+});

--- a/frontend/src/components/FlowEditor/utils/formFieldsDualModel.ts
+++ b/frontend/src/components/FlowEditor/utils/formFieldsDualModel.ts
@@ -1,0 +1,144 @@
+import type { FormField, FieldType, ValidationRule } from '@/components/form-builder/types';
+import type { SelectedField } from '../ConfigPanel/EntityFieldPicker';
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isFieldType(value: unknown): value is FieldType {
+  return (
+    value === 'text' ||
+    value === 'textarea' ||
+    value === 'number' ||
+    value === 'email' ||
+    value === 'phone' ||
+    value === 'date' ||
+    value === 'datetime' ||
+    value === 'select' ||
+    value === 'multiSelect' ||
+    value === 'radio' ||
+    value === 'checkbox' ||
+    value === 'file' ||
+    value === 'signature' ||
+    value === 'rating' ||
+    value === 'slider'
+  );
+}
+
+function coerceFieldType(value: unknown): FieldType {
+  if (isFieldType(value)) return value;
+  const raw = String(value || '').toLowerCase();
+
+  if (raw.includes('email')) return 'email';
+  if (raw.includes('phone') || raw.includes('tel')) return 'phone';
+  if (raw.includes('datetime')) return 'datetime';
+  if (raw === 'date' || raw.includes('date')) return 'date';
+  if (raw.includes('number') || raw.includes('int') || raw.includes('float') || raw.includes('decimal')) {
+    return 'number';
+  }
+  if (raw.includes('textarea') || raw.includes('longtext')) return 'textarea';
+  if (raw.includes('multi') && raw.includes('select')) return 'multiSelect';
+  if (raw.includes('select') || raw.includes('choice')) return 'select';
+  if (raw.includes('radio')) return 'radio';
+  if (raw.includes('checkbox') || raw.includes('bool')) return 'checkbox';
+  if (raw.includes('file')) return 'file';
+  if (raw.includes('signature')) return 'signature';
+  if (raw.includes('rating')) return 'rating';
+  if (raw.includes('slider')) return 'slider';
+
+  return 'text';
+}
+
+function coerceBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (value === 1 || value === '1' || value === 'true') return true;
+  if (value === 0 || value === '0' || value === 'false') return false;
+  return Boolean(value);
+}
+
+function coerceValidation(value: unknown): ValidationRule[] {
+  return Array.isArray(value) ? (value as ValidationRule[]) : [];
+}
+
+export function isFormBuilderFieldArray(value: unknown): value is FormField[] {
+  if (!Array.isArray(value)) return false;
+  return value.every((v) => isRecord(v) && typeof v.id === 'string' && typeof v.label === 'string');
+}
+
+export function isSelectedFieldArray(value: unknown): value is SelectedField[] {
+  if (!Array.isArray(value)) return false;
+  return value.every((v) => isRecord(v) && (typeof v.name === 'string' || typeof v.fieldId === 'string'));
+}
+
+export function toFormFieldsFromSelectedFields(selected: SelectedField[]): FormField[] {
+  return (selected || [])
+    .filter((f) => isRecord(f))
+    .map((f) => {
+      const id = String(f.name ?? (f as any).key ?? (f as any).id ?? f.fieldId ?? '').trim();
+
+      return {
+        id,
+        type: coerceFieldType((f as any).type),
+        label: String((f as any).customLabel ?? (f as any).label ?? id),
+        placeholder: (f as any).placeholder,
+        helpText: (f as any).helpText,
+        required: coerceBoolean((f as any).required ?? (f as any).is_required),
+        validation: coerceValidation((f as any).validation),
+        options: Array.isArray((f as any).options) ? (f as any).options : undefined,
+      } satisfies FormField;
+    })
+    .filter((f) => Boolean(f.id));
+}
+
+export function toSelectedFieldsFromFormFields(fields: FormField[]): SelectedField[] {
+  return (fields || [])
+    .filter((f) => isRecord(f) && typeof f.id === 'string')
+    .map((f) => {
+      return {
+        // EntityField shape (best-effort)
+        name: String(f.id),
+        label: String(f.label ?? f.id),
+        type: String(f.type ?? 'text'),
+        required: Boolean(f.required),
+
+        // SelectedField extras
+        fieldId: String(f.id),
+      } as SelectedField;
+    });
+}
+
+export function getResolvedFormFields(data: unknown): FormField[] {
+  if (!isRecord(data)) return [];
+
+  if (isFormBuilderFieldArray((data as any).formFields)) {
+    return (data as any).formFields;
+  }
+
+  if (isFormBuilderFieldArray((data as any).fields)) {
+    return (data as any).fields;
+  }
+
+  if (isSelectedFieldArray((data as any).fields)) {
+    return toFormFieldsFromSelectedFields((data as any).fields);
+  }
+
+  return [];
+}
+
+export function getResolvedSelectedFields(data: unknown): SelectedField[] {
+  if (!isRecord(data)) return [];
+
+  if (isSelectedFieldArray((data as any).fields)) {
+    return (data as any).fields;
+  }
+
+  if (isFormBuilderFieldArray((data as any).formFields)) {
+    return toSelectedFieldsFromFormFields((data as any).formFields);
+  }
+
+  if (isFormBuilderFieldArray((data as any).fields)) {
+    return toSelectedFieldsFromFormFields((data as any).fields);
+  }
+
+  return [];
+}

--- a/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeNormalization.ts
@@ -12,6 +12,12 @@
 import { Node } from '@xyflow/react';
 import { NODE_TYPE_REGISTRY } from '../nodeTypes';
 import { formatEntityTypeLabel } from './formatEntityTypeLabel';
+import {
+  getResolvedFormFields,
+  isFormBuilderFieldArray,
+  isSelectedFieldArray,
+  toFormFieldsFromSelectedFields,
+} from './formFieldsDualModel';
 
 const LEGACY_FORM_STEP_TYPE_MAP: Record<string, 'form'> = {
   formStep: 'form',
@@ -107,6 +113,28 @@ export function normalizeNodeData(node: Node): Node {
         nodeType: canonicalFormType,
       },
     } as Node;
+  }
+
+  // --------------------------------------------------------------------------
+  // Form Fields Dual-Model: ensure formFields exists for form-like nodes.
+  // --------------------------------------------------------------------------
+  if (next.type === 'form') {
+    const data: any = next.data || {};
+
+    if (!isFormBuilderFieldArray(data.formFields)) {
+      const resolved = getResolvedFormFields(data);
+      if (resolved.length > 0) {
+        next = { ...next, data: { ...data, formFields: resolved } } as Node;
+      } else if (isSelectedFieldArray(data.fields)) {
+        next = {
+          ...next,
+          data: {
+            ...data,
+            formFields: toFormFieldsFromSelectedFields(data.fields),
+          },
+        } as Node;
+      }
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/frontend/src/components/FormSubmission/ExecutionFormStep.tsx
+++ b/frontend/src/components/FormSubmission/ExecutionFormStep.tsx
@@ -35,7 +35,8 @@ type FormStepNodeData = {
   name?: string;
   entity_type?: string;
   entityType?: string;
-  fields?: SelectedFieldLike[];
+  fields?: Array<Record<string, any>>;
+  formFields?: Array<Record<string, any>>;
 };
 
 export interface ExecutionFormStepProps {
@@ -119,12 +120,16 @@ export const ExecutionFormStep: React.FC<ExecutionFormStepProps> = ({
   const entityType = nodeData.entity_type || nodeData.entityType;
 
   const fields: FieldConfig[] = useMemo(() => {
-    const selected = Array.isArray(nodeData.fields) ? nodeData.fields : [];
-    return selected.map((f) => {
+    const raw = Array.isArray((nodeData as any).formFields) ? (nodeData as any).formFields : nodeData.fields;
+    const selected = Array.isArray(raw) ? raw : [];
+
+    return selected.map((f: any) => {
       const autoPopulateSource = f.cascadeFrom;
+      const key = String(f.key ?? f.name ?? f.id ?? '');
+
       return {
-        key: String(f.key),
-        label: f.label || String(f.key),
+        key,
+        label: f.label || key,
         type: f.type || 'text',
         required: Boolean(f.required),
         placeholder: f.placeholder,

--- a/frontend/src/utils/flowUtils.ts
+++ b/frontend/src/utils/flowUtils.ts
@@ -93,16 +93,19 @@ function extractNodeOutputs(node: Node): UpstreamOutput[] {
   const data = (node.data ?? {}) as Record<string, any>;
 
   // Handle form nodes (formStep, formStepSingle, formProcess)
-  if (
-    (node.type?.includes('form') || node.type?.includes('Form')) &&
-    Array.isArray(data.fields)
-  ) {
-    for (const field of data.fields as any[]) {
+  if (node.type?.includes('form') || node.type?.includes('Form')) {
+    const rawFields = Array.isArray((data as any).formFields)
+      ? (data as any).formFields
+      : Array.isArray((data as any).fields)
+        ? (data as any).fields
+        : [];
+
+    for (const field of rawFields as any[]) {
       outputs.push({
         nodeId: node.id,
         nodeLabel: data.label || data.stepTitle || 'Unnamed Form',
         nodeType: node.type,
-        fieldName: field.name || field.id,
+        fieldName: field.name || field.id || field.key,
         fieldLabel: field.label,
         fieldType: field.type,
         sampleValue: field.defaultValue || getSampleValue(field.type),


### PR DESCRIPTION
## What
- Add `formFields` as the canonical **FormBuilder/runtime** field model while keeping legacy `fields` (EntityFieldPicker selection) for backward compatibility.
- Add adapters/resolvers (`formFieldsDualModel.ts`) and normalize form nodes on load.
- Update key consumers (DynamicConfigPanel, FormNodeConfig, TabbedConfigPanel, preview, mapping, runtime) to use resolvers consistently.

## Why
Fixes the long-standing mismatch where `node.data.fields` alternated between `SelectedField[]` and `FormField[]`, breaking preview/runtime/mapping depending on which UI wrote last.

## Tests
- `npm --prefix frontend run test:ci`
- `npm --prefix frontend run verify-standards`

## Risk / Rollback
Low: additive-only. We dual-read and single-write for the builder path, and we keep legacy `fields` untouched. Rollback is a revert of this PR.