### PR TITLE
WorkForms: a11y for tabs + cancel confirm

### DIFF
--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -787,6 +787,33 @@ const FormsFlowsCatalog: React.FC = () => {
     navigate('/workforms/editor');
   };
 
+  const tabOrder: TabOption[] = ['workflows', 'forms', 'templates'];
+
+  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, current: TabOption) => {
+    const idx = tabOrder.indexOf(current);
+    if (idx === -1) return;
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      setActiveTab(tabOrder[(idx + 1) % tabOrder.length]);
+    }
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      setActiveTab(tabOrder[(idx - 1 + tabOrder.length) % tabOrder.length]);
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      setActiveTab(tabOrder[0]);
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      setActiveTab(tabOrder[tabOrder.length - 1]);
+    }
+  };
+
   // NEW: Handle Quick Run (one-click execution)
   const handleQuickRun = async (item: CatalogItem, event: React.MouseEvent) => {
     event.stopPropagation(); // Prevent card click from triggering
@@ -891,25 +918,44 @@ const FormsFlowsCatalog: React.FC = () => {
       </Header>
 
       {/* Phase 5: Tabbed View - Logic vs Data + Templates (Phase 2.2) */}
-      <TabsContainer>
+      <TabsContainer role="tablist" aria-label="Catalog tabs">
         <Tab
+          type="button"
+          role="tab"
           data-testid="workforms-catalog-tab-workflows"
           $active={activeTab === 'workflows'}
+          aria-selected={activeTab === 'workflows'}
+          tabIndex={activeTab === 'workflows' ? 0 : -1}
           onClick={() => setActiveTab('workflows')}
+          onKeyDown={(e) => handleTabKeyDown(e, 'workflows')}
         >
           <Workflow size={18} />
           WorkForms (Automation)
           {workflowsCount > 0 && <TabBadge>{workflowsCount}</TabBadge>}
         </Tab>
-        <Tab data-testid="workforms-catalog-tab-forms" $active={activeTab === 'forms'} onClick={() => setActiveTab('forms')}>
+        <Tab
+          type="button"
+          role="tab"
+          data-testid="workforms-catalog-tab-forms"
+          $active={activeTab === 'forms'}
+          aria-selected={activeTab === 'forms'}
+          tabIndex={activeTab === 'forms' ? 0 : -1}
+          onClick={() => setActiveTab('forms')}
+          onKeyDown={(e) => handleTabKeyDown(e, 'forms')}
+        >
           <Database size={18} />
           Forms (Data)
           {formsCount > 0 && <TabBadge>{formsCount}</TabBadge>}
         </Tab>
         <Tab
+          type="button"
+          role="tab"
           data-testid="workforms-catalog-tab-templates"
           $active={activeTab === 'templates'}
+          aria-selected={activeTab === 'templates'}
+          tabIndex={activeTab === 'templates' ? 0 : -1}
           onClick={() => setActiveTab('templates')}
+          onKeyDown={(e) => handleTabKeyDown(e, 'templates')}
         >
           <Boxes size={18} />
           Industry Templates

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -498,6 +498,32 @@ const FormsFlowsHistory: React.FC = () => {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [runsLoadError, setRunsLoadError] = useState<string | null>(null);
   
+  const tabOrder: Array<'submissions' | 'workflows'> = ['submissions', 'workflows'];
+
+  const handleTabKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    current: 'submissions' | 'workflows'
+  ) => {
+    const idx = tabOrder.indexOf(current);
+    if (idx === -1) return;
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+      const next = current === 'submissions' ? 'workflows' : 'submissions';
+      setExpandedWorkflow(null);
+      setPage(1);
+      setActiveTab(next);
+    }
+
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault();
+      const next = event.key === 'Home' ? 'submissions' : 'workflows';
+      setExpandedWorkflow(null);
+      setPage(1);
+      setActiveTab(next);
+    }
+  };
+
   // Fetch completed/cancelled submissions
   const fetchSubmissions = async () => {
     setLoading(true);
@@ -642,24 +668,34 @@ const FormsFlowsHistory: React.FC = () => {
     <ErrorBoundary>
       <Container role="region" aria-label="Form History">
       {/* Tabs */}
-      <TabsContainer>
+      <TabsContainer role="tablist" aria-label="History tabs">
         <Tab
+          type="button"
+          role="tab"
           $active={activeTab === 'submissions'}
+          aria-selected={activeTab === 'submissions'}
+          tabIndex={activeTab === 'submissions' ? 0 : -1}
           onClick={() => {
             setExpandedWorkflow(null);
             setPage(1);
             setActiveTab('submissions');
           }}
+          onKeyDown={(e) => handleTabKeyDown(e, 'submissions')}
         >
           Form Submissions
         </Tab>
         <Tab
+          type="button"
+          role="tab"
           $active={activeTab === 'workflows'}
+          aria-selected={activeTab === 'workflows'}
+          tabIndex={activeTab === 'workflows' ? 0 : -1}
           onClick={() => {
             setExpandedWorkflow(null);
             setPage(1);
             setActiveTab('workflows');
           }}
+          onKeyDown={(e) => handleTabKeyDown(e, 'workflows')}
         >
           WorkForm Runs
         </Tab>

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -397,71 +397,6 @@ const CancelButton = styled.button`
   }
 `;
 
-const Modal = styled.div<{ $isOpen: boolean }>`
-  display: ${({ $isOpen }) => $isOpen ? 'flex' : 'none'};
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgb(var(--color-text-primary) / 0.50);
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-`;
-
-const ModalContent = styled.div`
-  background: rgb(var(--color-surface));
-  border-radius: var(--radius-lg, 12px);
-  padding: 24px;
-  max-width: 400px;
-  width: 90%;
-`;
-
-const ModalTitle = styled.h3`
-  font-size: 18px;
-  font-weight: 600;
-  color: rgb(var(--color-text-primary));
-  margin: 0 0 12px;
-`;
-
-const ModalText = styled.p`
-  font-size: 14px;
-  color: rgb(var(--color-text-secondary));
-  margin: 0 0 20px;
-`;
-
-const ModalActions = styled.div`
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
-`;
-
-const ModalButton = styled.button<{ $variant?: 'danger' }>`
-  padding: 10px 20px;
-  border: none;
-  border-radius: var(--radius-md, 8px);
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: opacity 0.15s ease;
-  
-  background: ${({ $variant }) => 
-    $variant === 'danger' ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'
-  };
-  color: ${({ $variant }) => 
-    $variant === 'danger' ? 'white' : 'rgb(var(--color-text-primary))'
-  };
-  
-  &:hover {
-    opacity: 0.9;
-  }
-  
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-`;
 
 // ============================================================================
 // Component
@@ -475,8 +410,6 @@ const FormsFlowsInProgress: React.FC = () => {
   const [filterMode, setFilterMode] = useState<'all' | 'my' | 'team'>('all');
   const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
   const [cancelingId, setCancelingId] = useState<string | null>(null);
-  const [showCancelModal, setShowCancelModal] = useState(false);
-  const [selectedSubmission, setSelectedSubmission] = useState<FormSubmission | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const { id: submissionId } = useParams<{ id?: string }>();
@@ -549,26 +482,24 @@ const FormsFlowsInProgress: React.FC = () => {
     refetchInterval: 10000,
   });
 
-  // Handle cancel confirmation
-  const handleCancelClick = (submission: FormSubmission) => {
-    setSelectedSubmission(submission);
-    setShowCancelModal(true);
-  };
-  
-  // Handle cancel workflow
-  const handleCancelConfirm = async () => {
-    if (!selectedSubmission) return;
-    
-    setCancelingId(selectedSubmission.id);
+  const handleCancelClick = async (submission: FormSubmission) => {
+    const ok = await confirmDialog({
+      title: 'Cancel submission?',
+      content: `Are you sure you want to cancel "${submission.form_name}"? This action cannot be undone.`,
+      okText: 'Yes, cancel',
+      cancelText: 'Keep working',
+      danger: true,
+    });
+
+    if (!ok) return;
+
+    setCancelingId(submission.id);
     try {
-      await workflowExecutionService.cancelExecution(selectedSubmission.id, {
+      await workflowExecutionService.cancelExecution(submission.id, {
         reason: 'Cancelled by user',
       });
-      
-      // Update UI immediately
-      setSubmissions(prev => prev.filter(s => s.id !== selectedSubmission.id));
-      setShowCancelModal(false);
-      setSelectedSubmission(null);
+
+      setSubmissions((prev) => prev.filter((s) => s.id !== submission.id));
     } catch (error) {
       console.error('Failed to cancel workflow:', error);
       const ui = getWorkformsErrorUi(error, 'inProgress.cancel');
@@ -849,7 +780,11 @@ const FormsFlowsInProgress: React.FC = () => {
                       <Play size={16} aria-hidden="true" />
                       Resume
                     </ResumeButton>
-                    <CancelButton onClick={() => handleCancelClick(submission)} aria-label={`Cancel ${submission.form_name}`}>
+                    <CancelButton
+                      onClick={() => void handleCancelClick(submission)}
+                      disabled={cancelingId === submission.id}
+                      aria-label={`Cancel ${submission.form_name}`}
+                    >
                       <X size={16} />
                     </CancelButton>
                   </CardActions>
@@ -858,29 +793,6 @@ const FormsFlowsInProgress: React.FC = () => {
             })}
           </CardGrid>
         )}
-      
-      {/* Cancel Confirmation Modal */}
-      <Modal $isOpen={showCancelModal} onClick={() => setShowCancelModal(false)}>
-        <ModalContent onClick={(e) => e.stopPropagation()}>
-          <ModalTitle>Cancel submission?</ModalTitle>
-          <ModalText>
-            Are you sure you want to cancel "{selectedSubmission?.form_name}"?
-            This action cannot be undone.
-          </ModalText>
-          <ModalActions>
-            <ModalButton onClick={() => setShowCancelModal(false)}>
-              Keep Working
-            </ModalButton>
-            <ModalButton
-              $variant="danger"
-              onClick={handleCancelConfirm}
-              disabled={!!cancelingId}
-            >
-              {cancelingId ? 'Cancelling...' : 'Yes, Cancel'}
-            </ModalButton>
-          </ModalActions>
-        </ModalContent>
-      </Modal>
       </Container>
     </ErrorBoundary>
   );


### PR DESCRIPTION
### What\n- Add keyboard navigation + ARIA roles for WorkForms Catalog + History tablists\n- Replace custom cancel modal in In Progress with AntD confirmDialog (better focus/escape behavior)\n\n### Testing\n- npm --prefix frontend run verify-standards\n- npm --prefix frontend run test:ci