### PR TITLE
WorkForms editor: fix dynamic panel aliases

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.test.tsx
@@ -18,9 +18,9 @@ import { FormBuilderProvider } from '../../../contexts/FormBuilderContext';
 vi.mock('../config', () => ({
   schemaRegistry: {
     getSchema: vi.fn((type: string) => {
-      if (type === 'form') {
+      if (type === 'form' || type === 'formStep') {
         return {
-          displayName: 'Form',
+          displayName: type === 'formStep' ? 'Form Step' : 'Form',
           sections: [
             {
               id: 'basic',
@@ -194,6 +194,51 @@ describe('DynamicConfigPanel', () => {
       // Should render form fields
       expect(screen.getByTestId('field-name')).toBeInTheDocument();
       expect(screen.getByTestId('field-description')).toBeInTheDocument();
+    });
+
+    it('aliases form step name/description into label + stepTitle/stepDescription', async () => {
+      const formStepNode: Node = {
+        id: 'step-1',
+        type: 'formStep',
+        position: { x: 0, y: 0 },
+        data: {
+          nodeType: 'formStep',
+          name: 'Old',
+          description: 'Old desc',
+          label: 'Old',
+          stepTitle: 'Old',
+          stepDescription: 'Old desc',
+        },
+      };
+
+      renderWithProviders(
+        <DynamicConfigPanel
+          node={formStepNode}
+          nodes={mockNodes}
+          edges={mockEdges}
+          onUpdateNode={mockOnUpdateNode}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('field-name'), { target: { value: 'New Step' } });
+
+      await waitFor(() => {
+        expect(mockOnUpdateNode).toHaveBeenCalled();
+      });
+
+      const lastCall = mockOnUpdateNode.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe('step-1');
+      expect(lastCall?.[1]?.name).toBe('New Step');
+      expect(lastCall?.[1]?.label).toBe('New Step');
+      expect(lastCall?.[1]?.stepTitle).toBe('New Step');
+
+      fireEvent.change(screen.getByTestId('field-description'), { target: { value: 'New desc' } });
+
+      await waitFor(() => {
+        const call = mockOnUpdateNode.mock.calls.at(-1);
+        expect(call?.[1]?.description).toBe('New desc');
+        expect(call?.[1]?.stepDescription).toBe('New desc');
+      });
     });
 
     /**

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -497,6 +497,55 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
         return draft;
       }
 
+      const isFormStep =
+        semanticNodeType === 'formStep' ||
+        semanticNodeType === 'formStepSingle' ||
+        semanticNodeType === 'formStepSingleNode';
+
+      // Form steps historically used `name`/`description` in schemas but nodes display `stepTitle/stepDescription`.
+      // Keep these keys in sync so editing feels responsive and saved data remains backwards compatible.
+      if (isFormStep && fieldId === 'name') {
+        const next: any = {
+          ...prev,
+          name: value,
+          title: value,
+          label: value,
+          stepTitle: value,
+        };
+
+        onUpdateNode(node.id, next);
+
+        if (field) {
+          const error = validateField(field, value, next);
+          setErrors((errs) => ({
+            ...errs,
+            [fieldId]: error || '',
+          }));
+        }
+
+        return next;
+      }
+
+      if (isFormStep && fieldId === 'description') {
+        const next: any = {
+          ...prev,
+          description: value,
+          stepDescription: value,
+        };
+
+        onUpdateNode(node.id, next);
+
+        if (field) {
+          const error = validateField(field, value, next);
+          setErrors((errs) => ({
+            ...errs,
+            [fieldId]: error || '',
+          }));
+        }
+
+        return next;
+      }
+
       // Canonical node title: keep legacy keys in sync for backwards compatibility.
       if (fieldId === 'title') {
         const next: any = {

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -8608,7 +8608,8 @@ function getDefaultNodeData(nodeTypeId: string): Record<string, any> {
     defaults.type = mappedType;
 
     // Used by the visual TriggerNode component (kept for backward compatibility)
-    defaults.triggerType = mappedType;
+    // Normalize legacy "formSubmit" into the TriggerNode's supported "form" trigger type.
+    defaults.triggerType = mappedType === 'formSubmit' ? 'form' : mappedType;
 
     // Triggers are entrypoints
     defaults.maxInputs = 0;

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -2888,9 +2888,10 @@ const triggerFormSchema: NodeConfigSchema = {
       fields: [
         {
           id: 'formId',
-          type: 'text',
-          label: 'Form ID',
-          placeholder: 'ID of form to watch...',
+          type: 'formReference',
+          label: 'Form',
+          placeholder: 'Select a form...',
+          helpText: 'Select the form whose submissions should trigger this workflow',
           required: true,
         },
       ]

--- a/frontend/src/components/FlowEditor/nodes/TriggerNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/TriggerNode.tsx
@@ -21,7 +21,8 @@ import { getNodeTypeDefinition } from '../nodeTypes';
 // ============================================================================
 
 export interface TriggerNodeData extends BaseNodeData {
-  triggerType: 'manual' | 'schedule' | 'webhook' | 'event' | 'form';
+  // `formSubmit` is legacy drift from earlier editor defaults; normalize it to `form` at runtime.
+  triggerType: 'manual' | 'schedule' | 'webhook' | 'event' | 'form' | 'formSubmit';
   schedule?: string; // cron expression
   webhookUrl?: string;
   eventEntity?: string;
@@ -104,13 +105,15 @@ const TriggerBadge = styled.span<{ $type: string }>`
 export const TriggerNode = React.memo<NodeProps<Node<TriggerNodeData>>>((props) => {
   const { data, selected, id } = props;
   const {
-    triggerType,
+    triggerType: rawTriggerType,
     schedule,
     webhookUrl,
     eventEntity,
     eventType,
     formId,
   } = data;
+
+  const triggerType = rawTriggerType === 'formSubmit' ? 'form' : rawTriggerType;
 
   const scheduleSummary = (data as any)?.scheduleSummary as string | undefined;
   

--- a/frontend/src/components/FlowEditor/nodes/__tests__/TriggerNode.legacyTriggerType.test.tsx
+++ b/frontend/src/components/FlowEditor/nodes/__tests__/TriggerNode.legacyTriggerType.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { TriggerNode } from '../TriggerNode';
+
+vi.mock('../BaseNode', () => ({
+  BaseNode: ({ children }: any) => <div data-testid="base-node">{children}</div>,
+}));
+
+vi.mock('../../nodeTypes', () => ({
+  getNodeTypeDefinition: vi.fn(() => ({
+    id: 'triggerForm',
+    name: 'Form Trigger',
+    category: 'trigger',
+    color: 'rgb(var(--color-primary))',
+    icon: '🧾',
+    description: 'Form submit',
+    maxInputs: 0,
+    maxOutputs: 1,
+  })),
+}));
+
+describe('TriggerNode (legacy triggerType)', () => {
+  it('normalizes triggerType=formSubmit to form for rendering', () => {
+    render(
+      <TriggerNode
+        id="n1"
+        selected={false}
+        dragging={false}
+        data={{
+          triggerType: 'formSubmit' as any,
+          formId: 'form-123',
+          label: 'Trigger',
+          maxInputs: 0,
+          maxOutputs: 1,
+        }}
+        type="triggerForm"
+        xPos={0}
+        yPos={0}
+        zIndex={0}
+        isConnectable={true}
+      />
+    );
+
+    expect(screen.getByText('FORM')).toBeInTheDocument();
+    expect(screen.getByText('Form ID:')).toBeInTheDocument();
+    expect(screen.getByText('form-123')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fix several high-impact WorkForms editor config panel issues where schemas wrote keys nodes don\u2019t read.

Changes:
- DynamicConfigPanel: for formStep nodes, keep name/description in sync with label + stepTitle/stepDescription (immediate visual feedback, backwards compatible persistence).
- UnifiedFlowEditor defaults: normalize triggerForm triggerType drift (formSubmit \u2192 form) while preserving type mapping used by trigger schema.
- TriggerNode: accept legacy triggerType=formSubmit and normalize to form for rendering.
- triggerForm schema: use formReference field type (dropdown) instead of free-text Form ID.

Tests:
- vitest: DynamicConfigPanel alias regression
- vitest: TriggerNode legacy triggerType regression
- frontend type-check
