### PR TITLE
Mobile: enforce OpenAPI contract

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -74,6 +74,21 @@ jobs:
         working-directory: ./backend
         run: pip install -r requirements.txt
 
+      - name: Generate OpenAPI schema (artifact)
+        working-directory: ./backend
+        env:
+          DJANGO_SETTINGS_MODULE: projectmeats.settings.test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_projectmeats
+        run: python manage.py spectacular --format openapi-json --verbosity 0 > ../openapi-schema.json
+
+      - name: Upload OpenAPI schema artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openapi-schema
+          path: openapi-schema.json
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Validate migrations
         env:
           DJANGO_SETTINGS_MODULE: projectmeats.settings.test
@@ -150,10 +165,17 @@ jobs:
   mobile-checks:
     name: Mobile Lint/Test/Type Check
     runs-on: ubuntu-latest
+    needs: [validate-migrations]
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download OpenAPI schema artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: openapi-schema
+          path: mobile
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/mobile/src/__tests__/openapi.contract.test.ts
+++ b/mobile/src/__tests__/openapi.contract.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable import/first */
+// Contract test: ensure mobile ApiService endpoints exist in backend OpenAPI schema.
+// This runs in the mobile CI job (Node-only). The schema is generated in a Python job
+// and downloaded as an artifact into mobile/openapi-schema.json.
+
+import fs from 'fs';
+import path from 'path';
+
+jest.mock('axios', () => {
+  const axiosMock = {
+    create: jest.fn(() => ({
+      get: jest.fn(),
+      post: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    })),
+  };
+
+  return {
+    __esModule: true,
+    default: axiosMock,
+    ...axiosMock,
+  };
+});
+
+import { ApiService } from '../services/ApiService';
+
+type OpenApiSpec = {
+  paths?: Record<string, Record<string, unknown>>;
+};
+
+const internalApi = (ApiService as any).api as {
+  get: jest.Mock;
+  post: jest.Mock;
+};
+
+function loadOpenApiSchema(): OpenApiSpec | null {
+  const schemaPath = path.resolve(process.cwd(), 'openapi-schema.json');
+  if (!fs.existsSync(schemaPath)) {
+    return null;
+  }
+
+  const raw = fs.readFileSync(schemaPath, 'utf8');
+  return JSON.parse(raw) as OpenApiSpec;
+}
+
+describe('OpenAPI contract – mobile ApiService', () => {
+  it('uses endpoints that exist in backend OpenAPI schema', async () => {
+    const spec = loadOpenApiSchema();
+    if (!spec) {
+      // Local dev runs may not have the CI-generated artifact.
+      return;
+    }
+
+    const basePath = new URL(((ApiService as any).baseURL as string) ?? '').pathname.replace(/\/+$/, '');
+    const paths = spec.paths ?? {};
+
+    const expectExists = (relativePath: string, method: 'get' | 'post') => {
+      const fullPath = `${basePath}${relativePath}`;
+      expect(paths[fullPath]).toBeDefined();
+      expect(paths[fullPath]?.[method]).toBeDefined();
+    };
+
+    // Stub API responses so the methods can run.
+    internalApi.post.mockResolvedValue({
+      data: {
+        token: 'tok',
+        user: { id: 1, username: 'u', email: '', first_name: '', last_name: '' },
+        tenant: { id: 't1', name: 'Tenant', slug: 'tenant', role: 'user', is_guest: true },
+        message: 'ok',
+      },
+    });
+    await ApiService.guestLogin();
+    expectExists('/auth/guest-login/', 'post');
+
+    internalApi.get.mockResolvedValue({
+      data: {
+        valid: true,
+        email: 'user@example.com',
+        role: 'user',
+        is_reusable: false,
+        uses_remaining: 1,
+        tenant: { name: 'Tenant', slug: 'tenant' },
+        message: null,
+        expires_at: '2026-01-01T00:00:00Z',
+      },
+    });
+    await ApiService.validateInvite('tok-1');
+    expectExists('/invitations/validate/', 'get');
+
+    internalApi.post.mockResolvedValue({
+      data: {
+        token: 'tok',
+        user: { id: 1, username: 'u', email: 'user@example.com', first_name: '', last_name: '' },
+        tenant: { id: 't1', name: 'Tenant', slug: 'tenant' },
+        role: 'user',
+      },
+    });
+    await ApiService.acceptInvite({
+      token: 'tok-1',
+      username: 'u',
+      email: 'user@example.com',
+      password: 'password123',
+    });
+    expectExists('/auth/signup-with-invitation/', 'post');
+
+    internalApi.post.mockResolvedValue({
+      data: {
+        token: 'tok',
+        user: { id: 1, username: 'u', email: 'user@example.com', first_name: '', last_name: '' },
+        tenants: [],
+      },
+    });
+    await ApiService.login({ username: 'u', password: 'p' });
+    expectExists('/auth/login/', 'post');
+
+    internalApi.post.mockResolvedValue({ data: { message: 'ok' } });
+    await ApiService.logout();
+    expectExists('/auth/logout/', 'post');
+  });
+});


### PR DESCRIPTION
Add a CI-backed OpenAPI contract check for the mobile ApiService.

Changes:
- PR Validation: generate backend OpenAPI schema (DRF Spectacular) during validate-migrations and upload as an artifact.
- Mobile checks: download that schema artifact and run a Jest contract test ensuring ApiService endpoints exist in the OpenAPI spec.

Why:
- Prevents silent endpoint drift between mobile and backend without requiring Python in the mobile job.

Testing (local):
- bash .github/scripts/check_infrastructure.sh
- npm --prefix mobile test
- npm --prefix mobile run type-check
- npm --prefix mobile run lint
