### PR TITLE
CI: enforce secrets manifest across all workflows

### DIFF
--- a/.github/scripts/validate-workflows.sh
+++ b/.github/scripts/validate-workflows.sh
@@ -47,15 +47,30 @@ validate_yaml_syntax() {
     return 0
 }
 
-# Check workflow secrets against env manifest (key workflows only)
-check_manifest_secrets_for_key_workflows() {
-    log_info "Checking workflow secrets against manifests/env.manifest.json (key workflows)..."
+# Check workflow secrets against env manifest (all workflows)
+check_manifest_secrets_for_all_workflows() {
+    local report_only="${WORKFLOW_SECRETS_MANIFEST_REPORT_ONLY:-0}"
+
+    if [[ "$report_only" == "1" ]]; then
+        log_warn "Checking workflow secrets against manifests/env.manifest.json (ALL workflows, report-only)..."
+    else
+        log_info "Checking workflow secrets against manifests/env.manifest.json (ALL workflows)..."
+    fi
 
     if ! python - <<'PY'
 import json
 import re
 import sys
+import os
 from pathlib import Path
+
+try:
+    import yaml
+except Exception as e:
+    print(f"ERROR: pyyaml not available: {e}", file=sys.stderr)
+    raise SystemExit(1)
+
+report_only = os.environ.get('WORKFLOW_SECRETS_MANIFEST_REPORT_ONLY') == '1'
 
 manifest_path = Path('manifests/env.manifest.json')
 if not manifest_path.exists():
@@ -73,41 +88,75 @@ for _cat, items in env_secrets.items():
     if isinstance(items, dict):
         allowed |= set(items.keys())
 
+# GitHub-provided token is always available
 allowed |= {'GITHUB_TOKEN'}
 
-key_workflows = [
-    'reusable-deploy.yml',
-    'main-pipeline.yml',
-    'build-dev-image.yml',
-    '41-auto-promote-dev-to-uat.yml',
-    '42-auto-promote-uat-to-main.yml',
-]
+# Scan only inside GitHub Actions expression blocks (${{ ... }}) to avoid false positives in comments.
+expr_block_re = re.compile(r"\$\{\{.*?\}\}", re.DOTALL)
+secret_dot_re = re.compile(r"\bsecrets\.([A-Z0-9_]+)\b")
+secret_bracket_re = re.compile(r"secrets\[['\"]([A-Z0-9_]+)['\"]\]")
+secret_dynamic_index_re = re.compile(r"\bsecrets\[(?!['\"]).+?\]")
 
-secret_re = re.compile(r"secrets\.([A-Z0-9_]+)")
+wf_dir = Path('.github/workflows')
+workflow_files = sorted([p for p in wf_dir.rglob('*.yml')] + [p for p in wf_dir.rglob('*.yaml')])
+workflow_files = [p for p in workflow_files if 'archived' not in p.parts]
 
 errors = []
-for wf in key_workflows:
-    wf_path = Path('.github/workflows') / wf
-    if not wf_path.exists():
+for wf_path in workflow_files:
+    text = wf_path.read_text(encoding='utf-8', errors='ignore')
+
+    referenced = set()
+    has_dynamic_index = False
+
+    for block in expr_block_re.findall(text):
+        referenced |= set(secret_dot_re.findall(block))
+        referenced |= set(secret_bracket_re.findall(block))
+        if secret_dynamic_index_re.search(block):
+            has_dynamic_index = True
+
+    # Validate reusable workflow contract secrets: on.workflow_call.secrets (YAML keys)
+    try:
+        data = yaml.safe_load(text) or {}
+    except Exception as e:
+        errors.append(f"{wf_path.name}: failed to parse YAML for secrets contract validation: {e}")
         continue
 
-    text = wf_path.read_text(encoding='utf-8', errors='ignore')
-    referenced = set(secret_re.findall(text))
+    on_section = None
+    if isinstance(data, dict):
+        on_section = data.get('on') if 'on' in data else data.get(True)
+
+    if isinstance(on_section, dict):
+        workflow_call = on_section.get('workflow_call')
+        if isinstance(workflow_call, dict):
+            declared_secrets = workflow_call.get('secrets')
+            if isinstance(declared_secrets, dict):
+                for k in declared_secrets.keys():
+                    if isinstance(k, str):
+                        referenced.add(k)
 
     missing = sorted(referenced - allowed)
     if missing:
-        errors.append(f"{wf}: missing from manifest: {', '.join(missing)}")
+        errors.append(f"{wf_path.name}: missing from manifest: {', '.join(missing)}")
+
+    if has_dynamic_index:
+        errors.append(f"{wf_path.name}: dynamic secrets[...] indexing detected (not allowed)")
 
 if errors:
     for e in errors:
-        print(f"ERROR: {e}", file=sys.stderr)
+        level = 'WARN' if report_only else 'ERROR'
+        print(f"{level}: {e}", file=sys.stderr)
+
+    if report_only:
+        raise SystemExit(0)
+
     raise SystemExit(1)
+
+print('✓ All workflow secrets are manifest-defined')
 PY
     then
         return 1
     fi
 
-    log_info "✓ Key workflow secrets are manifest-defined"
     return 0
 }
 
@@ -463,7 +512,7 @@ main() {
     local failed=0
     
     validate_yaml_syntax || ((failed++))
-    check_manifest_secrets_for_key_workflows || ((failed++))
+    check_manifest_secrets_for_all_workflows || ((failed++))
     check_cache_config || ((failed++))
     check_health_checks || ((failed++))
     check_fetch_depth || ((failed++))

--- a/.github/workflows/98-ops-db-surgery.yml
+++ b/.github/workflows/98-ops-db-surgery.yml
@@ -62,29 +62,12 @@ jobs:
         id: context
         run: |
           {
-            # Prefer canonical environment-scoped secrets.
-            if [ -n "${{ secrets.SSH_HOST }}" ] && [ -n "${{ secrets.SSH_USER }}" ]; then
-              echo "HOST=${{ secrets.SSH_HOST }}"
-              echo "USER=${{ secrets.SSH_USER }}"
-            elif [ "${{ inputs.environment }}" == "prod" ]; then
-              echo "HOST=${{ secrets.PRODUCTION_HOST }}"
-              echo "USER=${{ secrets.PRODUCTION_USER }}"
-            elif [ "${{ inputs.environment }}" == "uat" ]; then
-              echo "HOST=${{ secrets.STAGING_HOST }}"
-              echo "USER=${{ secrets.STAGING_USER }}"
-            else
-              echo "HOST=${{ secrets.DEV_HOST }}"
-              echo "USER=${{ secrets.DEV_USER }}"
-            fi
+            # Canonical environment-scoped secrets (manifests/env.manifest.json)
+            echo "HOST=${{ secrets.SSH_HOST }}"
+            echo "USER=${{ secrets.SSH_USER }}"
 
-            # Prefer canonical SSH_PASSWORD if set; fall back to DEV_SSH_PASSWORD for dev.
-            if [ -n "${{ secrets.SSH_PASSWORD }}" ]; then
-              echo "PASS=${{ secrets.SSH_PASSWORD }}"
-            elif [ "${{ inputs.environment }}" == "dev" ] && [ -n "${{ secrets.DEV_SSH_PASSWORD }}" ]; then
-              echo "PASS=${{ secrets.DEV_SSH_PASSWORD }}"
-            else
-              echo "PASS="
-            fi
+            # Prefer password auth if SSH_KEY is not provided.
+            echo "PASS=${{ secrets.SSH_PASSWORD }}"
           } >> "$GITHUB_OUTPUT"
       
       - name: Execute SQL Surgery

--- a/.github/workflows/99-ops-management-command.yml
+++ b/.github/workflows/99-ops-management-command.yml
@@ -55,33 +55,10 @@ jobs:
         id: context
         run: |
           {
-            # Prefer environment-scoped canonical names (env.manifest.json):
-            #   SSH_HOST / SSH_USER / SSH_PASSWORD / SSH_KEY
-            # Fall back to legacy/prefixed names if canonical aren't present.
-            if [ -n "${{ secrets.SSH_HOST }}" ] && [ -n "${{ secrets.SSH_USER }}" ]; then
-              echo "HOST=\"${{ secrets.SSH_HOST }}\""
-              echo "USER=\"${{ secrets.SSH_USER }}\""
-            elif [ "${{ inputs.environment }}" == "prod" ]; then
-              echo "HOST=\"${{ secrets.PRODUCTION_HOST }}\""
-              echo "USER=\"${{ secrets.PRODUCTION_USER }}\""
-            elif [ "${{ inputs.environment }}" == "uat" ]; then
-              echo "HOST=\"${{ secrets.STAGING_HOST }}\""
-              echo "USER=\"${{ secrets.STAGING_USER }}\""
-            else
-              echo "HOST=\"${{ secrets.DEV_HOST }}\""
-              echo "USER=\"${{ secrets.DEV_USER }}\""
-            fi
-
-            # Password selection:
-            # - Prefer canonical SSH_PASSWORD if set
-            # - Fall back to DEV_SSH_PASSWORD for dev only
-            if [ -n "${{ secrets.SSH_PASSWORD }}" ]; then
-              echo "PASS=\"${{ secrets.SSH_PASSWORD }}\""
-            elif [ "${{ inputs.environment }}" == "dev" ] && [ -n "${{ secrets.DEV_SSH_PASSWORD }}" ]; then
-              echo "PASS=\"${{ secrets.DEV_SSH_PASSWORD }}\""
-            else
-              echo "PASS=\"\""
-            fi
+            # Canonical environment-scoped secrets (manifests/env.manifest.json)
+            echo "HOST=\"${{ secrets.SSH_HOST }}\""
+            echo "USER=\"${{ secrets.SSH_USER }}\""
+            echo "PASS=\"${{ secrets.SSH_PASSWORD }}\""
           } >> "$GITHUB_OUTPUT"
 
       - name: Execute Remote Command
@@ -93,11 +70,8 @@ jobs:
           DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
           DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
           # Core Django settings
-          # Prefer canonical env.manifest.json names; allow legacy fallback for safety.
-          SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY || secrets.SECRET_KEY }}
+          SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
           DJANGO_SETTINGS_MODULE: ${{ secrets.DJANGO_SETTINGS_MODULE }}
-          # Database configuration (optional; DB_* vars are the primary interface)
-          DATABASE_URL: ${{ secrets.DATABASE_URL || '' }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_USER: ${{ secrets.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}

--- a/.github/workflows/db-sync-prod-to-uat.yml
+++ b/.github/workflows/db-sync-prod-to-uat.yml
@@ -28,40 +28,39 @@ jobs:
       - name: Run infrastructure checks
         run: bash .github/scripts/check_infrastructure.sh
 
-  sync-database:
-    name: "Sync Production Data to UAT"
+  export-production:
+    name: "Export Production Business Data"
     runs-on: ubuntu-latest
     needs: [check_infrastructure]
+    environment: production-backend
     timeout-minutes: 30
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      
+
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql-client sshpass
-      
+          sudo apt-get install -y postgresql-client sshpass netcat-openbsd
+
       - name: Setup SSH tunnel to Production DB
         env:
           SSHPASS: ${{ secrets.SSH_PASSWORD }}
         run: |
           set -euo pipefail
-          
+
           echo "🔌 Starting SSH tunnel to Production DB..."
-          
-          # Start SSH tunnel with verbose logging for debugging
+
           sshpass -e ssh -v -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-            -N -L 5433:${{ secrets.PROD_DB_HOST }}:${{ secrets.PROD_DB_PORT || '5432' }} \
+            -N -L 5433:${{ secrets.DB_HOST }}:${{ secrets.DB_PORT || '5432' }} \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} &
-          
+
           SSH_PID=$!
           echo "PROD_SSH_PID=$SSH_PID" >> $GITHUB_ENV
-          
+
           echo "⏳ Waiting for Production tunnel (PID: $SSH_PID)..."
-          
-          # Retry loop with exponential backoff
+
           for i in {1..10}; do
             if nc -zv localhost 5433 2>/dev/null; then
               echo "✅ Production tunnel established (attempt $i/10)"
@@ -70,57 +69,24 @@ jobs:
             echo "⚠️  Tunnel not ready, retrying in 3 seconds... (attempt $i/10)"
             sleep 3
           done
-          
+
           echo "❌ Production tunnel failed to establish after 10 attempts"
           kill $SSH_PID 2>/dev/null || true
           exit 1
-      
-      - name: Setup SSH tunnel to UAT DB
-        env:
-          SSHPASS: ${{ secrets.UAT_SSH_PASSWORD }}
-        run: |
-          set -euo pipefail
-          
-          echo "🔌 Starting SSH tunnel to UAT DB..."
-          
-          # Start SSH tunnel with verbose logging for debugging
-          sshpass -e ssh -v -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-            -N -L 5434:${{ secrets.UAT_DB_HOST }}:${{ secrets.UAT_DB_PORT || '5432' }} \
-            ${{ secrets.UAT_SSH_USER }}@${{ secrets.UAT_SSH_HOST }} &
-          
-          SSH_PID=$!
-          echo "UAT_SSH_PID=$SSH_PID" >> $GITHUB_ENV
-          
-          echo "⏳ Waiting for UAT tunnel (PID: $SSH_PID)..."
-          
-          # Retry loop with exponential backoff
-          for i in {1..10}; do
-            if nc -zv localhost 5434 2>/dev/null; then
-              echo "✅ UAT tunnel established (attempt $i/10)"
-              exit 0
-            fi
-            echo "⚠️  Tunnel not ready, retrying in 3 seconds... (attempt $i/10)"
-            sleep 3
-          done
-          
-          echo "❌ UAT tunnel failed to establish after 10 attempts"
-          kill $SSH_PID 2>/dev/null || true
-          exit 1
-      
+
       - name: Extract Production data
         env:
-          PGPASSWORD: ${{ secrets.PROD_DB_PASSWORD }}
+          PGPASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           set -euo pipefail
-          
+
           echo "📦 Extracting Production business data..."
-          
-          # Dump only business data (exclude auth/session tables)
+
           pg_dump \
             -h localhost \
             -p 5433 \
-            -U "${{ secrets.PROD_DB_USER }}" \
-            -d "${{ secrets.PROD_DB_NAME }}" \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
             --no-owner \
             --no-privileges \
             --data-only \
@@ -135,239 +101,286 @@ jobs:
             --exclude-schema='information_schema' \
             --exclude-schema='pg_catalog' \
             > /tmp/prod_data.sql
-          
+
           echo "✅ Extracted $(wc -l < /tmp/prod_data.sql) lines of data"
-      
+
       - name: Filter out test tenants
         run: |
           set -euo pipefail
-          
+
           echo "🔍 Filtering test tenants (schema_name starting with 'test_')..."
-          
-          # Create filtered SQL that excludes test tenant data
-          # This preserves UAT seed data while importing production data
+
           grep -v "^INSERT INTO.*apps_tenants_tenant.*'test_" /tmp/prod_data.sql > /tmp/filtered_data.sql || true
-          
-          # If grep found no matches, use original dump
+
           if [ ! -s /tmp/filtered_data.sql ]; then
             cp /tmp/prod_data.sql /tmp/filtered_data.sql
           fi
-          
+
           ORIGINAL_LINES=$(wc -l < /tmp/prod_data.sql)
           FILTERED_LINES=$(wc -l < /tmp/filtered_data.sql)
           REMOVED_LINES=$((ORIGINAL_LINES - FILTERED_LINES))
-          
+
           echo "📊 Removed $REMOVED_LINES lines containing test tenant data"
-      
+
+      - name: Upload filtered data artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: prod_filtered_data
+          path: /tmp/filtered_data.sql
+          retention-days: 2
+
+      - name: Cleanup production tunnel
+        if: always()
+        run: |
+          set -euo pipefail
+
+          echo "🧹 Cleaning up production SSH tunnel..."
+
+          if [ -n "${PROD_SSH_PID:-}" ]; then
+            kill "$PROD_SSH_PID" 2>/dev/null || true
+          fi
+
+          rm -f /tmp/prod_data.sql /tmp/filtered_data.sql
+
+          echo "✅ Cleanup complete"
+
+  import-uat:
+    name: "Import Production Data to UAT"
+    runs-on: ubuntu-latest
+    needs: [check_infrastructure, export-production]
+    environment: uat-backend
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client sshpass netcat-openbsd
+
+      - name: Download filtered data artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: prod_filtered_data
+          path: /tmp
+
+      - name: Setup SSH tunnel to UAT DB
+        env:
+          SSHPASS: ${{ secrets.SSH_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          echo "🔌 Starting SSH tunnel to UAT DB..."
+
+          sshpass -e ssh -v -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -N -L 5433:${{ secrets.DB_HOST }}:${{ secrets.DB_PORT || '5432' }} \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} &
+
+          SSH_PID=$!
+          echo "UAT_SSH_PID=$SSH_PID" >> $GITHUB_ENV
+
+          echo "⏳ Waiting for UAT tunnel (PID: $SSH_PID)..."
+
+          for i in {1..10}; do
+            if nc -zv localhost 5433 2>/dev/null; then
+              echo "✅ UAT tunnel established (attempt $i/10)"
+              exit 0
+            fi
+            echo "⚠️  Tunnel not ready, retrying in 3 seconds... (attempt $i/10)"
+            sleep 3
+          done
+
+          echo "❌ UAT tunnel failed to establish after 10 attempts"
+          kill $SSH_PID 2>/dev/null || true
+          exit 1
+
       - name: Backup UAT database before sync
         env:
-          PGPASSWORD: ${{ secrets.UAT_DB_PASSWORD }}
+          PGPASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           set -euo pipefail
-          
+
           echo "💾 Creating UAT backup..."
-          
+
           pg_dump \
             -h localhost \
-            -p 5434 \
-            -U "${{ secrets.UAT_DB_USER }}" \
-            -d "${{ secrets.UAT_DB_NAME }}" \
+            -p 5433 \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
             --format=custom \
             > "/tmp/uat_backup_$(date +%Y%m%d_%H%M%S).dump"
-          
+
           echo "✅ Backup created"
-      
+
       - name: Clear UAT business data (preserve system tables)
         env:
-          PGPASSWORD: ${{ secrets.UAT_DB_PASSWORD }}
+          PGPASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           set -euo pipefail
-          
+
           echo "🧹 Clearing UAT business data (preserving test tenants)..."
-          
-          # Create SQL to truncate business tables while preserving test tenant data
+
           cat > /tmp/clear_uat.sql <<- 'SQL'
-          	-- Disable triggers to allow truncation
-          	SET session_replication_role = 'replica';
-          	
-          	-- Get list of all tenant-aware tables (those with tenant_id column)
-          	DO $$
-          	DECLARE
-          	  r RECORD;
-          	BEGIN
-          	  FOR r IN (
-          	    SELECT table_schema, table_name
-          	    FROM information_schema.columns
-          	    WHERE column_name = 'tenant_id'
-          	      AND table_schema NOT IN ('pg_catalog', 'information_schema')
-          	      AND table_name NOT LIKE 'auth_%'
-          	      AND table_name NOT LIKE 'django_%'
-          	  ) LOOP
-          	    -- Delete only non-test tenant data
-          	    EXECUTE format('DELETE FROM %I.%I WHERE tenant_id NOT IN (SELECT id FROM apps_tenants_tenant WHERE schema_name LIKE ''test_%%'');', 
-          	      r.table_schema, r.table_name);
-          	    RAISE NOTICE 'Cleared %', r.table_name;
-          	  END LOOP;
-          	END $$;
-          	
-          	-- Re-enable triggers
-          	SET session_replication_role = 'origin';
-          	SQL
+          -- Disable triggers to allow truncation
+          SET session_replication_role = 'replica';
           
+          -- Get list of all tenant-aware tables (those with tenant_id column)
+          DO $$
+          DECLARE
+            r RECORD;
+          BEGIN
+            FOR r IN (
+              SELECT table_schema, table_name
+              FROM information_schema.columns
+              WHERE column_name = 'tenant_id'
+                AND table_schema NOT IN ('pg_catalog', 'information_schema')
+                AND table_name NOT LIKE 'auth_%'
+                AND table_name NOT LIKE 'django_%'
+            ) LOOP
+              -- Delete only non-test tenant data
+              EXECUTE format('DELETE FROM %I.%I WHERE tenant_id NOT IN (SELECT id FROM apps_tenants_tenant WHERE schema_name LIKE ''test_%%'');',
+                r.table_schema, r.table_name);
+              RAISE NOTICE 'Cleared %', r.table_name;
+            END LOOP;
+          END $$;
+          
+          -- Re-enable triggers
+          SET session_replication_role = 'origin';
+          SQL
+
           psql \
             -h localhost \
-            -p 5434 \
-            -U "${{ secrets.UAT_DB_USER }}" \
-            -d "${{ secrets.UAT_DB_NAME }}" \
+            -p 5433 \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
             -f /tmp/clear_uat.sql
-          
+
           echo "✅ UAT business data cleared"
-      
+
       - name: Import Production data to UAT
         env:
-          PGPASSWORD: ${{ secrets.UAT_DB_PASSWORD }}
+          PGPASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           set -euo pipefail
-          
+
           echo "📥 Importing Production data to UAT..."
-          
+
           psql \
             -h localhost \
-            -p 5434 \
-            -U "${{ secrets.UAT_DB_USER }}" \
-            -d "${{ secrets.UAT_DB_NAME }}" \
+            -p 5433 \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
             -v ON_ERROR_STOP=1 \
             -f /tmp/filtered_data.sql
-          
+
           echo "✅ Import completed"
-      
+
       - name: Fix foreign key references (Post-Restore Fixup)
         env:
-          PGPASSWORD: ${{ secrets.UAT_DB_PASSWORD }}
+          PGPASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           set -euo pipefail
-          
+
           echo "🔧 Fixing foreign key references to UAT superuser..."
-          
-          # Get UAT superuser ID
+
           UAT_SUPERUSER_ID=$(psql \
             -h localhost \
-            -p 5434 \
-            -U "${{ secrets.UAT_DB_USER }}" \
-            -d "${{ secrets.UAT_DB_NAME }}" \
-            -t -c "SELECT id FROM auth_user WHERE is_superuser = true LIMIT 1;")
-          
+            -p 5433 \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
+            -t -c "SELECT id FROM auth_user WHERE is_superuser = true LIMIT 1;" | xargs)
+
           if [ -z "$UAT_SUPERUSER_ID" ]; then
             echo "❌ No UAT superuser found"
             exit 1
           fi
-          
+
           echo "Found UAT superuser ID: $UAT_SUPERUSER_ID"
-          
-          # Update all owner_id and created_by_id references
+
           cat > /tmp/fixup.sql <<- SQL
-          	-- Update all owner_id fields
-          	UPDATE apps_suppliers_supplier SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
-          	UPDATE apps_plants_plant SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
-          	UPDATE apps_customers_customer SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
-          	
-          	-- Update all created_by_id fields
-          	UPDATE apps_suppliers_supplier SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
-          	UPDATE apps_plants_plant SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
-          	UPDATE apps_customers_customer SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
-          	UPDATE apps_purchase_orders_purchaseorder SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
-          	
-          	-- Update any updated_by_id fields
-          	UPDATE apps_suppliers_supplier SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
-          	UPDATE apps_plants_plant SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
-          	UPDATE apps_customers_customer SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
-          	SQL
+          -- Update all owner_id fields
+          UPDATE apps_suppliers_supplier SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
+          UPDATE apps_plants_plant SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
+          UPDATE apps_customers_customer SET owner_id = $UAT_SUPERUSER_ID WHERE owner_id IS NOT NULL;
           
+          -- Update all created_by_id fields
+          UPDATE apps_suppliers_supplier SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
+          UPDATE apps_plants_plant SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
+          UPDATE apps_customers_customer SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
+          UPDATE apps_purchase_orders_purchaseorder SET created_by_id = $UAT_SUPERUSER_ID WHERE created_by_id IS NOT NULL;
+          
+          -- Update any updated_by_id fields
+          UPDATE apps_suppliers_supplier SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
+          UPDATE apps_plants_plant SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
+          UPDATE apps_customers_customer SET updated_by_id = $UAT_SUPERUSER_ID WHERE updated_by_id IS NOT NULL;
+          SQL
+
           psql \
             -h localhost \
-            -p 5434 \
-            -U "${{ secrets.UAT_DB_USER }}" \
-            -d "${{ secrets.UAT_DB_NAME }}" \
+            -p 5433 \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
             -f /tmp/fixup.sql
-          
+
           echo "✅ Foreign key references fixed"
-      
+
       - name: Validate data integrity
         env:
-          PGPASSWORD: ${{ secrets.UAT_DB_PASSWORD }}
+          PGPASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           set -euo pipefail
-          
+
           echo "🔍 Validating data integrity..."
-          
-          # Count tenants (should include test tenants + production tenants)
+
           TENANT_COUNT=$(psql \
             -h localhost \
-            -p 5434 \
-            -U "${{ secrets.UAT_DB_USER }}" \
-            -d "${{ secrets.UAT_DB_NAME }}" \
-            -t -c "SELECT COUNT(*) FROM apps_tenants_tenant;")
-          
+            -p 5433 \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
+            -t -c "SELECT COUNT(*) FROM apps_tenants_tenant;" | xargs)
+
           echo "Total tenants in UAT: $TENANT_COUNT"
-          
-          # Count test tenants (should be preserved)
+
           TEST_TENANT_COUNT=$(psql \
             -h localhost \
-            -p 5434 \
-            -U "${{ secrets.UAT_DB_USER }}" \
-            -d "${{ secrets.UAT_DB_NAME }}" \
-            -t -c "SELECT COUNT(*) FROM apps_tenants_tenant WHERE schema_name LIKE 'test_%';")
-          
+            -p 5433 \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
+            -t -c "SELECT COUNT(*) FROM apps_tenants_tenant WHERE schema_name LIKE 'test_%';" | xargs)
+
           echo "Test tenants preserved: $TEST_TENANT_COUNT"
-          
+
           if [ "$TEST_TENANT_COUNT" -eq 0 ]; then
             echo "⚠️ Warning: No test tenants found in UAT"
           fi
-          
-          # Check for orphaned references
+
           ORPHANED=$(psql \
             -h localhost \
-            -p 5434 \
-            -U "${{ secrets.UAT_DB_USER }}" \
-            -d "${{ secrets.UAT_DB_NAME }}" \
-            -t -c "SELECT COUNT(*) FROM apps_suppliers_supplier WHERE owner_id NOT IN (SELECT id FROM auth_user);")
-          
+            -p 5433 \
+            -U "${{ secrets.DB_USER }}" \
+            -d "${{ secrets.DB_NAME }}" \
+            -t -c "SELECT COUNT(*) FROM apps_suppliers_supplier WHERE owner_id NOT IN (SELECT id FROM auth_user);" | xargs)
+
           if [ "$ORPHANED" -gt 0 ]; then
             echo "❌ Found $ORPHANED orphaned owner_id references"
             exit 1
           fi
-          
+
           echo "✅ Data integrity validated"
-      
-      - name: Cleanup tunnels
+
+      - name: Cleanup UAT tunnel
         if: always()
         run: |
           set -euo pipefail
-          
-          echo "🧹 Cleaning up SSH tunnels..."
-          
-          if [ -n "${PROD_SSH_PID:-}" ]; then
-            kill $PROD_SSH_PID 2>/dev/null || true
-          fi
-          
+
+          echo "🧹 Cleaning up UAT SSH tunnel..."
+
           if [ -n "${UAT_SSH_PID:-}" ]; then
-            kill $UAT_SSH_PID 2>/dev/null || true
+            kill "$UAT_SSH_PID" 2>/dev/null || true
           fi
-          
-          # Remove temp files
-          rm -f /tmp/prod_data.sql /tmp/filtered_data.sql /tmp/clear_uat.sql /tmp/fixup.sql
-          
+
+          rm -f /tmp/filtered_data.sql /tmp/clear_uat.sql /tmp/fixup.sql
+
           echo "✅ Cleanup complete"
-      
-      - name: Send notification on failure
-        if: failure()
-        run: |
-          echo "❌ Production-to-UAT database sync FAILED"
-          echo "Check workflow logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          # TODO: Add Slack/email notification integration
-      
-      - name: Send notification on success
-        if: success()
-        run: |
-          echo "✅ Production-to-UAT database sync completed successfully"
-          echo "UAT database now contains fresh production data with preserved test tenants"


### PR DESCRIPTION
### What\n- Expand workflow secret validation to *all* workflows (supports secrets.NAME + secrets['NAME'] and validates workflow_call secret contracts)\n- Align ops workflows to canonical environment-scoped secret names (removes legacy DEV_/STAGING_/PRODUCTION_ fallbacks)\n- Refactor db-sync workflow to use environment-scoped canonical secrets by splitting export/import jobs\n\n### How to run\n- bash .github/scripts/check_infrastructure.sh\n\n### Rollback\n- Revert this PR (validator + workflow changes are self-contained)