### PR TITLE
Security: restrict product entity options visibility

### DIFF
--- a/backend/apps/core/entity_views.py
+++ b/backend/apps/core/entity_views.py
@@ -330,12 +330,18 @@ def entity_lookup(request, entity_type):
             tenant = tenant_user.tenant
 
     # Build base queryset with tenant filter where applicable.
-    # Some entities are system-wide (e.g., Product) or utility (e.g., User).
+    # Some entities are system-wide (e.g., system.Product) or utility (e.g., User).
     queryset = model.objects.all()
 
     if entity_type == 'user':
         # Safe default: only allow selecting the current user.
         queryset = queryset.filter(id=request.user.id)
+    elif entity_type == 'product':
+        # system.Product has no tenant FK; apply visibility rules so we don't leak
+        # tenant-owned custom products or tenant-hidden system products.
+        from apps.system.services.product_visibility import visible_products_qs
+
+        queryset = visible_products_qs(tenant=tenant, qs=queryset)
     else:
         if not tenant:
             return Response(
@@ -354,6 +360,8 @@ def entity_lookup(request, entity_type):
             search_fields.append('name')
         if hasattr(model, 'code'):
             search_fields.append('code')
+        if hasattr(model, 'product_code'):
+            search_fields.append('product_code')
         if hasattr(model, 'company_name'):
             search_fields.append('company_name')
         if hasattr(model, 'email'):
@@ -385,6 +393,9 @@ def entity_lookup(request, entity_type):
             # Add code if available
             if hasattr(obj, 'code') and obj.code:
                 label = f"{obj.name} ({obj.code})"
+            # Product uses product_code not code
+            if hasattr(obj, 'product_code') and getattr(obj, 'product_code', None):
+                label = f"{obj.product_code} - {obj.name}"
         elif hasattr(obj, 'company_name'):
             label = obj.company_name
         elif hasattr(obj, 'email'):

--- a/backend/apps/core/tests/test_entity_lookup_product_visibility.py
+++ b/backend/apps/core/tests/test_entity_lookup_product_visibility.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.core import entity_views
+from apps.system.models import Product, TenantProductPreference
+from apps.tenants.models import Tenant, TenantUser
+from apps.tenants.rls import set_current_tenant
+
+
+User = get_user_model()
+
+
+class EntityLookupProductVisibilityTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f"u-{unique}", password="pw")
+
+        self.tenant_a = Tenant.objects.create(
+            name=f"Tenant A {unique}",
+            slug=f"tenant-a-{unique}",
+            contact_email=f"a-{unique}@example.com",
+            is_active=True,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f"Tenant B {unique}",
+            slug=f"tenant-b-{unique}",
+            contact_email=f"b-{unique}@example.com",
+            is_active=True,
+        )
+
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role="admin", is_active=True)
+        TenantUser.objects.create(tenant=self.tenant_b, user=self.user, role="admin", is_active=True)
+
+        self.system_product = Product.objects.create(
+            product_code=f"SYS-{unique}",
+            name="System Product",
+            is_system=True,
+            protein_type="",
+        )
+        self.custom_a = Product.objects.create(
+            product_code=f"CUST-A-{unique}",
+            name="Custom A",
+            is_system=False,
+            protein_type="",
+        )
+
+        # Tenant A owns custom_a, and hides system_product
+        set_current_tenant(str(self.tenant_a.id))
+        TenantProductPreference.objects.create(
+            tenant=self.tenant_a,
+            product=self.custom_a,
+            is_active=True,
+            is_custom=True,
+            display_name="Tenant A Custom",
+        )
+        TenantProductPreference.objects.create(
+            tenant=self.tenant_a,
+            product=self.system_product,
+            is_active=False,
+            is_custom=False,
+        )
+
+    def tearDown(self):
+        with connection.cursor() as cursor:
+            cursor.execute("RESET app.current_tenant_id")
+            cursor.execute("RESET app.current_tenant")
+
+    def test_entity_lookup_product_respects_visibility(self):
+        set_current_tenant(str(self.tenant_a.id))
+        request = self.factory.get("/api/v1/entities/product/lookup/?page=1&page_size=200")
+        force_authenticate(request, user=self.user)
+        request.tenant = self.tenant_a
+
+        response = entity_views.entity_lookup(request, entity_type="product")
+        self.assertEqual(response.status_code, 200)
+
+        values = {row["value"] for row in response.data.get("options", [])}
+
+        # Hidden system product must not be visible
+        self.assertNotIn(str(self.system_product.id), values)
+
+        # Tenant custom product is visible
+        self.assertIn(str(self.custom_a.id), values)

--- a/backend/tenant_apps/workflows/tests/test_entity_options_product_visibility.py
+++ b/backend/tenant_apps/workflows/tests/test_entity_options_product_visibility.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.db import connection
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.system.models import Product, TenantProductPreference
+from apps.tenants.models import Tenant, TenantUser
+from apps.tenants.rls import set_current_tenant
+from tenant_apps.workflows.views import EntityOptionsAPIView, QuickCreateEntityAPIView
+
+
+User = get_user_model()
+
+
+class EntityOptionsProductVisibilityTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f"u-{unique}", password="pw")
+
+        self.tenant_a = Tenant.objects.create(
+            name=f"Tenant A {unique}",
+            slug=f"tenant-a-{unique}",
+            contact_email=f"a-{unique}@example.com",
+            is_active=True,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f"Tenant B {unique}",
+            slug=f"tenant-b-{unique}",
+            contact_email=f"b-{unique}@example.com",
+            is_active=True,
+        )
+
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role="admin", is_active=True)
+        TenantUser.objects.create(tenant=self.tenant_b, user=self.user, role="admin", is_active=True)
+
+        # Products are global (system.Product)
+        self.system_product = Product.objects.create(
+            product_code=f"SYS-{unique}",
+            name="System Product",
+            is_system=True,
+            protein_type="",
+        )
+        self.custom_a = Product.objects.create(
+            product_code=f"CUST-A-{unique}",
+            name="Custom A",
+            is_system=False,
+            protein_type="",
+        )
+        self.custom_b = Product.objects.create(
+            product_code=f"CUST-B-{unique}",
+            name="Custom B",
+            is_system=False,
+            protein_type="",
+        )
+
+        # Tenant A owns custom_a, and hides system_product
+        set_current_tenant(str(self.tenant_a.id))
+        TenantProductPreference.objects.create(
+            tenant=self.tenant_a,
+            product=self.custom_a,
+            is_active=True,
+            is_custom=True,
+            display_name="Tenant A Custom",
+        )
+        TenantProductPreference.objects.create(
+            tenant=self.tenant_a,
+            product=self.system_product,
+            is_active=False,
+            is_custom=False,
+        )
+
+        # Tenant B owns custom_b
+        set_current_tenant(str(self.tenant_b.id))
+        TenantProductPreference.objects.create(
+            tenant=self.tenant_b,
+            product=self.custom_b,
+            is_active=True,
+            is_custom=True,
+            display_name="Tenant B Custom",
+        )
+
+    def tearDown(self):
+        with connection.cursor() as cursor:
+            cursor.execute("RESET app.current_tenant_id")
+            cursor.execute("RESET app.current_tenant")
+
+    def _get_options(self, *, tenant: Tenant, query: str = ""):
+        set_current_tenant(str(tenant.id))
+        request = self.factory.get(f"/api/v1/workflows/entity-options/product/?limit=500{query}")
+        force_authenticate(request, user=self.user)
+        request.tenant = tenant
+        response = EntityOptionsAPIView.as_view()(request, entity_type="product")
+        self.assertEqual(response.status_code, 200)
+        return response.data
+
+    def test_entity_options_product_respects_visibility_tenant_a(self):
+        data = self._get_options(tenant=self.tenant_a)
+        options = data["options"]
+        values = {row["value"] for row in options}
+        labels = {row["label"] for row in options}
+
+        # Hidden system product must not be visible
+        self.assertNotIn(str(self.system_product.id), values)
+
+        # Tenant A custom product is visible to Tenant A
+        self.assertIn(str(self.custom_a.id), values)
+        self.assertIn("Tenant A Custom", " ".join(labels))
+
+        # Tenant B custom product must not leak
+        self.assertNotIn(str(self.custom_b.id), values)
+
+        # Search should not resurrect hidden products
+        searched = self._get_options(tenant=self.tenant_a, query="&q=System")
+        searched_values = {row["value"] for row in searched["options"]}
+        self.assertNotIn(str(self.system_product.id), searched_values)
+
+        # Tenant members should not be able to quick-create global products
+        self.assertFalse(data.get("can_create"))
+
+    def test_entity_options_product_respects_visibility_tenant_b(self):
+        data = self._get_options(tenant=self.tenant_b)
+        values = {row["value"] for row in data["options"]}
+
+        # System product is visible by default to tenant B (not hidden there)
+        self.assertIn(str(self.system_product.id), values)
+
+        # Tenant B custom product is visible to Tenant B
+        self.assertIn(str(self.custom_b.id), values)
+
+        # Tenant A custom product must not leak
+        self.assertNotIn(str(self.custom_a.id), values)
+
+    def test_quick_create_product_denies_tenant_user_even_with_django_perm(self):
+        perm = Permission.objects.get(codename="add_product")
+        self.user.user_permissions.add(perm)
+
+        set_current_tenant(str(self.tenant_a.id))
+        request = self.factory.post(
+            "/api/v1/workflows/quick-create/product/",
+            {"product_code": "X", "name": "Should not create"},
+            format="json",
+        )
+        force_authenticate(request, user=self.user)
+        request.tenant = self.tenant_a
+
+        response = QuickCreateEntityAPIView.as_view()(request, entity_type="product")
+        self.assertEqual(response.status_code, 403)

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2931,15 +2931,44 @@ class EntityOptionsAPIView(APIView):
         try:
             if hasattr(model, "tenant"):
                 queryset = model.objects.filter(tenant=tenant)
+            elif entity_type == "product":
+                # system.Product is global (no tenant FK).
+                # Apply central visibility rules so we do not leak:
+                # - tenant-hidden system products
+                # - tenant-owned custom products (is_system=False)
+                from django.db.models import Prefetch
+
+                from apps.system.models import TenantProductPreference
+                from apps.system.services.product_visibility import visible_products_qs
+
+                queryset = visible_products_qs(tenant=tenant, qs=model.objects.all()).prefetch_related(
+                    Prefetch(
+                        "tenant_preferences",
+                        queryset=TenantProductPreference.objects.filter(tenant=tenant),
+                    )
+                )
             else:
-                queryset = model.objects.all()
+                # Fail closed for global/non-tenant models (unless explicitly allowlisted).
+                return Response(
+                    {"error": "Entity options are not available for this entity type."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
 
             # Search functionality
             search_query = request.query_params.get("q", "").strip()
             if search_query:
                 # Build search filter based on common fields
                 search_filter = Q()
-                searchable_fields = ["name", "title", "code", "email", "first_name", "last_name", "company_name"]
+                searchable_fields = [
+                    "name",
+                    "title",
+                    "code",
+                    "product_code",
+                    "email",
+                    "first_name",
+                    "last_name",
+                    "company_name",
+                ]
                 for field_name in searchable_fields:
                     if hasattr(model, field_name):
                         search_filter |= Q(**{f"{field_name}__icontains": search_query})
@@ -2961,7 +2990,19 @@ class EntityOptionsAPIView(APIView):
             for obj in queryset:
                 # Try to get a display label
                 label = str(obj)
-                if hasattr(obj, "name"):
+
+                if entity_type == "product":
+                    # Prefer tenant override when present.
+                    pref = None
+                    try:
+                        pref = obj.tenant_preferences.all()[0] if hasattr(obj, "tenant_preferences") else None
+                    except Exception:
+                        pref = None
+
+                    effective_name = getattr(pref, "effective_name", "") or getattr(obj, "name", "") or str(obj)
+                    product_code = getattr(obj, "product_code", "")
+                    label = f"{product_code} - {effective_name}" if product_code else effective_name
+                elif hasattr(obj, "name"):
                     label = obj.name
                 elif hasattr(obj, "title"):
                     label = obj.title
@@ -2991,7 +3032,10 @@ class EntityOptionsAPIView(APIView):
 
             is_global_admin = request.user.groups.filter(name='Global System Admins').exists()
 
-            if entity_type in QUICK_CREATE_MEMBER_ENTITY_TYPES:
+            if entity_type == "product":
+                # Products are system-wide; only superusers/global admins should create them.
+                can_create = bool(getattr(request.user, "is_superuser", False)) or is_global_admin
+            elif entity_type in QUICK_CREATE_MEMBER_ENTITY_TYPES:
                 can_create = bool(getattr(request.user, "is_superuser", False)) or is_global_admin or _is_active_tenant_member()
             else:
                 can_create = request.user.has_perm(f"{model._meta.app_label}.add_{model._meta.model_name}")
@@ -3233,7 +3277,11 @@ class QuickCreateEntityAPIView(APIView):
 
         is_global_admin = request.user.groups.filter(name='Global System Admins').exists()
 
-        if entity_type in QUICK_CREATE_MEMBER_ENTITY_TYPES:
+        if entity_type == "product":
+            # Products are system-wide master data.
+            if not (getattr(request.user, "is_superuser", False) or is_global_admin):
+                return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
+        elif entity_type in QUICK_CREATE_MEMBER_ENTITY_TYPES:
             if not (getattr(request.user, "is_superuser", False) or is_global_admin or _is_active_tenant_member()):
                 return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
         else:


### PR DESCRIPTION
### What\n- WorkForms entity-options: for product, route through visible_products_qs and prefetch tenant preferences (prevents cross-tenant custom product leakage)\n- Fail closed for non-tenant global models unless allowlisted\n- Harden quick-create(product) so only superusers/Global System Admins can create global master products\n- Add regression tests for both /workflows/entity-options/product and /entities/product/lookup\n\n### Testing\n- python backend/manage.py test tenant_apps.workflows.tests.test_entity_options_product_visibility apps.core.tests.test_entity_lookup_product_visibility --keepdb --noinput