### PR TITLE
FlowEditor: remove hardcoded colors

### DIFF
--- a/frontend/.eslint/scripts/check-colors.cjs
+++ b/frontend/.eslint/scripts/check-colors.cjs
@@ -58,6 +58,10 @@ const STANDARDIZED_COLORS = {
 // (Avoids false positives like order numbers "#12345".)
 const HEX_COLOR_REGEX = /#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b/g;
 
+// Match hardcoded comma-based rgb()/rgba() colors.
+// NOTE: We scope enforcement to FlowEditor + WorkForms to avoid mass legacy churn.
+const RGB_COLOR_REGEX = /\brgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(?:,\s*[0-9.]+\s*)?\)/g;
+
 function isNumericOnlyShortHex(color) {
   // Heuristic: ignore short numeric-only tokens like "#405" in names (not actual colors).
   // We still catch #000000/#111111 etc.
@@ -72,17 +76,29 @@ function getSuggestion(color) {
 }
 
 function checkFile(filePath) {
+  const repoRoot = path.join(__dirname, '../..');
+  const relativePath = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+  const enforceRgb =
+    relativePath.includes('src/components/FlowEditor/') ||
+    relativePath.includes('src/components/WorkForms/');
+
   const content = fs.readFileSync(filePath, 'utf8');
   const lines = content.split('\n');
   const violations = [];
-  
+
   lines.forEach((line, lineIndex) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*')) {
+      return;
+    }
+
     let match;
-    const regex = new RegExp(HEX_COLOR_REGEX, 'g');
-    while ((match = regex.exec(line)) !== null) {
+
+    const hexRegex = new RegExp(HEX_COLOR_REGEX, 'g');
+    while ((match = hexRegex.exec(line)) !== null) {
       const color = match[0];
       const columnIndex = match.index;
-      
+
       if (isNumericOnlyShortHex(color)) {
         continue;
       }
@@ -92,11 +108,30 @@ function checkFile(filePath) {
         column: columnIndex + 1,
         color,
         suggestion: getSuggestion(color),
-        lineContent: line.trim()
+        lineContent: trimmed,
+      });
+    }
+
+    if (!enforceRgb) {
+      return;
+    }
+
+    const rgbRegex = new RegExp(RGB_COLOR_REGEX, 'g');
+    while ((match = rgbRegex.exec(line)) !== null) {
+      const color = match[0];
+      const columnIndex = match.index;
+
+      violations.push({
+        line: lineIndex + 1,
+        column: columnIndex + 1,
+        color,
+        suggestion:
+          'Use theme tokens (e.g. rgb(var(--color-text-primary)) or rgba(var(--color-overlay), 0.5)).',
+        lineContent: trimmed,
       });
     }
   });
-  
+
   return violations;
 }
 
@@ -105,7 +140,7 @@ async function main() {
   const specificFile = args.find(arg => !arg.startsWith('--'));
   const showSuggestions = args.includes('--fix');
   
-  console.log('🔍 Checking for hardcoded hex colors...\n');
+  console.log('🔍 Checking for hardcoded colors...\n');
   
   let files;
   if (specificFile) {

--- a/frontend/src/components/FlowEditor/AISuggestionBadge.tsx
+++ b/frontend/src/components/FlowEditor/AISuggestionBadge.tsx
@@ -25,7 +25,7 @@ export const AISuggestionBadge: React.FC<AISuggestionBadgeProps> = ({ mode, reas
           alignItems: 'center', 
           gap: '4px',
           padding: '2px 8px',
-          backgroundColor: isAI ? 'rgb(34, 197, 94)' : 'rgb(234, 179, 8)',
+          backgroundColor: isAI ? 'rgb(var(--color-success))' : 'rgb(var(--color-warning))',
           color: 'white',
           borderRadius: '12px',
           fontSize: '12px',

--- a/frontend/src/components/FlowEditor/ConfigPanel/ConditionBuilder.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/ConditionBuilder.tsx
@@ -228,7 +228,7 @@ const ConditionItem = styled.div`
   
   &:hover {
     border-color: rgb(var(--color-primary));
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.05);
   }
 `;
 
@@ -282,8 +282,8 @@ const DeleteButton = styled.button`
   flex-shrink: 0;
   
   &:hover {
-    background: rgba(239, 68, 68, 0.1);
-    color: rgb(239, 68, 68);
+    background: rgba(var(--color-error), 0.1);
+    color: rgb(var(--color-error));
   }
 `;
 
@@ -313,8 +313,8 @@ const LogicLine = styled.div`
 
 const LogicBadge = styled.div<{ $logic: ConditionLogic }>`
   padding: 4px 12px;
-  background: ${props => props.$logic === 'and' ? 'rgba(59, 130, 246, 0.1)' : 'rgba(234, 179, 8, 0.1)'};
-  color: ${props => props.$logic === 'and' ? 'rgb(59, 130, 246)' : 'rgb(234, 179, 8)'};
+  background: ${props => props.$logic === 'and' ? 'rgba(var(--color-info), 0.1)' : 'rgba(var(--color-warning), 0.1)'};
+  color: ${props => props.$logic === 'and' ? 'rgb(var(--color-info))' : 'rgb(var(--color-warning))'};
   border-radius: var(--radius-sm);
   font-size: 11px;
   font-weight: 700;

--- a/frontend/src/components/FlowEditor/ConfigPanel/DataMappingPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DataMappingPanel.tsx
@@ -100,7 +100,7 @@ const MappingRow = styled.div<{ hasError?: boolean }>`
   background: rgb(var(--color-background-secondary));
   border-radius: 6px;
   border: 1px solid ${props => 
-    props.hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'
+    props.hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'
   };
 `;
 
@@ -177,7 +177,7 @@ const DeleteButton = styled.button`
   justify-content: center;
 
   &:hover {
-    background: rgb(239, 68, 68);
+    background: rgb(var(--color-error));
     color: white;
   }
 `;
@@ -219,14 +219,14 @@ const ValidationMessage = styled.div<{ type: 'error' | 'success' }>`
   font-size: 12px;
   color: ${props => 
     props.type === 'error' 
-      ? 'rgb(239, 68, 68)' 
-      : 'rgb(34, 197, 94)'
+      ? 'rgb(var(--color-error))' 
+      : 'rgb(var(--color-success))'
   };
   padding: 8px 12px;
   background: ${props => 
     props.type === 'error' 
-      ? 'rgba(239, 68, 68, 0.1)' 
-      : 'rgba(34, 197, 94, 0.1)'
+      ? 'rgba(var(--color-error), 0.1)' 
+      : 'rgba(var(--color-success), 0.1)'
   };
   border-radius: 6px;
   margin-top: 8px;
@@ -244,8 +244,8 @@ const InfoBox = styled.div`
   align-items: flex-start;
   gap: 8px;
   padding: 12px;
-  background: rgba(59, 130, 246, 0.1);
-  border: 1px solid rgba(59, 130, 246, 0.3);
+  background: rgba(var(--color-info), 0.1);
+  border: 1px solid rgba(var(--color-info), 0.3);
   border-radius: 6px;
   font-size: 13px;
   color: rgb(var(--color-text-secondary));

--- a/frontend/src/components/FlowEditor/ConfigPanel/DeveloperJsonEditor.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DeveloperJsonEditor.tsx
@@ -167,12 +167,12 @@ const PlainTextarea = styled.textarea`
   font-size: 12px;
   line-height: 1.5;
   color: rgb(var(--color-text-primary));
-  background: rgba(0, 0, 0, 0.02);
+  background: rgba(var(--color-overlay), 0.02);
 `;
 
 const ErrorText = styled.div`
   font-size: 12px;
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
 `;
 
 export default DeveloperJsonEditor;

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -1233,7 +1233,7 @@ const Button = styled.button<{ variant?: 'primary' | 'secondary' | 'danger'; ful
         background: rgb(var(--color-error));
         color: white;
         &:hover:not(:disabled) {
-          background: rgb(239, 68, 68);
+          background: rgb(var(--color-error));
         }
       `;
     } else {

--- a/frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPicker.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPicker.tsx
@@ -182,11 +182,11 @@ const FieldBadge = styled.span<{ variant?: 'required' | 'type' }>`
   font-weight: 500;
   border-radius: 3px;
   background: ${props => {
-    if (props.variant === 'required') return 'rgba(239, 68, 68, 0.1)';
+    if (props.variant === 'required') return 'rgba(var(--color-error), 0.1)';
     return 'rgba(var(--color-primary), 0.1)';
   }};
   color: ${props => {
-    if (props.variant === 'required') return 'rgb(239, 68, 68)';
+    if (props.variant === 'required') return 'rgb(var(--color-error))';
     return 'rgb(var(--color-primary))';
   }};
 `;
@@ -223,8 +223,8 @@ const RemoveButton = styled.button`
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(239, 68, 68, 0.1);
-    color: rgb(239, 68, 68);
+    background: rgba(var(--color-error), 0.1);
+    color: rgb(var(--color-error));
   }
 `;
 
@@ -265,10 +265,10 @@ const LoadingText = styled.div`
 
 const ErrorText = styled.div`
   padding: 12px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: rgba(var(--color-error), 0.1);
+  border: 1px solid rgba(var(--color-error), 0.3);
   border-radius: 6px;
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   font-size: 14px;
 `;
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/FieldConfigurationPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FieldConfigurationPanel.tsx
@@ -130,11 +130,11 @@ const Badge = styled.span<{ variant?: 'info' | 'warning' }>`
   font-weight: 500;
   border-radius: 3px;
   background: ${props => {
-    if (props.variant === 'warning') return 'rgba(234, 179, 8, 0.1)';
+    if (props.variant === 'warning') return 'rgba(var(--color-warning), 0.1)';
     return 'rgba(var(--color-primary), 0.1)';
   }};
   color: ${props => {
-    if (props.variant === 'warning') return 'rgb(234, 179, 8)';
+    if (props.variant === 'warning') return 'rgb(var(--color-warning))';
     return 'rgb(var(--color-primary))';
   }};
 `;
@@ -172,8 +172,8 @@ const RemoveButton = styled.button`
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(239, 68, 68, 0.1);
-    color: rgb(239, 68, 68);
+    background: rgba(var(--color-error), 0.1);
+    color: rgb(var(--color-error));
   }
 `;
 
@@ -398,7 +398,7 @@ export const FieldConfigurationPanel: React.FC<FieldConfigurationPanelProps> = (
         <PreviewSection>
           <PreviewLabel>
             {displayLabel}
-            {field.required && <span style={{ color: 'rgb(239, 68, 68)' }}> *</span>}
+            {field.required && <span style={{ color: 'rgb(var(--color-error))' }}> *</span>}
           </PreviewLabel>
           {displayHelpText && (
             <HelpText style={{ marginBottom: '8px' }}>{displayHelpText}</HelpText>

--- a/frontend/src/components/FlowEditor/ConfigPanel/FieldMappingPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FieldMappingPanel.tsx
@@ -188,7 +188,7 @@ const FieldCard = styled.div<{ $mapped?: boolean; $selected?: boolean }>`
   background: rgb(var(--color-background));
   border: 2px solid ${props => 
     props.$selected ? 'rgb(var(--color-primary))' :
-    props.$mapped ? 'rgba(34, 197, 94, 0.3)' : 
+    props.$mapped ? 'rgba(var(--color-success), 0.3)' : 
     'rgb(var(--color-border))'};
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -197,7 +197,7 @@ const FieldCard = styled.div<{ $mapped?: boolean; $selected?: boolean }>`
   
   &:hover {
     border-color: rgb(var(--color-primary));
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.05);
   }
 `;
 
@@ -227,18 +227,18 @@ const FieldBadge = styled.div<{ $type: 'required' | 'mapped' | 'auto' }>`
   ${props => {
     if (props.$type === 'required') {
       return `
-        background: rgba(239, 68, 68, 0.1);
-        color: rgb(239, 68, 68);
+        background: rgba(var(--color-error), 0.1);
+        color: rgb(var(--color-error));
       `;
     } else if (props.$type === 'mapped') {
       return `
-        background: rgba(34, 197, 94, 0.1);
-        color: rgb(34, 197, 94);
+        background: rgba(var(--color-success), 0.1);
+        color: rgb(var(--color-success));
       `;
     } else {
       return `
-        background: rgba(59, 130, 246, 0.1);
-        color: rgb(59, 130, 246);
+        background: rgba(var(--color-info), 0.1);
+        color: rgb(var(--color-info));
       `;
     }
   }}
@@ -283,7 +283,7 @@ const MappingItem = styled.div`
   
   &:hover {
     border-color: rgb(var(--color-primary));
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.05);
   }
 `;
 
@@ -360,18 +360,18 @@ const ValidationAlert = styled.div<{ $type: 'error' | 'warning' | 'success' }>`
   ${props => {
     if (props.$type === 'error') {
       return `
-        background: rgba(239, 68, 68, 0.1);
-        color: rgb(239, 68, 68);
+        background: rgba(var(--color-error), 0.1);
+        color: rgb(var(--color-error));
       `;
     } else if (props.$type === 'warning') {
       return `
-        background: rgba(234, 179, 8, 0.1);
-        color: rgb(234, 179, 8);
+        background: rgba(var(--color-warning), 0.1);
+        color: rgb(var(--color-warning));
       `;
     } else {
       return `
-        background: rgba(34, 197, 94, 0.1);
-        color: rgb(34, 197, 94);
+        background: rgba(var(--color-success), 0.1);
+        color: rgb(var(--color-success));
       `;
     }
   }}
@@ -720,8 +720,8 @@ export const FieldMappingPanel: React.FC<FieldMappingPanelProps> = ({
                       <ArrowRight size={14} />
                       <span>{getEntityFieldLabel(mapping.entityField)}</span>
                     </MappingPath>
-                    {!validation.valid && <AlertCircle size={14} color="rgb(239, 68, 68)" />}
-                    {validation.valid && <CheckCircle size={14} color="rgb(34, 197, 94)" />}
+                    {!validation.valid && <AlertCircle size={14} color="rgb(var(--color-error))" />}
+                    {validation.valid && <CheckCircle size={14} color="rgb(var(--color-success))" />}
                   </MappingTitle>
                   <MappingActions>
                     {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}

--- a/frontend/src/components/FlowEditor/ConfigPanel/FieldPropertiesEditor.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FieldPropertiesEditor.tsx
@@ -87,7 +87,7 @@ const ModalOverlay = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -102,7 +102,7 @@ const EditorPanel = styled(Panel)`
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 10px 40px rgba(var(--color-overlay), 0.3);
 `;
 
 const ScrollableContent = styled(PanelContent)`
@@ -139,11 +139,11 @@ const Badge = styled.span<{ $variant?: 'type' | 'required' }>`
   font-weight: 500;
   border-radius: 3px;
   background: ${props => {
-    if (props.$variant === 'required') return 'rgba(239, 68, 68, 0.1)';
+    if (props.$variant === 'required') return 'rgba(var(--color-error), 0.1)';
     return 'rgba(var(--color-primary), 0.1)';
   }};
   color: ${props => {
-    if (props.$variant === 'required') return 'rgb(239, 68, 68)';
+    if (props.$variant === 'required') return 'rgb(var(--color-error))';
     return 'rgb(var(--color-primary))';
   }};
 `;
@@ -173,11 +173,11 @@ const OverrideNote = styled.div`
   align-items: flex-start;
   gap: 8px;
   padding: 8px 12px;
-  background: rgba(59, 130, 246, 0.1);
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(var(--color-info), 0.1);
+  border: 1px solid rgba(var(--color-info), 0.2);
   border-radius: 6px;
   font-size: 12px;
-  color: rgb(59, 130, 246);
+  color: rgb(var(--color-info));
   margin-top: 8px;
 
   svg {

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormFieldConfigPanel.tsx
@@ -604,7 +604,7 @@ export const FormFieldConfigPanel: React.FC<FormFieldConfigPanelProps> = ({
                       menu: (base) => ({
                         ...base,
                         borderRadius: 'var(--radius-md)',
-                        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+                        boxShadow: '0 4px 12px rgba(var(--color-overlay), 0.15)',
                         zIndex: 9999,
                       }),
                     }}

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx
@@ -141,11 +141,11 @@ const LoadingText = styled.div`
 
 const ErrorText = styled.div`
   font-size: 14px;
-  color: rgb(239, 68, 68); /* error color */
+  color: rgb(var(--color-error)); /* error color */
   padding: 12px;
-  background: rgba(239, 68, 68, 0.1);
+  background: rgba(var(--color-error), 0.1);
   border-radius: 6px;
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid rgba(var(--color-error), 0.3);
 `;
 
 const ButtonGroup = styled.div`

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
@@ -168,7 +168,7 @@ const FieldItem = styled.div`
   
   &:hover {
     border-color: rgb(var(--color-primary));
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.05);
   }
 `;
 
@@ -220,10 +220,10 @@ const FieldMeta = styled.div`
 const FieldBadge = styled.span<{ $type?: 'required' | 'optional' }>`
   padding: 2px 6px;
   background: ${props => props.$type === 'required' 
-    ? 'rgba(239, 68, 68, 0.1)' 
+    ? 'rgba(var(--color-error), 0.1)' 
     : 'rgba(var(--color-border), 0.5)'};
   color: ${props => props.$type === 'required' 
-    ? 'rgb(239, 68, 68)' 
+    ? 'rgb(var(--color-error))' 
     : 'rgb(var(--color-text-tertiary))'};
   border-radius: var(--radius-sm);
   font-weight: 600;
@@ -595,7 +595,7 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
                   width: '100%',
                   padding: '10px 12px',
                   fontSize: '14px',
-                  border: entitiesError ? '1px solid rgb(239, 68, 68)' : '1px solid rgb(var(--color-border))',
+                  border: entitiesError ? '1px solid rgb(var(--color-error))' : '1px solid rgb(var(--color-border))',
                   borderRadius: '6px',
                   background: 'rgb(var(--color-background))',
                   color: 'rgb(var(--color-text-primary))',
@@ -618,7 +618,7 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
                   <option disabled>No entities available</option>
                 )}
               </select>
-              <HelpText style={{ color: entitiesError ? 'rgb(239, 68, 68)' : undefined }}>
+              <HelpText style={{ color: entitiesError ? 'rgb(var(--color-error))' : undefined }}>
                 {entitiesLoading ? (
                   '⏳ Loading entities...'
                 ) : entitiesError ? (
@@ -1086,7 +1086,7 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
             left: 0,
             right: 0,
             bottom: 0,
-            background: 'rgba(0, 0, 0, 0.5)',
+            background: 'rgba(var(--color-overlay), 0.5)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -1105,7 +1105,7 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
               overflow: 'hidden',
               display: 'flex',
               flexDirection: 'column',
-              boxShadow: '0 10px 40px rgba(0, 0, 0, 0.3)',
+              boxShadow: '0 10px 40px rgba(var(--color-overlay), 0.3)',
             }}
           >
             <div

--- a/frontend/src/components/FlowEditor/ConfigPanel/LiveFormPreview.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/LiveFormPreview.tsx
@@ -68,7 +68,7 @@ const PreviewCard = styled.div`
   background: white;
   border-radius: 12px;
   padding: 24px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
 `;
 
 const FormTitle = styled.h2`
@@ -136,7 +136,7 @@ const Input = styled.input`
   &:focus {
     outline: none;
     border-color: rgb(var(--color-info));
-    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+    box-shadow: 0 0 0 3px rgba(var(--color-primary), 0.1);
   }
   
   &::placeholder {
@@ -159,7 +159,7 @@ const Textarea = styled.textarea`
   &:focus {
     outline: none;
     border-color: rgb(var(--color-info));
-    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+    box-shadow: 0 0 0 3px rgba(var(--color-primary), 0.1);
   }
   
   &::placeholder {
@@ -180,7 +180,7 @@ const Select = styled.select`
   &:focus {
     outline: none;
     border-color: rgb(var(--color-info));
-    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+    box-shadow: 0 0 0 3px rgba(var(--color-primary), 0.1);
   }
 `;
 
@@ -236,7 +236,7 @@ const FileInput = styled.div`
   
   &:hover {
     border-color: rgb(var(--color-info));
-    background: rgba(99, 102, 241, 0.05);
+    background: rgba(var(--color-primary), 0.05);
   }
 `;
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
@@ -50,7 +50,7 @@ const ChildItem = styled.div<{ $expanded: boolean }>`
   
   &:hover {
     border-color: rgba(var(--color-primary), 0.5);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.05);
   }
 `;
 
@@ -135,8 +135,8 @@ const IconButton = styled.button`
 
 const DeleteButton = styled(IconButton)`
   &:hover {
-    background: rgba(239, 68, 68, 0.1);
-    color: rgb(239, 68, 68);
+    background: rgba(var(--color-error), 0.1);
+    color: rgb(var(--color-error));
   }
 `;
 
@@ -179,7 +179,7 @@ const EmptyState = styled.div`
 `;
 
 const ErrorMessage = styled.div`
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   font-size: 12px;
   margin-top: 4px;
 `;
@@ -328,7 +328,7 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
                           <div key={childField.id} style={{ marginBottom: '12px' }}>
                             <label style={{ fontSize: '13px', fontWeight: 500, marginBottom: '4px', display: 'block' }}>
                               {childField.label}
-                              {childField.required && <span style={{ color: 'rgb(239, 68, 68)' }}> *</span>}
+                              {childField.required && <span style={{ color: 'rgb(var(--color-error))' }}> *</span>}
                             </label>
                             {/* Simple inline renderer for now */}
                             {childField.type === 'text' && (

--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanel.tsx
@@ -96,7 +96,7 @@ const PanelOverlay = styled.div<{ $isOpen: boolean }>`
   right: 0;
   bottom: 0;
   left: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(var(--color-overlay), 0.3);
   z-index: 1000;
   display: ${props => props.$isOpen ? 'block' : 'none'};
   animation: fadeIn 0.2s ease;
@@ -228,11 +228,11 @@ const ValidationMessage = styled.div<{ $severity: 'error' | 'warning' }>`
   font-size: 12px;
   line-height: 1.5;
   background: ${props => props.$severity === 'error' 
-    ? 'rgba(239, 68, 68, 0.1)' 
-    : 'rgba(234, 179, 8, 0.1)'};
+    ? 'rgba(var(--color-error), 0.1)' 
+    : 'rgba(var(--color-warning), 0.1)'};
   color: ${props => props.$severity === 'error' 
-    ? 'rgb(239, 68, 68)' 
-    : 'rgb(234, 179, 8)'};
+    ? 'rgb(var(--color-error))' 
+    : 'rgb(var(--color-warning))'};
 `;
 
 
@@ -343,7 +343,7 @@ const IconButton = styled.button`
   }
   
   &:hover.delete {
-    background: rgb(239, 68, 68);
+    background: rgb(var(--color-error));
     color: white;
   }
 `;

--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanelWithShadow.tsx
@@ -83,7 +83,7 @@ const ActionBar = styled.div<{ $show: boolean }>`
   padding: 16px;
   border-top: 1px solid rgb(var(--color-border));
   background: rgb(var(--color-surface));
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 -2px 8px rgba(var(--color-overlay), 0.05);
 `;
 
 const ConfirmationModal = styled.div<{ $show: boolean }>`
@@ -93,7 +93,7 @@ const ConfirmationModal = styled.div<{ $show: boolean }>`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   align-items: center;
   justify-content: center;
   z-index: 2000;
@@ -110,7 +110,7 @@ const ConfirmationDialog = styled.div`
   border-radius: 12px;
   padding: 24px;
   max-width: 400px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 8px 32px rgba(var(--color-overlay), 0.3);
   animation: slideUp 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   
   @keyframes slideUp {

--- a/frontend/src/components/FlowEditor/ConfigPanel/SectionConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/SectionConfigPanel.tsx
@@ -87,7 +87,7 @@ const Container = styled.div`
   height: 100vh;
   background: rgb(var(--color-surface));
   border-left: 1px solid rgb(var(--color-border));
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
+  box-shadow: -4px 0 12px rgba(var(--color-overlay), 0.1);
   display: flex;
   flex-direction: column;
   z-index: 1000;

--- a/frontend/src/components/FlowEditor/ConfigPanel/StepManagerPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/StepManagerPanel.tsx
@@ -218,11 +218,11 @@ const StepStatus = styled.div`
   }
 
   &.configured {
-    color: rgb(34, 197, 94); /* Success green */
+    color: rgb(var(--color-success)); /* Success green */
   }
 
   &.error {
-    color: rgb(239, 68, 68); /* Error red */
+    color: rgb(var(--color-error)); /* Error red */
   }
 `;
 
@@ -253,8 +253,8 @@ const ActionButton = styled.button`
   }
 
   &.delete:hover {
-    border-color: rgb(239, 68, 68);
-    color: rgb(239, 68, 68);
+    border-color: rgb(var(--color-error));
+    color: rgb(var(--color-error));
   }
 
   svg {

--- a/frontend/src/components/FlowEditor/ConfigPanel/SubFlowLibraryDialog.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/SubFlowLibraryDialog.tsx
@@ -41,7 +41,7 @@ export interface SubFlowLibraryDialogProps {
 const Overlay = styled.div<{ $isOpen: boolean }>`
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   display: ${props => props.$isOpen ? 'flex' : 'none'};
   align-items: center;
   justify-content: center;
@@ -52,7 +52,7 @@ const Overlay = styled.div<{ $isOpen: boolean }>`
 const Dialog = styled.div`
   background: rgb(var(--color-background));
   border-radius: var(--radius-lg);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px rgba(var(--color-overlay), 0.3);
   width: 90%;
   max-width: 900px;
   max-height: 85vh;
@@ -142,7 +142,7 @@ const TemplateCard = styled.div`
   
   &:hover {
     border-color: rgb(var(--color-primary));
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
     transform: translateY(-2px);
   }
 `;

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
@@ -306,7 +306,7 @@ const PanelContainer = styled(motion.div)`
   max-width: 100vw;
   background: rgb(var(--color-background));
   border-left: 1px solid rgb(var(--color-border));
-  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.1);
+  box-shadow: -4px 0 24px rgba(var(--color-overlay), 0.1);
   display: flex;
   flex-direction: column;
   z-index: 10000;

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
@@ -88,7 +88,7 @@ const ActionBar = styled.div<{ $show: boolean }>`
   padding-bottom: calc(16px + env(safe-area-inset-bottom));
   border-top: 1px solid rgb(var(--color-border));
   background: rgb(var(--color-surface));
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 -2px 8px rgba(var(--color-overlay), 0.05);
 
   @media (max-width: 600px) {
     width: 100vw;
@@ -102,7 +102,7 @@ const ConfirmationModal = styled.div<{ $show: boolean }>`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   align-items: center;
   justify-content: center;
   z-index: 2000;
@@ -119,7 +119,7 @@ const DialogBox = styled.div`
   border-radius: var(--radius-lg);
   padding: 24px;
   min-width: 400px;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 24px rgba(var(--color-overlay), 0.15);
 `;
 
 const DialogHeader = styled.h3`

--- a/frontend/src/components/FlowEditor/ConfigPanel/ValidationRuleBuilder.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/ValidationRuleBuilder.tsx
@@ -172,7 +172,7 @@ const RuleItem = styled.div`
   
   &:hover {
     border-color: rgb(var(--color-primary));
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.05);
   }
 `;
 
@@ -272,7 +272,7 @@ const Modal = styled.div<{ $isOpen: boolean }>`
   display: ${props => props.$isOpen ? 'flex' : 'none'};
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   align-items: center;
   justify-content: center;
   z-index: 1000;
@@ -282,7 +282,7 @@ const Modal = styled.div<{ $isOpen: boolean }>`
 const ModalContent = styled.div`
   background: rgb(var(--color-surface));
   border-radius: var(--radius-lg);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px rgba(var(--color-overlay), 0.3);
   width: 100%;
   max-width: 500px;
   max-height: 90vh;

--- a/frontend/src/components/FlowEditor/ConfigPanel/VariablePicker.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VariablePicker.tsx
@@ -363,7 +363,7 @@ const PickerContainer = styled.div<{ $position?: { top: number; left: number } }
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 8px 24px rgba(var(--color-overlay), 0.15);
   display: flex;
   flex-direction: column;
   z-index: 10000;
@@ -482,7 +482,7 @@ const VariableKey = styled.div`
 const ScopeWarning = styled.span`
   display: flex;
   align-items: center;
-  color: rgb(234, 179, 8);
+  color: rgb(var(--color-warning));
   opacity: 0.9;
 `;
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx
@@ -141,7 +141,7 @@ const PickerContainer = styled.div<{ $position?: { top: number; left: number } }
   background: white;
   border: 1px solid rgb(var(--color-border));
   border-radius: 8px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 10px 30px rgba(var(--color-overlay), 0.15);
   z-index: 10000;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/FlowEditor/ConfigPanel/VisualFormBuilderPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VisualFormBuilderPanel.tsx
@@ -157,7 +157,7 @@ const FieldCard = styled.div<{ isDragging?: boolean; isExpanded?: boolean }>`
   
   &:hover {
     border-color: rgb(var(--color-primary));
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.1);
   }
 `;
 
@@ -201,7 +201,7 @@ const FieldLabel = styled.div`
 
 const RequiredBadge = styled.span`
   font-size: 10px;
-  background: rgb(239, 68, 68);
+  background: rgb(var(--color-error));
   color: white;
   padding: 2px 6px;
   border-radius: 4px;
@@ -225,13 +225,13 @@ const IconButton = styled.button<{ variant?: 'danger' }>`
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  color: ${props => props.variant === 'danger' ? 'rgb(239, 68, 68)' : 'rgb(var(--color-text-secondary))'};
+  color: ${props => props.variant === 'danger' ? 'rgb(var(--color-error))' : 'rgb(var(--color-text-secondary))'};
   display: flex;
   align-items: center;
   transition: all 0.2s;
   
   &:hover {
-    background: ${props => props.variant === 'danger' ? 'rgba(239, 68, 68, 0.1)' : 'rgb(var(--color-surface-hover))'};
+    background: ${props => props.variant === 'danger' ? 'rgba(var(--color-error), 0.1)' : 'rgb(var(--color-surface-hover))'};
   }
 `;
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/shared/StyledComponents.ts
+++ b/frontend/src/components/FlowEditor/ConfigPanel/shared/StyledComponents.ts
@@ -29,7 +29,7 @@ export const PanelOverlay = styled.div<{ $isOpen?: boolean }>`
   right: 0;
   bottom: 0;
   left: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(var(--color-overlay), 0.4);
   z-index: 1000;
   display: ${props => props.$isOpen === false ? 'none' : 'block'};
   animation: fadeIn 0.2s ease-out;
@@ -55,7 +55,7 @@ export const Panel = styled.div<{ $width?: string }>`
   max-width: 900px;
   min-width: 480px;
   background: rgb(var(--color-surface));
-  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.15);
+  box-shadow: -4px 0 24px rgba(var(--color-overlay), 0.15);
   display: flex;
   flex-direction: column;
   z-index: 1001;
@@ -156,7 +156,7 @@ export const PanelFooter = styled.div`
   justify-content: flex-end;
   gap: 12px;
   background: rgb(var(--color-surface));
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 -2px 8px rgba(var(--color-overlay), 0.05);
 `;
 
 // ============================================================================
@@ -472,7 +472,7 @@ export const Button = styled.button<{
         return `
           background: rgb(var(--color-error));
           color: white;
-          &:hover { background: rgb(239, 40, 40); }
+          &:hover { background: rgb(var(--color-danger)); }
           &:active { transform: translateY(1px); }
         `;
       case 'ghost':

--- a/frontend/src/components/FlowEditor/HelpModal.tsx
+++ b/frontend/src/components/FlowEditor/HelpModal.tsx
@@ -99,7 +99,7 @@ const helpSections: HelpSection[] = [
 const Overlay = styled.div`
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -116,7 +116,7 @@ const Overlay = styled.div`
 const Modal = styled.div`
   background: rgb(var(--color-background));
   border-radius: var(--radius-lg, 8px);
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 25px 50px -12px rgba(var(--color-overlay), 0.25);
   width: 100%;
   max-width: 900px;
   max-height: 90vh;
@@ -236,7 +236,7 @@ const KeyBadge = styled.div`
   min-width: 140px;
   text-align: center;
   white-space: nowrap;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-sm);
 `;
 
 const Description = styled.div`

--- a/frontend/src/components/FlowEditor/Modals/EntityFormStepModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/EntityFormStepModal.tsx
@@ -83,7 +83,7 @@ const ModalOverlay = styled.div<{ $isOpen: boolean }>`
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(var(--color-overlay), 0.7);
   z-index: 9999;
   align-items: center;
   justify-content: center;
@@ -98,7 +98,7 @@ const ModalContainer = styled.div`
   max-width: 1800px;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px rgba(var(--color-overlay), 0.3);
   border: 1px solid rgb(var(--color-border));
 `;
 

--- a/frontend/src/components/FlowEditor/Modals/FlowPreviewModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FlowPreviewModal.tsx
@@ -59,7 +59,7 @@ interface LogEntry {
 const Overlay = styled.div<{ isOpen: boolean }>`
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(var(--color-overlay), 0.7);
   display: ${props => props.isOpen ? 'flex' : 'none'};
   align-items: center;
   justify-content: center;
@@ -75,7 +75,7 @@ const Overlay = styled.div<{ isOpen: boolean }>`
 const Modal = styled.div`
   background: rgb(var(--color-surface));
   border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 20px 60px rgba(var(--color-overlay), 0.4);
   width: 95vw;
   max-width: 1400px;
   height: 90vh;
@@ -141,7 +141,7 @@ const Button = styled.button<{ variant?: 'primary' | 'ghost' | 'danger' }>`
       `;
     } else if (props.variant === 'danger') {
       return `
-        background: rgb(239, 68, 68);
+        background: rgb(var(--color-error));
         color: white;
         &:hover { opacity: 0.9; }
       `;
@@ -204,18 +204,18 @@ const LogItem = styled.div<{ level: 'info' | 'success' | 'warning' | 'error' }>`
   line-height: 1.5;
   background: ${props => {
     switch (props.level) {
-      case 'success': return 'rgba(34, 197, 94, 0.1)';
-      case 'warning': return 'rgba(234, 179, 8, 0.1)';
-      case 'error': return 'rgba(239, 68, 68, 0.1)';
-      default: return 'rgba(59, 130, 246, 0.1)';
+      case 'success': return 'rgba(var(--color-success), 0.1)';
+      case 'warning': return 'rgba(var(--color-warning), 0.1)';
+      case 'error': return 'rgba(var(--color-error), 0.1)';
+      default: return 'rgba(var(--color-info), 0.1)';
     }
   }};
   border-left: 3px solid ${props => {
     switch (props.level) {
-      case 'success': return 'rgb(34, 197, 94)';
-      case 'warning': return 'rgb(234, 179, 8)';
-      case 'error': return 'rgb(239, 68, 68)';
-      default: return 'rgb(59, 130, 246)';
+      case 'success': return 'rgb(var(--color-success))';
+      case 'warning': return 'rgb(var(--color-warning))';
+      case 'error': return 'rgb(var(--color-error))';
+      default: return 'rgb(var(--color-info))';
     }
   }};
 `;
@@ -247,18 +247,18 @@ const PreviewNode = styled.div<{ status: NodeExecutionState['status'] }>`
   border-radius: 8px;
   border: 2px solid ${props => {
     switch (props.status) {
-      case 'active': return 'rgb(59, 130, 246)';
-      case 'complete': return 'rgb(34, 197, 94)';
-      case 'error': return 'rgb(239, 68, 68)';
+      case 'active': return 'rgb(var(--color-info))';
+      case 'complete': return 'rgb(var(--color-success))';
+      case 'error': return 'rgb(var(--color-error))';
       case 'skipped': return 'rgb(var(--color-text-tertiary))';
       default: return 'rgb(var(--color-border))';
     }
   }};
   background: ${props => {
     switch (props.status) {
-      case 'active': return 'rgba(59, 130, 246, 0.1)';
-      case 'complete': return 'rgba(34, 197, 94, 0.1)';
-      case 'error': return 'rgba(239, 68, 68, 0.1)';
+      case 'active': return 'rgba(var(--color-info), 0.1)';
+      case 'complete': return 'rgba(var(--color-success), 0.1)';
+      case 'error': return 'rgba(var(--color-error), 0.1)';
       default: return 'rgb(var(--color-surface))';
     }
   }};
@@ -268,8 +268,8 @@ const PreviewNode = styled.div<{ status: NodeExecutionState['status'] }>`
   ${props => props.status === 'active' && `
     animation: pulse 2s ease-in-out infinite;
     @keyframes pulse {
-      0%, 100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4); }
-      50% { box-shadow: 0 0 0 8px rgba(59, 130, 246, 0); }
+      0%, 100% { box-shadow: 0 0 0 0 rgba(var(--color-info), 0.4); }
+      50% { box-shadow: 0 0 0 8px rgba(var(--color-info), 0); }
     }
   `}
 `;
@@ -296,9 +296,9 @@ const StatusBadge = styled.div<{ status: NodeExecutionState['status'] }>`
   letter-spacing: 0.5px;
   background: ${props => {
     switch (props.status) {
-      case 'active': return 'rgb(59, 130, 246)';
-      case 'complete': return 'rgb(34, 197, 94)';
-      case 'error': return 'rgb(239, 68, 68)';
+      case 'active': return 'rgb(var(--color-info))';
+      case 'complete': return 'rgb(var(--color-success))';
+      case 'error': return 'rgb(var(--color-error))';
       case 'skipped': return 'rgb(var(--color-text-tertiary))';
       default: return 'rgb(var(--color-border))';
     }
@@ -309,7 +309,7 @@ const StatusBadge = styled.div<{ status: NodeExecutionState['status'] }>`
 const NodeData = styled.pre`
   font-size: 12px;
   padding: 12px;
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(var(--color-overlay), 0.05);
   border-radius: 4px;
   overflow-x: auto;
   color: rgb(var(--color-text-secondary));

--- a/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
@@ -88,7 +88,7 @@ const ModalOverlay = styled.div<{ $isOpen: boolean }>`
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(var(--color-overlay), 0.7);
   z-index: 9999;
   align-items: center;
   justify-content: center;
@@ -103,7 +103,7 @@ const ModalContainer = styled.div`
   max-width: 1200px;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px rgba(var(--color-overlay), 0.3);
   border: 1px solid rgb(var(--color-border));
 `;
 
@@ -113,7 +113,7 @@ const ModalHeader = styled.div`
   justify-content: space-between;
   padding: 20px 24px;
   border-bottom: 1px solid rgb(var(--color-border));
-  background: linear-gradient(135deg, rgba(139, 92, 246, 0.1), rgba(139, 92, 246, 0.05));
+  background: linear-gradient(135deg, rgba(var(--color-primary), 0.1), rgba(var(--color-primary), 0.05));
 `;
 
 const HeaderLeft = styled.div`
@@ -177,21 +177,21 @@ const StepBadge = styled.div<{ $active: boolean; $completed: boolean }>`
   border-radius: 8px;
   background: ${props =>
     props.$active
-      ? 'rgba(139, 92, 246, 0.15)'
+      ? 'rgba(var(--color-primary), 0.15)'
       : props.$completed
-      ? 'rgba(34, 197, 94, 0.15)'
+      ? 'rgba(var(--color-success), 0.15)'
       : 'transparent'};
   border: 1px solid ${props =>
     props.$active
-      ? 'rgb(139, 92, 246)'
+      ? 'rgb(var(--color-primary))'
       : props.$completed
-      ? 'rgb(34, 197, 94)'
+      ? 'rgb(var(--color-success))'
       : 'rgb(var(--color-border))'};
   color: ${props =>
     props.$active
-      ? 'rgb(139, 92, 246)'
+      ? 'rgb(var(--color-primary))'
       : props.$completed
-      ? 'rgb(34, 197, 94)'
+      ? 'rgb(var(--color-success))'
       : 'rgb(var(--color-text-secondary))'};
   font-size: 14px;
   font-weight: 600;
@@ -211,7 +211,7 @@ const SectionHeader = styled.div`
   margin-bottom: 16px;
   
   .icon {
-    color: rgb(139, 92, 246);
+    color: rgb(var(--color-primary));
   }
   
   h3 {
@@ -250,8 +250,8 @@ const Input = styled.input`
   
   &:focus {
     outline: none;
-    border-color: rgb(139, 92, 246);
-    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+    border-color: rgb(var(--color-primary));
+    box-shadow: 0 0 0 3px rgba(var(--color-primary), 0.1);
   }
   
   &::placeholder {
@@ -274,8 +274,8 @@ const TextArea = styled.textarea`
   
   &:focus {
     outline: none;
-    border-color: rgb(139, 92, 246);
-    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+    border-color: rgb(var(--color-primary));
+    box-shadow: 0 0 0 3px rgba(var(--color-primary), 0.1);
   }
   
   &::placeholder {
@@ -302,8 +302,8 @@ const CheckboxLabel = styled.label`
   transition: all 0.2s ease;
   
   &:hover {
-    border-color: rgb(139, 92, 246);
-    background: rgba(139, 92, 246, 0.05);
+    border-color: rgb(var(--color-primary));
+    background: rgba(var(--color-primary), 0.05);
   }
   
   input[type="checkbox"] {
@@ -370,12 +370,12 @@ const Button = styled.button<{ $variant?: 'primary' | 'secondary' | 'ghost' }>`
   ${props => {
     if (props.$variant === 'primary') {
       return `
-        background: linear-gradient(135deg, rgb(139, 92, 246), rgb(109, 40, 217));
+        background: linear-gradient(135deg, rgb(var(--color-primary)), rgb(var(--color-primary-active)));
         color: white;
         
         &:hover:not(:disabled) {
           transform: translateY(-1px);
-          box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+          box-shadow: 0 4px 12px rgba(var(--color-primary), 0.3);
         }
       `;
     } else if (props.$variant === 'secondary') {

--- a/frontend/src/components/FlowEditor/Modals/SharedTemplateDeleteModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/SharedTemplateDeleteModal.tsx
@@ -88,7 +88,7 @@ interface UsageInfo {
 const ModalOverlay = styled.div`
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(var(--color-overlay), 0.7);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
@@ -100,7 +100,7 @@ const ModalOverlay = styled.div`
 const ModalContent = styled.div`
   background: rgb(var(--color-surface));
   border-radius: var(--radius-xl);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px rgba(var(--color-overlay), 0.3);
   max-width: 600px;
   width: 100%;
   overflow: hidden;

--- a/frontend/src/components/FlowEditor/Modals/WorkflowManagementModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/WorkflowManagementModal.tsx
@@ -40,7 +40,7 @@ const ModalOverlay = styled.div<{ $isOpen: boolean }>`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   display: ${props => props.$isOpen ? 'flex' : 'none'};
   align-items: center;
   justify-content: center;
@@ -68,7 +68,7 @@ const ModalContent = styled.div`
   max-width: 500px;
   max-height: 90vh;
   overflow-y: auto;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 20px 25px -5px rgba(var(--color-overlay), 0.1), 0 10px 10px -5px rgba(var(--color-overlay), 0.04);
   
   /* Phase 8.4: Smooth scale-in animation */
   animation: scaleIn 0.2s cubic-bezier(0.4, 0, 0.2, 1);
@@ -140,7 +140,7 @@ const Label = styled.label`
 `;
 
 const RequiredIndicator = styled.span`
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   margin-left: 4px;
 `;
 
@@ -150,14 +150,14 @@ const Input = styled.input<{ $hasError?: boolean }>`
   font-size: 14px;
   color: rgb(var(--color-text-primary));
   background: rgb(var(--color-background));
-  border: 1px solid ${props => props.$hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'};
+  border: 1px solid ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-md);
   transition: all 0.15s ease;
   
   &:focus {
     outline: none;
-    border-color: ${props => props.$hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-primary))'};
-    box-shadow: 0 0 0 3px ${props => props.$hasError ? 'rgba(239, 68, 68, 0.1)' : 'rgba(var(--color-primary-rgb), 0.1)'};
+    border-color: ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-primary))'};
+    box-shadow: 0 0 0 3px ${props => props.$hasError ? 'rgba(var(--color-error), 0.1)' : 'rgba(var(--color-primary-rgb), 0.1)'};
   }
   
   &::placeholder {
@@ -218,7 +218,7 @@ const ErrorText = styled.div`
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   margin-top: 6px;
   
   svg {
@@ -268,16 +268,16 @@ const StatusBadge = styled.div<{ $status: 'draft' | 'active' | 'archived' }>`
   border-radius: var(--radius-sm);
   background: ${props => {
     switch (props.$status) {
-      case 'draft': return 'rgba(234, 179, 8, 0.1)';
-      case 'active': return 'rgba(34, 197, 94, 0.1)';
-      case 'archived': return 'rgba(156, 163, 175, 0.1)';
+      case 'draft': return 'rgba(var(--color-warning), 0.1)';
+      case 'active': return 'rgba(var(--color-success), 0.1)';
+      case 'archived': return 'rgba(var(--color-border), 0.1)';
     }
   }};
   color: ${props => {
     switch (props.$status) {
-      case 'draft': return 'rgb(234, 179, 8)';
-      case 'active': return 'rgb(34, 197, 94)';
-      case 'archived': return 'rgb(107, 114, 128)';
+      case 'draft': return 'rgb(var(--color-warning))';
+      case 'active': return 'rgb(var(--color-success))';
+      case 'archived': return 'rgb(var(--color-text-tertiary))';
     }
   }};
 `;

--- a/frontend/src/components/FlowEditor/NestedContainer/ContainerBreadcrumbs.tsx
+++ b/frontend/src/components/FlowEditor/NestedContainer/ContainerBreadcrumbs.tsx
@@ -59,10 +59,10 @@ const BreadcrumbItem = styled.button<{ $isLast: boolean }>`
   gap: 6px;
   padding: 4px 8px;
   background: ${props => props.$isLast 
-    ? 'rgba(139, 92, 246, 0.15)' 
+    ? 'rgba(var(--color-primary), 0.15)' 
     : 'transparent'};
   color: ${props => props.$isLast 
-    ? 'rgb(139, 92, 246)' 
+    ? 'rgb(var(--color-primary))' 
     : 'rgb(var(--color-text-secondary))'};
   border: none;
   border-radius: 4px;
@@ -72,8 +72,8 @@ const BreadcrumbItem = styled.button<{ $isLast: boolean }>`
   transition: all 0.2s ease;
   
   &:hover:not(:disabled) {
-    background: rgba(139, 92, 246, 0.1);
-    color: rgb(139, 92, 246);
+    background: rgba(var(--color-primary), 0.1);
+    color: rgb(var(--color-primary));
   }
   
   svg {

--- a/frontend/src/components/FlowEditor/NodeContextMenu.tsx
+++ b/frontend/src/components/FlowEditor/NodeContextMenu.tsx
@@ -70,8 +70,8 @@ const MenuContainer = styled.div<{ x: number; y: number; flipX: boolean; flipY: 
   border: 1px solid rgb(var(--color-border));
   border-radius: 12px;
   box-shadow:
-    0 20px 25px -5px rgba(0, 0, 0, 0.12),
-    0 10px 10px -5px rgba(0, 0, 0, 0.08);
+    0 20px 25px -5px rgba(var(--color-overlay), 0.12),
+    0 10px 10px -5px rgba(var(--color-overlay), 0.08);
   padding: 6px;
   min-width: 220px;
   z-index: 9999;
@@ -104,7 +104,7 @@ const MenuItem = styled.button<{ danger?: boolean }>`
   border: none;
   background: transparent;
   color: ${props =>
-    props.danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-text-primary))'};
+    props.danger ? 'rgb(var(--color-error))' : 'rgb(var(--color-text-primary))'};
   font-size: 14px;
   font-family: inherit;
   text-align: left;
@@ -114,8 +114,8 @@ const MenuItem = styled.button<{ danger?: boolean }>`
 
   &:hover {
     background: ${props =>
-      props.danger ? 'rgba(239, 68, 68, 0.1)' : 'rgb(var(--color-primary) / 0.1)'};
-    color: ${props => (props.danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-primary))')};
+      props.danger ? 'rgba(var(--color-error), 0.1)' : 'rgb(var(--color-primary) / 0.1)'};
+    color: ${props => (props.danger ? 'rgb(var(--color-error))' : 'rgb(var(--color-primary))')};
     transform: translateX(2px);
   }
 
@@ -131,7 +131,7 @@ const MenuItem = styled.button<{ danger?: boolean }>`
   &:disabled:hover {
     background: transparent;
     color: ${props =>
-      props.danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-text-primary))'};
+      props.danger ? 'rgb(var(--color-error))' : 'rgb(var(--color-text-primary))'};
     transform: none;
   }
 

--- a/frontend/src/components/FlowEditor/SidePanel.tsx
+++ b/frontend/src/components/FlowEditor/SidePanel.tsx
@@ -61,7 +61,7 @@ const Backdrop = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(var(--color-overlay), 0.5);
   z-index: 9999;
   display: flex;
   justify-content: flex-end;
@@ -73,7 +73,7 @@ const PanelContent = styled.div`
   width: 450px;
   max-width: 90vw;
   background: rgb(var(--color-surface));
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
+  box-shadow: -4px 0 12px rgba(var(--color-overlay), 0.1);
   animation: slideIn 0.25s ease-out;
   overflow-y: auto;
 

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.accessibility.css
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.accessibility.css
@@ -52,7 +52,7 @@
   position: absolute;
   top: 10px;
   right: 10px;
-  background: rgba(0, 0, 0, 0.75);
+  background: rgba(var(--color-overlay), 0.75);
   color: white;
   padding: 8px 12px;
   border-radius: 6px;
@@ -68,8 +68,8 @@
 }
 
 .keyboard-hint kbd {
-  background: rgba(255, 255, 255, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(var(--color-header-background), 0.2);
+  border: 1px solid rgba(var(--color-header-background), 0.3);
   border-radius: 3px;
   padding: 2px 6px;
   font-family: monospace;
@@ -334,19 +334,19 @@
 @media (prefers-color-scheme: dark) {
   /* Ensure sufficient contrast in dark mode */
   .unified-flow-editor {
-    --focus-ring-color: rgb(147, 197, 253); /* Lighter blue */
+    --focus-ring-color: rgb(var(--color-info));
   }
 
   .unified-flow-editor button:focus-visible,
   .unified-flow-editor [tabindex]:focus-visible {
     outline-color: var(--focus-ring-color);
-    box-shadow: 0 0 0 4px rgba(147, 197, 253, 0.3);
+    box-shadow: 0 0 0 4px rgba(var(--color-info), 0.3);
   }
 
   /* Higher contrast for text */
   .unified-flow-editor label,
   .unified-flow-editor .label-text {
-    color: rgb(229, 231, 235); /* gray-200 */
+    color: rgb(var(--color-text-primary));
   }
 }
 

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.responsive.css
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.responsive.css
@@ -83,7 +83,7 @@
     width: 100% !important;
     max-height: 70vh !important;
     border-radius: var(--radius-lg) var(--radius-lg) 0 0 !important;
-    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15) !important;
+    box-shadow: 0 -4px 12px rgba(var(--color-overlay), 0.15) !important;
   }
 
   /* Canvas - Full viewport */
@@ -335,7 +335,7 @@
 @media (prefers-color-scheme: dark) {
   /* Higher contrast in dark mode */
   .react-flow__node {
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3) !important;
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.3) !important;
   }
 
   /* Dimmer backgrounds */

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -262,19 +262,19 @@ const EditorContainer = styled.div<{ $isFullscreen?: boolean }>`
     stroke-width: 3 !important;
     stroke-dasharray: 5, 5;
     animation: dash 0.5s linear infinite;
-    filter: drop-shadow(0 0 4px rgba(102, 126, 234, 0.4));
+    filter: drop-shadow(0 0 4px rgba(var(--color-primary), 0.4));
   }
   
   /* Phase 7.2: Enhanced snap feedback */
   .react-flow__node.dragging {
-    box-shadow: 0 8px 24px rgba(102, 126, 234, 0.3) !important;
+    box-shadow: 0 8px 24px rgba(var(--color-primary), 0.3) !important;
     transform: scale(1.02);
     transition: none !important; /* Override smooth animation during drag */
   }
   
   /* Phase 7.2: Grid alignment indicator */
   .react-flow__node.snapped {
-    box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.5) !important;
+    box-shadow: 0 0 0 2px rgba(var(--color-primary), 0.5) !important;
   }
   
   /* Phase 8.4: Smooth animations for node layout changes */
@@ -311,7 +311,7 @@ const RightSidebar = styled.div<{ $isOpen: boolean }>`
   width: 400px;
   background: rgb(var(--color-surface));
   border-left: 1px solid rgb(var(--color-border));
-  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+  box-shadow: -2px 0 8px rgba(var(--color-overlay), 0.1);
   z-index: 10000;
   display: ${props => props.$isOpen ? 'flex' : 'none'} !important;
   opacity: ${props => props.$isOpen ? '1' : '0'} !important;
@@ -335,14 +335,14 @@ const DeprecationBanner = styled.div`
   z-index: 1000;
   width: calc(100% - 40px);
   max-width: 800px;
-  background: rgb(255, 243, 205);
-  border: 1px solid rgb(234, 179, 8);
+  background: rgba(var(--color-warning), 0.18);
+  border: 1px solid rgb(var(--color-warning));
   border-radius: var(--radius-md);
   padding: 12px 16px;
   display: flex;
   align-items: center;
   gap: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.15);
   animation: slideDown 0.3s ease-out;
   
   @keyframes slideDown {
@@ -359,7 +359,7 @@ const DeprecationBanner = styled.div`
 
 const BannerIcon = styled.div`
   flex-shrink: 0;
-  color: rgb(234, 179, 8);
+  color: rgb(var(--color-warning));
   display: flex;
   align-items: center;
 `;
@@ -371,13 +371,13 @@ const BannerContent = styled.div`
 const BannerTitle = styled.div`
   font-weight: 600;
   font-size: 14px;
-  color: rgb(120, 53, 15);
+  color: rgb(var(--color-text-primary));
   margin-bottom: 4px;
 `;
 
 const BannerMessage = styled.div`
   font-size: 13px;
-  color: rgb(146, 64, 14);
+  color: rgb(var(--color-text-secondary));
   line-height: 1.4;
 `;
 
@@ -389,7 +389,7 @@ const BannerActions = styled.div`
 
 const MigrateButton = styled.button`
   padding: 6px 12px;
-  background: rgb(234, 179, 8);
+  background: rgb(var(--color-warning));
   color: white;
   border: none;
   border-radius: var(--radius-sm);
@@ -400,14 +400,14 @@ const MigrateButton = styled.button`
   white-space: nowrap;
   
   &:hover {
-    background: rgb(202, 138, 4);
+    opacity: 0.9;
   }
 `;
 
 const CloseButton = styled.button`
   padding: 4px;
   background: transparent;
-  color: rgb(146, 64, 14);
+  color: rgb(var(--color-text-secondary));
   border: none;
   cursor: pointer;
   display: flex;
@@ -439,7 +439,7 @@ const ModeSelectorContainer = styled.div`
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-md);
   padding: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.1);
   z-index: 10;
 `;
 
@@ -567,7 +567,7 @@ const WizardCard = styled.div`
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 8px 32px rgba(var(--color-overlay), 0.1);
   padding: 48px;
   text-align: center;
 `;
@@ -638,7 +638,7 @@ const FlowTypeCard = styled.button<{ $selected: boolean }>`
   &:hover {
     border-color: rgb(var(--color-primary));
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
   }
   
   &:active {
@@ -816,7 +816,7 @@ const NodePalette = styled.div`
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
   overflow-y: auto;
   z-index: 10;
 `;
@@ -979,7 +979,7 @@ const NodeItem = styled.div<{ $color: string }>`
   
   &:hover {
     background: rgb(var(--color-surface));
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 6px rgba(var(--color-overlay), 0.1);
   }
   
   &:active {
@@ -1003,7 +1003,7 @@ const FavoriteButton = styled.button<{ $isFavorite?: boolean }>`
   background: transparent;
   border: none;
   cursor: pointer;
-  color: ${props => props.$isFavorite ? 'rgb(234, 179, 8)' : 'rgb(var(--color-text-tertiary))'};
+  color: ${props => props.$isFavorite ? 'rgb(var(--color-warning))' : 'rgb(var(--color-text-tertiary))'};
   opacity: ${props => props.$isFavorite ? '1' : '0'};
   transition: opacity 0.2s ease, color 0.2s ease;
   
@@ -1012,7 +1012,7 @@ const FavoriteButton = styled.button<{ $isFavorite?: boolean }>`
   }
   
   &:hover {
-    color: rgb(234, 179, 8);
+    color: rgb(var(--color-warning));
     transform: scale(1.1);
   }
 `;
@@ -1194,7 +1194,7 @@ const LoadMenuDropdown = styled.div`
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.15);
   z-index: 100;
   display: flex;
   flex-direction: column;
@@ -1302,9 +1302,9 @@ const DeleteButton = styled.button`
   justify-content: center;
   
   &:hover {
-    background: rgba(239, 68, 68, 0.1);
-    border-color: rgb(239, 68, 68);
-    color: rgb(239, 68, 68);
+    background: rgba(var(--color-error), 0.1);
+    border-color: rgb(var(--color-error));
+    color: rgb(var(--color-error));
   }
   
   svg {
@@ -1326,7 +1326,7 @@ const ConfirmModal = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1353,7 +1353,7 @@ const ConfirmContent = styled.div`
   width: 90%;
   max-width: 400px;
   padding: 24px;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 20px 25px -5px rgba(var(--color-overlay), 0.1);
   
   /* Phase 8.4: Smooth scale-in animation */
   animation: scaleIn 0.2s cubic-bezier(0.4, 0, 0.2, 1);
@@ -1395,14 +1395,14 @@ const ConfirmButton = styled.button<{ $variant?: 'danger' | 'secondary' }>`
   font-size: 14px;
   font-weight: 600;
   color: ${props => props.$variant === 'danger' ? 'white' : 'rgb(var(--color-text-primary))'};
-  background: ${props => props.$variant === 'danger' ? 'rgb(239, 68, 68)' : 'transparent'};
-  border: 1px solid ${props => props.$variant === 'danger' ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'};
+  background: ${props => props.$variant === 'danger' ? 'rgb(var(--color-error))' : 'transparent'};
+  border: 1px solid ${props => props.$variant === 'danger' ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
   
   &:hover {
-    background: ${props => props.$variant === 'danger' ? 'rgb(220, 38, 38)' : 'rgb(var(--color-background))'};
+    background: ${props => props.$variant === 'danger' ? 'rgb(var(--color-danger))' : 'rgb(var(--color-background))'};
   }
   
   &:disabled {
@@ -1421,7 +1421,7 @@ const KeyboardShortcutsModal = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1438,7 +1438,7 @@ const KeyboardShortcutsContent = styled.div`
   max-width: 600px;
   max-height: 80vh;
   overflow-y: auto;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 20px 25px -5px rgba(var(--color-overlay), 0.1);
   animation: scaleIn 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 `;
 
@@ -1512,7 +1512,7 @@ const ShortcutKey = styled.kbd`
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-sm);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 1px 2px rgba(var(--color-overlay), 0.05);
 `;
 
 const ViewportToolbar = styled.div`
@@ -1564,7 +1564,7 @@ const AlignmentToolbar = styled.div`
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-lg);
   padding: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.15);
   z-index: 15;
   
   /* Hide when no nodes selected */
@@ -1618,7 +1618,7 @@ const DragGhost = styled.div<{ $color?: string }>`
   border-radius: var(--radius-md);
   font-size: 14px;
   font-weight: 500;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 8px 24px rgba(var(--color-overlay), 0.2);
   transform: translate(-50%, -50%);
   white-space: nowrap;
   display: flex;
@@ -1659,7 +1659,7 @@ const SettingsPanel = styled.div`
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-md);
   padding: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
   z-index: 10;
   display: flex;
   flex-direction: column;
@@ -2226,7 +2226,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
       background: rgb(var(--color-surface));
       /* Must sit above fullscreen canvas (EditorContainer uses z-index: 9990) */
       z-index: 10050;
-      box-shadow: -4px 0 12px rgba(0,0,0,0.1);
+      box-shadow: -4px 0 12px rgba(var(--color-overlay), 0.1);
       display: none;
       pointer-events: none;
     `;
@@ -2267,7 +2267,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           background: rgb(var(--color-surface));
           /* Must sit above fullscreen canvas (EditorContainer uses z-index: 9990) */
           z-index: 10050;
-          box-shadow: -4px 0 12px rgba(0,0,0,0.1);
+          box-shadow: -4px 0 12px rgba(var(--color-overlay), 0.1);
           display: flex;
           pointer-events: auto;
         `;
@@ -7500,8 +7500,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             title="Test Workflow Execution"
             style={{ 
               fontWeight: 600, 
-              color: 'rgb(34, 197, 94)', // Success green
-              borderColor: 'rgb(34, 197, 94, 0.3)'
+              color: 'rgb(var(--color-success))', // Success green
+              borderColor: 'rgba(var(--color-success), 0.3)'
             }}
             disabled={nodes.length === 0}
           >
@@ -7515,8 +7515,8 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             title="Run Flow Preview"
             style={{ 
               fontWeight: 600, 
-              color: 'rgb(139, 92, 246)', // Purple accent
-              borderColor: 'rgb(139, 92, 246, 0.3)'
+              color: 'rgb(var(--color-primary))', // Purple accent
+              borderColor: 'rgb(var(--color-primary) / 0.3)'
             }}
             disabled={nodes.length === 0}
           >
@@ -7783,12 +7783,12 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
               const registry = type ? NODE_TYPE_REGISTRY[type] : undefined;
               return registry?.color || 'rgb(var(--color-text-tertiary))';
             }}
-            maskColor="rgba(0, 0, 0, 0.1)"
+            maskColor="rgba(var(--color-overlay), 0.1)"
             style={{
-              backgroundColor: 'rgba(255, 255, 255, 0.95)',
+              backgroundColor: 'rgba(var(--color-header-background), 0.95)',
               border: '1px solid rgb(var(--color-border))',
               borderRadius: 'var(--radius-md)',
-              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+              boxShadow: '0 4px 12px rgba(var(--color-overlay), 0.1)',
             }}
             pannable
             zoomable
@@ -8166,7 +8166,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           style={{ 
             left: dragPosition.x, 
             top: dragPosition.y,
-            boxShadow: nearbyNode ? '0 0 0 3px rgba(var(--color-success), 0.5)' : '0 8px 24px rgba(0, 0, 0, 0.2)',
+            boxShadow: nearbyNode ? '0 0 0 3px rgba(var(--color-success), 0.5)' : '0 8px 24px rgba(var(--color-overlay), 0.2)',
           }}
           $color={NODE_TYPE_REGISTRY[dragNodeType]?.color}
         >
@@ -8329,13 +8329,13 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           },
           success: {
             iconTheme: {
-              primary: 'rgb(34, 197, 94)', // green-500
+              primary: 'rgb(var(--color-success))', // green-500
               secondary: 'white',
             },
           },
           error: {
             iconTheme: {
-              primary: 'rgb(239, 68, 68)', // red-500
+              primary: 'rgb(var(--color-error))', // red-500
               secondary: 'white',
             },
           },

--- a/frontend/src/components/FlowEditor/__tests__/containerStyling.test.ts
+++ b/frontend/src/components/FlowEditor/__tests__/containerStyling.test.ts
@@ -23,29 +23,29 @@ describe('Container Styling Utilities', () => {
       
       expect(theme.background).toBe('rgb(var(--color-surface))');
       expect(theme.border).toBe('rgb(var(--color-border))');
-      expect(theme.shadow).toBe('0 2px 8px rgba(0, 0, 0, 0.1)');
+      expect(theme.shadow).toBe('0 2px 8px rgba(var(--color-overlay), 0.1)');
     });
 
     it('should return lighter theme for collapsed container', () => {
       const theme = getContainerTheme(false, false, false);
       
       expect(theme.background).toBe('rgb(var(--color-surface) / 0.95)');
-      expect(theme.shadow).toBe('0 1px 4px rgba(0, 0, 0, 0.08)');
+      expect(theme.shadow).toBe('0 1px 4px rgba(var(--color-overlay), 0.08)');
     });
 
     it('should emphasize shadow when dragging', () => {
       const theme = getContainerTheme(true, true, false);
       
-      expect(theme.shadow).toBe('0 8px 24px rgba(102, 126, 234, 0.3)');
-      expect(theme.border).toBe('rgb(102, 126, 234)');
+      expect(theme.shadow).toBe('0 8px 24px rgba(var(--color-primary), 0.3)');
+      expect(theme.border).toBe('rgb(var(--color-primary))');
     });
 
     it('should highlight as drop target', () => {
       const theme = getContainerTheme(true, false, true);
       
-      expect(theme.background).toBe('rgba(102, 126, 234, 0.05)');
-      expect(theme.border).toBe('rgb(34, 197, 94)');
-      expect(theme.shadow).toContain('rgba(34, 197, 94, 0.2)');
+      expect(theme.background).toBe('rgba(var(--color-primary), 0.05)');
+      expect(theme.border).toBe('rgb(var(--color-success))');
+      expect(theme.shadow).toContain('rgba(var(--color-success), 0.2)');
     });
   });
 

--- a/frontend/src/components/FlowEditor/analytics/WorkflowAnalyticsDashboard.tsx
+++ b/frontend/src/components/FlowEditor/analytics/WorkflowAnalyticsDashboard.tsx
@@ -88,10 +88,10 @@ interface WorkflowAnalyticsDashboardProps {
 }
 
 const STATUS_COLORS = {
-  success: 'rgb(34, 197, 94)',
-  failure: 'rgb(239, 68, 68)',
-  pending: 'rgb(234, 179, 8)',
-  running: 'rgb(59, 130, 246)'
+  success: 'rgb(var(--color-success))',
+  failure: 'rgb(var(--color-error))',
+  pending: 'rgb(var(--color-warning))',
+  running: 'rgb(var(--color-info))'
 };
 
 const CHART_COLORS = ['rgb(var(--color-primary))', 'rgb(var(--color-info))', 'rgb(var(--color-info))', 'rgb(var(--color-info))'];

--- a/frontend/src/components/FlowEditor/components/AISuggestionsPanel.tsx
+++ b/frontend/src/components/FlowEditor/components/AISuggestionsPanel.tsx
@@ -44,7 +44,7 @@ const Panel = styled.div<{ $isVisible: boolean }>`
   max-height: 400px;
   background: rgb(var(--color-surface));
   border-radius: 12px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 10px 40px rgba(var(--color-overlay), 0.15);
   border: 1px solid rgb(var(--color-border));
   overflow: hidden;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -150,14 +150,14 @@ const ConfidenceBadge = styled.div<{ $confidence: number }>`
   font-size: 11px;
   font-weight: 600;
   background: ${props => {
-    if (props.$confidence >= 0.8) return 'rgba(34, 197, 94, 0.15)';
-    if (props.$confidence >= 0.6) return 'rgba(234, 179, 8, 0.15)';
-    return 'rgba(59, 130, 246, 0.15)';
+    if (props.$confidence >= 0.8) return 'rgba(var(--color-success), 0.15)';
+    if (props.$confidence >= 0.6) return 'rgba(var(--color-warning), 0.15)';
+    return 'rgba(var(--color-info), 0.15)';
   }};
   color: ${props => {
-    if (props.$confidence >= 0.8) return 'rgb(22, 163, 74)';
-    if (props.$confidence >= 0.6) return 'rgb(202, 138, 4)';
-    return 'rgb(37, 99, 235)';
+    if (props.$confidence >= 0.8) return 'rgb(var(--color-success))';
+    if (props.$confidence >= 0.6) return 'rgb(var(--color-warning))';
+    return 'rgb(var(--color-info))';
   }};
 `;
 
@@ -204,11 +204,11 @@ const ModeBadge = styled.span<{ $mode: 'ai' | 'static' }>`
   font-weight: 600;
   margin-left: 8px;
   background: ${props => props.$mode === 'ai' 
-    ? 'rgba(147, 51, 234, 0.1)' 
-    : 'rgba(59, 130, 246, 0.1)'};
+    ? 'rgba(var(--color-primary), 0.1)' 
+    : 'rgba(var(--color-info), 0.1)'};
   color: ${props => props.$mode === 'ai' 
-    ? 'rgb(147, 51, 234)' 
-    : 'rgb(59, 130, 246)'};
+    ? 'rgb(var(--color-primary))' 
+    : 'rgb(var(--color-info))'};
   
   svg {
     color: inherit;
@@ -220,7 +220,7 @@ const ErrorState = styled.div`
   text-align: center;
   
   svg {
-    color: rgb(239, 68, 68);
+    color: rgb(var(--color-error));
     margin-bottom: 8px;
   }
   

--- a/frontend/src/components/FlowEditor/components/AutoMappingSuggestionsPanel.tsx
+++ b/frontend/src/components/FlowEditor/components/AutoMappingSuggestionsPanel.tsx
@@ -61,12 +61,12 @@ const SuggestionCard = styled.div<{ $score: number }>`
   padding: 0.75rem;
   background: ${props => 
     props.$score >= 0.9 
-      ? 'rgba(34, 197, 94, 0.05)' 
+      ? 'rgba(var(--color-success), 0.05)' 
       : 'rgb(var(--color-background-secondary))'
   };
   border: 1px solid ${props => 
     props.$score >= 0.9 
-      ? 'rgba(34, 197, 94, 0.2)' 
+      ? 'rgba(var(--color-success), 0.2)' 
       : 'rgb(var(--color-border))'
   };
   border-radius: var(--radius-sm);
@@ -74,7 +74,7 @@ const SuggestionCard = styled.div<{ $score: number }>`
   
   &:hover {
     border-color: rgb(var(--color-primary));
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.05);
   }
 `;
 

--- a/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
+++ b/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
@@ -927,8 +927,8 @@ const SectionTitle = styled.h3`
 
 const DurationBadge = styled.span`
   padding: 2px 8px;
-  background: rgba(34, 197, 94, 0.1);
-  color: rgb(34, 197, 94);
+  background: rgba(var(--color-success), 0.1);
+  color: rgb(var(--color-success));
   border-radius: 4px;
   font-size: 11px;
   font-weight: 500;
@@ -1021,7 +1021,7 @@ const RunButton = styled.button`
   &:hover:not(:disabled) {
     background: rgba(var(--color-primary), 0.9);
     transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 8px rgba(var(--color-overlay), 0.1);
   }
   
   &:disabled {
@@ -1114,15 +1114,15 @@ const LoadingState = styled.div`
 const ErrorState = styled.div`
   h4 {
     margin: 0 0 12px 0;
-    color: rgb(239, 68, 68);
+    color: rgb(var(--color-error));
   }
   
   pre {
     margin: 0;
     padding: 12px;
-    background: rgba(239, 68, 68, 0.1);
+    background: rgba(var(--color-error), 0.1);
     border-radius: 4px;
-    color: rgb(239, 68, 68);
+    color: rgb(var(--color-error));
     font-size: 13px;
   }
 `;
@@ -1157,15 +1157,15 @@ const HistoryIcon = styled.div<{ $status: string }>`
   border-radius: 50%;
   background: ${props => {
     switch (props.$status) {
-      case 'success': return 'rgba(34, 197, 94, 0.1)';
-      case 'error': return 'rgba(239, 68, 68, 0.1)';
+      case 'success': return 'rgba(var(--color-success), 0.1)';
+      case 'error': return 'rgba(var(--color-error), 0.1)';
       default: return 'rgba(var(--color-primary), 0.1)';
     }
   }};
   color: ${props => {
     switch (props.$status) {
-      case 'success': return 'rgb(34, 197, 94)';
-      case 'error': return 'rgb(239, 68, 68)';
+      case 'success': return 'rgb(var(--color-success))';
+      case 'error': return 'rgb(var(--color-error))';
       default: return 'rgb(var(--color-primary))';
     }
   }};

--- a/frontend/src/components/FlowEditor/components/EnhancedContextMenu.tsx
+++ b/frontend/src/components/FlowEditor/components/EnhancedContextMenu.tsx
@@ -50,7 +50,7 @@ const MenuContainer = styled.div<{ x: number; y: number }>`
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 8px 24px rgba(var(--color-overlay), 0.15);
   min-width: 200px;
   z-index: 10000;
   padding: 6px;
@@ -84,7 +84,7 @@ const MenuItem = styled.button<{ $danger?: boolean; $disabled?: boolean }>`
     props.$disabled
       ? 'rgb(var(--color-text-tertiary))'
       : props.$danger
-      ? 'rgb(239, 68, 68)'
+      ? 'rgb(var(--color-error))'
       : 'rgb(var(--color-text-primary))'};
   text-align: left;
   opacity: ${props => props.$disabled ? 0.5 : 1};
@@ -92,7 +92,7 @@ const MenuItem = styled.button<{ $danger?: boolean; $disabled?: boolean }>`
   &:hover:not(:disabled) {
     background: ${props =>
       props.$danger
-        ? 'rgba(239, 68, 68, 0.1)'
+        ? 'rgba(var(--color-error), 0.1)'
         : 'rgb(var(--color-surface-hover))'};
   }
 

--- a/frontend/src/components/FlowEditor/components/NodeBadge.tsx
+++ b/frontend/src/components/FlowEditor/components/NodeBadge.tsx
@@ -85,11 +85,11 @@ const BadgeContainer = styled.div<{
   
   background: ${props => {
     switch (props.$status) {
-      case 'error': return 'rgb(220, 38, 38)';
-      case 'warning': return 'rgb(245, 158, 11)';
-      case 'success': return 'rgb(22, 163, 74)';
-      case 'processing': return 'rgb(59, 130, 246)';
-      default: return 'rgb(100, 116, 139)';
+      case 'error': return 'rgb(var(--color-danger))';
+      case 'warning': return 'rgb(var(--color-warning))';
+      case 'success': return 'rgb(var(--color-success))';
+      case 'processing': return 'rgb(var(--color-info))';
+      default: return 'rgb(var(--color-text-tertiary))';
     }
   }};
   

--- a/frontend/src/components/FlowEditor/components/PerformanceOverlay.tsx
+++ b/frontend/src/components/FlowEditor/components/PerformanceOverlay.tsx
@@ -73,9 +73,9 @@ const OverlayContainer = styled.div<{
     }
   }}
   
-  background: rgba(0, 0, 0, 0.85);
+  background: rgba(var(--color-overlay), 0.85);
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(var(--color-header-background), 0.1);
   border-radius: 8px;
   padding: 12px 16px;
   font-family: 'SF Mono', 'Monaco', 'Cascadia Code', 'Courier New', monospace;
@@ -84,7 +84,7 @@ const OverlayContainer = styled.div<{
   color: rgb(var(--color-text-primary, 255, 255, 255));
   z-index: 9999;
   min-width: 200px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.3);
   user-select: none;
   
   /* Prevent overlay from blocking interactions */
@@ -107,7 +107,7 @@ const MetricRow = styled.div<{ $warning?: boolean }>`
 `;
 
 const MetricLabel = styled.span`
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(var(--color-header-background), 0.7);
   margin-right: 16px;
 `;
 
@@ -118,7 +118,7 @@ const MetricValue = styled.span<{ $color?: string }>`
 
 const Divider = styled.div`
   height: 1px;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(var(--color-header-background), 0.1);
   margin: 12px 0;
 `;
 
@@ -134,21 +134,21 @@ const Badge = styled.span<{ $type: 'success' | 'warning' | 'error' }>`
     switch (props.$type) {
       case 'success':
         return `
-          background: rgba(34, 197, 94, 0.2);
-          color: rgb(34, 197, 94);
-          border: 1px solid rgba(34, 197, 94, 0.4);
+          background: rgba(var(--color-success), 0.2);
+          color: rgb(var(--color-success));
+          border: 1px solid rgba(var(--color-success), 0.4);
         `;
       case 'warning':
         return `
-          background: rgba(234, 179, 8, 0.2);
-          color: rgb(234, 179, 8);
-          border: 1px solid rgba(234, 179, 8, 0.4);
+          background: rgba(var(--color-warning), 0.2);
+          color: rgb(var(--color-warning));
+          border: 1px solid rgba(var(--color-warning), 0.4);
         `;
       case 'error':
         return `
-          background: rgba(239, 68, 68, 0.2);
-          color: rgb(239, 68, 68);
-          border: 1px solid rgba(239, 68, 68, 0.4);
+          background: rgba(var(--color-error), 0.2);
+          color: rgb(var(--color-error));
+          border: 1px solid rgba(var(--color-error), 0.4);
         `;
     }
   }}
@@ -172,7 +172,7 @@ const Title = styled.div`
 const ToggleButton = styled.button`
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(var(--color-header-background), 0.5);
   font-size: 18px;
   cursor: pointer;
   padding: 0;
@@ -184,7 +184,7 @@ const ToggleButton = styled.button`
   transition: color 0.2s;
   
   &:hover {
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(var(--color-header-background), 0.9);
   }
 `;
 
@@ -279,10 +279,10 @@ export const PerformanceOverlay: React.FC<PerformanceOverlayProps> = ({
           <MetricValue
             $color={
               fps >= 55
-                ? 'rgb(34, 197, 94)'
+                ? 'rgb(var(--color-success))'
                 : fps >= 30
-                ? 'rgb(234, 179, 8)'
-                : 'rgb(239, 68, 68)'
+                ? 'rgb(var(--color-warning))'
+                : 'rgb(var(--color-error))'
             }
           >
             {fps}
@@ -306,7 +306,7 @@ export const PerformanceOverlay: React.FC<PerformanceOverlayProps> = ({
           {isVirtualized && (
             <MetricRow>
               <MetricLabel>Rendered:</MetricLabel>
-              <MetricValue $color="rgb(102, 126, 234)">
+              <MetricValue $color="rgb(var(--color-primary))">
                 {virtualizationRatio.toFixed(1)}%
               </MetricValue>
             </MetricRow>
@@ -319,8 +319,8 @@ export const PerformanceOverlay: React.FC<PerformanceOverlayProps> = ({
               <MetricValue
                 $color={
                   highMemory
-                    ? 'rgb(239, 68, 68)'
-                    : 'rgb(34, 197, 94)'
+                    ? 'rgb(var(--color-error))'
+                    : 'rgb(var(--color-success))'
                 }
               >
                 {memoryMB} MB
@@ -335,10 +335,10 @@ export const PerformanceOverlay: React.FC<PerformanceOverlayProps> = ({
               <MetricValue
                 $color={
                   slowRender
-                    ? 'rgb(239, 68, 68)'
+                    ? 'rgb(var(--color-error))'
                     : avgRenderTime > 10
-                    ? 'rgb(234, 179, 8)'
-                    : 'rgb(34, 197, 94)'
+                    ? 'rgb(var(--color-warning))'
+                    : 'rgb(var(--color-success))'
                 }
               >
                 {avgRenderTime.toFixed(2)} ms
@@ -351,7 +351,7 @@ export const PerformanceOverlay: React.FC<PerformanceOverlayProps> = ({
             <>
               <Divider />
               <MetricRow>
-                <MetricLabel style={{ color: 'rgb(239, 68, 68)' }}>
+                <MetricLabel style={{ color: 'rgb(var(--color-error))' }}>
                   ⚠️ Warnings:
                 </MetricLabel>
               </MetricRow>

--- a/frontend/src/components/FlowEditor/components/SnapPreviewOverlay.tsx
+++ b/frontend/src/components/FlowEditor/components/SnapPreviewOverlay.tsx
@@ -51,15 +51,15 @@ const SnapPreviewBox = styled.div<{
   width: ${props => props.width}px;
   height: ${props => props.height}px;
   
-  border: 2px dashed rgb(102, 126, 234);
+  border: 2px dashed rgb(var(--color-primary));
   border-radius: var(--radius-md);
-  background: rgba(102, 126, 234, 0.1);
+  background: rgba(var(--color-primary), 0.1);
   
   animation: ${pulse} 1.5s ease-in-out infinite;
   
   box-shadow: 
-    0 0 0 4px rgba(102, 126, 234, 0.1),
-    inset 0 0 20px rgba(102, 126, 234, 0.2);
+    0 0 0 4px rgba(var(--color-primary), 0.1),
+    inset 0 0 20px rgba(var(--color-primary), 0.2);
     
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 `;
@@ -70,7 +70,7 @@ const SnapLabel = styled.div<{ left: number; top: number }>`
   top: ${props => props.top - 30}px;
   
   padding: 4px 12px;
-  background: rgba(102, 126, 234, 0.95);
+  background: rgba(var(--color-primary), 0.95);
   color: white;
   font-size: 11px;
   font-weight: 600;
@@ -79,7 +79,7 @@ const SnapLabel = styled.div<{ left: number; top: number }>`
   border-radius: var(--radius-sm);
   white-space: nowrap;
   
-  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4);
+  box-shadow: 0 2px 8px rgba(var(--color-primary), 0.4);
   animation: ${fadeIn} 0.2s ease-out;
   
   &::after {
@@ -92,7 +92,7 @@ const SnapLabel = styled.div<{ left: number; top: number }>`
     height: 0;
     border-left: 4px solid transparent;
     border-right: 4px solid transparent;
-    border-top: 4px solid rgba(102, 126, 234, 0.95);
+    border-top: 4px solid rgba(var(--color-primary), 0.95);
   }
 `;
 
@@ -104,7 +104,7 @@ const SnapLine = styled.div<{
   orientation: 'horizontal' | 'vertical';
 }>`
   position: absolute;
-  background: rgba(102, 126, 234, 0.4);
+  background: rgba(var(--color-primary), 0.4);
   
   ${props => props.orientation === 'horizontal' ? `
     left: ${Math.min(props.x1, props.x2)}px;
@@ -128,13 +128,13 @@ const SnapPoint = styled.div<{ left: number; top: number }>`
   width: 8px;
   height: 8px;
   
-  background: rgb(102, 126, 234);
+  background: rgb(var(--color-primary));
   border: 2px solid white;
   border-radius: 50%;
   
   box-shadow: 
-    0 0 0 2px rgba(102, 126, 234, 0.3),
-    0 2px 4px rgba(0, 0, 0, 0.2);
+    0 0 0 2px rgba(var(--color-primary), 0.3),
+    0 2px 4px rgba(var(--color-overlay), 0.2);
     
   animation: ${pulse} 1s ease-in-out infinite;
 `;

--- a/frontend/src/components/FlowEditor/components/ValidationDrawer.tsx
+++ b/frontend/src/components/FlowEditor/components/ValidationDrawer.tsx
@@ -69,7 +69,7 @@ export const ValidationDrawer: React.FC<ValidationDrawerProps> = ({
               $isExpanded={expandedSections.has('errors')}
             >
               <SectionTitle>
-                <AlertCircle size={18} color="rgb(239, 68, 68)" />
+                <AlertCircle size={18} color="rgb(var(--color-error))" />
                 <span>Errors ({errorIssues.length})</span>
               </SectionTitle>
               {expandedSections.has('errors') ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
@@ -105,7 +105,7 @@ export const ValidationDrawer: React.FC<ValidationDrawerProps> = ({
               $isExpanded={expandedSections.has('warnings')}
             >
               <SectionTitle>
-                <AlertTriangle size={18} color="rgb(234, 179, 8)" />
+                <AlertTriangle size={18} color="rgb(var(--color-warning))" />
                 <span>Warnings ({warningIssues.length})</span>
               </SectionTitle>
               {expandedSections.has('warnings') ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
@@ -138,7 +138,7 @@ export const ValidationDrawer: React.FC<ValidationDrawerProps> = ({
               $isExpanded={expandedSections.has('info')}
             >
               <SectionTitle>
-                <Info size={18} color="rgb(59, 130, 246)" />
+                <Info size={18} color="rgb(var(--color-info))" />
                 <span>Info ({infoIssues.length})</span>
               </SectionTitle>
               {expandedSections.has('info') ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
@@ -161,7 +161,7 @@ export const ValidationDrawer: React.FC<ValidationDrawerProps> = ({
         {/* All Clear */}
         {validation.issues.length === 0 && (
           <AllClearMessage>
-            <AlertCircle size={48} color="rgb(34, 197, 94)" />
+            <AlertCircle size={48} color="rgb(var(--color-success))" />
             <h3>All Clear!</h3>
             <p>No validation issues found. Your workflow is ready to publish.</p>
           </AllClearMessage>
@@ -180,7 +180,7 @@ const DrawerContainer = styled.div`
   right: 0;
   background: rgb(var(--color-surface));
   border-top: 1px solid rgb(var(--color-border));
-  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 -4px 12px rgba(var(--color-overlay), 0.1);
   z-index: 1000;
   max-height: 400px;
   display: flex;
@@ -225,11 +225,11 @@ const StatusBadge = styled.span<{ $isValid: boolean }>`
   font-size: 12px;
   font-weight: 500;
   background: ${props => props.$isValid 
-    ? 'rgba(34, 197, 94, 0.1)' 
-    : 'rgba(239, 68, 68, 0.1)'};
+    ? 'rgba(var(--color-success), 0.1)' 
+    : 'rgba(var(--color-error), 0.1)'};
   color: ${props => props.$isValid 
-    ? 'rgb(34, 197, 94)' 
-    : 'rgb(239, 68, 68)'};
+    ? 'rgb(var(--color-success))' 
+    : 'rgb(var(--color-error))'};
 `;
 
 const CloseButton = styled.button`
@@ -300,9 +300,9 @@ const IssueCard = styled.div<{ $severity: 'error' | 'warning' | 'info'; $isClick
   background: rgb(var(--color-surface));
   border-left: 3px solid ${props => {
     switch (props.$severity) {
-      case 'error': return 'rgb(239, 68, 68)';
-      case 'warning': return 'rgb(234, 179, 8)';
-      case 'info': return 'rgb(59, 130, 246)';
+      case 'error': return 'rgb(var(--color-error))';
+      case 'warning': return 'rgb(var(--color-warning))';
+      case 'info': return 'rgb(var(--color-info))';
     }
   }};
   border-radius: 4px;
@@ -350,7 +350,7 @@ const AllClearMessage = styled.div`
     margin: 16px 0 8px;
     font-size: 20px;
     font-weight: 600;
-    color: rgb(34, 197, 94);
+    color: rgb(var(--color-success));
   }
   
   p {

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/complexRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/complexRenderers.tsx
@@ -291,7 +291,7 @@ const FieldContainer = styled.div`
 `;
 
 const ErrorMessage = styled.div`
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   font-size: 13px;
   margin-top: 4px;
 `;

--- a/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
@@ -28,20 +28,20 @@ interface ConditionalEdgeData extends Record<string, unknown> {
 
 const ConditionLabel = styled.div`
   position: absolute;
-  background: rgb(251, 191, 36);
-  border: 2px solid rgb(245, 158, 11);
+  background: rgba(var(--color-warning), 0.18);
+  border: 2px solid rgb(var(--color-warning));
   border-radius: var(--radius-md, 6px);
   padding: 4px 12px;
   font-size: 12px;
   font-weight: 600;
-  color: rgb(120, 53, 15);
+  color: rgb(var(--color-text-primary));
   pointer-events: all;
   cursor: pointer;
   transition: all 0.2s ease;
   box-shadow: 0 2px 4px rgb(245 158 11 / 0.2);
 
   &:hover {
-    background: rgb(245, 158, 11);
+    background: rgb(var(--color-warning));
     color: white;
     transform: scale(1.05);
     box-shadow: 0 4px 8px rgb(245 158 11 / 0.3);
@@ -57,7 +57,7 @@ const ConditionLabel = styled.div`
 
 const TrueFalseIndicator = styled.div<{ isTrue?: boolean }>`
   position: absolute;
-  background: ${props => props.isTrue ? 'rgb(34, 197, 94)' : 'rgb(239, 68, 68)'};
+  background: ${props => props.isTrue ? 'rgb(var(--color-success))' : 'rgb(var(--color-error))'};
   border: 2px solid white;
   border-radius: 50%;
   width: 20px;
@@ -106,7 +106,7 @@ export const ConditionalEdge = React.memo<EdgeProps<Edge<ConditionalEdgeData>>>(
   const isTrue = data?.isTrue;
 
   const edgeStyle: React.CSSProperties = {
-    stroke: 'rgb(245, 158, 11)', // Orange
+    stroke: 'rgb(var(--color-warning))', // Orange
     strokeWidth: 2.5,
     strokeDasharray: animated ? '8,4' : undefined,
     transition: 'all 0.3s ease',
@@ -118,7 +118,7 @@ export const ConditionalEdge = React.memo<EdgeProps<Edge<ConditionalEdgeData>>>(
     type: MarkerType.ArrowClosed,
     width: 24,
     height: 24,
-    color: 'rgb(245, 158, 11)',
+    color: 'rgb(var(--color-warning))',
   };
 
   return (
@@ -136,8 +136,8 @@ export const ConditionalEdge = React.memo<EdgeProps<Edge<ConditionalEdgeData>>>(
         >
           <path
             d="M 0,6 L 6,0 L 12,6 L 6,12 Z"
-            fill="rgb(245, 158, 11)"
-            stroke="rgb(245, 158, 11)"
+            fill="rgb(var(--color-warning))"
+            stroke="rgb(var(--color-warning))"
             strokeWidth="1"
           />
         </marker>
@@ -155,7 +155,7 @@ export const ConditionalEdge = React.memo<EdgeProps<Edge<ConditionalEdgeData>>>(
 
       {/* Animated flow indicator */}
       {animated && (
-        <circle r="4" fill="rgb(245, 158, 11)">
+        <circle r="4" fill="rgb(var(--color-warning))">
           <animateMotion dur="1.5s" repeatCount="indefinite" path={edgePath} />
         </circle>
       )}

--- a/frontend/src/components/FlowEditor/edges/CustomEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/CustomEdge.tsx
@@ -92,19 +92,19 @@ const getEdgeStyle = (edgeType?: string, animated?: boolean) => {
     case 'conditional':
       return {
         ...baseStyle,
-        stroke: 'rgb(59, 130, 246)', // Blue
+        stroke: 'rgb(var(--color-info))',
         strokeDasharray: animated ? '5,5' : undefined,
       };
     case 'success':
       return {
         ...baseStyle,
-        stroke: 'rgb(34, 197, 94)', // Green
+        stroke: 'rgb(var(--color-success))',
         strokeWidth: 2.5,
       };
     case 'error':
       return {
         ...baseStyle,
-        stroke: 'rgb(239, 68, 68)', // Red
+        stroke: 'rgb(var(--color-error))',
         strokeDasharray: '4,4',
       };
     default:

--- a/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
@@ -79,13 +79,13 @@ const EdgeLabel = styled.div<{ $status: ConnectionStatus }>`
   color: ${(props) => {
     switch (props.$status) {
       case 'valid':
-        return 'rgb(34, 197, 94)'; // Success green
+        return 'rgb(var(--color-success))'; // Success green
       case 'invalid':
-        return 'rgb(239, 68, 68)'; // Error red
+        return 'rgb(var(--color-error))'; // Error red
       case 'warning':
-        return 'rgb(234, 179, 8)'; // Warning yellow
+        return 'rgb(var(--color-warning))'; // Warning yellow
       case 'info':
-        return 'rgb(59, 130, 246)'; // Info blue
+        return 'rgb(var(--color-info))'; // Info blue
       default:
         return 'rgb(var(--color-text-secondary))';
     }
@@ -104,7 +104,7 @@ const EdgeLabel = styled.div<{ $status: ConnectionStatus }>`
     opacity: 1;
     animation: none;
     transform: translate(-50%, -50%) scale(1.05);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.15);
   }
 
   svg {
@@ -125,7 +125,7 @@ const EdgeToolbarCard = styled.div`
   padding: 4px;
   border-radius: 8px;
   border: 1px solid rgb(var(--color-border));
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.15);
   pointer-events: all;
   opacity: 0;
   transform: scale(0.9);
@@ -156,7 +156,7 @@ const EdgeEditCard = styled.div`
   padding: 8px;
   border-radius: 10px;
   border: 1px solid rgb(var(--color-border));
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 8px 20px rgba(var(--color-overlay), 0.2);
   pointer-events: all;
   min-width: 220px;
 `;
@@ -258,13 +258,13 @@ const DataKeyChip = styled.span`
 function getEdgeColor(status: ConnectionStatus): string {
   switch (status) {
     case 'valid':
-      return 'rgb(34, 197, 94)'; // Success
+      return 'rgb(var(--color-success))'; // Success
     case 'invalid':
-      return 'rgb(239, 68, 68)'; // Error
+      return 'rgb(var(--color-error))'; // Error
     case 'warning':
-      return 'rgb(234, 179, 8)'; // Warning
+      return 'rgb(var(--color-warning))'; // Warning
     case 'info':
-      return 'rgb(59, 130, 246)'; // Info
+      return 'rgb(var(--color-info))'; // Info
     default:
       return 'rgb(var(--color-border))';
   }

--- a/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
@@ -37,13 +37,13 @@ const dashMove = keyframes`
 
 const ErrorLabel = styled.div`
   position: absolute;
-  background: rgb(254, 226, 226);
+  background: rgba(var(--color-error), 0.12);
   border: 2px solid rgb(var(--color-error));
   border-radius: var(--radius-md, 6px);
   padding: 4px 12px;
   font-size: 12px;
   font-weight: 700;
-  color: rgb(153, 27, 27);
+  color: rgb(var(--color-danger));
   pointer-events: all;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -97,7 +97,7 @@ const ToolbarBtn = styled.button`
 `;
 const ErrorBadge = styled.div`
   position: absolute;
-  background: rgb(220, 38, 38);
+  background: rgb(var(--color-danger));
   border: 2px solid white;
   border-radius: 50%;
   min-width: 20px;
@@ -189,7 +189,7 @@ export const ErrorEdge = React.memo<EdgeProps<Edge<ErrorEdgeData>>>(({
     type: MarkerType.ArrowClosed,
     width: 24,
     height: 24,
-    color: 'rgb(239, 68, 68)',
+    color: 'rgb(var(--color-error))',
   };
 
   return (
@@ -207,7 +207,7 @@ export const ErrorEdge = React.memo<EdgeProps<Edge<ErrorEdgeData>>>(({
         >
           <path
             d="M 8,2 L 14,14 L 2,14 Z"
-            fill="rgb(239, 68, 68)"
+            fill="rgb(var(--color-error))"
             stroke="white"
             strokeWidth="1"
           />
@@ -239,10 +239,10 @@ export const ErrorEdge = React.memo<EdgeProps<Edge<ErrorEdgeData>>>(({
       {/* Animated pulsing dots for errors */}
       {animated && (
         <>
-          <circle r="4" fill="rgb(239, 68, 68)" opacity="0.8">
+          <circle r="4" fill="rgb(var(--color-error))" opacity="0.8">
             <animateMotion dur="2s" repeatCount="indefinite" path={edgePath} />
           </circle>
-          <circle r="4" fill="rgb(239, 68, 68)" opacity="0.6">
+          <circle r="4" fill="rgb(var(--color-error))" opacity="0.6">
             <animateMotion dur="2s" begin="0.5s" repeatCount="indefinite" path={edgePath} />
           </circle>
         </>

--- a/frontend/src/components/FlowEditor/edges/InsertNodeEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/InsertNodeEdge.tsx
@@ -20,7 +20,7 @@ const AddButton = styled.button`
   color: rgb(var(--color-text-secondary));
   cursor: pointer;
   transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 4px rgba(var(--color-overlay), 0.05);
 
   &:hover {
     background: rgb(var(--color-primary));

--- a/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
@@ -28,20 +28,20 @@ interface SuccessEdgeData extends Record<string, unknown> {
 
 const SuccessLabel = styled.div`
   position: absolute;
-  background: rgb(220, 252, 231);
-  border: 2px solid rgb(34, 197, 94);
+  background: rgba(var(--color-success), 0.12);
+  border: 2px solid rgb(var(--color-success));
   border-radius: var(--radius-md, 6px);
   padding: 4px 12px;
   font-size: 12px;
   font-weight: 600;
-  color: rgb(21, 128, 61);
+  color: rgb(var(--color-success));
   pointer-events: all;
   cursor: pointer;
   transition: all 0.2s ease;
   box-shadow: 0 2px 4px rgb(34 197 94 / 0.2);
 
   &:hover {
-    background: rgb(34, 197, 94);
+    background: rgb(var(--color-success));
     color: white;
     transform: scale(1.05);
     box-shadow: 0 4px 8px rgb(34 197 94 / 0.3);
@@ -58,7 +58,7 @@ const SuccessLabel = styled.div`
 
 const SuccessBadge = styled.div`
   position: absolute;
-  background: rgb(22, 163, 74);
+  background: rgb(var(--color-success));
   border: 2px solid white;
   border-radius: 50%;
   min-width: 20px;
@@ -109,7 +109,7 @@ export const SuccessEdge = React.memo<EdgeProps<Edge<SuccessEdgeData>>>(({
   const successCount = data?.successCount;
 
   const edgeStyle: React.CSSProperties = {
-    stroke: 'rgb(34, 197, 94)', // Green
+    stroke: 'rgb(var(--color-success))', // Green
     strokeWidth: 3,
     transition: 'all 0.3s ease',
     ...style,
@@ -120,7 +120,7 @@ export const SuccessEdge = React.memo<EdgeProps<Edge<SuccessEdgeData>>>(({
     type: MarkerType.ArrowClosed,
     width: 24,
     height: 24,
-    color: 'rgb(34, 197, 94)',
+    color: 'rgb(var(--color-success))',
   };
 
   return (
@@ -136,7 +136,7 @@ export const SuccessEdge = React.memo<EdgeProps<Edge<SuccessEdgeData>>>(({
           orient="auto"
           markerUnits="userSpaceOnUse"
         >
-          <circle cx="8" cy="8" r="7" fill="rgb(34, 197, 94)" stroke="white" strokeWidth="1" />
+          <circle cx="8" cy="8" r="7" fill="rgb(var(--color-success))" stroke="white" strokeWidth="1" />
           <path
             d="M 5,8 L 7,10 L 11,6"
             fill="none"
@@ -161,13 +161,13 @@ export const SuccessEdge = React.memo<EdgeProps<Edge<SuccessEdgeData>>>(({
       {/* Animated sparkle effect for success */}
       {animated && (
         <>
-          <circle r="3" fill="rgb(34, 197, 94)" opacity="1">
+          <circle r="3" fill="rgb(var(--color-success))" opacity="1">
             <animateMotion dur="1.5s" repeatCount="indefinite" path={edgePath} />
           </circle>
-          <circle r="2" fill="rgb(134, 239, 172)" opacity="0.7">
+          <circle r="2" fill="rgba(var(--color-success), 0.35)" opacity="0.7">
             <animateMotion dur="1.5s" begin="0.3s" repeatCount="indefinite" path={edgePath} />
           </circle>
-          <circle r="2" fill="rgb(134, 239, 172)" opacity="0.7">
+          <circle r="2" fill="rgba(var(--color-success), 0.35)" opacity="0.7">
             <animateMotion dur="1.5s" begin="0.6s" repeatCount="indefinite" path={edgePath} />
           </circle>
         </>

--- a/frontend/src/components/FlowEditor/hooks/useContainerManagement.ts
+++ b/frontend/src/components/FlowEditor/hooks/useContainerManagement.ts
@@ -79,7 +79,7 @@ const MIN_CONTAINER_HEIGHT = 300;
  * // Group selected nodes
  * const container = createContainerFromSelection({
  *   label: 'Login Flow',
- *   backgroundColor: 'rgba(103, 126, 234, 0.05)'
+ *   backgroundColor: 'rgba(var(--color-primary), 0.05)'
  * });
  * ```
  */

--- a/frontend/src/components/FlowEditor/hooks/useOnboardingTour.tsx
+++ b/frontend/src/components/FlowEditor/hooks/useOnboardingTour.tsx
@@ -221,7 +221,7 @@ export const workflowEditorTourSteps: Step[] = [
           <li>Add more nodes and connect them</li>
           <li>Click <strong>Save</strong> when done</li>
         </ol>
-        <p style={{ margin: '8px 0 0 0', fontSize: '14px', color: '#666' }}>
+        <p style={{ margin: '8px 0 0 0', fontSize: '14px', color: 'rgb(var(--color-text-secondary))' }}>
           💡 Press <code>Shift+?</code> anytime to see all keyboard shortcuts
         </p>
       </div>
@@ -309,7 +309,7 @@ export const tourOptions: Partial<Options> = {
   textColor: 'rgb(var(--color-text-primary))',
   backgroundColor: 'rgb(var(--color-background))',
   arrowColor: 'rgb(var(--color-background))',
-  overlayColor: 'rgba(0, 0, 0, 0.5)',
+  overlayColor: 'rgba(var(--color-overlay), 0.5)',
   // Keep the tour UI above fullscreen Workforms editor surfaces + portals.
   zIndex: 20000,
   showProgress: true,
@@ -325,7 +325,7 @@ export const tourStyles: PartialDeep<Styles> = {
     borderRadius: '8px',
     padding: '16px',
     fontSize: '14px',
-    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+    boxShadow: '0 4px 12px rgba(var(--color-overlay), 0.15)',
   },
   buttonClose: {
     zIndex: 20001,

--- a/frontend/src/components/FlowEditor/nodes/ActionNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ActionNode.tsx
@@ -87,7 +87,7 @@ const ConfigValue = styled.span<{ $empty?: boolean }>`
   font-style: ${(p) => (p.$empty ? 'italic' : 'normal')};
   font-family: monospace;
   font-size: 10px;
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(var(--color-overlay), 0.05);
   padding: 2px 4px;
   border-radius: 2px;
 `;
@@ -98,8 +98,8 @@ const ActionBadge = styled.span<{ $type: string }>`
   border-radius: var(--radius-sm);
   font-size: 10px;
   font-weight: 600;
-  background: rgba(139, 92, 246, 0.2);
-  color: rgb(139, 92, 246);
+  background: rgba(var(--color-primary), 0.2);
+  color: rgb(var(--color-primary));
   margin-bottom: 6px;
 `;
 

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -81,17 +81,17 @@ const NodeContainer = styled.div<{
   min-width: 180px;
   background: rgb(var(--color-surface, 255, 255, 255));
   border: 2px solid ${props => {
-    if (props.$isDirty) return 'rgb(234, 179, 8)'; // Yellow for dirty (Phase 2)
+    if (props.$isDirty) return 'rgb(var(--color-warning))'; // Yellow for dirty (Phase 2)
     if (props.$selected) return props.$color;
-    if (props.$status === 'error') return 'rgb(239, 68, 68)';
-    if (props.$isPinned) return 'rgb(99, 102, 241)'; // Indigo for pinned
+    if (props.$status === 'error') return 'rgb(var(--color-error))';
+    if (props.$isPinned) return 'rgb(var(--color-primary))'; // Indigo for pinned
     return 'rgb(var(--color-border))';
   }};
   border-radius: var(--radius-lg);
   padding: 0;
   box-shadow: ${props => props.$selected 
-    ? '0 4px 12px rgba(0, 0, 0, 0.15)' 
-    : '0 2px 6px rgba(0, 0, 0, 0.1)'};
+    ? '0 4px 12px rgba(var(--color-overlay), 0.15)' 
+    : '0 2px 6px rgba(var(--color-overlay), 0.1)'};
   transition: all 0.2s ease;
   
   /* Drag preview - semi-transparent ghost */
@@ -103,10 +103,10 @@ const NodeContainer = styled.div<{
     
     @keyframes dirtyPulse {
       0%, 100% {
-        box-shadow: 0 2px 6px rgba(234, 179, 8, 0.3);
+        box-shadow: 0 2px 6px rgba(var(--color-warning), 0.3);
       }
       50% {
-        box-shadow: 0 4px 12px rgba(234, 179, 8, 0.5);
+        box-shadow: 0 4px 12px rgba(var(--color-warning), 0.5);
       }
     }
   `}
@@ -120,7 +120,7 @@ const NodeContainer = styled.div<{
       left: -4px;
       right: -4px;
       bottom: -4px;
-      border: 2px dashed rgb(99, 102, 241);
+      border: 2px dashed rgb(var(--color-primary));
       border-radius: var(--radius-lg);
       pointer-events: none;
       opacity: 0.3;
@@ -128,7 +128,7 @@ const NodeContainer = styled.div<{
   `}
   
   &:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.15);
   }
 `;
 
@@ -172,8 +172,8 @@ const NodeTitle = styled.span<{ $editable?: boolean }>`
 
 const NodeTitleInput = styled.input`
   flex: 1;
-  background: rgba(255, 255, 255, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: rgba(var(--color-header-background), 0.2);
+  border: 1px solid rgba(var(--color-header-background), 0.5);
   border-radius: 4px;
   padding: 2px 6px;
   color: white;
@@ -182,7 +182,7 @@ const NodeTitleInput = styled.input`
   outline: none;
   
   &:focus {
-    background: rgba(255, 255, 255, 0.3);
+    background: rgba(var(--color-header-background), 0.3);
     border-color: white;
   }
 `;
@@ -193,7 +193,7 @@ const StepNumber = styled.span`
   justify-content: center;
   width: 20px;
   height: 20px;
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(var(--color-header-background), 0.3);
   border-radius: 50%;
   font-size: 11px;
   font-weight: 700;
@@ -245,11 +245,11 @@ const BreakpointDot = styled.div`
 const ErrorMessage = styled.div`
   margin-top: 8px;
   padding: 6px 8px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgb(239, 68, 68);
+  background: rgba(var(--color-error), 0.1);
+  border: 1px solid rgb(var(--color-error));
   border-radius: var(--radius-sm);
   font-size: 11px;
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
 `;
 
 const StyledHandle = styled(Handle)<{ $color: string }>`
@@ -284,7 +284,7 @@ const ToolbarCard = styled.div`
   padding: 6px;
   border-radius: 8px;
   border: 1px solid rgb(var(--color-border));
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.15);
 `;
 
 const ToolbarBtn = styled.button<{ $danger?: boolean }>`
@@ -293,13 +293,13 @@ const ToolbarBtn = styled.button<{ $danger?: boolean }>`
   border: none;
   background: transparent;
   cursor: pointer;
-  color: ${(props) => (props.$danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-text-secondary))')};
+  color: ${(props) => (props.$danger ? 'rgb(var(--color-error))' : 'rgb(var(--color-text-secondary))')};
   transition: all 0.15s ease;
 
   &:hover {
     background: ${(props) =>
-      props.$danger ? 'rgba(239, 68, 68, 0.1)' : 'rgba(var(--color-primary), 0.1)'};
-    color: ${(props) => (props.$danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-primary))')};
+      props.$danger ? 'rgba(var(--color-error), 0.1)' : 'rgba(var(--color-primary), 0.1)'};
+    color: ${(props) => (props.$danger ? 'rgb(var(--color-error))' : 'rgb(var(--color-primary))')};
   }
 `;
 
@@ -343,8 +343,8 @@ const HeaderToggleButton = styled.button`
   width: 24px;
   height: 24px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(var(--color-header-background), 0.45);
+  background: rgba(var(--color-header-background), 0.16);
   color: white;
   cursor: pointer;
   display: flex;
@@ -355,7 +355,7 @@ const HeaderToggleButton = styled.button`
 
   &:hover {
     opacity: 1;
-    background: rgba(255, 255, 255, 0.22);
+    background: rgba(var(--color-header-background), 0.22);
     transform: scale(1.05);
   }
 
@@ -686,7 +686,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
           type="source"
           position={Position.Bottom}
           id="error"
-          $color="rgb(239, 68, 68)"
+          $color="rgb(var(--color-error))"
           style={{
             left: '82%',
             transform: 'translateX(-50%)',

--- a/frontend/src/components/FlowEditor/nodes/ConditionIfNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ConditionIfNode.tsx
@@ -71,11 +71,11 @@ const RuleValue = styled.span`
 const LogicalOperatorBadge = styled.div`
   display: inline-block;
   padding: 2px 8px;
-  background: rgba(59, 130, 246, 0.2);
+  background: rgba(var(--color-info), 0.2);
   border-radius: var(--radius-sm);
   font-size: 10px;
   font-weight: 700;
-  color: rgb(59, 130, 246);
+  color: rgb(var(--color-info));
   margin-top: 6px;
 `;
 
@@ -92,8 +92,8 @@ const BranchHandle = styled(Handle)<{ $type: 'true' | 'false' }>`
   width: 12px;
   height: 12px;
   background: ${props => props.$type === 'true' 
-    ? 'rgb(34, 197, 94)' 
-    : 'rgb(239, 68, 68)'};
+    ? 'rgb(var(--color-success))' 
+    : 'rgb(var(--color-error))'};
   border: 2px solid rgb(var(--color-surface));
   position: relative !important;
   transform: none !important;
@@ -112,8 +112,8 @@ const BranchHandle = styled(Handle)<{ $type: 'true' | 'false' }>`
     font-size: 10px;
     font-weight: 700;
     color: ${props => props.$type === 'true' 
-      ? 'rgb(34, 197, 94)' 
-      : 'rgb(239, 68, 68)'};
+      ? 'rgb(var(--color-success))' 
+      : 'rgb(var(--color-error))'};
     white-space: nowrap;
   }
 `;

--- a/frontend/src/components/FlowEditor/nodes/ConditionalBranchNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ConditionalBranchNode.tsx
@@ -88,15 +88,15 @@ const NodeContainer = styled.div<{ isEvaluating?: boolean }>`
   background: rgb(var(--color-surface));
   border: 2px solid ${props => 
     props.isEvaluating 
-      ? 'rgb(59, 130, 246)' 
+      ? 'rgb(var(--color-info))' 
       : 'rgb(var(--color-border))'
   };
   border-radius: var(--radius-md);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.1);
   transition: all 0.2s ease;
   
   &:hover {
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 4px 16px rgba(var(--color-overlay), 0.15);
   }
 `;
 
@@ -105,14 +105,14 @@ const NodeHeader = styled.div`
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  background: rgba(59, 130, 246, 0.08);
-  border-bottom: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(var(--color-info), 0.08);
+  border-bottom: 1px solid rgba(var(--color-info), 0.2);
 `;
 
 const IconWrapper = styled.div`
   display: flex;
   align-items: center;
-  color: rgb(59, 130, 246);
+  color: rgb(var(--color-info));
 `;
 
 const NodeTitle = styled.div`
@@ -142,9 +142,9 @@ const ConditionSummary = styled.div`
   color: rgb(var(--color-text-secondary));
   margin-bottom: 12px;
   padding: 8px 12px;
-  background: rgba(59, 130, 246, 0.05);
+  background: rgba(var(--color-info), 0.05);
   border-radius: var(--radius-sm);
-  border-left: 3px solid rgb(59, 130, 246);
+  border-left: 3px solid rgb(var(--color-info));
 `;
 
 const BranchesContainer = styled.div`
@@ -160,14 +160,14 @@ const BranchRow = styled.div<{ branchType: 'true' | 'false' }>`
   padding: 8px 12px;
   background: ${props => 
     props.branchType === 'true' 
-      ? 'rgba(34, 197, 94, 0.08)' 
-      : 'rgba(239, 68, 68, 0.08)'
+      ? 'rgba(var(--color-success), 0.08)' 
+      : 'rgba(var(--color-error), 0.08)'
   };
   border-radius: var(--radius-sm);
   border: 1px solid ${props => 
     props.branchType === 'true' 
-      ? 'rgba(34, 197, 94, 0.2)' 
-      : 'rgba(239, 68, 68, 0.2)'
+      ? 'rgba(var(--color-success), 0.2)' 
+      : 'rgba(var(--color-error), 0.2)'
   };
 `;
 
@@ -177,8 +177,8 @@ const BranchLabel = styled.div<{ branchType: 'true' | 'false' }>`
   font-weight: 500;
   color: ${props => 
     props.branchType === 'true' 
-      ? 'rgb(34, 197, 94)' 
-      : 'rgb(239, 68, 68)'
+      ? 'rgb(var(--color-success))' 
+      : 'rgb(var(--color-error))'
   };
 `;
 
@@ -190,13 +190,13 @@ const BranchBadge = styled.div<{ branchType: 'true' | 'false' }>`
   border-radius: var(--radius-xs);
   background: ${props => 
     props.branchType === 'true' 
-      ? 'rgba(34, 197, 94, 0.15)' 
-      : 'rgba(239, 68, 68, 0.15)'
+      ? 'rgba(var(--color-success), 0.15)' 
+      : 'rgba(var(--color-error), 0.15)'
   };
   color: ${props => 
     props.branchType === 'true' 
-      ? 'rgb(34, 197, 94)' 
-      : 'rgb(239, 68, 68)'
+      ? 'rgb(var(--color-success))' 
+      : 'rgb(var(--color-error))'
   };
 `;
 
@@ -208,13 +208,13 @@ const EvaluationResult = styled.div<{ result: boolean }>`
   border-radius: var(--radius-sm);
   background: ${props => 
     props.result 
-      ? 'rgba(34, 197, 94, 0.1)' 
-      : 'rgba(239, 68, 68, 0.1)'
+      ? 'rgba(var(--color-success), 0.1)' 
+      : 'rgba(var(--color-error), 0.1)'
   };
   color: ${props => 
     props.result 
-      ? 'rgb(34, 197, 94)' 
-      : 'rgb(239, 68, 68)'
+      ? 'rgb(var(--color-success))' 
+      : 'rgb(var(--color-error))'
   };
   text-align: center;
 `;
@@ -224,8 +224,8 @@ const StyledHandle = styled(Handle)<{ handleType: 'true' | 'false' }>`
   height: 14px;
   border: 2px solid ${props => 
     props.handleType === 'true' 
-      ? 'rgb(34, 197, 94)' 
-      : 'rgb(239, 68, 68)'
+      ? 'rgb(var(--color-success))' 
+      : 'rgb(var(--color-error))'
   };
   background: rgb(var(--color-surface));
   border-radius: 6px;
@@ -245,8 +245,8 @@ const StyledHandle = styled(Handle)<{ handleType: 'true' | 'false' }>`
   &:hover {
     background: ${props => 
       props.handleType === 'true' 
-        ? 'rgba(34, 197, 94, 0.2)' 
-        : 'rgba(239, 68, 68, 0.2)'
+        ? 'rgba(var(--color-success), 0.2)' 
+        : 'rgba(var(--color-error), 0.2)'
     };
     transform: scale(1.08);
   }

--- a/frontend/src/components/FlowEditor/nodes/ContainerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ContainerNode.tsx
@@ -226,7 +226,7 @@ const NodeCount = styled.div`
  *     label: 'Authentication Flow',
  *     description: 'User login and session management',
  *     childNodeIds: ['node-1', 'node-2', 'node-3'],
- *     backgroundColor: 'rgba(103, 126, 234, 0.05)',
+ *     backgroundColor: 'rgba(var(--color-primary), 0.05)',
  *     borderColor: 'rgb(var(--color-primary))',
  *   },
  * };

--- a/frontend/src/components/FlowEditor/nodes/DocumentNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/DocumentNode.tsx
@@ -98,31 +98,31 @@ const getDocumentTypeInfo = (documentType: DocumentType) => {
       return {
         icon: FilePlus,
         label: 'Generate Document',
-        color: 'rgb(34, 197, 94)', // Green
+        color: 'rgb(var(--color-success))', // Green
       };
     case 'merge':
       return {
         icon: Layers,
         label: 'Merge Documents',
-        color: 'rgb(59, 130, 246)', // Blue
+        color: 'rgb(var(--color-info))', // Blue
       };
     case 'sign':
       return {
         icon: FileCheck,
         label: 'Request Signature',
-        color: 'rgb(147, 51, 234)', // Purple
+        color: 'rgb(var(--color-primary))',
       };
     case 'store':
       return {
         icon: FolderOpen,
         label: 'Store Document',
-        color: 'rgb(234, 179, 8)', // Yellow
+        color: 'rgb(var(--color-warning))', // Yellow
       };
     default:
       return {
         icon: FileText,
         label: 'Document',
-        color: 'rgb(156, 163, 175)', // Gray
+        color: 'rgb(var(--color-text-tertiary))',
       };
   }
 };

--- a/frontend/src/components/FlowEditor/nodes/FormProcessAddButtonNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessAddButtonNode.tsx
@@ -26,7 +26,7 @@ const CircleButton = styled.button`
   color: white;
   box-shadow:
     0 12px 24px rgba(var(--color-primary), 0.25),
-    0 2px 8px rgba(0, 0, 0, 0.10);
+    0 2px 8px rgba(var(--color-overlay), 0.10);
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
@@ -57,9 +57,9 @@ const ChildContainer = styled.div<{ stepIndex: number; isFirst: boolean; isLast:
   margin-bottom: ${props => props.isLast ? '0' : '24px'};
   padding: 16px;
   background: rgb(var(--color-background-primary));
-  border: 2px solid rgba(139, 92, 246, 0.2);
+  border: 2px solid rgba(var(--color-primary), 0.2);
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 6px rgba(var(--color-overlay), 0.05);
   transition: all 0.2s ease;
   
   /* Step indicator line */
@@ -72,14 +72,14 @@ const ChildContainer = styled.div<{ stepIndex: number; isFirst: boolean; isLast:
       transform: translateX(-50%);
       width: 2px;
       height: 24px;
-      background: rgba(139, 92, 246, 0.3);
+      background: rgba(var(--color-primary), 0.3);
       pointer-events: none;
     }
   `}
   
   &:hover {
-    border-color: rgba(139, 92, 246, 0.4);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    border-color: rgba(var(--color-primary), 0.4);
+    box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.08);
   }
   
   /* Drag handle indicator */
@@ -90,7 +90,7 @@ const ChildContainer = styled.div<{ stepIndex: number; isFirst: boolean; isLast:
     top: 50%;
     transform: translateY(-50%);
     font-size: 14px;
-    color: rgba(139, 92, 246, 0.3);
+    color: rgba(var(--color-primary), 0.3);
     cursor: grab;
     user-select: none;
     opacity: 0;
@@ -109,13 +109,13 @@ const StepBadge = styled.div`
   position: absolute;
   top: -12px;
   left: 12px;
-  background: rgba(139, 92, 246, 0.9);
+  background: rgba(var(--color-primary), 0.9);
   color: white;
   font-size: 11px;
   font-weight: 600;
   padding: 4px 10px;
   border-radius: 12px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 4px rgba(var(--color-overlay), 0.15);
   z-index: 1;
   pointer-events: none;
   user-select: none;

--- a/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
@@ -71,13 +71,13 @@ const ContainerWrapper = styled.div<{ isExpanded: boolean }>`
   border-width: 2px;
   border-style: ${props => props.isExpanded ? 'dashed' : 'solid'};
   border-color: ${props => props.isExpanded 
-    ? 'rgba(139, 92, 246, 0.4)' 
-    : 'rgba(139, 92, 246, 0.6)'};
+    ? 'rgba(var(--color-primary), 0.4)' 
+    : 'rgba(var(--color-primary), 0.6)'};
   
   border-radius: 12px;
   box-shadow: 
-    0 4px 12px rgba(0, 0, 0, 0.12),
-    0 0 0 4px rgba(139, 92, 246, 0.15);
+    0 4px 12px rgba(var(--color-overlay), 0.12),
+    0 0 0 4px rgba(var(--color-primary), 0.15);
   
   /* FIX: Smooth transition but preserve border */
   transition: 
@@ -100,7 +100,7 @@ const ContainerWrapper = styled.div<{ isExpanded: boolean }>`
       right: 12px;
       font-size: 10px;
       font-weight: 500;
-      color: rgba(139, 92, 246, 0.5);
+      color: rgba(var(--color-primary), 0.5);
       text-transform: uppercase;
       letter-spacing: 0.5px;
       pointer-events: none;
@@ -109,26 +109,26 @@ const ContainerWrapper = styled.div<{ isExpanded: boolean }>`
   
   &:hover {
     box-shadow: 
-      0 6px 16px rgba(0, 0, 0, 0.18),
-      0 0 0 4px rgba(139, 92, 246, 0.25);
+      0 6px 16px rgba(var(--color-overlay), 0.18),
+      0 0 0 4px rgba(var(--color-primary), 0.25);
   }
   
   &.selected {
     border-color: ${props => props.isExpanded 
-      ? 'rgba(139, 92, 246, 0.6)' 
-      : 'rgb(139, 92, 246)'};
+      ? 'rgba(var(--color-primary), 0.6)' 
+      : 'rgb(var(--color-primary))'};
     box-shadow: 
-      0 8px 20px rgba(0, 0, 0, 0.25),
-      0 0 0 4px rgba(139, 92, 246, 0.4);
+      0 8px 20px rgba(var(--color-overlay), 0.25),
+      0 0 0 4px rgba(var(--color-primary), 0.4);
   }
   
   &.drag-over {
-    border-color: rgb(34, 197, 94);
+    border-color: rgb(var(--color-success));
     border-style: ${props => props.isExpanded ? 'dashed' : 'solid'};
     box-shadow: 
-      0 8px 20px rgba(34, 197, 94, 0.3),
-      0 0 0 4px rgba(34, 197, 94, 0.4);
-    background: rgba(34, 197, 94, 0.08);
+      0 8px 20px rgba(var(--color-success), 0.3),
+      0 0 0 4px rgba(var(--color-success), 0.4);
+    background: rgba(var(--color-success), 0.08);
   }
 `;
 
@@ -138,7 +138,7 @@ const ContainerHeader = styled.div`
   gap: 10px;
   padding: 12px 16px;
   /* Solid color header like regular nodes */
-  background: rgb(139, 92, 246);
+  background: rgb(var(--color-primary));
   border-bottom: none;
   border-radius: 10px 10px 0 0;
   cursor: grab;
@@ -147,7 +147,7 @@ const ContainerHeader = styled.div`
   overflow: hidden; /* Contain header styling within rounded corners */
   
   &:hover {
-    background: rgb(124, 77, 235); /* Slightly darker on hover */
+    background: rgb(var(--color-primary-hover));
   }
 
   &:active {
@@ -168,7 +168,7 @@ const ExpandIcon = styled.button`
   cursor: pointer;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.16);
+    background: rgba(var(--color-header-background), 0.16);
   }
 `;
 
@@ -184,14 +184,14 @@ const ContainerTitle = styled.div`
     margin: 0;
     font-size: 15px;
     font-weight: 700;
-    color: rgba(255, 255, 255, 0.98);
+    color: rgba(var(--color-header-background), 0.98);
     line-height: 1.3;
   }
   
   p {
     margin: 4px 0 0;
     font-size: 12px;
-    color: rgba(255, 255, 255, 0.85);
+    color: rgba(var(--color-header-background), 0.85);
     line-height: 1.2;
   }
 `;
@@ -204,8 +204,8 @@ const StatusBadge = styled.div<{ type: 'configured' | 'draft' }>`
   text-transform: uppercase;
   letter-spacing: 0.5px;
   background: ${props => props.type === 'configured' 
-    ? 'rgba(255, 255, 255, 0.3)' 
-    : 'rgba(255, 255, 255, 0.2)'};
+    ? 'rgba(var(--color-header-background), 0.3)' 
+    : 'rgba(var(--color-header-background), 0.2)'};
   color: white;
 `;
 
@@ -224,8 +224,8 @@ const ChildNodesArea = styled.div`
   position: relative;
   min-height: 300px;
   border-radius: 8px;
-  border: 1px dashed rgba(139, 92, 246, 0.2);
-  background: rgba(255, 255, 255, 0.02);
+  border: 1px dashed rgba(var(--color-primary), 0.2);
+  background: rgba(var(--color-header-background), 0.02);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -234,7 +234,7 @@ const ChildNodesArea = styled.div`
   
   &:empty::before {
     content: 'Drag nodes here to add steps to this form process';
-    color: rgba(139, 92, 246, 0.4);
+    color: rgba(var(--color-primary), 0.4);
     font-size: 13px;
     text-align: center;
     font-style: italic;
@@ -312,11 +312,11 @@ const EmptyState = styled.div`
   .drop-hint {
     margin-top: 12px;
     padding: 8px 12px;
-    background: rgba(139, 92, 246, 0.1);
-    border: 1px dashed rgba(139, 92, 246, 0.3);
+    background: rgba(var(--color-primary), 0.1);
+    border: 1px dashed rgba(var(--color-primary), 0.3);
     border-radius: 6px;
     font-size: 12px;
-    color: rgb(139, 92, 246);
+    color: rgb(var(--color-primary));
     font-weight: 500;
   }
 `;
@@ -325,7 +325,7 @@ const ConfigButton = styled.button`
   width: 100%;
   padding: 10px;
   margin-top: 12px;
-  background: linear-gradient(135deg, rgb(139, 92, 246), rgb(109, 40, 217));
+  background: linear-gradient(135deg, rgb(var(--color-primary)), rgb(var(--color-primary-active)));
   color: white;
   border: none;
   border-radius: 6px;
@@ -338,7 +338,7 @@ const ConfigButton = styled.button`
   
   &:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+    box-shadow: 0 4px 12px rgba(var(--color-primary), 0.3);
   }
   
   &:active {
@@ -353,7 +353,7 @@ const ToolbarCard = styled.div`
   padding: 6px;
   border-radius: 8px;
   border: 1px solid rgb(var(--color-border));
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.15);
   z-index: 50;
 `;
 
@@ -363,13 +363,13 @@ const ToolbarBtn = styled.button<{ $danger?: boolean }>`
   border: none;
   background: transparent;
   cursor: pointer;
-  color: ${(props) => (props.$danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-text-secondary))')};
+  color: ${(props) => (props.$danger ? 'rgb(var(--color-error))' : 'rgb(var(--color-text-secondary))')};
   transition: all 0.15s ease;
 
   &:hover {
     background: ${(props) =>
-      props.$danger ? 'rgba(239, 68, 68, 0.1)' : 'rgba(var(--color-primary), 0.1)'};
-    color: ${(props) => (props.$danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-primary))')};
+      props.$danger ? 'rgba(var(--color-error), 0.1)' : 'rgba(var(--color-primary), 0.1)'};
+    color: ${(props) => (props.$danger ? 'rgb(var(--color-error))' : 'rgb(var(--color-primary))')};
   }
 `;
 
@@ -386,15 +386,15 @@ const StepItem = styled.div`
   align-items: center;
   gap: 10px;
   padding: 8px 12px;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(var(--color-header-background), 0.05);
   border-radius: 6px;
-  border: 1px solid rgba(139, 92, 246, 0.2);
+  border: 1px solid rgba(var(--color-primary), 0.2);
   font-size: 12px;
   transition: all 0.2s ease;
   
   &:hover {
-    background: rgba(139, 92, 246, 0.08);
-    border-color: rgba(139, 92, 246, 0.3);
+    background: rgba(var(--color-primary), 0.08);
+    border-color: rgba(var(--color-primary), 0.3);
   }
 `;
 
@@ -402,8 +402,8 @@ const StepNumber = styled.div`
   min-width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: rgba(139, 92, 246, 0.2);
-  color: rgb(139, 92, 246);
+  background: rgba(var(--color-primary), 0.2);
+  color: rgb(var(--color-primary));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -433,9 +433,9 @@ const EnterButton = styled.button`
   width: 100%;
   padding: 10px;
   margin-top: 8px;
-  background: rgba(59, 130, 246, 0.15);
-  color: rgb(59, 130, 246);
-  border: 1px solid rgba(59, 130, 246, 0.3);
+  background: rgba(var(--color-info), 0.15);
+  color: rgb(var(--color-info));
+  border: 1px solid rgba(var(--color-info), 0.3);
   border-radius: 6px;
   font-size: 13px;
   font-weight: 600;
@@ -449,8 +449,8 @@ const EnterButton = styled.button`
   z-index: 20; 
   
   &:hover {
-    background: rgba(59, 130, 246, 0.25);
-    border-color: rgba(59, 130, 246, 0.5);
+    background: rgba(var(--color-info), 0.25);
+    border-color: rgba(var(--color-info), 0.5);
     transform: translateY(-1px);
   }
   
@@ -684,9 +684,9 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
                     fontWeight: 700,
                     fontSize: '16px',
                     borderRadius: 8,
-                    border: '1px solid rgba(255,255,255,0.45)',
+                    border: '1px solid rgba(var(--color-header-background), 0.45)',
                     padding: '6px 8px',
-                    background: 'rgba(255,255,255,0.16)',
+                    background: 'rgba(var(--color-header-background), 0.16)',
                     color: 'white',
                   }}
                   onClick={(e) => e.stopPropagation()}
@@ -784,7 +784,7 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
                       {stats.stepOrder.size > 5 && (
                         <div style={{ 
                           fontSize: '11px', 
-                          color: 'rgba(139, 92, 246, 0.6)',
+                          color: 'rgba(var(--color-primary), 0.6)',
                           textAlign: 'center',
                           marginTop: '4px',
                         }}>
@@ -798,10 +798,10 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
                     <div style={{
                       marginTop: '12px',
                       padding: '8px 12px',
-                      background: 'rgba(59, 130, 246, 0.1)',
+                      background: 'rgba(var(--color-info), 0.1)',
                       borderRadius: '6px',
                       fontSize: '12px',
-                      color: 'rgb(59, 130, 246)',
+                      color: 'rgb(var(--color-info))',
                     }}>
                       ℹ️ Child nodes are visible on the main canvas
                     </div>

--- a/frontend/src/components/FlowEditor/nodes/FormReferenceNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormReferenceNode.tsx
@@ -280,7 +280,7 @@ export const FormReferenceNode = React.memo<NodeProps<Node<FormReferenceNodeData
         id: 'formReference',
         name: 'Form Reference',
         category: 'form',
-        color: 'rgb(99, 102, 241)', // Indigo
+        color: 'rgb(var(--color-primary))', // Indigo
         icon: '📋',
         description: 'Embed a reusable form inside the workflow',
         maxInputs: 1,

--- a/frontend/src/components/FlowEditor/nodes/FormStepNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormStepNode.tsx
@@ -137,7 +137,7 @@ const ToolbarCard = styled.div`
   border-radius: 10px;
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 8px 22px rgba(var(--color-overlay), 0.12);
 `;
 
 const ToolbarBtn = styled.button<{ $danger?: boolean }>`
@@ -149,7 +149,7 @@ const ToolbarBtn = styled.button<{ $danger?: boolean }>`
   border-radius: 8px;
   border: 1px solid rgb(var(--color-border));
   background: rgb(var(--color-background));
-  color: ${(p) => (p.$danger ? 'rgb(239, 68, 68)' : 'rgb(var(--color-text-primary))')};
+  color: ${(p) => (p.$danger ? 'rgb(var(--color-error))' : 'rgb(var(--color-text-primary))')};
   cursor: pointer;
 
   &:hover {

--- a/frontend/src/components/FlowEditor/nodes/FormStepSingleNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormStepSingleNode.tsx
@@ -153,7 +153,7 @@ const FieldLabel = styled.span`
 `;
 
 const RequiredBadge = styled.span`
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   font-weight: 700;
 `;
 

--- a/frontend/src/components/FlowEditor/nodes/LoopNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/LoopNode.tsx
@@ -100,9 +100,9 @@ const Badge = styled.div`
   border-radius: 999px;
   font-size: 11px;
   font-weight: 800;
-  background: rgba(234, 179, 8, 0.14);
-  border: 1px solid rgba(234, 179, 8, 0.28);
-  color: rgb(234, 179, 8);
+  background: rgba(var(--color-warning), 0.14);
+  border: 1px solid rgba(var(--color-warning), 0.28);
+  color: rgb(var(--color-warning));
 `;
 
 const HandleLabel = styled.div<{ $pos: 'top' | 'bottom'; $left: string }>`
@@ -121,8 +121,8 @@ const BodyHint = styled.div`
   margin-top: 10px;
   padding: 10px;
   border-radius: var(--radius-md);
-  border: 1px dashed rgba(234, 179, 8, 0.35);
-  background: rgba(234, 179, 8, 0.06);
+  border: 1px dashed rgba(var(--color-warning), 0.35);
+  background: rgba(var(--color-warning), 0.06);
   color: rgb(var(--color-text-secondary));
   font-size: 12px;
 `;
@@ -131,8 +131,8 @@ const IterationCounter = styled.div`
   margin-top: 10px;
   padding: 8px 10px;
   border-radius: var(--radius-md);
-  background: rgba(234, 179, 8, 0.1);
-  color: rgb(234, 179, 8);
+  background: rgba(var(--color-warning), 0.1);
+  color: rgb(var(--color-warning));
   font-size: 12px;
   font-weight: 700;
   text-align: center;

--- a/frontend/src/components/FlowEditor/nodes/OutlookEmailNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/OutlookEmailNode.tsx
@@ -13,7 +13,7 @@ const NodeContainer = styled.div`
   border-radius: 8px;
   padding: 12px;
   min-width: 200px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(var(--color-overlay), 0.1);
   
   &.selected {
     border-color: rgb(var(--color-primary));

--- a/frontend/src/components/FlowEditor/nodes/ParallelPathNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/ParallelPathNode.tsx
@@ -72,15 +72,15 @@ const PathIndicator = styled.div<{ $index: number }>`
   align-items: center;
   gap: 8px;
   padding: 4px 8px;
-  background: rgba(139, 92, 246, 0.1);
-  border-left: 3px solid rgb(139, 92, 246);
+  background: rgba(var(--color-primary), 0.1);
+  border-left: 3px solid rgb(var(--color-primary));
   border-radius: 4px;
   font-size: 11px;
 `;
 
 const PathNumber = styled.span`
   font-weight: 700;
-  color: rgb(139, 92, 246);
+  color: rgb(var(--color-primary));
   min-width: 24px;
 `;
 
@@ -99,11 +99,11 @@ const StrategyBadge = styled.span<{ $type: 'wait' | 'error' }>`
   font-size: 10px;
   font-weight: 600;
   background: ${props => props.$type === 'wait' 
-    ? 'rgba(59, 130, 246, 0.15)' 
-    : 'rgba(239, 68, 68, 0.15)'};
+    ? 'rgba(var(--color-info), 0.15)' 
+    : 'rgba(var(--color-error), 0.15)'};
   color: ${props => props.$type === 'wait' 
-    ? 'rgb(59, 130, 246)' 
-    : 'rgb(239, 68, 68)'};
+    ? 'rgb(var(--color-info))' 
+    : 'rgb(var(--color-error))'};
 `;
 
 const ConfigRow = styled.div`

--- a/frontend/src/components/FlowEditor/nodes/SmartWorkFormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/SmartWorkFormNode.tsx
@@ -366,7 +366,7 @@ const StepCard = styled.div<{ $active?: boolean; $isDrop?: boolean }>`
   ${(p) =>
     p.$isDrop
       ? `
-    outline: 2px dashed rgb(34, 197, 94);
+    outline: 2px dashed rgb(var(--color-success));
     outline-offset: 2px;
   `
       : ''}
@@ -887,7 +887,7 @@ export const SmartWorkFormNode = React.memo<NodeProps<SmartWorkFormFlowNode>>(({
                       <div style={{ display: 'flex', gap: 10, marginTop: 2 }}>
                         <FieldType>{f.type || 'text'}</FieldType>
                         {f.required ? (
-                          <FieldType style={{ color: 'rgb(239, 68, 68)' }}>required</FieldType>
+                          <FieldType style={{ color: 'rgb(var(--color-error))' }}>required</FieldType>
                         ) : null}
                       </div>
                     </div>

--- a/frontend/src/components/FlowEditor/nodes/SubWorkflowNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/SubWorkflowNode.tsx
@@ -100,7 +100,7 @@ const WorkflowIcon = styled.div`
   width: 24px;
   height: 24px;
   border-radius: 4px;
-  background: linear-gradient(135deg, rgb(99, 102, 241) 0%, rgb(139, 92, 246) 100%);
+  background: linear-gradient(135deg, rgb(var(--color-primary)) 0%, rgb(var(--color-primary)) 100%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -121,8 +121,8 @@ const WorkflowName = styled.div`
 
 const VersionBadge = styled.span`
   padding: 2px 6px;
-  background: rgba(99, 102, 241, 0.15);
-  color: rgb(99, 102, 241);
+  background: rgba(var(--color-primary), 0.15);
+  color: rgb(var(--color-primary));
   font-size: 9px;
   font-weight: 600;
   border-radius: var(--radius-sm);
@@ -153,7 +153,7 @@ const MappingItem = styled.div`
   gap: 6px;
   font-size: 10px;
   padding: 3px 6px;
-  background: rgba(99, 102, 241, 0.05);
+  background: rgba(var(--color-primary), 0.05);
   border-radius: 3px;
 `;
 
@@ -196,7 +196,7 @@ const ConfigOption = styled.div`
 
 const ConfigIcon = styled.span<{ $active: boolean }>`
   color: ${props => props.$active 
-    ? 'rgb(34, 197, 94)' 
+    ? 'rgb(var(--color-success))' 
     : 'rgb(var(--color-text-tertiary))'};
   font-size: 11px;
 `;
@@ -208,17 +208,17 @@ const ErrorStrategyBadge = styled.span<{ $strategy: string }>`
   font-weight: 600;
   background: ${props => {
     switch (props.$strategy) {
-      case 'fail': return 'rgba(239, 68, 68, 0.15)';
-      case 'continue': return 'rgba(234, 179, 8, 0.15)';
-      case 'retry': return 'rgba(59, 130, 246, 0.15)';
-      default: return 'rgba(0, 0, 0, 0.05)';
+      case 'fail': return 'rgba(var(--color-error), 0.15)';
+      case 'continue': return 'rgba(var(--color-warning), 0.15)';
+      case 'retry': return 'rgba(var(--color-info), 0.15)';
+      default: return 'rgba(var(--color-overlay), 0.05)';
     }
   }};
   color: ${props => {
     switch (props.$strategy) {
-      case 'fail': return 'rgb(239, 68, 68)';
-      case 'continue': return 'rgb(234, 179, 8)';
-      case 'retry': return 'rgb(59, 130, 246)';
+      case 'fail': return 'rgb(var(--color-error))';
+      case 'continue': return 'rgb(var(--color-warning))';
+      case 'retry': return 'rgb(var(--color-info))';
       default: return 'rgb(var(--color-text-secondary))';
     }
   }};

--- a/frontend/src/components/FlowEditor/nodes/TerminalNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/TerminalNode.tsx
@@ -101,25 +101,25 @@ const getTerminalTypeInfo = (terminalType: TerminalType) => {
       return {
         icon: CheckCircle2,
         label: 'Success',
-        color: 'rgb(34, 197, 94)', // Green
+        color: 'rgb(var(--color-success))', // Green
       };
     case 'error':
       return {
         icon: XCircle,
         label: 'Error',
-        color: 'rgb(239, 68, 68)', // Red
+        color: 'rgb(var(--color-error))', // Red
       };
     case 'cancel':
       return {
         icon: Ban,
         label: 'Cancelled',
-        color: 'rgb(156, 163, 175)', // Gray
+        color: 'rgb(var(--color-text-tertiary))',
       };
     default:
       return {
         icon: CheckCircle2,
         label: 'End',
-        color: 'rgb(156, 163, 175)', // Gray
+        color: 'rgb(var(--color-text-tertiary))',
       };
   }
 };

--- a/frontend/src/components/FlowEditor/nodes/TriggerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/TriggerNode.tsx
@@ -64,7 +64,7 @@ const ConfigValue = styled.span`
   white-space: nowrap;
   font-family: monospace;
   font-size: 10px;
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(var(--color-overlay), 0.05);
   padding: 2px 4px;
   border-radius: 2px;
 `;
@@ -77,22 +77,22 @@ const TriggerBadge = styled.span<{ $type: string }>`
   font-weight: 600;
   background: ${props => {
     switch (props.$type) {
-      case 'manual': return 'rgba(34, 197, 94, 0.2)';
-      case 'schedule': return 'rgba(59, 130, 246, 0.2)';
-      case 'webhook': return 'rgba(168, 85, 247, 0.2)';
-      case 'event': return 'rgba(234, 179, 8, 0.2)';
-      case 'form': return 'rgba(236, 72, 153, 0.2)';
-      default: return 'rgba(148, 163, 184, 0.2)';
+      case 'manual': return 'rgba(var(--color-success), 0.2)';
+      case 'schedule': return 'rgba(var(--color-info), 0.2)';
+      case 'webhook': return 'rgba(var(--color-info), 0.2)';
+      case 'event': return 'rgba(var(--color-warning), 0.2)';
+      case 'form': return 'rgba(var(--color-primary), 0.2)';
+      default: return 'rgba(var(--color-border), 0.2)';
     }
   }};
   color: ${props => {
     switch (props.$type) {
-      case 'manual': return 'rgb(34, 197, 94)';
-      case 'schedule': return 'rgb(59, 130, 246)';
-      case 'webhook': return 'rgb(168, 85, 247)';
-      case 'event': return 'rgb(234, 179, 8)';
-      case 'form': return 'rgb(236, 72, 153)';
-      default: return 'rgb(148, 163, 184)';
+      case 'manual': return 'rgb(var(--color-success))';
+      case 'schedule': return 'rgb(var(--color-info))';
+      case 'webhook': return 'rgb(var(--color-info))';
+      case 'event': return 'rgb(var(--color-warning))';
+      case 'form': return 'rgb(var(--color-primary))';
+      default: return 'rgb(var(--color-text-tertiary))';
     }
   }};
 `;
@@ -130,7 +130,7 @@ export const TriggerNode = React.memo<NodeProps<Node<TriggerNodeData>>>((props) 
     id: 'triggerManual',
     name: 'Manual Trigger',
     category: 'trigger' as const,
-    color: 'rgb(34, 197, 94)',
+    color: 'rgb(var(--color-success))',
     icon: '▶️',
     description: 'User starts the workflow manually',
     maxInputs: 0,

--- a/frontend/src/components/FlowEditor/nodes/UtilityNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/UtilityNode.tsx
@@ -111,31 +111,31 @@ const getUtilityTypeInfo = (utilityType: UtilityType) => {
       return {
         icon: Shuffle,
         label: 'Transform Data',
-        color: 'rgb(59, 130, 246)', // Blue
+        color: 'rgb(var(--color-info))', // Blue
       };
     case 'lookup':
       return {
         icon: Search,
         label: 'Lookup Records',
-        color: 'rgb(147, 51, 234)', // Purple
+        color: 'rgb(var(--color-primary))',
       };
     case 'merge':
       return {
         icon: GitMerge,
         label: 'Merge Data',
-        color: 'rgb(34, 197, 94)', // Green
+        color: 'rgb(var(--color-success))', // Green
       };
     case 'comment':
       return {
         icon: MessageCircle,
         label: 'Comment',
-        color: 'rgb(234, 179, 8)', // Yellow
+        color: 'rgb(var(--color-warning))', // Yellow
       };
     default:
       return {
         icon: Code,
         label: 'Utility',
-        color: 'rgb(156, 163, 175)', // Gray
+        color: 'rgb(var(--color-text-tertiary))',
       };
   }
 };

--- a/frontend/src/components/FlowEditor/nodes/WaitStateNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/WaitStateNode.tsx
@@ -92,31 +92,31 @@ const getWaitTypeInfo = (waitType: WaitType) => {
       return {
         icon: UserCheck,
         label: 'Waiting for Approval',
-        color: 'rgb(234, 179, 8)', // Yellow
+        color: 'rgb(var(--color-warning))', // Yellow
       };
     case 'document':
       return {
         icon: FileText,
         label: 'Waiting for Document',
-        color: 'rgb(59, 130, 246)', // Blue
+        color: 'rgb(var(--color-info))', // Blue
       };
     case 'response':
       return {
         icon: MessageSquare,
         label: 'Waiting for Response',
-        color: 'rgb(147, 51, 234)', // Purple
+        color: 'rgb(var(--color-primary))',
       };
     case 'payment':
       return {
         icon: CreditCard,
         label: 'Waiting for Payment',
-        color: 'rgb(34, 197, 94)', // Green
+        color: 'rgb(var(--color-success))', // Green
       };
     default:
       return {
         icon: Clock,
         label: 'Waiting',
-        color: 'rgb(156, 163, 175)', // Gray
+        color: 'rgb(var(--color-text-tertiary))',
       };
   }
 };

--- a/frontend/src/components/FlowEditor/panels/BatchOperationsToolbar.tsx
+++ b/frontend/src/components/FlowEditor/panels/BatchOperationsToolbar.tsx
@@ -46,7 +46,7 @@ const ToolbarContainer = styled.div<{ $visible: boolean; $position: { x: number;
   padding: 8px;
   display: ${(props) => (props.$visible ? 'flex' : 'none')};
   gap: 4px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.15);
   z-index: 1000;
   backdrop-filter: blur(10px);
   animation: slideInDown 0.2s ease-out;

--- a/frontend/src/components/FlowEditor/panels/DryRunDebuggerPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/DryRunDebuggerPanel.tsx
@@ -29,7 +29,7 @@ const PanelOverlay = styled.div<{ $isVisible: boolean }>`
   width: ${(props) => (props.$isVisible ? '520px' : '0')};
   background: rgb(var(--color-background));
   border-left: 1px solid rgb(var(--color-border));
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
+  box-shadow: -4px 0 12px rgba(var(--color-overlay), 0.1);
   z-index: 120;
   transition: width 0.25s ease;
   overflow: hidden;

--- a/frontend/src/components/FlowEditor/panels/NodeDebuggerPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/NodeDebuggerPanel.tsx
@@ -494,9 +494,9 @@ const WarningBanner = styled.div`
   align-items: center;
   gap: 8px;
   padding: 12px 20px;
-  background: rgb(234, 179, 8, 0.1);
-  border-bottom: 1px solid rgb(234, 179, 8);
-  color: rgb(234, 179, 8);
+  background: rgba(var(--color-warning), 0.1);
+  border-bottom: 1px solid rgb(var(--color-warning));
+  color: rgb(var(--color-warning));
   font-size: 13px;
 `;
 
@@ -565,9 +565,9 @@ const ErrorBadge = styled.div`
   align-items: center;
   gap: 4px;
   padding: 4px 8px;
-  background: rgb(239, 68, 68, 0.1);
+  background: rgba(var(--color-error), 0.1);
   border-radius: 4px;
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   font-size: 11px;
   font-weight: 500;
 `;
@@ -602,9 +602,9 @@ const StatusBanner = styled.div<{ $success: boolean }>`
   gap: 8px;
   padding: 12px 16px;
   border-radius: 6px;
-  background: ${props => props.$success ? 'rgb(34, 197, 94, 0.1)' : 'rgb(239, 68, 68, 0.1)'};
-  border: 1px solid ${props => props.$success ? 'rgb(34, 197, 94)' : 'rgb(239, 68, 68)'};
-  color: ${props => props.$success ? 'rgb(34, 197, 94)' : 'rgb(239, 68, 68)'};
+  background: ${props => props.$success ? 'rgba(var(--color-success), 0.1)' : 'rgba(var(--color-error), 0.1)'};
+  border: 1px solid ${props => props.$success ? 'rgb(var(--color-success))' : 'rgb(var(--color-error))'};
+  color: ${props => props.$success ? 'rgb(var(--color-success))' : 'rgb(var(--color-error))'};
   font-size: 14px;
   font-weight: 500;
   margin-bottom: 16px;
@@ -624,9 +624,9 @@ const ErrorItem = styled.div`
   align-items: flex-start;
   gap: 8px;
   padding: 8px 12px;
-  background: rgb(239, 68, 68, 0.05);
-  border-left: 3px solid rgb(239, 68, 68);
-  color: rgb(239, 68, 68);
+  background: rgba(var(--color-error), 0.05);
+  border-left: 3px solid rgb(var(--color-error));
+  color: rgb(var(--color-error));
   font-size: 13px;
   margin-bottom: 8px;
 `;
@@ -640,9 +640,9 @@ const WarningItem = styled.div`
   align-items: flex-start;
   gap: 8px;
   padding: 8px 12px;
-  background: rgb(234, 179, 8, 0.05);
-  border-left: 3px solid rgb(234, 179, 8);
-  color: rgb(234, 179, 8);
+  background: rgba(var(--color-warning), 0.05);
+  border-left: 3px solid rgb(var(--color-warning));
+  color: rgb(var(--color-warning));
   font-size: 13px;
   margin-bottom: 8px;
 `;
@@ -661,7 +661,7 @@ const ExecuteButton = styled.button`
   width: 100%;
   padding: 12px 20px;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   border: none;
   border-radius: 6px;
   font-size: 14px;

--- a/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
@@ -39,7 +39,7 @@ const PanelOverlay = styled.div<{ $isVisible: boolean }>`
   width: ${props => props.$isVisible ? '450px' : '0'};
   background: rgb(var(--color-background));
   border-left: 1px solid rgb(var(--color-border));
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
+  box-shadow: -4px 0 12px rgba(var(--color-overlay), 0.1);
   z-index: 100;
   transition: width 0.3s ease;
   overflow: hidden;
@@ -147,7 +147,7 @@ const PreviewViewport = styled.div<{ $size: ViewportSize }>`
   max-width: 100%;
   background: white;
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
   padding: 24px;
   transition: width 0.3s ease;
 `;
@@ -172,17 +172,17 @@ const FieldLabel = styled.label`
 
 const FieldInput = styled.input<{ $hasError?: boolean }>`
   padding: 10px 12px;
-  border: 1px solid ${props => props.$hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'};
+  border: 1px solid ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-md);
   font-size: 14px;
   color: rgb(var(--color-text-primary));
-  background: ${props => props.$hasError ? 'rgb(254, 242, 242)' : 'rgb(var(--color-surface))'};
+  background: ${props => props.$hasError ? 'rgba(var(--color-error), 0.08)' : 'rgb(var(--color-surface))'};
   transition: all 0.15s ease;
   
   &:focus {
     outline: none;
-    border-color: ${props => props.$hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-primary))'};
-    box-shadow: 0 0 0 3px ${props => props.$hasError ? 'rgba(239, 68, 68, 0.1)' : 'rgba(var(--color-primary), 0.1)'};
+    border-color: ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-primary))'};
+    box-shadow: 0 0 0 3px ${props => props.$hasError ? 'rgba(var(--color-error), 0.1)' : 'rgba(var(--color-primary), 0.1)'};
   }
   
   &::placeholder {
@@ -192,11 +192,11 @@ const FieldInput = styled.input<{ $hasError?: boolean }>`
 
 const FieldTextarea = styled.textarea<{ $hasError?: boolean }>`
   padding: 10px 12px;
-  border: 1px solid ${props => props.$hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'};
+  border: 1px solid ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-md);
   font-size: 14px;
   color: rgb(var(--color-text-primary));
-  background: ${props => props.$hasError ? 'rgb(254, 242, 242)' : 'rgb(var(--color-surface))'};
+  background: ${props => props.$hasError ? 'rgba(var(--color-error), 0.08)' : 'rgb(var(--color-surface))'};
   font-family: inherit;
   resize: vertical;
   min-height: 80px;
@@ -204,8 +204,8 @@ const FieldTextarea = styled.textarea<{ $hasError?: boolean }>`
   
   &:focus {
     outline: none;
-    border-color: ${props => props.$hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-primary))'};
-    box-shadow: 0 0 0 3px ${props => props.$hasError ? 'rgba(239, 68, 68, 0.1)' : 'rgba(var(--color-primary), 0.1)'};
+    border-color: ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-primary))'};
+    box-shadow: 0 0 0 3px ${props => props.$hasError ? 'rgba(var(--color-error), 0.1)' : 'rgba(var(--color-primary), 0.1)'};
   }
   
   &::placeholder {
@@ -215,18 +215,18 @@ const FieldTextarea = styled.textarea<{ $hasError?: boolean }>`
 
 const FieldSelect = styled.select<{ $hasError?: boolean }>`
   padding: 10px 12px;
-  border: 1px solid ${props => props.$hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'};
+  border: 1px solid ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-md);
   font-size: 14px;
   color: rgb(var(--color-text-primary));
-  background: ${props => props.$hasError ? 'rgb(254, 242, 242)' : 'rgb(var(--color-surface))'};
+  background: ${props => props.$hasError ? 'rgba(var(--color-error), 0.08)' : 'rgb(var(--color-surface))'};
   cursor: pointer;
   transition: all 0.15s ease;
   
   &:focus {
     outline: none;
-    border-color: ${props => props.$hasError ? 'rgb(239, 68, 68)' : 'rgb(var(--color-primary))'};
-    box-shadow: 0 0 0 3px ${props => props.$hasError ? 'rgba(239, 68, 68, 0.1)' : 'rgba(var(--color-primary), 0.1)'};
+    border-color: ${props => props.$hasError ? 'rgb(var(--color-error))' : 'rgb(var(--color-primary))'};
+    box-shadow: 0 0 0 3px ${props => props.$hasError ? 'rgba(var(--color-error), 0.1)' : 'rgba(var(--color-primary), 0.1)'};
   }
 `;
 
@@ -237,7 +237,7 @@ const FieldHelpText = styled.span`
 
 const FieldError = styled.div`
   font-size: 12px;
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   margin-top: 4px;
   display: flex;
   align-items: center;
@@ -246,8 +246,8 @@ const FieldError = styled.div`
 `;
 
 const ValidationSummary = styled.div`
-  background: rgb(254, 226, 226);
-  border: 1px solid rgb(239, 68, 68);
+  background: rgba(var(--color-error), 0.12);
+  border: 1px solid rgb(var(--color-error));
   border-radius: var(--radius-md);
   padding: 12px 16px;
   margin-bottom: 20px;
@@ -257,7 +257,7 @@ const ValidationTitle = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   font-weight: 600;
   font-size: 14px;
   margin-bottom: 8px;
@@ -266,7 +266,7 @@ const ValidationTitle = styled.div`
 const ValidationList = styled.ul`
   margin: 0;
   padding-left: 20px;
-  color: rgb(185, 28, 28);
+  color: rgb(var(--color-danger));
   font-size: 13px;
   
   li {
@@ -712,7 +712,7 @@ export const PreviewPanel: React.FC<PreviewPanelProps> = ({
                   <FormField key={field.id}>
                     <FieldLabel>
                       {field.label}
-                      {field.required && <span style={{ color: 'rgb(239, 68, 68)' }}> *</span>}
+                      {field.required && <span style={{ color: 'rgb(var(--color-error))' }}> *</span>}
                     </FieldLabel>
                     
                     {/* Textarea */}

--- a/frontend/src/components/FlowEditor/templates/TemplateSelector.tsx
+++ b/frontend/src/components/FlowEditor/templates/TemplateSelector.tsx
@@ -32,7 +32,7 @@ const Overlay = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(var(--color-overlay), 0.7);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -48,7 +48,7 @@ const Modal = styled.div`
   max-height: 90vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px rgba(var(--color-overlay), 0.3);
 `;
 
 const Header = styled.div`
@@ -162,7 +162,7 @@ const TemplateCard = styled.div`
   &:hover {
     border-color: rgb(var(--color-primary));
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
   }
 `;
 

--- a/frontend/src/components/FlowEditor/utils/containerStyling.ts
+++ b/frontend/src/components/FlowEditor/utils/containerStyling.ts
@@ -35,10 +35,10 @@ export function getContainerTheme(
   const theme: ContainerTheme = {
     background: 'rgb(var(--color-surface))',
     border: 'rgb(var(--color-border))',
-    shadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
-    hoverShadow: '0 4px 16px rgba(0, 0, 0, 0.15)',
-    dragShadow: '0 8px 24px rgba(102, 126, 234, 0.3)',
-    headerBackground: 'rgba(102, 126, 234, 0.08)',
+    shadow: '0 2px 8px rgba(var(--color-overlay), 0.1)',
+    hoverShadow: '0 4px 16px rgba(var(--color-overlay), 0.15)',
+    dragShadow: '0 8px 24px rgba(var(--color-primary), 0.3)',
+    headerBackground: 'rgba(var(--color-primary), 0.08)',
     headerText: 'rgb(var(--color-text-primary))',
     iconColor: 'rgb(var(--color-primary))',
   };
@@ -48,21 +48,21 @@ export function getContainerTheme(
     // NOTE: theme RGB tokens are stored as "r g b" and must be wrapped with rgb(... / alpha)
     // (not rgba(var(--token), a)).
     theme.background = 'rgb(var(--color-surface) / 0.95)';
-    theme.shadow = '0 1px 4px rgba(0, 0, 0, 0.08)';
-    theme.headerBackground = 'rgba(102, 126, 234, 0.05)';
+    theme.shadow = '0 1px 4px rgba(var(--color-overlay), 0.08)';
+    theme.headerBackground = 'rgba(var(--color-primary), 0.05)';
   }
 
   // Dragging state - emphasized shadow
   if (isDragging) {
     theme.shadow = theme.dragShadow;
-    theme.border = 'rgb(102, 126, 234)'; // Primary color
+    theme.border = 'rgb(var(--color-primary))';
   }
 
   // Drop target state - visual indicator
   if (isDropTarget) {
-    theme.background = 'rgba(102, 126, 234, 0.05)';
-    theme.border = 'rgb(34, 197, 94)'; // Success color
-    theme.shadow = '0 0 0 2px rgba(34, 197, 94, 0.2)';
+    theme.background = 'rgba(var(--color-primary), 0.05)';
+    theme.border = 'rgb(var(--color-success))';
+    theme.shadow = '0 0 0 2px rgba(var(--color-success), 0.2)';
   }
 
   return theme;

--- a/frontend/src/components/FlowEditor/utils/validationEngine.ts
+++ b/frontend/src/components/FlowEditor/utils/validationEngine.ts
@@ -308,7 +308,7 @@ export function getValidationBadgeColor(issues: ValidationIssue[]): string | nul
   const hasError = issues.some(i => i.severity === 'error');
   const hasWarning = issues.some(i => i.severity === 'warning');
   
-  if (hasError) return 'rgb(239, 68, 68)'; // Red
-  if (hasWarning) return 'rgb(234, 179, 8)'; // Yellow
-  return 'rgb(59, 130, 246)'; // Blue (info)
+  if (hasError) return 'rgb(var(--color-error))'; // Red
+  if (hasWarning) return 'rgb(var(--color-warning))'; // Yellow
+  return 'rgb(var(--color-info))'; // Blue (info)
 }

--- a/frontend/src/components/WorkForms/FormPreviewModal.tsx
+++ b/frontend/src/components/WorkForms/FormPreviewModal.tsx
@@ -39,7 +39,7 @@ const Overlay = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -60,7 +60,7 @@ const Modal = styled.div`
   max-height: 90vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px rgba(var(--color-overlay), 0.3);
   animation: slideUp 0.3s ease-out;
 
   @keyframes slideUp {
@@ -112,9 +112,9 @@ const StatusBadge = styled.span<{ $status: 'draft' | 'active' | 'inactive' }>`
   ${props => {
     switch (props.$status) {
       case 'active':
-        return 'background: rgb(34, 197, 94, 0.1); color: rgb(34, 197, 94);';
+        return 'background: rgba(var(--color-success), 0.1); color: rgb(var(--color-success));';
       case 'draft':
-        return 'background: rgb(234, 179, 8, 0.1); color: rgb(234, 179, 8);';
+        return 'background: rgba(var(--color-warning), 0.1); color: rgb(var(--color-warning));';
       case 'inactive':
         return 'background: rgb(var(--color-border)); color: rgb(var(--color-text-secondary));';
     }

--- a/frontend/src/components/WorkForms/FormSelectorModal.tsx
+++ b/frontend/src/components/WorkForms/FormSelectorModal.tsx
@@ -33,7 +33,7 @@ export interface FormSelectorModalProps {
 const Overlay = styled.div<{ $isOpen: boolean }>`
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(var(--color-overlay), 0.5);
   display: ${props => props.$isOpen ? 'flex' : 'none'};
   align-items: center;
   justify-content: center;
@@ -54,7 +54,7 @@ const Modal = styled.div`
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 20px 25px -5px rgba(var(--color-overlay), 0.1), 0 10px 10px -5px rgba(var(--color-overlay), 0.04);
   animation: slideUp 0.3s;
   
   @keyframes slideUp {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -68,6 +68,9 @@
   --color-error: 239, 68, 68; /* red-500 */
   --color-info: 59, 130, 246; /* blue-500 */
 
+  /* --- Overlay/Backdrop --- */
+  --color-overlay: 0, 0, 0;
+
   /* --- Shadows --- */
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Deliverables\n- Replace remaining hardcoded numeric rgb/rgba literals across FlowEditor + WorkForms with theme tokens (CSS custom properties).\n- Add/extend color lint guardrail: lint:colors now also flags numeric rgb/rgba in FlowEditor/WorkForms to prevent regressions.\n\n## Why\nKeeps editor theming tenant-safe + consistent with design system; reduces dark-mode/theming drift and makes future refactors safer.\n\n## Testing\n- npm --prefix frontend run verify-standards\n- npm --prefix frontend run test:ci\n\n## Notes\n- Enforcement is scoped to FlowEditor/WorkForms to avoid legacy churn elsewhere.