### PR TITLE
WorkForms: execution story timeline

### DIFF
--- a/frontend/src/features/workforms/ExecutionStoryView.tsx
+++ b/frontend/src/features/workforms/ExecutionStoryView.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+
+import type { WorkFormExecution } from '@/services/workformExecutionService';
+import { buildExecutionStory } from './executionStory';
+
+function formatTs(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toISOString().replace('.000Z', 'Z');
+}
+
+function variantStyles(variant: string): { border: string; background: string; color: string } {
+  switch (variant) {
+    case 'error':
+      return {
+        border: 'rgb(var(--color-error))',
+        background: 'rgb(var(--color-error) / 0.08)',
+        color: 'rgb(var(--color-error))',
+      };
+    case 'success':
+      return {
+        border: 'rgb(var(--color-success))',
+        background: 'rgb(var(--color-success) / 0.10)',
+        color: 'rgb(var(--color-success))',
+      };
+    case 'warning':
+      return {
+        border: 'rgb(var(--color-warning))',
+        background: 'rgb(var(--color-warning) / 0.10)',
+        color: 'rgb(var(--color-warning))',
+      };
+    case 'info':
+      return {
+        border: 'rgb(var(--color-info))',
+        background: 'rgb(var(--color-info) / 0.10)',
+        color: 'rgb(var(--color-info))',
+      };
+    default:
+      return {
+        border: 'rgb(var(--color-border))',
+        background: 'rgb(var(--color-surface))',
+        color: 'rgb(var(--color-text-secondary))',
+      };
+  }
+}
+
+export const ExecutionStoryView: React.FC<{ execution: WorkFormExecution }> = ({ execution }) => {
+  const events = React.useMemo(() => buildExecutionStory(execution), [execution]);
+
+  return (
+    <section aria-labelledby="execution-story-heading">
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
+        <h2 id="execution-story-heading" style={{ margin: 0, fontSize: 15, fontWeight: 700 }}>
+          Execution story
+        </h2>
+        <div style={{ color: 'rgb(var(--color-text-tertiary))', fontSize: 12 }}>
+          {execution.started_at ? (
+            <time dateTime={execution.started_at}>Started: {formatTs(execution.started_at)}</time>
+          ) : null}
+          {execution.completed_at ? (
+            <>
+              {' '}•{' '}
+              <time dateTime={execution.completed_at}>Completed: {formatTs(execution.completed_at)}</time>
+            </>
+          ) : null}
+        </div>
+      </div>
+
+      {events.length === 0 ? (
+        <div style={{ color: 'rgb(var(--color-text-secondary))', marginTop: 8 }}>
+          No events recorded yet.
+        </div>
+      ) : (
+        <ol
+          role="list"
+          aria-label="Execution story"
+          style={{
+            margin: '12px 0 0',
+            padding: 0,
+            listStyle: 'none',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          {events.map((ev) => {
+            const styles = variantStyles(ev.variant);
+            return (
+              <li
+                key={ev.key}
+                role="listitem"
+                style={{
+                  border: `1px solid ${styles.border}`,
+                  borderRadius: 12,
+                  padding: 12,
+                  background: styles.background,
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    gap: 12,
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <div style={{ fontWeight: 700, color: 'rgb(var(--color-text-primary))' }}>{ev.title}</div>
+
+                    {ev.node?.id ? (
+                      <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
+                        Step:{' '}
+                        <span style={{ fontWeight: 600 }}>
+                          {ev.node.label ?? ev.node.id}
+                        </span>
+                        {ev.node.label ? (
+                          <span style={{ color: 'rgb(var(--color-text-tertiary))' }}> ({ev.node.id})</span>
+                        ) : null}
+                        {ev.node.type ? <span> • {ev.node.type}</span> : null}
+                      </div>
+                    ) : null}
+
+                    {ev.description ? (
+                      <div style={{ color: styles.color, fontSize: 13, fontWeight: 600 }}>{ev.description}</div>
+                    ) : null}
+                  </div>
+
+                  {ev.ts ? (
+                    <time dateTime={ev.ts} style={{ color: 'rgb(var(--color-text-tertiary))', fontSize: 12 }}>
+                      {formatTs(ev.ts)}
+                    </time>
+                  ) : null}
+                </div>
+
+                {ev.meta ? (
+                  <details style={{ marginTop: 8 }}>
+                    <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
+                      Details (JSON)
+                    </summary>
+                    <pre
+                      style={{
+                        background: 'rgb(var(--color-surface))',
+                        border: '1px solid rgb(var(--color-border))',
+                        borderRadius: 8,
+                        padding: 12,
+                        overflow: 'auto',
+                        maxHeight: 240,
+                        marginTop: 8,
+                      }}
+                    >
+                      {JSON.stringify(ev.meta, null, 2)}
+                    </pre>
+                  </details>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+};

--- a/frontend/src/features/workforms/executionStory.test.ts
+++ b/frontend/src/features/workforms/executionStory.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildExecutionStory } from './executionStory';
+
+describe('buildExecutionStory', () => {
+  it('humanizes known events and maps node labels', () => {
+    const execution: any = {
+      id: 'ex-1',
+      node_labels: { n1: 'Send Email' },
+      audit_trail: [{ event: 'execution_start' }, { event: 'node_enter', node_id: 'n1' }],
+    };
+
+    const story = buildExecutionStory(execution);
+
+    expect(story[0].title).toBe('Run started');
+    expect(story[1].title).toBe('Entered step');
+    expect(story[1].node?.label).toBe('Send Email');
+  });
+
+  it('renders unknown events as a fallback title', () => {
+    const execution: any = {
+      id: 'ex-1',
+      audit_trail: [{ event: 'weird_backend_event' }],
+    };
+
+    const story = buildExecutionStory(execution);
+    expect(story[0].title).toBe('weird backend event');
+  });
+
+  it('includes action_error message and routed_to description when present', () => {
+    const execution: any = {
+      id: 'ex-1',
+      node_labels: { n2: 'Create Task' },
+      audit_trail: [{ event: 'action_error', error: 'Boom', routed_to: 'n2' }],
+    };
+
+    const story = buildExecutionStory(execution);
+
+    expect(story[0].variant).toBe('error');
+    expect(story[0].description).toMatch(/Boom/);
+    expect(story[0].description).toMatch(/Routed to: Create Task/);
+  });
+});

--- a/frontend/src/features/workforms/executionStory.ts
+++ b/frontend/src/features/workforms/executionStory.ts
@@ -1,0 +1,109 @@
+import type {
+  WorkFormExecution,
+  WorkFormExecutionAuditEvent,
+} from '@/services/workformExecutionService';
+
+export type ExecutionStoryEventVariant = 'default' | 'info' | 'success' | 'warning' | 'error';
+
+export type ExecutionStoryEvent = {
+  key: string;
+  ts?: string;
+  title: string;
+  variant: ExecutionStoryEventVariant;
+  node?: {
+    id?: string;
+    label?: string;
+    type?: string;
+  };
+  description?: string;
+  meta?: Record<string, unknown>;
+};
+
+const EVENT_TITLES: Record<string, string> = {
+  execution_start: 'Run started',
+  execution_complete: 'Run completed',
+  node_enter: 'Entered step',
+  node_terminal: 'Reached end',
+  action_start: 'Started action',
+  action_success: 'Action completed',
+  action_error: 'Action failed',
+  loop_enqueued: 'Loop enqueued',
+};
+
+function humanizeEvent(raw: string): string {
+  if (!raw) return 'Event';
+  const direct = EVENT_TITLES[raw];
+  if (direct) return direct;
+  return raw.split('_').join(' ');
+}
+
+function getEventVariant(raw: string): ExecutionStoryEventVariant {
+  if (raw === 'action_error') return 'error';
+  if (raw === 'action_success' || raw === 'execution_complete' || raw === 'node_terminal') return 'success';
+  if (raw === 'execution_start' || raw === 'node_enter' || raw === 'action_start' || raw === 'loop_enqueued') return 'info';
+  return 'default';
+}
+
+function getEventError(row: WorkFormExecutionAuditEvent): string | undefined {
+  const candidates = [row.error, row.detail, row.message];
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.trim()) return c;
+  }
+  return undefined;
+}
+
+function toMeta(row: WorkFormExecutionAuditEvent): Record<string, unknown> | undefined {
+  const { event: _event, ts: _ts, node_id: _nodeId, node_type: _nodeType, ...rest } = row;
+  const keys = Object.keys(rest);
+  if (keys.length === 0) return undefined;
+
+  const meta: Record<string, unknown> = {};
+  for (const k of keys) {
+    const v = (rest as any)[k];
+    // Avoid huge blobs in the story details.
+    if (k === 'context' || k === 'inputs' || k === 'raw') continue;
+    meta[k] = v;
+  }
+
+  return Object.keys(meta).length ? meta : undefined;
+}
+
+export function buildExecutionStory(execution: WorkFormExecution): ExecutionStoryEvent[] {
+  const labels = execution.node_labels ?? {};
+  const trail = Array.isArray(execution.audit_trail) ? execution.audit_trail : [];
+
+  return trail.map((row, idx) => {
+    const event = typeof row.event === 'string' ? row.event : 'event';
+    const nodeId = typeof row.node_id === 'string' && row.node_id.trim() ? row.node_id : undefined;
+
+    const routedTo = typeof row.routed_to === 'string' && row.routed_to.trim() ? row.routed_to : undefined;
+
+    const descParts: string[] = [];
+
+    const err = getEventError(row);
+    if (event === 'action_error' && err) {
+      descParts.push(err);
+    }
+
+    if (routedTo) {
+      const label = labels[routedTo];
+      descParts.push(`Routed to: ${label ?? routedTo}`);
+    }
+
+    return {
+      key: `${execution.id}:audit:${idx}`,
+      ts: typeof row.ts === 'string' ? row.ts : undefined,
+      title: humanizeEvent(event),
+      variant: getEventVariant(event),
+      node: nodeId
+        ? {
+            id: nodeId,
+            label: labels[nodeId],
+            type: typeof row.node_type === 'string' ? row.node_type : undefined,
+          }
+        : undefined,
+      description: descParts.length ? descParts.join(' • ') : undefined,
+      meta: toMeta(row),
+    };
+  });
+}

--- a/frontend/src/pages/WorkForms/ExecutionDetails.test.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.test.tsx
@@ -24,17 +24,28 @@ describe('WorkFormExecutionDetails', () => {
       status: 'failed',
       initial_data: { entity_type: 'customer', entity_id: '1' },
       context_data: {},
-      audit_trail: [],
+      audit_trail: [
+        { event: 'execution_start', ts: '2026-01-01T00:00:00Z' },
+        { event: 'node_enter', node_id: 'n1', node_type: 'actionEmail', ts: '2026-01-01T00:00:01Z' },
+        {
+          event: 'action_error',
+          node_id: 'n1',
+          node_type: 'actionEmail',
+          error: 'Boom',
+          routed_to: 'n2',
+          ts: '2026-01-01T00:00:02Z',
+        },
+      ],
       node_statuses: {},
-      node_labels: { n1: 'Send Email' },
+      node_labels: { n1: 'Send Email', n2: 'Create Task' },
       current_node_id: 'n1',
       current_node_type: 'actionEmail',
       current_node_label: 'Send Email',
       last_event: 'action_error',
-      errors: [{ node_id: 'n1', node_label: 'Send Email', error: 'Boom' }],
+      errors: [{ node_id: 'n1', node_label: 'Send Email', error: 'Boom', routed_to: 'n2' }],
       started_by: null,
       started_by_name: null,
-      started_at: null,
+      started_at: '2026-01-01T00:00:00Z',
       completed_at: null,
       error_message: 'Boom',
       created_on: '2026-01-01T00:00:00Z',
@@ -60,17 +71,24 @@ describe('WorkFormExecutionDetails', () => {
     expect(await screen.findByText('My WorkForm')).toBeInTheDocument();
     expect(screen.getByText(/Status:/i)).toBeInTheDocument();
 
+    expect(await screen.findByRole('heading', { name: /execution story/i })).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: /execution story/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Action failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Routed to: Create Task/i)).toBeInTheDocument();
+
     expect(await screen.findByText(/^Current step$/i)).toBeInTheDocument();
     expect(screen.getByText(/Node:/i)).toBeInTheDocument();
     expect(screen.getAllByText('Send Email').length).toBeGreaterThan(0);
     expect(screen.getAllByText(/n1/i).length).toBeGreaterThan(0);
 
+    expect(await screen.findByText(/^Errors$/i)).toBeInTheDocument();
+    expect(screen.getAllByText('Boom').length).toBeGreaterThan(0);
+
+    await userEvent.click(screen.getByText(/^Debug data$/i));
     expect(await screen.findByText(/^Inputs$/i)).toBeInTheDocument();
     await userEvent.click(screen.getByText(/View raw inputs/i));
     expect(await screen.findByText(/entity_type/i)).toBeInTheDocument();
-
-    expect(await screen.findByText(/^Errors$/i)).toBeInTheDocument();
-    expect(screen.getAllByText('Boom').length).toBeGreaterThan(0);
   });
 
   it('renders a helpful error panel when the run cannot be loaded', async () => {

--- a/frontend/src/pages/WorkForms/ExecutionDetails.tsx
+++ b/frontend/src/pages/WorkForms/ExecutionDetails.tsx
@@ -11,6 +11,7 @@ import { PageContainer } from '@/components/ui/PageContainer';
 import { workformExecutionService } from '@/services/workformExecutionService';
 import { formSubmissionService } from '@/services/quickActionsService';
 import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
+import { ExecutionStoryView } from '@/features/workforms/ExecutionStoryView';
 
 export const WorkFormExecutionDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -111,7 +112,9 @@ export const WorkFormExecutionDetails: React.FC = () => {
               </div>
             ) : null}
 
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 12 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <ExecutionStoryView execution={execution} />
+
               <div data-testid="workform-execution-current-step">
                 <div style={{ fontWeight: 600, marginBottom: 6 }}>Current step</div>
                 {execution.current_node_id ? (
@@ -214,124 +217,132 @@ export const WorkFormExecutionDetails: React.FC = () => {
                 </div>
               ) : null}
 
-              <div>
-                <div style={{ fontWeight: 600, marginBottom: 6 }}>Inputs</div>
-                <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
-                  {execution.initial_data && typeof execution.initial_data === 'object'
-                    ? `${Object.keys(execution.initial_data).length} key(s)`
-                    : 'No inputs captured.'}
-                </div>
-                <details style={{ marginTop: 8 }}>
-                  <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>View raw inputs</summary>
-                  <pre
-                    style={{
-                      background: 'rgb(var(--color-surface))',
-                      border: '1px solid rgb(var(--color-border))',
-                      borderRadius: 8,
-                      padding: 12,
-                      overflow: 'auto',
-                      maxHeight: 240,
-                      marginTop: 8,
-                    }}
-                  >
-                    {JSON.stringify(execution.initial_data ?? {}, null, 2)}
-                  </pre>
-                </details>
-              </div>
+              <details data-testid="workform-execution-debug" style={{ border: '1px solid rgb(var(--color-border))', borderRadius: 12, padding: 12 }}>
+                <summary style={{ cursor: 'pointer', fontWeight: 600, color: 'rgb(var(--color-text-primary))' }}>
+                  Debug data
+                </summary>
 
-              {execution.node_statuses && Object.keys(execution.node_statuses).length > 0 ? (
-                <div>
-                  <div style={{ fontWeight: 600, marginBottom: 6 }}>Step status</div>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                    {Object.entries(execution.node_statuses)
-                      .filter(([k, v]) => Boolean(k) && Boolean(v))
-                      .sort(([a], [b]) => {
-                        const la = execution.node_labels?.[a] ?? a;
-                        const lb = execution.node_labels?.[b] ?? b;
-                        return la.localeCompare(lb);
-                      })
-                      .map(([nodeId, status]) => (
-                        <div key={`${execution.id}:status:${nodeId}`} style={{ color: 'rgb(var(--color-text-secondary))' }}>
-                          <span style={{ fontWeight: 600 }}>{execution.node_labels?.[nodeId] ?? nodeId}</span>
-                          {execution.node_labels?.[nodeId] ? (
-                            <span style={{ color: 'rgb(var(--color-text-tertiary))' }}> ({nodeId})</span>
-                          ) : null}
-                          : <span style={{ fontWeight: 600 }}>{String(status)}</span>
-                        </div>
-                      ))}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 16, marginTop: 12 }}>
+                  <div>
+                    <div style={{ fontWeight: 600, marginBottom: 6 }}>Inputs</div>
+                    <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
+                      {execution.initial_data && typeof execution.initial_data === 'object'
+                        ? `${Object.keys(execution.initial_data).length} key(s)`
+                        : 'No inputs captured.'}
+                    </div>
+                    <details style={{ marginTop: 8 }}>
+                      <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>View raw inputs</summary>
+                      <pre
+                        style={{
+                          background: 'rgb(var(--color-surface))',
+                          border: '1px solid rgb(var(--color-border))',
+                          borderRadius: 8,
+                          padding: 12,
+                          overflow: 'auto',
+                          maxHeight: 240,
+                          marginTop: 8,
+                        }}
+                      >
+                        {JSON.stringify(execution.initial_data ?? {}, null, 2)}
+                      </pre>
+                    </details>
                   </div>
 
-                  <details style={{ marginTop: 8 }}>
-                    <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
-                      View raw status map
-                    </summary>
-                    <pre
-                      style={{
-                        background: 'rgb(var(--color-surface))',
-                        border: '1px solid rgb(var(--color-border))',
-                        borderRadius: 8,
-                        padding: 12,
-                        overflow: 'auto',
-                        maxHeight: 240,
-                        marginTop: 8,
-                      }}
-                    >
-                      {JSON.stringify(execution.node_statuses, null, 2)}
-                    </pre>
-                  </details>
-                </div>
-              ) : null}
+                  {execution.node_statuses && Object.keys(execution.node_statuses).length > 0 ? (
+                    <div>
+                      <div style={{ fontWeight: 600, marginBottom: 6 }}>Step status</div>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        {Object.entries(execution.node_statuses)
+                          .filter(([k, v]) => Boolean(k) && Boolean(v))
+                          .sort(([a], [b]) => {
+                            const la = execution.node_labels?.[a] ?? a;
+                            const lb = execution.node_labels?.[b] ?? b;
+                            return la.localeCompare(lb);
+                          })
+                          .map(([nodeId, status]) => (
+                            <div key={`${execution.id}:status:${nodeId}`} style={{ color: 'rgb(var(--color-text-secondary))' }}>
+                              <span style={{ fontWeight: 600 }}>{execution.node_labels?.[nodeId] ?? nodeId}</span>
+                              {execution.node_labels?.[nodeId] ? (
+                                <span style={{ color: 'rgb(var(--color-text-tertiary))' }}> ({nodeId})</span>
+                              ) : null}
+                              : <span style={{ fontWeight: 600 }}>{String(status)}</span>
+                            </div>
+                          ))}
+                      </div>
 
-              <div>
-                <div style={{ fontWeight: 600, marginBottom: 6 }}>Context</div>
-                <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
-                  Use this for debugging; most UI panels should rely on derived fields (current step, errors, status).
-                </div>
-                <details style={{ marginTop: 8 }}>
-                  <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
-                    View raw context
-                  </summary>
-                  <pre
-                    style={{
-                      background: 'rgb(var(--color-surface))',
-                      border: '1px solid rgb(var(--color-border))',
-                      borderRadius: 8,
-                      padding: 12,
-                      overflow: 'auto',
-                      maxHeight: 360,
-                      marginTop: 8,
-                    }}
-                  >
-                    {JSON.stringify(execution.context_data ?? {}, null, 2)}
-                  </pre>
-                </details>
-              </div>
+                      <details style={{ marginTop: 8 }}>
+                        <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
+                          View raw status map
+                        </summary>
+                        <pre
+                          style={{
+                            background: 'rgb(var(--color-surface))',
+                            border: '1px solid rgb(var(--color-border))',
+                            borderRadius: 8,
+                            padding: 12,
+                            overflow: 'auto',
+                            maxHeight: 240,
+                            marginTop: 8,
+                          }}
+                        >
+                          {JSON.stringify(execution.node_statuses, null, 2)}
+                        </pre>
+                      </details>
+                    </div>
+                  ) : null}
 
-              <div>
-                <div style={{ fontWeight: 600, marginBottom: 6 }}>Audit Trail</div>
-                {Array.isArray(execution.audit_trail) && execution.audit_trail.length > 0 ? (
-                  <details>
-                    <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
-                      View raw audit trail ({execution.audit_trail.length} event(s))
-                    </summary>
-                    <pre
-                      style={{
-                        background: 'rgb(var(--color-surface))',
-                        border: '1px solid rgb(var(--color-border))',
-                        borderRadius: 8,
-                        padding: 12,
-                        overflow: 'auto',
-                        maxHeight: 360,
-                        marginTop: 8,
-                      }}
-                    >
-                      {JSON.stringify(execution.audit_trail, null, 2)}
-                    </pre>
-                  </details>
-                ) : (
-                  <div style={{ color: 'rgb(var(--color-text-secondary))' }}>No audit entries yet.</div>
-                )}
-              </div>
+                  <div>
+                    <div style={{ fontWeight: 600, marginBottom: 6 }}>Context</div>
+                    <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
+                      Use this for debugging; most UI panels should rely on derived fields (current step, errors, status).
+                    </div>
+                    <details style={{ marginTop: 8 }}>
+                      <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
+                        View raw context
+                      </summary>
+                      <pre
+                        style={{
+                          background: 'rgb(var(--color-surface))',
+                          border: '1px solid rgb(var(--color-border))',
+                          borderRadius: 8,
+                          padding: 12,
+                          overflow: 'auto',
+                          maxHeight: 360,
+                          marginTop: 8,
+                        }}
+                      >
+                        {JSON.stringify(execution.context_data ?? {}, null, 2)}
+                      </pre>
+                    </details>
+                  </div>
+
+                  <div>
+                    <div style={{ fontWeight: 600, marginBottom: 6 }}>Audit Trail</div>
+                    {Array.isArray(execution.audit_trail) && execution.audit_trail.length > 0 ? (
+                      <details>
+                        <summary style={{ cursor: 'pointer', color: 'rgb(var(--color-text-secondary))' }}>
+                          View raw audit trail ({execution.audit_trail.length} event(s))
+                        </summary>
+                        <pre
+                          style={{
+                            background: 'rgb(var(--color-surface))',
+                            border: '1px solid rgb(var(--color-border))',
+                            borderRadius: 8,
+                            padding: 12,
+                            overflow: 'auto',
+                            maxHeight: 360,
+                            marginTop: 8,
+                          }}
+                        >
+                          {JSON.stringify(execution.audit_trail, null, 2)}
+                        </pre>
+                      </details>
+                    ) : (
+                      <div style={{ color: 'rgb(var(--color-text-secondary))' }}>No audit entries yet.</div>
+                    )}
+                  </div>
+                </div>
+              </details>
             </div>
           </div>
         )}


### PR DESCRIPTION
### What\n- Add user-first Execution story timeline derived from audit_trail (node label mapping + routed_to + errors)\n- Collapse raw JSON panels under a single "Debug data" expander\n- Add unit tests for story mapping + update ExecutionDetails tests\n\n### Testing\n- npm --prefix frontend run verify-standards\n- npm --prefix frontend run test:ci