### PR TITLE
WorkForms: user-visible error states + retries

### DIFF
--- a/frontend/src/features/workforms/workformsErrors.test.ts
+++ b/frontend/src/features/workforms/workformsErrors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { getWorkformsErrorMessage, getWorkformsErrorUi } from './workformsErrors';
+
+describe('workformsErrors', () => {
+  it('prefers backend detail/error/message over generic fallback', () => {
+    const err = { response: { status: 500, data: { detail: 'Backend exploded' } } };
+    expect(getWorkformsErrorMessage(err, 'Fallback')).toBe('Backend exploded');
+  });
+
+  it('hides Axios-style status-code messages behind fallback', () => {
+    const err = { message: 'Request failed with status code 500' };
+    expect(getWorkformsErrorMessage(err, 'Fallback')).toBe('Fallback');
+  });
+
+  it('maps 403 to access denied', () => {
+    const err = { response: { status: 403, data: { detail: 'Forbidden' } } };
+    expect(getWorkformsErrorUi(err, 'catalog.load').title).toMatch(/access/i);
+  });
+
+  it('maps 404 to not found (execution details specific message)', () => {
+    const err = { response: { status: 404, data: { detail: 'Not found.' } } };
+    const ui = getWorkformsErrorUi(err, 'executionDetails.load');
+    expect(ui.title).toBe('Not found');
+    expect(ui.message).toMatch(/run/i);
+  });
+
+  it('maps offline-like errors', () => {
+    const err = { message: 'Network Error' };
+    const ui = getWorkformsErrorUi(err, 'history.load');
+    expect(ui.title).toMatch(/offline/i);
+  });
+
+  it('uses context title for 5xx errors', () => {
+    const err = { response: { status: 500, data: { detail: 'Boom' } } };
+    const ui = getWorkformsErrorUi(err, 'catalog.load');
+    expect(ui.title).toBe("Couldn't load catalog");
+    expect(ui.message).toBe('Boom');
+  });
+});

--- a/frontend/src/features/workforms/workformsErrors.ts
+++ b/frontend/src/features/workforms/workformsErrors.ts
@@ -1,0 +1,124 @@
+export type WorkformsErrorContext =
+  | 'catalog.load'
+  | 'catalog.start'
+  | 'catalog.delete'
+  | 'execute.start'
+  | 'executionDetails.load'
+  | 'inProgress.load'
+  | 'history.load'
+  | 'inProgress.cancel';
+
+type ErrorWithResponse = {
+  response?: {
+    status?: number;
+    data?: any;
+  };
+  message?: string;
+};
+
+function getHttpStatus(error: unknown): number | undefined {
+  const e = error as ErrorWithResponse | null;
+  const status = e?.response?.status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+function getBackendMessage(error: unknown): string | undefined {
+  const e = error as ErrorWithResponse | null;
+  const data = e?.response?.data;
+
+  const candidates = [
+    typeof data?.detail === 'string' ? data.detail : undefined,
+    typeof data?.error === 'string' ? data.error : undefined,
+    typeof data?.message === 'string' ? data.message : undefined,
+    typeof (error as any)?.message === 'string' ? (error as any).message : undefined,
+  ].filter(Boolean) as string[];
+
+  return candidates[0];
+}
+
+function isOfflineLike(error: unknown): boolean {
+  const msg = getBackendMessage(error);
+  if (!msg) return false;
+  return /network\s*error|failed\s*to\s*fetch|networkerror|offline/i.test(msg);
+}
+
+export function getWorkformsErrorMessage(error: unknown, fallback: string): string {
+  const msg = getBackendMessage(error);
+  if (!msg) return fallback;
+
+  // Avoid leaking overly-technical Axios-ish messages as primary UX.
+  if (/request failed with status code \d+/i.test(msg)) {
+    return fallback;
+  }
+
+  return msg;
+}
+
+export function getWorkformsErrorUi(
+  error: unknown,
+  context: WorkformsErrorContext
+): { title: string; message: string } {
+  const status = getHttpStatus(error);
+
+  if (status === 401) {
+    return { title: 'Please sign in', message: 'Your session has expired. Sign in to continue.' };
+  }
+
+  if (status === 403) {
+    return {
+      title: "You don't have access",
+      message: 'You do not have permission to complete this action. Contact your administrator for access.',
+    };
+  }
+
+  if (status === 404) {
+    const messageByContext: Partial<Record<WorkformsErrorContext, string>> = {
+      'executionDetails.load':
+        'This WorkForm run could not be found. It may have been deleted or you may not have access.',
+      'execute.start': 'This WorkForm could not be found. It may have been deleted or you may not have access.',
+    };
+    return {
+      title: 'Not found',
+      message: messageByContext[context] ?? 'This item could not be found. It may have been deleted or you may not have access.',
+    };
+  }
+
+  if (isOfflineLike(error)) {
+    return { title: "You're offline", message: 'Check your internet connection, then try again.' };
+  }
+
+  const fallbackByContext: Record<WorkformsErrorContext, { title: string; message: string }> = {
+    'catalog.load': {
+      title: "Couldn't load catalog",
+      message: 'We could not load WorkForms and forms right now. Please try again.',
+    },
+    'catalog.start': { title: 'Error', message: 'Failed to start. Please try again.' },
+    'catalog.delete': { title: 'Error', message: 'Failed to delete WorkForm. Please try again.' },
+    'execute.start': { title: 'Error', message: 'Failed to start WorkForm.' },
+    'executionDetails.load': {
+      title: "Couldn't load run",
+      message: 'We could not load this WorkForm run. Please try again.',
+    },
+    'inProgress.load': {
+      title: "Couldn't load in-progress work",
+      message: 'We could not load in-progress items. Please try again.',
+    },
+    'history.load': { title: "Couldn't load history", message: 'We could not load history. Please try again.' },
+    'inProgress.cancel': { title: 'Error', message: 'Failed to cancel. Please try again.' },
+  };
+
+  if (status && status >= 500) {
+    const fallback = fallbackByContext[context];
+    return {
+      title: fallback.title,
+      message: getWorkformsErrorMessage(error, fallback.message),
+    };
+  }
+
+  const fallback = fallbackByContext[context];
+
+  return {
+    title: fallback.title,
+    message: getWorkformsErrorMessage(error, fallback.message),
+  };
+}

--- a/frontend/src/pages/WorkForms/Catalog.errorState.test.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.errorState.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import Catalog from './Catalog';
+import { getAvailableWorkForms } from '../../services/workformsApi';
+import { quickActionsService } from '@/services/quickActionsService';
+
+vi.mock('../../services/workformsApi', () => ({
+  getAvailableWorkForms: vi.fn(),
+  createFormSubmission: vi.fn(),
+}));
+
+vi.mock('@/services/quickActionsService', () => ({
+  quickActionsService: {
+    getAvailableForms: vi.fn(),
+  },
+}));
+
+vi.mock('../../hooks/useWorkFormPermissions', () => ({
+  useWorkFormPermissions: () => ({
+    permissions: {
+      can_create: true,
+      can_edit: true,
+      can_publish: true,
+      can_archive: true,
+      can_delete: true,
+      allowed_modes: ['wizard', 'visual', 'expert'],
+      allowed_node_categories: [],
+      can_access_system_templates: true,
+      can_create_global_templates: false,
+      max_active_flows: null,
+      role: 'owner',
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  getUpgradeMessage: () => null,
+}));
+
+vi.mock('../../contexts/QuickActionsContext', () => ({
+  useQuickActions: () => ({
+    refreshQuickActions: vi.fn(),
+  }),
+}));
+
+describe('WorkForms Catalog error state', () => {
+  it('shows a retryable error state when both WorkForms and forms fail to load', async () => {
+    const err = { response: { status: 500, data: { detail: 'Boom' } } };
+
+    vi.mocked(getAvailableWorkForms).mockRejectedValueOnce(err);
+    vi.mocked(quickActionsService.getAvailableForms).mockRejectedValueOnce(err);
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/workforms/catalog']}>
+          <Routes>
+            <Route path="/workforms/catalog" element={<Catalog />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Couldn't load catalog")).toBeInTheDocument();
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -19,6 +19,7 @@
 import React, { useState } from 'react';
 import { logger } from '@/utils/logger';
 import { showAlert } from '@/utils/uiDialogs';
+import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
 
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -569,8 +570,8 @@ const FormsFlowsCatalog: React.FC = () => {
       showAlert({ type: 'success', title: 'Deleted', content: 'WorkForm deleted successfully.' });
     },
     onError: (error: any) => {
-      const msg = error?.message || 'Failed to delete WorkForm.';
-      showAlert({ type: 'error', title: 'Error', content: msg });
+      const ui = getWorkformsErrorUi(error, 'catalog.delete');
+      showAlert({ type: 'error', title: ui.title, content: ui.message });
     },
   });
 
@@ -581,6 +582,7 @@ const FormsFlowsCatalog: React.FC = () => {
     data: forms = [],
     isLoading,
     error,
+    refetch,
   } = useQuery<CatalogItem[]>({
     queryKey: ['workforms-catalog-items'],
     queryFn: async () => {
@@ -591,6 +593,8 @@ const FormsFlowsCatalog: React.FC = () => {
         quickActionsService.getAvailableForms(),
       ]);
 
+      const bothFailed = workformsResult.status === 'rejected' && targetsResult.status === 'rejected';
+
       const workforms = workformsResult.status === 'fulfilled' ? workformsResult.value : [];
       if (workformsResult.status === 'rejected') {
         logger.error('[Catalog] Error fetching workforms:', workformsResult.reason);
@@ -599,6 +603,10 @@ const FormsFlowsCatalog: React.FC = () => {
       const targets = targetsResult.status === 'fulfilled' ? targetsResult.value : [];
       if (targetsResult.status === 'rejected') {
         logger.error('[Catalog] Error fetching available targets:', targetsResult.reason);
+      }
+
+      if (bothFailed) {
+        throw (targetsResult.status === 'rejected' ? targetsResult.reason : workformsResult.reason) ?? new Error('Failed to load catalog');
       }
 
       const mappedWorkforms: CatalogItem[] = (workforms || []).map((wf) => {
@@ -797,10 +805,11 @@ const FormsFlowsCatalog: React.FC = () => {
       navigate(`/workforms/in-progress/${submission.id}`);
     } catch (error) {
       logger.error('[Catalog] Quick Run failed:', error);
+      const ui = getWorkformsErrorUi(error, 'catalog.start');
       showAlert({
         type: 'error',
-        title: 'Error',
-        content: 'Failed to start. Please try again.',
+        title: ui.title,
+        content: ui.message,
       });
     } finally {
       setIsQuickRunning(null);
@@ -830,10 +839,11 @@ const FormsFlowsCatalog: React.FC = () => {
       navigate(`/workforms/in-progress/${submission.id}`);
     } catch (error) {
       logger.error('[Catalog] Failed to start form submission', error);
+      const ui = getWorkformsErrorUi(error, 'catalog.start');
       showAlert({
         type: 'error',
-        title: 'Error',
-        content: 'Failed to start form. Please try again.',
+        title: ui.title,
+        content: ui.message,
       });
     }
   };
@@ -843,6 +853,8 @@ const FormsFlowsCatalog: React.FC = () => {
     const date = new Date(dateString);
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   };
+
+  const catalogErrorUi = error ? getWorkformsErrorUi(error, 'catalog.load') : null;
 
   return (
     <Container data-testid="workforms-catalog-page">
@@ -905,7 +917,16 @@ const FormsFlowsCatalog: React.FC = () => {
         </Tab>
       </TabsContainer>
 
-      {activeTab !== 'templates' && (
+      {catalogErrorUi && !isLoading && forms.length === 0 ? (
+        <EmptyState role="status" aria-live="polite">
+          <EmptyStateIcon aria-hidden="true">⚠️</EmptyStateIcon>
+          <EmptyStateTitle>{catalogErrorUi.title}</EmptyStateTitle>
+          <EmptyStateDescription>{catalogErrorUi.message}</EmptyStateDescription>
+          <Button variant="primary" onClick={() => void refetch()}>
+            Try again
+          </Button>
+        </EmptyState>
+      ) : activeTab !== 'templates' && (
         <>
           {/* NEW: Category Filters for Protein Type and Department */}
           <CategoryBar>

--- a/frontend/src/pages/WorkForms/ExecutionDetails.test.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.test.tsx
@@ -72,4 +72,31 @@ describe('WorkFormExecutionDetails', () => {
     expect(await screen.findByText(/^Errors$/i)).toBeInTheDocument();
     expect(screen.getAllByText('Boom').length).toBeGreaterThan(0);
   });
+
+  it('renders a helpful error panel when the run cannot be loaded', async () => {
+    vi.mocked(workformExecutionService.getExecution).mockRejectedValueOnce({
+      response: { status: 404, data: { detail: 'Not found.' } },
+    });
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/workforms/executions/ex-missing']}>
+          <Routes>
+            <Route path="/workforms/executions/:id" element={<WorkFormExecutionDetails />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText('Not found')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view history/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /back to catalog/i })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/WorkForms/ExecutionDetails.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { PageContainer } from '@/components/ui/PageContainer';
 import { workformExecutionService } from '@/services/workformExecutionService';
 import { formSubmissionService } from '@/services/quickActionsService';
+import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
 
 export const WorkFormExecutionDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -56,7 +57,23 @@ export const WorkFormExecutionDetails: React.FC = () => {
         {query.isLoading ? (
           <div>Loading run…</div>
         ) : query.isError || !execution ? (
-          <div>Run not found.</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={{ fontWeight: 700 }}>{getWorkformsErrorUi(query.error, 'executionDetails.load').title}</div>
+            <div style={{ color: 'rgb(var(--color-text-secondary))' }}>
+              {getWorkformsErrorUi(query.error, 'executionDetails.load').message}
+            </div>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              <Button variant="secondary" onClick={() => void query.refetch()}>
+                Try again
+              </Button>
+              <Button variant="secondary" onClick={() => navigate('/workforms/history')}>
+                View History
+              </Button>
+              <Button variant="secondary" onClick={() => navigate('/workforms/catalog')}>
+                Back to Catalog
+              </Button>
+            </div>
+          </div>
         ) : (
           <div data-testid="workform-execution-details-page" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -27,6 +27,7 @@ import {
 } from 'lucide-react';
 import { businessApi } from '../../services/businessApi';
 import { workformExecutionService, WorkFormExecution } from '@/services/workformExecutionService';
+import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
 
 // ============================================================================
 // Types
@@ -494,10 +495,13 @@ const FormsFlowsHistory: React.FC = () => {
   const [workflowExecutions, setWorkflowExecutions] = useState<WorkFormExecution[]>([]);
   const [workflowsLoading, setWorkflowsLoading] = useState(false);
   const [expandedWorkflow, setExpandedWorkflow] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [runsLoadError, setRunsLoadError] = useState<string | null>(null);
   
   // Fetch completed/cancelled submissions
   const fetchSubmissions = async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const params: Record<string, string> = {
         status: 'completed,cancelled',
@@ -514,6 +518,7 @@ const FormsFlowsHistory: React.FC = () => {
     } catch (error) {
       console.error('Failed to fetch history:', error);
       setSubmissions([]);
+      setLoadError(getWorkformsErrorUi(error, 'history.load').message);
     } finally {
       setLoading(false);
     }
@@ -541,6 +546,7 @@ const FormsFlowsHistory: React.FC = () => {
   // Fetch workflow executions
   const fetchWorkflowExecutions = async () => {
     setWorkflowsLoading(true);
+    setRunsLoadError(null);
     try {
       const params: Record<string, string> = {
         status: 'completed,failed,cancelled',
@@ -557,6 +563,7 @@ const FormsFlowsHistory: React.FC = () => {
     } catch (error) {
       console.error('Failed to fetch workflow executions:', error);
       setWorkflowExecutions([]);
+      setRunsLoadError(getWorkformsErrorUi(error, 'history.load').message);
     } finally {
       setWorkflowsLoading(false);
     }
@@ -708,6 +715,17 @@ const FormsFlowsHistory: React.FC = () => {
       
       {currentLoading ? (
         <LoadingState role="status" aria-live="polite">Loading history...</LoadingState>
+      ) : currentData.length === 0 && ((activeTab === 'submissions' && loadError) || (activeTab === 'workflows' && runsLoadError)) ? (
+        <EmptyState role="status" aria-live="polite">
+          <EmptyIcon aria-hidden="true">
+            <FileText size={48} />
+          </EmptyIcon>
+          <EmptyTitle>Couldn't load history</EmptyTitle>
+          <EmptyMessage>{activeTab === 'submissions' ? loadError : runsLoadError}</EmptyMessage>
+          <ActionButton onClick={() => (activeTab === 'submissions' ? fetchSubmissions() : fetchWorkflowExecutions())}>
+            Try again
+          </ActionButton>
+        </EmptyState>
       ) : currentData.length === 0 ? (
         <EmptyState role="status" aria-live="polite">
           <EmptyIcon aria-hidden="true">

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -26,6 +26,7 @@ import { businessApi } from '../../services/businessApi';
 import { useQuickActions } from '../../contexts/QuickActionsContext';
 import { workflowExecutionService } from '../../services/workflowExecutionService';
 import { workformExecutionService } from '@/services/workformExecutionService';
+import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
 
 // ============================================================================
 // Types
@@ -476,6 +477,7 @@ const FormsFlowsInProgress: React.FC = () => {
   const [cancelingId, setCancelingId] = useState<string | null>(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [selectedSubmission, setSelectedSubmission] = useState<FormSubmission | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const { id: submissionId } = useParams<{ id?: string }>();
   const navigate = useNavigate();
@@ -484,11 +486,12 @@ const FormsFlowsInProgress: React.FC = () => {
   useEffect(() => {
     if (!submissionId) return;
 
-    resumeSubmission(submissionId).catch(() => {
+    resumeSubmission(submissionId).catch((error) => {
+      const ui = getWorkformsErrorUi(error, 'inProgress.load');
       showAlert({
         type: 'error',
-        title: 'Error',
-        content: 'Failed to load the selected in-progress workflow. Please try again.',
+        title: ui.title,
+        content: ui.message,
       });
     });
   }, [resumeSubmission, submissionId]);
@@ -496,6 +499,7 @@ const FormsFlowsInProgress: React.FC = () => {
   // Fetch in-progress submissions
   const fetchSubmissions = async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const params: any = { status: 'in_progress,draft' };
       
@@ -510,6 +514,7 @@ const FormsFlowsInProgress: React.FC = () => {
     } catch (error) {
       console.error('Failed to fetch submissions:', error);
       setSubmissions([]);
+      setLoadError(getWorkformsErrorUi(error, 'inProgress.load').message);
     } finally {
       setLoading(false);
     }
@@ -566,10 +571,11 @@ const FormsFlowsInProgress: React.FC = () => {
       setSelectedSubmission(null);
     } catch (error) {
       console.error('Failed to cancel workflow:', error);
+      const ui = getWorkformsErrorUi(error, 'inProgress.cancel');
       showAlert({
         type: 'error',
-        title: 'Error',
-        content: 'Failed to cancel workflow. Please try again.',
+        title: ui.title,
+        content: ui.message,
       });
     } finally {
       setCancelingId(null);
@@ -626,6 +632,43 @@ const FormsFlowsInProgress: React.FC = () => {
           </Tab>
         </TabsContainer>
 
+        {loadError && activeTab === 'submissions' ? (
+          <div
+            role="status"
+            aria-live="polite"
+            style={{
+              margin: '12px 0',
+              padding: '12px',
+              border: '1px solid rgb(var(--color-border))',
+              borderRadius: 12,
+              background: 'rgb(var(--color-primary) / 0.06)',
+              color: 'rgb(var(--color-text-primary))',
+              display: 'flex',
+              justifyContent: 'space-between',
+              gap: 12,
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <span>{loadError}</span>
+            <button
+              type="button"
+              onClick={() => fetchSubmissions()}
+              style={{
+                border: '1px solid rgb(var(--color-border))',
+                background: 'rgb(var(--color-surface))',
+                color: 'rgb(var(--color-text-primary))',
+                padding: '6px 10px',
+                borderRadius: 10,
+                cursor: 'pointer',
+                fontWeight: 600,
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        ) : null}
+
         <Toolbar>
           <ToolbarLeft>
             <SearchInput
@@ -670,6 +713,22 @@ const FormsFlowsInProgress: React.FC = () => {
 
             if (executionsQuery.isLoading) {
               return <LoadingState role="status" aria-live="polite">Loading runs…</LoadingState>;
+            }
+
+            if (executionsQuery.isError) {
+              const ui = getWorkformsErrorUi(executionsQuery.error, 'inProgress.load');
+              return (
+                <EmptyState role="status" aria-live="polite">
+                  <EmptyIcon aria-hidden="true">
+                    <Clock size={48} />
+                  </EmptyIcon>
+                  <EmptyTitle>{ui.title}</EmptyTitle>
+                  <EmptyMessage>{ui.message}</EmptyMessage>
+                  <ResumeButton onClick={() => void executionsQuery.refetch()} aria-label="Try again">
+                    Try again
+                  </ResumeButton>
+                </EmptyState>
+              );
             }
 
             if (filtered.length === 0) {
@@ -803,9 +862,9 @@ const FormsFlowsInProgress: React.FC = () => {
       {/* Cancel Confirmation Modal */}
       <Modal $isOpen={showCancelModal} onClick={() => setShowCancelModal(false)}>
         <ModalContent onClick={(e) => e.stopPropagation()}>
-          <ModalTitle>Cancel Workflow?</ModalTitle>
+          <ModalTitle>Cancel submission?</ModalTitle>
           <ModalText>
-            Are you sure you want to cancel "{selectedSubmission?.form_name}"? 
+            Are you sure you want to cancel "{selectedSubmission?.form_name}"?
             This action cannot be undone.
           </ModalText>
           <ModalActions>


### PR DESCRIPTION
### What\n- Add shared WorkForms error normalization helper (workformsErrors)\n- Catalog: show retryable error empty-state when both WorkForms + Forms fail to load\n- In Progress + History: distinguish empty vs failed loads with retry UI\n- Execution Details: replace "Run not found" with contextual error panel + CTAs\n\n### Testing\n- npm --prefix frontend run verify-standards\n- npm --prefix frontend run test:ci\n\n### Notes\n- Additive-only UI change; no API contract changes.