### PR TITLE
Mobile: align guest/invite auth endpoints

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -39,12 +39,14 @@ export default function App() {
       const token = await AsyncStorage.getItem('authToken');
       const userData = await AsyncStorage.getItem('userData');
       const tenantData = await AsyncStorage.getItem('currentTenant');
-      
+      const isGuestFlag = await AsyncStorage.getItem('isGuest');
+
       if (token && userData) {
         setIsAuthenticated(true);
+        setIsGuest(isGuestFlag === '1');
         setUser(JSON.parse(userData));
         ApiService.setAuthToken(token);
-        
+
         if (tenantData) {
           const parsed = JSON.parse(tenantData);
           setCurrentTenant(parsed);
@@ -64,7 +66,8 @@ export default function App() {
     try {
       await AsyncStorage.setItem('authToken', token);
       await AsyncStorage.setItem('userData', JSON.stringify(userData));
-      
+      await AsyncStorage.setItem('isGuest', '0');
+
       setIsAuthenticated(true);
       setIsGuest(false);
       setUser(userData);
@@ -86,7 +89,14 @@ export default function App() {
 
   const handleLogout = async () => {
     try {
-      await AsyncStorage.multiRemove(['authToken', 'userData', 'currentTenant']);
+      // Best-effort server-side token invalidation (no-op if already logged out).
+      try {
+        await ApiService.logout();
+      } catch {
+        // Ignore network/auth errors during logout; local logout still proceeds.
+      }
+
+      await AsyncStorage.multiRemove(['authToken', 'userData', 'currentTenant', 'isGuest']);
       setIsAuthenticated(false);
       setIsGuest(false);
       setUser(null);
@@ -98,12 +108,12 @@ export default function App() {
     }
   };
 
-  // Guest session handler: no full auth, limited to guest tenant
-  const handleGuestLogin = (session: GuestSession) => {
+  // Guest session handler: guest user is authenticated via Token auth, but we keep a separate UX.
+  const handleGuestLogin = async (session: GuestSession) => {
     const guestTenant: Tenant = {
-      id: session.tenant_id,
-      name: session.tenant_name,
-      slug: session.tenant_slug,
+      id: session.tenant.id,
+      name: session.tenant.name,
+      slug: session.tenant.slug,
       contact_email: '',
       contact_phone: '',
       is_active: true,
@@ -114,10 +124,23 @@ export default function App() {
       updated_at: new Date().toISOString(),
       settings: {},
     };
-    setCurrentTenant(guestTenant);
-    ApiService.setTenantId(String(session.tenant_id));
-    setIsGuest(true);
-    setIsAuthenticated(true);
+
+    try {
+      await AsyncStorage.setItem('authToken', session.token);
+      await AsyncStorage.setItem('userData', JSON.stringify(session.user));
+      await AsyncStorage.setItem('currentTenant', JSON.stringify(guestTenant));
+      await AsyncStorage.setItem('isGuest', '1');
+
+      ApiService.setAuthToken(session.token);
+      ApiService.setTenantId(String(session.tenant.id));
+
+      setUser(session.user);
+      setCurrentTenant(guestTenant);
+      setIsGuest(true);
+      setIsAuthenticated(true);
+    } catch (error) {
+      console.error('Error saving guest session:', error);
+    }
   };
 
   if (isLoading) {

--- a/mobile/src/__tests__/ApiService.test.ts
+++ b/mobile/src/__tests__/ApiService.test.ts
@@ -38,47 +38,32 @@ describe('ApiService – guest mode', () => {
     internalApi.defaults.headers.common = {};
   });
 
-  it('setGuestToken sets Authorization header with GuestToken scheme', () => {
-    ApiService.setGuestToken('gt_abc123');
-    expect(internalApi.defaults.headers.common['Authorization']).toBe(
-      'GuestToken gt_abc123'
-    );
-  });
-
-  it('loginAsGuest POSTs to /auth/guest-session/ with tenant_slug', async () => {
+  it('guestLogin POSTs to /auth/guest-login/', async () => {
     const mockSession = {
-      guest_token: 'gt_test',
-      tenant_id: 'uuid-1',
-      tenant_name: 'Test',
-      tenant_slug: 'test',
-      expires_at: '2026-03-19T00:00:00Z',
-      permissions: ['view_workforms'],
+      token: 'tok_guest',
+      user: {
+        id: 1,
+        username: 'guest',
+        email: '',
+        first_name: 'Guest',
+        last_name: '',
+        is_active: true,
+        date_joined: '2026-03-19T00:00:00Z',
+      },
+      tenant: {
+        id: 'uuid-1',
+        name: 'Guest Tenant',
+        slug: 'guest',
+        role: 'admin',
+        is_guest: true,
+      },
+      message: 'Welcome',
     };
     internalApi.post.mockResolvedValueOnce({ data: mockSession });
 
-    const result = await ApiService.loginAsGuest('test');
-    expect(result.guest_token).toBe('gt_test');
-    expect(internalApi.post).toHaveBeenCalledWith('/auth/guest-session/', {
-      tenant_slug: 'test',
-    });
-  });
-
-  it('loginAsGuest includes access_code when provided', async () => {
-    internalApi.post.mockResolvedValueOnce({ data: {} });
-
-    await ApiService.loginAsGuest('secure', 'SECRET');
-    expect(internalApi.post).toHaveBeenCalledWith('/auth/guest-session/', {
-      tenant_slug: 'secure',
-      access_code: 'SECRET',
-    });
-  });
-
-  it('loginAsGuest omits access_code when not provided', async () => {
-    internalApi.post.mockResolvedValueOnce({ data: {} });
-
-    await ApiService.loginAsGuest('no-code');
-    const callArgs = internalApi.post.mock.calls[0][1];
-    expect(callArgs).not.toHaveProperty('access_code');
+    const result = await ApiService.guestLogin();
+    expect(result.token).toBe('tok_guest');
+    expect(internalApi.post).toHaveBeenCalledWith('/auth/guest-login/');
   });
 });
 
@@ -87,28 +72,28 @@ describe('ApiService – invite flow', () => {
     jest.clearAllMocks();
   });
 
-  it('validateInvite calls GET /auth/invites/{token}/', async () => {
+  it('validateInvite calls GET /invitations/validate/?token=...', async () => {
     const mockInvite = {
-      token: 'tok-1',
-      tenant_id: 'uuid-1',
-      tenant_name: 'Acme',
-      tenant_slug: 'acme',
-      invited_by: 'admin',
-      invited_email: 'user@example.com',
+      valid: true,
+      email: 'user@example.com',
       role: 'user',
+      is_reusable: false,
+      uses_remaining: 1,
+      tenant: { name: 'Acme', slug: 'acme' },
+      message: null,
       expires_at: '2026-03-25T00:00:00Z',
-      is_expired: false,
-      is_accepted: false,
     };
     internalApi.get.mockResolvedValueOnce({ data: mockInvite });
 
     const result = await ApiService.validateInvite('tok-1');
     expect(result.token).toBe('tok-1');
-    expect(result.is_expired).toBe(false);
-    expect(internalApi.get).toHaveBeenCalledWith('/auth/invites/tok-1/');
+    expect(result.valid).toBe(true);
+    expect(internalApi.get).toHaveBeenCalledWith('/invitations/validate/', {
+      params: { token: 'tok-1' },
+    });
   });
 
-  it('acceptInvite POSTs to /auth/invites/accept/', async () => {
+  it('acceptInvite POSTs to /auth/signup-with-invitation/', async () => {
     const mockLoginResponse = {
       token: 'auth-token-abc',
       user: {
@@ -120,20 +105,30 @@ describe('ApiService – invite flow', () => {
         is_active: true,
         date_joined: '2026-03-18T00:00:00Z',
       },
+      tenant: {
+        id: 'uuid-1',
+        name: 'Acme',
+        slug: 'acme',
+      },
+      role: 'user',
     };
     internalApi.post.mockResolvedValueOnce({ data: mockLoginResponse });
 
     const result = await ApiService.acceptInvite({
       token: 'tok-1',
       username: 'newuser',
+      email: 'user@example.com',
       password: 'password123',
     });
     expect(result.token).toBe('auth-token-abc');
     expect(result.user.username).toBe('newuser');
-    expect(internalApi.post).toHaveBeenCalledWith('/auth/invites/accept/', {
-      token: 'tok-1',
+    expect(internalApi.post).toHaveBeenCalledWith('/auth/signup-with-invitation/', {
+      invitation_token: 'tok-1',
       username: 'newuser',
+      email: 'user@example.com',
       password: 'password123',
+      first_name: undefined,
+      last_name: undefined,
     });
   });
 });

--- a/mobile/src/__tests__/types.test.ts
+++ b/mobile/src/__tests__/types.test.ts
@@ -11,15 +11,27 @@ import {
 describe('GuestSession type', () => {
   it('should have the required fields', () => {
     const session: GuestSession = {
-      guest_token: 'gt_abc123',
-      tenant_id: 'uuid-1',
-      tenant_name: 'Test Tenant',
-      tenant_slug: 'test-tenant',
-      expires_at: '2026-03-19T00:00:00Z',
-      permissions: ['view_workforms'],
+      token: 'tok_guest',
+      user: {
+        id: 1,
+        username: 'guest',
+        email: '',
+        first_name: 'Guest',
+        last_name: '',
+        is_active: true,
+        date_joined: '2026-03-19T00:00:00Z',
+      },
+      tenant: {
+        id: 'uuid-1',
+        name: 'Guest Tenant',
+        slug: 'guest',
+        role: 'admin',
+        is_guest: true,
+      },
+      message: 'Welcome',
     };
-    expect(session.guest_token).toBe('gt_abc123');
-    expect(session.permissions).toContain('view_workforms');
+    expect(session.token).toBe('tok_guest');
+    expect(session.tenant.is_guest).toBe(true);
   });
 });
 
@@ -27,45 +39,26 @@ describe('TenantInvite type', () => {
   it('should have the required fields', () => {
     const invite: TenantInvite = {
       token: 'uuid-token',
-      tenant_id: 'uuid-1',
-      tenant_name: 'Test Tenant',
-      tenant_slug: 'test-tenant',
-      invited_by: 'admin',
-      invited_email: 'user@example.com',
+      valid: true,
+      email: 'user@example.com',
       role: 'user',
+      is_reusable: false,
+      uses_remaining: 1,
+      tenant: { name: 'Test Tenant', slug: 'test-tenant' },
+      message: null,
       expires_at: '2026-03-25T00:00:00Z',
-      is_expired: false,
-      is_accepted: false,
     };
-    expect(invite.is_expired).toBe(false);
+    expect(invite.valid).toBe(true);
     expect(invite.role).toBe('user');
-  });
-
-  it('should accept all valid role values', () => {
-    const roles: TenantInvite['role'][] = ['admin', 'manager', 'user', 'readonly'];
-    roles.forEach((role) => {
-      const invite: TenantInvite = {
-        token: 'tok',
-        tenant_id: '1',
-        tenant_name: 'T',
-        tenant_slug: 't',
-        invited_by: 'a',
-        invited_email: 'e@e.com',
-        role,
-        expires_at: '',
-        is_expired: false,
-        is_accepted: false,
-      };
-      expect(invite.role).toBe(role);
-    });
   });
 });
 
 describe('InviteAcceptRequest type', () => {
-  it('should require token, username, password', () => {
+  it('should require token, username, email, password', () => {
     const req: InviteAcceptRequest = {
       token: 'uuid-token',
       username: 'newuser',
+      email: 'user@example.com',
       password: 'password123',
     };
     expect(req.token).toBe('uuid-token');
@@ -76,6 +69,7 @@ describe('InviteAcceptRequest type', () => {
     const req: InviteAcceptRequest = {
       token: 'tok',
       username: 'u',
+      email: 'e@e.com',
       password: 'p',
       first_name: 'John',
       last_name: 'Doe',

--- a/mobile/src/screens/GuestLoginScreen.tsx
+++ b/mobile/src/screens/GuestLoginScreen.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   View,
   Text,
-  TextInput,
   TouchableOpacity,
   StyleSheet,
   Alert,
@@ -18,31 +17,25 @@ type GuestLoginNavigationProp = StackNavigationProp<RootStackParamList, 'Guest'>
 
 interface Props {
   navigation: GuestLoginNavigationProp;
-  onGuestLogin: (session: GuestSession) => void;
+  onGuestLogin: (session: GuestSession) => Promise<void>;
 }
 
 export default function GuestLoginScreen({ navigation, onGuestLogin }: Props) {
-  const [tenantSlug, setTenantSlug] = useState('');
-  const [accessCode, setAccessCode] = useState('');
+  // Backend guest mode logs into a pre-configured guest tenant.
   const [loading, setLoading] = useState(false);
 
   const handleGuestLogin = async () => {
-    if (!tenantSlug.trim()) {
-      Alert.alert('Error', 'Please enter a workspace name');
-      return;
-    }
-
     setLoading(true);
     try {
-      const session = await ApiService.loginAsGuest(tenantSlug.trim(), accessCode.trim() || undefined);
-      ApiService.setGuestToken(session.guest_token);
-      onGuestLogin(session);
+      // Backend endpoint does not accept tenant slug/access code; it logs into a configured guest tenant.
+      const session = await ApiService.guestLogin();
+      await onGuestLogin(session);
     } catch (error: any) {
       const message =
         error.response?.status === 404
-          ? 'Workspace not found. Please check the name and try again.'
-          : error.response?.status === 403
-          ? 'Guest access is not enabled for this workspace, or the access code is incorrect.'
+          ? 'Guest account is not configured on the server.'
+          : error.response?.status === 503
+          ? 'Guest access is temporarily unavailable.'
           : 'Unable to start guest session. Please try again.';
       Alert.alert('Access Denied', message);
     } finally {
@@ -70,28 +63,6 @@ export default function GuestLoginScreen({ navigation, onGuestLogin }: Props) {
           </View>
 
           <View style={styles.form}>
-            <Text style={styles.label}>Workspace Name</Text>
-            <TextInput
-              style={styles.input}
-              placeholder="e.g. acme-meats"
-              value={tenantSlug}
-              onChangeText={setTenantSlug}
-              autoCapitalize="none"
-              autoCorrect={false}
-              editable={!loading}
-            />
-
-            <Text style={styles.label}>Access Code (optional)</Text>
-            <TextInput
-              style={styles.input}
-              placeholder="Enter access code if required"
-              value={accessCode}
-              onChangeText={setAccessCode}
-              autoCapitalize="none"
-              autoCorrect={false}
-              editable={!loading}
-            />
-
             <TouchableOpacity
               style={[styles.primaryButton, loading && styles.disabledButton]}
               onPress={handleGuestLogin}
@@ -160,22 +131,7 @@ const styles = StyleSheet.create({
     width: '100%',
     maxWidth: 320,
   },
-  label: {
-    fontSize: 13,
-    color: '#5d6d7e',
-    marginBottom: 6,
-    marginLeft: 2,
-    fontWeight: '500',
-  },
-  input: {
-    backgroundColor: '#fff',
-    borderRadius: 8,
-    padding: 14,
-    marginBottom: 16,
-    fontSize: 15,
-    borderWidth: 1,
-    borderColor: '#e1e5e9',
-  },
+
   primaryButton: {
     backgroundColor: '#27ae60',
     borderRadius: 8,

--- a/mobile/src/screens/InviteScreen.tsx
+++ b/mobile/src/screens/InviteScreen.tsx
@@ -47,28 +47,18 @@ export default function InviteScreen({ navigation, route, onInviteAccepted }: Pr
     setValidating(true);
     try {
       const result = await ApiService.validateInvite(token.trim());
-      if (result.is_expired) {
-        Alert.alert(
-          'Invite Expired',
-          'This invitation has expired. Please ask the workspace admin to send a new invite.'
-        );
-        return;
-      }
-      if (result.is_accepted) {
-        Alert.alert(
-          'Already Accepted',
-          'This invite has already been used. Please sign in with your existing account.'
-        );
-        return;
-      }
       setInvite(result);
-      // Pre-fill email as username
-      setUsername(result.invited_email);
+      // Suggest a username derived from the invited email.
+      const suggestion = result.email.includes('@') ? result.email.split('@')[0] : result.email;
+      setUsername(suggestion);
     } catch (error: any) {
+      const apiMessage = error.response?.data?.error;
       Alert.alert(
         'Invalid Invite',
         error.response?.status === 404
           ? 'This invite token was not found. Please check the link or code and try again.'
+          : apiMessage
+          ? String(apiMessage)
           : 'Unable to validate invite. Please try again.'
       );
     } finally {
@@ -99,6 +89,7 @@ export default function InviteScreen({ navigation, route, onInviteAccepted }: Pr
       const response = await ApiService.acceptInvite({
         token: invite.token,
         username: username.trim(),
+        email: invite.email,
         password,
         first_name: firstName.trim() || undefined,
         last_name: lastName.trim() || undefined,
@@ -183,11 +174,10 @@ export default function InviteScreen({ navigation, route, onInviteAccepted }: Pr
           <View style={styles.inviteBanner}>
             <Text style={styles.inviteBannerTitle}>
               You've been invited to{' '}
-              <Text style={styles.tenantName}>{invite.tenant_name}</Text>
+              <Text style={styles.tenantName}>{invite.tenant.name}</Text>
             </Text>
             <Text style={styles.inviteBannerMeta}>
-              Role: <Text style={styles.roleText}>{invite.role}</Text>  •  Invited
-              by {invite.invited_by}
+              Role: <Text style={styles.roleText}>{invite.role}</Text>
             </Text>
           </View>
 

--- a/mobile/src/services/ApiService.ts
+++ b/mobile/src/services/ApiService.ts
@@ -244,27 +244,42 @@ class ApiServiceClass {
   }
 
   // Guest mode endpoints
-  async loginAsGuest(tenantSlug: string, accessCode?: string): Promise<GuestSession> {
-    const payload: Record<string, string> = { tenant_slug: tenantSlug };
-    if (accessCode) {
-      payload.access_code = accessCode;
-    }
-    const response = await this.api.post('/auth/guest-session/', payload);
+  // Backend implementation is a legacy guest user login (Token auth), not a per-tenant guest session.
+  async guestLogin(): Promise<GuestSession> {
+    const response = await this.api.post('/auth/guest-login/');
     return response.data;
   }
 
-  setGuestToken(guestToken: string) {
-    this.api.defaults.headers.common['Authorization'] = `GuestToken ${guestToken}`;
+  /**
+   * @deprecated Backend does not currently support the GuestToken auth scheme.
+   * Prefer `setAuthToken()` with the token returned from `guestLogin()`.
+   */
+  setGuestToken(_guestToken: string) {
+    // Intentionally no-op to avoid setting an unsupported Authorization scheme.
   }
 
   // Invite-only endpoints
   async validateInvite(token: string): Promise<TenantInvite> {
-    const response = await this.api.get(`/auth/invites/${token}/`);
-    return response.data;
+    // Backend route: GET /api/v1/invitations/validate/?token=...
+    const response = await this.api.get('/invitations/validate/', {
+      params: { token },
+    });
+
+    // Include the token in the returned object for UI convenience.
+    return { token, ...response.data };
   }
 
   async acceptInvite(inviteData: InviteAcceptRequest): Promise<LoginResponse> {
-    const response = await this.api.post('/auth/invites/accept/', inviteData);
+    // Backend route: POST /api/v1/auth/signup-with-invitation/
+    const payload = {
+      invitation_token: inviteData.token,
+      username: inviteData.username,
+      email: inviteData.email,
+      password: inviteData.password,
+      first_name: inviteData.first_name,
+      last_name: inviteData.last_name,
+    };
+    const response = await this.api.post('/auth/signup-with-invitation/', payload);
     return response.data;
   }
 

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -6,8 +6,11 @@ export interface User {
   email: string;
   first_name: string;
   last_name: string;
-  is_active: boolean;
-  date_joined: string;
+  // Auth endpoints include these; other endpoints may omit them.
+  is_active?: boolean;
+  is_staff?: boolean;
+  is_superuser?: boolean;
+  date_joined?: string;
 }
 
 export interface Tenant {
@@ -31,7 +34,15 @@ export interface TenantUser {
   id: number;
   tenant: Tenant;
   user: User;
-  role: 'owner' | 'admin' | 'manager' | 'user' | 'readonly';
+  role:
+    | 'owner'
+    | 'admin'
+    | 'manager'
+    | 'plant_manager'
+    | 'sales_rep'
+    | 'auditor'
+    | 'user'
+    | 'readonly';
   is_active: boolean;
   created_at: string;
   updated_at: string;
@@ -41,7 +52,7 @@ export interface UserTenant {
   tenant_id: string;
   tenant_name: string;
   tenant_slug: string;
-  role: 'owner' | 'admin' | 'manager' | 'user' | 'readonly';
+  role: TenantUser['role'];
   is_active: boolean;
   is_trial: boolean;
   created_at: string;
@@ -83,13 +94,18 @@ export interface LoginResponse {
 }
 
 // Guest mode types
+// Backend: POST /api/v1/auth/guest-login/
 export interface GuestSession {
-  guest_token: string;
-  tenant_id: string;
-  tenant_name: string;
-  tenant_slug: string;
-  expires_at: string;
-  permissions: string[];
+  token: string;
+  user: User;
+  tenant: {
+    id: string;
+    name: string;
+    slug: string;
+    role: TenantUser['role'];
+    is_guest: true;
+  };
+  message: string;
 }
 
 export interface GuestUser {
@@ -104,22 +120,32 @@ export interface GuestUser {
 }
 
 // Invite-only flow types
+// Backend:
+// - GET /api/v1/invitations/validate/?token=...
+// - POST /api/v1/auth/signup-with-invitation/
 export interface TenantInvite {
+  /** The invite token that was validated (not returned by backend; we add it client-side). */
   token: string;
-  tenant_id: string;
-  tenant_name: string;
-  tenant_slug: string;
-  invited_by: string;
-  invited_email: string;
-  role: 'admin' | 'manager' | 'user' | 'readonly';
+  valid: true;
+  email: string;
+  role: TenantUser['role'];
+  is_reusable: boolean;
+  uses_remaining: number;
+  tenant: {
+    name: string;
+    slug: string;
+  };
+  message?: string | null;
   expires_at: string;
-  is_expired: boolean;
-  is_accepted: boolean;
 }
 
 export interface InviteAcceptRequest {
+  /** Invite token */
   token: string;
+  /** Desired username */
   username: string;
+  /** Account email (must match invite email for non-reusable invites) */
+  email: string;
   password: string;
   first_name?: string;
   last_name?: string;


### PR DESCRIPTION
Align mobile guest + invite flows with backend canonical endpoints.

Changes:
- Guest: use /api/v1/auth/guest-login/ (Token auth) and persist guest session (token/user/tenant/isGuest) via AsyncStorage.
- Invite: validate via /api/v1/invitations/validate/?token=... and accept via /api/v1/auth/signup-with-invitation/ (payload mapping incl email).
- Simplify GuestLoginScreen UI (remove unused tenant slug/access code fields).
- Update types and Jest tests to prevent endpoint drift.

Testing:
- npm --prefix mobile test
- npm --prefix mobile run type-check
- npm --prefix mobile run lint
