### PR TITLE
WorkForms: unify IA terminology

### DIFF
--- a/frontend/src/components/Entities/EntityWorkflowStatusPanel.test.tsx
+++ b/frontend/src/components/Entities/EntityWorkflowStatusPanel.test.tsx
@@ -30,7 +30,7 @@ describe('EntityWorkflowStatusPanel', () => {
       </QueryClientProvider>
     );
 
-    expect(await screen.findByText(/No workflow executions found/i)).toBeInTheDocument();
+    expect(await screen.findByText(/No WorkForm runs found/i)).toBeInTheDocument();
   });
 
   it('renders an execution with audit events and details link', async () => {

--- a/frontend/src/components/Entities/EntityWorkflowStatusPanel.tsx
+++ b/frontend/src/components/Entities/EntityWorkflowStatusPanel.tsx
@@ -115,13 +115,13 @@ export const EntityWorkflowStatusPanel: React.FC<EntityWorkflowStatusPanelProps>
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-      <Card size="small" title="WorkForm executions">
+      <Card size="small" title="WorkForm runs">
         {query.isLoading ? (
           <div style={{ padding: 12 }}>
             <Spin />
           </div>
         ) : executions.length === 0 ? (
-          <div style={{ color: 'rgb(var(--color-text-tertiary))' }}>No workflow executions found for this record.</div>
+          <div style={{ color: 'rgb(var(--color-text-tertiary))' }}>No WorkForm runs found for this record.</div>
         ) : (
           <Collapse
             items={executions.map((ex) => ({

--- a/frontend/src/components/FlowEditor/HelpModal.tsx
+++ b/frontend/src/components/FlowEditor/HelpModal.tsx
@@ -286,7 +286,7 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
     <Overlay onClick={handleOverlayClick}>
       <Modal role="dialog" aria-labelledby="help-modal-title" aria-modal="true">
         <Header>
-          <Title id="help-modal-title">Workflow Editor Help</Title>
+          <Title id="help-modal-title">WorkForms Editor Help</Title>
           <CloseButton 
             onClick={onClose}
             aria-label="Close help modal"

--- a/frontend/src/components/FlowEditor/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/FlowEditor/KeyboardShortcutsModal.tsx
@@ -189,7 +189,7 @@ ${shortcuts
       })
       .join('\n\n');
 
-    const blob = new Blob([`# Workflow Editor Keyboard Shortcuts\n\n${content}`], {
+    const blob = new Blob([`# WorkForms Editor Keyboard Shortcuts\n\n${content}`], {
       type: 'text/markdown',
     });
     const url = URL.createObjectURL(blob);

--- a/frontend/src/components/FlowEditor/Modals/WorkflowManagementModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/WorkflowManagementModal.tsx
@@ -313,11 +313,11 @@ export const WorkflowManagementModal: React.FC<WorkflowManagementModalProps> = (
     const newErrors: { name?: string } = {};
 
     if (!name.trim()) {
-      newErrors.name = 'Workflow name is required';
+      newErrors.name = 'WorkForm name is required';
     } else if (name.trim().length < 3) {
-      newErrors.name = 'Workflow name must be at least 3 characters';
+      newErrors.name = 'WorkForm name must be at least 3 characters';
     } else if (name.trim().length > 100) {
-      newErrors.name = 'Workflow name must be less than 100 characters';
+      newErrors.name = 'WorkForm name must be less than 100 characters';
     }
 
     setErrors(newErrors);
@@ -357,7 +357,7 @@ export const WorkflowManagementModal: React.FC<WorkflowManagementModalProps> = (
       <ModalContent onClick={handleContentClick} onKeyDown={handleKeyDown}>
         <ModalHeader>
           <ModalTitle>
-            {mode === 'create' ? 'Create New Workflow' : 'Edit Workflow'}
+            {mode === 'create' ? 'Create New WorkForm' : 'Edit WorkForm'}
           </ModalTitle>
           <CloseButton onClick={onClose} title="Close (ESC)">
             <X size={18} />
@@ -365,10 +365,10 @@ export const WorkflowManagementModal: React.FC<WorkflowManagementModalProps> = (
         </ModalHeader>
 
         <ModalBody>
-          {/* Workflow Name */}
+          {/* WorkForm Name */}
           <FormGroup>
             <Label htmlFor="workflow-name">
-              Workflow Name
+              WorkForm Name
               <RequiredIndicator>*</RequiredIndicator>
             </Label>
             <Input
@@ -387,7 +387,7 @@ export const WorkflowManagementModal: React.FC<WorkflowManagementModalProps> = (
               </ErrorText>
             )}
             <HelpText>
-              Choose a descriptive name that identifies the workflow's purpose
+              Choose a descriptive name that identifies the WorkForm's purpose
             </HelpText>
           </FormGroup>
 
@@ -400,10 +400,10 @@ export const WorkflowManagementModal: React.FC<WorkflowManagementModalProps> = (
               id="workflow-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="Describe what this workflow does and when to use it..."
+              placeholder="Describe what this WorkForm does and when to use it..."
             />
             <HelpText>
-              Optional. Add details to help team members understand this workflow.
+              Optional. Add details to help team members understand this WorkForm.
             </HelpText>
           </FormGroup>
 
@@ -433,7 +433,7 @@ export const WorkflowManagementModal: React.FC<WorkflowManagementModalProps> = (
           </Button>
           <Button $variant="primary" onClick={handleSave}>
             <Save size={16} />
-            {mode === 'create' ? 'Create Workflow' : 'Save Changes'}
+            {mode === 'create' ? 'Create WorkForm' : 'Save Changes'}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -4258,14 +4258,14 @@ export const parallelPathSchema: NodeConfigSchema = {
 };
 
 /**
- * Sub-Workflow Node Schema
+ * Sub-WorkForm Node Schema
  * 
- * Executes another workflow as a reusable sub-process.
+ * Runs another WorkForm as a reusable sub-process.
  */
 export const subWorkflowSchema: NodeConfigSchema = {
   nodeType: 'subWorkflow',
-  displayName: 'Sub-Workflow',
-  description: 'Execute another workflow as a sub-process',
+  displayName: 'Sub-WorkForm',
+  description: 'Run another WorkForm as a sub-process',
   icon: Package,
   version: '1.0.0',
   tags: ['logic', 'subflow', 'reusable'],
@@ -4273,21 +4273,21 @@ export const subWorkflowSchema: NodeConfigSchema = {
   sections: [
     {
       id: 'workflow',
-      title: 'Workflow Selection',
+      title: 'WorkForm Selection',
       icon: Package,
       defaultExpanded: true,
       fields: [
         {
           id: 'workflowId',
           type: 'text',
-          label: 'Workflow ID',
-          placeholder: 'Select workflow...',
+          label: 'WorkForm ID',
+          placeholder: 'Select WorkForm...',
           required: true,
         },
         {
           id: 'workflowName',
           type: 'text',
-          label: 'Workflow Name',
+          label: 'WorkForm Name',
           placeholder: 'Display name',
         },
         {
@@ -4336,9 +4336,9 @@ export const subWorkflowSchema: NodeConfigSchema = {
           type: 'select',
           label: 'On Error',
           options: [
-            { value: 'fail', label: 'Fail Parent Workflow' },
-            { value: 'continue', label: 'Continue Parent Workflow' },
-            { value: 'retry', label: 'Retry Sub-Workflow' },
+            { value: 'fail', label: 'Fail Parent WorkForm' },
+            { value: 'continue', label: 'Continue Parent WorkForm' },
+            { value: 'retry', label: 'Retry Sub-WorkForm' },
           ],
           defaultValue: 'fail',
           required: true,

--- a/frontend/src/components/FlowEditor/nodeTypes.ts
+++ b/frontend/src/components/FlowEditor/nodeTypes.ts
@@ -330,11 +330,11 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
   
   subWorkflow: {
     id: 'subWorkflow',
-    name: 'Sub-Workflow',
+    name: 'Sub-WorkForm',
     category: 'logic',
     icon: '🔗',
     color: 'rgb(var(--color-info))', // indigo
-    description: 'Execute another workflow as a sub-process',
+    description: 'Run another WorkForm as a sub-process',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
@@ -649,11 +649,11 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
   
   groupSubflow: {
     id: 'groupSubflow',
-    name: 'Sub-Workflow',
+    name: 'Sub-WorkForm',
     category: 'utility',
     icon: '📦',
     color: 'rgb(var(--color-text-secondary))',
-    description: 'Encapsulate reusable sub-workflow',
+    description: 'Encapsulate reusable sub-workform',
     maxInputs: 1,
     maxOutputs: 1,
     requiresConfig: true,
@@ -666,7 +666,7 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
     category: 'terminal',
     icon: '✅',
     color: 'rgb(var(--color-success))', // green
-    description: 'Successful completion of workflow',
+    description: 'Successful completion of WorkForm',
     maxInputs: 1,
     maxOutputs: 0,
   },
@@ -677,7 +677,7 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeDefinition> = {
     category: 'terminal',
     icon: '❌',
     color: 'rgb(var(--color-error))', // red
-    description: 'Error termination of workflow',
+    description: 'Error termination of WorkForm',
     maxInputs: 1,
     maxOutputs: 0,
   },

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -262,7 +262,7 @@ const Header: React.FC<HeaderProps> = () => {
                     }}
                   >
                     <span>🗂️</span>
-                    <span>View All Workflows</span>
+                    <span>View Legacy Workflows</span>
                   </SubmenuItem>
                   
                   {availableForms.filter((f) => (f.type ?? 'form') === 'form').length > 0 && (
@@ -321,7 +321,7 @@ const Header: React.FC<HeaderProps> = () => {
                               setShowQuickMenu(false);
                               setShowFormsSubmenu(false);
                             }}
-                            title={`Execute ${wf.name}`}
+                            title={`Run ${wf.name}`}
                           >
                             <span>▶️</span>
                             <span>{wf.name}</span>
@@ -351,7 +351,7 @@ const Header: React.FC<HeaderProps> = () => {
                         $theme={theme}
                         style={{ fontSize: '12px', fontStyle: 'italic', cursor: 'default', opacity: 0.6 }}
                       >
-                        <span>No published forms or workforms yet</span>
+                        <span>No published Forms or WorkForms yet</span>
                       </SubmenuItem>
                     )}
                 </FormsSubmenu>

--- a/frontend/src/components/WorkForms/FormPreviewModal.tsx
+++ b/frontend/src/components/WorkForms/FormPreviewModal.tsx
@@ -339,7 +339,7 @@ export const FormPreviewModal: React.FC<FormPreviewModalProps> = ({ form, onClos
         <Content>
           <InfoGrid>
             <InfoCard>
-              <InfoLabel>Workflow Steps</InfoLabel>
+              <InfoLabel>Steps</InfoLabel>
               <InfoValue>{form.entity_count}</InfoValue>
               <InfoSubtext>{form.entity_count === 1 ? 'step' : 'steps'} configured</InfoSubtext>
             </InfoCard>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,6 +1,6 @@
 {
   "workflowEditor": {
-    "title": "Workflow Editor",
+    "title": "WorkForms Editor",
     "save": "Save",
     "cancel": "Cancel",
     "delete": "Delete",
@@ -26,7 +26,7 @@
       "decision": "Decision",
       "loop": "Loop",
       "conditional": "Conditional Branch",
-      "subworkflow": "Sub-Workflow"
+      "subworkflow": "Sub-WorkForm"
     },
     "properties": {
       "title": "Properties",
@@ -46,8 +46,8 @@
       "duplicateName": "Name already exists"
     },
     "notifications": {
-      "saved": "Workflow saved successfully",
-      "deleted": "Workflow deleted successfully",
+      "saved": "WorkForm saved successfully",
+      "deleted": "WorkForm deleted successfully",
       "error": "An error occurred",
       "validationFailed": "Validation failed",
       "connectionCreated": "Connection created",
@@ -85,7 +85,7 @@
         "nodeMoved": "Node {{name}} moved to position {{x}}, {{y}}",
         "connectionCreated": "Connection created from {{source}} to {{target}}",
         "connectionDeleted": "Connection from {{source}} to {{target}} deleted",
-        "workflowSaved": "Workflow saved successfully",
+        "workflowSaved": "WorkForm saved successfully",
         "validationError": "Validation error: {{error}}"
       },
       "hints": {

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -800,7 +800,7 @@ const FormsFlowsCatalog: React.FC = () => {
       showAlert({
         type: 'error',
         title: 'Error',
-        content: 'Failed to start workflow. Please try again.',
+        content: 'Failed to start. Please try again.',
       });
     } finally {
       setIsQuickRunning(null);
@@ -847,7 +847,7 @@ const FormsFlowsCatalog: React.FC = () => {
   return (
     <Container data-testid="workforms-catalog-page">
       <Header>
-        <Title>Forms & Flows</Title>
+        <Title>WorkForms Catalog</Title>
         <HeaderActions>
           <SearchBar>
             <SearchIconWrapper>
@@ -856,7 +856,7 @@ const FormsFlowsCatalog: React.FC = () => {
             <SearchInput
               data-testid="workforms-catalog-search"
               type="text"
-              placeholder="Search forms..."
+              placeholder="Search WorkForms and forms..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
@@ -868,7 +868,7 @@ const FormsFlowsCatalog: React.FC = () => {
             title={
               !permissions.can_create
                 ? getUpgradeMessage('create', permissions.role)
-                : 'Create a new form or workflow'
+                : 'Create a new form or WorkForm'
             }
           >
             {!permissions.can_create && <Lock size={16} style={{ marginRight: '0.5rem' }} />}
@@ -886,7 +886,7 @@ const FormsFlowsCatalog: React.FC = () => {
           onClick={() => setActiveTab('workflows')}
         >
           <Workflow size={18} />
-          Workflows (Logic)
+          WorkForms (Automation)
           {workflowsCount > 0 && <TabBadge>{workflowsCount}</TabBadge>}
         </Tab>
         <Tab data-testid="workforms-catalog-tab-forms" $active={activeTab === 'forms'} onClick={() => setActiveTab('forms')}>
@@ -1093,7 +1093,7 @@ const FormsFlowsCatalog: React.FC = () => {
                         $isRunning={isQuickRunning === form.id}
                         onClick={(e) => handleQuickRun(form, e)}
                         disabled={isQuickRunning === form.id}
-                        title={isWorkform ? 'Execute this WorkForm' : 'Start this workflow with one click'}
+                        title={isWorkform ? 'Run this WorkForm' : 'Start this form'}
                       >
                         {isQuickRunning === form.id ? (
                           <>
@@ -1103,7 +1103,7 @@ const FormsFlowsCatalog: React.FC = () => {
                         ) : (
                           <>
                             <Play size={16} />
-                            {isWorkform ? 'Execute' : 'Quick Run'}
+                            {isWorkform ? 'Run' : 'Start'}
                           </>
                         )}
                       </QuickRunButton>
@@ -1190,7 +1190,7 @@ const FormsFlowsCatalog: React.FC = () => {
                         $isRunning={isQuickRunning === form.id}
                         onClick={(e) => handleQuickRun(form, e)}
                         disabled={isQuickRunning === form.id}
-                        title={isWorkform ? 'Execute this WorkForm' : 'Start this workflow with one click'}
+                        title={isWorkform ? 'Run this WorkForm' : 'Start this form'}
                       >
                         {isQuickRunning === form.id ? (
                           <>
@@ -1200,7 +1200,7 @@ const FormsFlowsCatalog: React.FC = () => {
                         ) : (
                           <>
                             <Play size={16} />
-                            {isWorkform ? 'Execute' : 'Quick Run'}
+                            {isWorkform ? 'Run' : 'Start'}
                           </>
                         )}
                       </QuickRunButton>

--- a/frontend/src/pages/WorkForms/Execute.tsx
+++ b/frontend/src/pages/WorkForms/Execute.tsx
@@ -75,14 +75,14 @@ export const ExecuteWorkForm: React.FC = () => {
         showAlert({
           type: 'error',
           title: 'Execution failed',
-          content: data.error_message || 'This workflow failed to execute.',
+          content: data.error_message || 'This WorkForm failed to run.',
         });
       }
 
       navigate(`/workforms/executions/${data.id}`, { replace: true });
     },
     onError: (err: any) => {
-      const msg = err?.response?.data?.error || err?.message || 'Failed to start workflow.';
+      const msg = err?.response?.data?.error || err?.message || 'Failed to start WorkForm.';
       showAlert({ type: 'error', title: 'Error', content: msg });
       navigate('/workforms/catalog', { replace: true });
     },

--- a/frontend/src/pages/WorkForms/ExecutionDetails.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.tsx
@@ -51,12 +51,12 @@ export const WorkFormExecutionDetails: React.FC = () => {
   });
 
   return (
-    <PageContainer title="Workflow Execution">
+    <PageContainer title="WorkForm Run">
       <Card padding="lg">
         {query.isLoading ? (
-          <div>Loading execution…</div>
+          <div>Loading run…</div>
         ) : query.isError || !execution ? (
-          <div>Execution not found.</div>
+          <div>Run not found.</div>
         ) : (
           <div data-testid="workform-execution-details-page" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -5,7 +5,7 @@
  * Implements Phase 1 of the Forms & Flows Enhancement Plan.
  * 
  * Created: 2026-02-03
- * Updated: Phase 5 - Added Workflow Executions tab
+ * Updated: Phase 5 - Added WorkForm Runs tab
  * 
  * Features:
  * - List of completed/cancelled submissions
@@ -654,7 +654,7 @@ const FormsFlowsHistory: React.FC = () => {
             setActiveTab('workflows');
           }}
         >
-          Workflow Executions
+          WorkForm Runs
         </Tab>
       </TabsContainer>
       
@@ -717,7 +717,7 @@ const FormsFlowsHistory: React.FC = () => {
           <EmptyMessage>
             {searchQuery || startDate || endDate
               ? 'No matching records found. Try adjusting your filters.'
-              : 'Completed and cancelled form submissions will appear here once a workflow finishes executing.'}
+              : 'Completed and cancelled form submissions will appear here once a WorkForm run completes.'}
           </EmptyMessage>
         </EmptyState>
       ) : (

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -622,7 +622,7 @@ const FormsFlowsInProgress: React.FC = () => {
             aria-selected={activeTab === 'executions'}
             onClick={() => setActiveTab('executions')}
           >
-            WorkForm Executions
+            WorkForm Runs
           </Tab>
         </TabsContainer>
 
@@ -630,19 +630,19 @@ const FormsFlowsInProgress: React.FC = () => {
           <ToolbarLeft>
             <SearchInput
               type="search"
-              placeholder={activeTab === 'executions' ? 'Search executions…' : 'Search in-progress forms…'}
+              placeholder={activeTab === 'executions' ? 'Search runs…' : 'Search in-progress forms…'}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              aria-label={activeTab === 'executions' ? 'Search executions' : 'Search in-progress forms'}
+              aria-label={activeTab === 'executions' ? 'Search runs' : 'Search in-progress forms'}
             />
             <FilterSelect
               value={filterMode}
               onChange={(e) => setFilterMode(e.target.value as any)}
-              aria-label="Filter workflows"
+              aria-label="Filter WorkForms"
             >
-              <option value="all">All Workflows</option>
-              <option value="my">My Workflows</option>
-              <option value="team">Team Workflows</option>
+              <option value="all">All WorkForms</option>
+              <option value="my">My WorkForms</option>
+              <option value="team">Team WorkForms</option>
             </FilterSelect>
           </ToolbarLeft>
           <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -669,7 +669,7 @@ const FormsFlowsInProgress: React.FC = () => {
             );
 
             if (executionsQuery.isLoading) {
-              return <LoadingState role="status" aria-live="polite">Loading executions…</LoadingState>;
+              return <LoadingState role="status" aria-live="polite">Loading runs…</LoadingState>;
             }
 
             if (filtered.length === 0) {
@@ -678,18 +678,18 @@ const FormsFlowsInProgress: React.FC = () => {
                   <EmptyIcon aria-hidden="true">
                     <Clock size={48} />
                   </EmptyIcon>
-                  <EmptyTitle>No executions in progress</EmptyTitle>
+                  <EmptyTitle>No runs in progress</EmptyTitle>
                   <EmptyMessage>
                     {searchQuery
-                      ? 'No matching executions found. Try a different search term.'
-                      : 'You have no active WorkForm executions running right now. Start one from the Catalog.'}
+                      ? 'No matching runs found. Try a different search term.'
+                      : 'You have no active WorkForm runs right now. Start one from the Catalog.'}
                   </EmptyMessage>
                 </EmptyState>
               );
             }
 
             return (
-              <CardGrid role="list" aria-label={`${filtered.length} executions in progress`}>
+              <CardGrid role="list" aria-label={`${filtered.length} runs in progress`}>
                 {filtered.map((ex) => (
                   <Card
                     key={ex.id}
@@ -741,7 +741,7 @@ const FormsFlowsInProgress: React.FC = () => {
             <EmptyMessage>
               {searchQuery
                 ? 'No matching forms found. Try a different search term.'
-                : 'You have no active form submissions or workflow executions running right now. Start a new one from the Catalog.'}
+                : 'You have no active form submissions or WorkForm runs right now. Start a new one from the Catalog.'}
             </EmptyMessage>
           </EmptyState>
         ) : (

--- a/frontend/src/pages/WorkForms/index.tsx
+++ b/frontend/src/pages/WorkForms/index.tsx
@@ -199,7 +199,7 @@ const WorkFormsLayout: React.FC = () => {
           </HeaderIcon>
           <div>
             <HeaderTitle>WorkForms</HeaderTitle>
-            <HeaderSubtitle>Manage your workflow tasks and form submissions</HeaderSubtitle>
+            <HeaderSubtitle>Manage your WorkForm tasks and form submissions</HeaderSubtitle>
           </div>
         </HeaderLeft>
       </Header>


### PR DESCRIPTION
## Deliverables\n- Standardize WorkForms user-facing terminology (WorkForm/WorkForms, Run vs Execution) across Catalog, In Progress, History, Execute/Details.\n- Align FlowEditor user-facing labels to WorkForms Editor and WorkForm naming (Help, shortcuts export, management modal, sub-workform).\n- Update EntityWorkflowStatusPanel empty-state copy + test to match WorkForm run wording.\n\n## Why\nReduces user confusion from mixed "workflow/execution/execute" language inside the WorkForms experience while keeping routes/APIs unchanged (additive-only).\n\n## Testing\n- npm --prefix frontend run verify-standards\n- npm --prefix frontend run test:ci\n