### PR TITLE
WorkForms editor: populate formReference metadata

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.formReferenceMetadata.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.formReferenceMetadata.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { Node, Edge } from '@xyflow/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { FormBuilderProvider } from '../../../contexts/FormBuilderContext';
+
+import { DynamicConfigPanel } from './DynamicConfigPanel';
+
+vi.mock('../config', () => ({
+  schemaRegistry: {
+    getSchema: vi.fn((type: string) => {
+      if (type === 'triggerForm') {
+        return {
+          displayName: 'Trigger (Form)',
+          sections: [
+            {
+              id: 'form',
+              title: 'Form Trigger',
+              fields: [
+                {
+                  id: 'formId',
+                  label: 'Form',
+                  type: 'formReference',
+                  required: true,
+                },
+              ],
+            },
+          ],
+        };
+      }
+      return null;
+    }),
+  },
+}));
+
+vi.mock('../../../services/workformsApi', () => ({
+  listTenantForms: vi.fn(async () => [
+    {
+      id: 'form-1',
+      name: 'Intake Form',
+      description: 'Main intake',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+  ]),
+  getTenantForm: vi.fn(async () => ({
+    id: 'form-1',
+    name: 'Intake Form',
+    description: 'Main intake',
+    form_definition: {
+      fields: [{ id: 'a' }, { id: 'b' }],
+    },
+  })),
+}));
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <FormBuilderProvider>{children}</FormBuilderProvider>
+    </QueryClientProvider>
+  );
+
+  return render(ui, { wrapper: Wrapper });
+};
+
+describe('DynamicConfigPanel (formReference metadata)', () => {
+  const mockNodes: Node[] = [];
+  const mockEdges: Edge[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches selected form metadata and stages node preview fields', async () => {
+    const onUpdateNode = vi.fn();
+    const node: Node = {
+      id: 'n1',
+      type: 'triggerForm',
+      position: { x: 0, y: 0 },
+      data: {
+        nodeType: 'triggerForm',
+        formId: '',
+      },
+    };
+
+    renderWithProviders(
+      <DynamicConfigPanel
+        node={node}
+        nodes={mockNodes}
+        edges={mockEdges}
+        onUpdateNode={onUpdateNode}
+      />
+    );
+
+    // Wait for the forms list to be loaded into the select.
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'form-1' } });
+
+    await waitFor(() => {
+      const lastCall = onUpdateNode.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe('n1');
+      expect(lastCall?.[1]?.formId).toBe('form-1');
+      expect(lastCall?.[1]?.tenantFormId).toBe('form-1');
+      expect(lastCall?.[1]?.formName).toBe('Intake Form');
+      expect(lastCall?.[1]?.formDescription).toBe('Main intake');
+      expect(lastCall?.[1]?.fieldCount).toBe(2);
+      expect(lastCall?.[1]?.sectionCount).toBe(1);
+    });
+  });
+});

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -55,7 +55,7 @@ import {
   renderValidationBuilder,
 } from '../config/fieldRenderers/complexRenderers';
 import { NestedChildrenRenderer } from './NestedChildrenRenderer';
-import { listTenantForms } from '../../../services/workformsApi';
+import { listTenantForms, getTenantForm } from '../../../services/workformsApi';
 
 // Import shared styled components
 import {
@@ -811,7 +811,56 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
             <Label>{field.label}</Label>
             <Select
               value={selected}
-              onChange={(e) => commonProps.onChange(e.target.value)}
+              onChange={async (e) => {
+                const selectedFormId = e.target.value;
+                commonProps.onChange(selectedFormId);
+
+                if (!node?.id) return;
+                if (!selectedFormId) return;
+
+                const nodeId = node.id;
+                const selectedFromList = forms.find((f: any) => String(f?.id) === String(selectedFormId));
+                const friendlyName =
+                  selectedFromList?.title ||
+                  selectedFromList?.display_name ||
+                  selectedFromList?.displayName ||
+                  selectedFromList?.name ||
+                  undefined;
+                const friendlyDescription = selectedFromList?.description || selectedFromList?.helpText || undefined;
+
+                try {
+                  const form = await getTenantForm(String(selectedFormId));
+                  const definition = (form as any).form_definition ?? (form as any).flow_data;
+
+                  let fieldCount = 0;
+                  let sectionCount = 0;
+
+                  if (definition?.fields && Array.isArray(definition.fields)) {
+                    fieldCount = definition.fields.length;
+                    sectionCount = 1;
+                  } else if (definition?.steps && Array.isArray(definition.steps)) {
+                    sectionCount = definition.steps.length;
+                    fieldCount = definition.steps.reduce((acc: number, step: any) => {
+                      const count = Array.isArray(step?.fields) ? step.fields.length : 0;
+                      return acc + count;
+                    }, 0);
+                  }
+
+                  if (!node?.id || node.id !== nodeId) return;
+
+                  onUpdateNode(nodeId, {
+                    // Keep common legacy keys in sync.
+                    formId: selectedFormId,
+                    tenantFormId: selectedFormId,
+                    formName: friendlyName ?? (form as any)?.name,
+                    formDescription: friendlyDescription ?? (form as any)?.description,
+                    fieldCount,
+                    sectionCount,
+                  });
+                } catch (err) {
+                  console.warn('[DynamicConfigPanel] Failed to load selected form metadata:', err);
+                }
+              }}
               disabled={field.disabled || commonProps.disabled || tenantFormsLoading}
               $hasError={Boolean(error)}
             >


### PR DESCRIPTION
When selecting a form in DynamicConfigPanel formReference fields, fetch tenant form details and populate node preview metadata.

Changes:
- DynamicConfigPanel (formReference): on selection, call getTenantForm() and compute fieldCount/sectionCount from form_definition/flow_data.
- Keep formId + tenantFormId in sync for backwards compatibility.
- Add regression test (DynamicConfigPanel.formReferenceMetadata).

Tests:
- vitest run DynamicConfigPanel.formReferenceMetadata.test
- frontend type-check
