### PR TITLE
WorkForms editor: nested children supports toggles

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { NestedChildrenRenderer } from './NestedChildrenRenderer';
+
+describe('NestedChildrenRenderer', () => {
+  it('supports toggle fields inside nested children', () => {
+    const onChange = vi.fn();
+
+    render(
+      <NestedChildrenRenderer
+        field={{
+          id: 'options',
+          label: 'Options',
+          type: 'nested-children',
+          itemSchema: {
+            fields: [
+              { id: 'label', label: 'Label', type: 'text' },
+              { id: 'disabled', label: 'Disabled', type: 'toggle' },
+            ],
+          },
+        } as any}
+        value={[{ label: 'A', disabled: false }]}
+        onChange={onChange}
+      />
+    );
+
+    const disabled = screen.getByLabelText('Disabled') as HTMLInputElement;
+    expect(disabled.checked).toBe(false);
+
+    fireEvent.click(disabled);
+
+    expect(onChange).toHaveBeenCalledWith([{ label: 'A', disabled: true }]);
+  });
+});

--- a/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
@@ -326,50 +326,143 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
                       <div key={section.id}>
                         {section.fields.map(childField => (
                           <div key={childField.id} style={{ marginBottom: '12px' }}>
-                            <label style={{ fontSize: '13px', fontWeight: 500, marginBottom: '4px', display: 'block' }}>
-                              {childField.label}
-                              {childField.required && <span style={{ color: 'rgb(var(--color-error))' }}> *</span>}
-                            </label>
-                            {/* Simple inline renderer for now */}
-                            {childField.type === 'text' && (
-                              <input
-                                type="text"
-                                value={child[childField.id] || ''}
-                                onChange={(e) => handleUpdateChild(index, { ...child, [childField.id]: e.target.value })}
-                                placeholder={
-                                  typeof childField.placeholder === 'string'
-                                    ? childField.placeholder
-                                    : childField.placeholder?.value
-                                }
-                                style={{
-                                  width: '100%',
-                                  padding: '8px 12px',
-                                  fontSize: '14px',
-                                  border: '1px solid rgb(var(--color-border))',
-                                  borderRadius: '6px'
-                                }}
-                              />
-                            )}
-                            {childField.type === 'textarea' && (
-                              <textarea
-                                value={child[childField.id] || ''}
-                                onChange={(e) => handleUpdateChild(index, { ...child, [childField.id]: e.target.value })}
-                                placeholder={
-                                  typeof childField.placeholder === 'string'
-                                    ? childField.placeholder
-                                    : childField.placeholder?.value
-                                }
-                                rows={3}
-                                style={{
-                                  width: '100%',
-                                  padding: '8px 12px',
-                                  fontSize: '14px',
-                                  border: '1px solid rgb(var(--color-border))',
-                                  borderRadius: '6px',
-                                  resize: 'vertical'
-                                }}
-                              />
-                            )}
+                            {(() => {
+                              const inputId = `nested-${field.id}-${index}-${childField.id}`;
+                              const placeholder =
+                                typeof childField.placeholder === 'string'
+                                  ? childField.placeholder
+                                  : (childField.placeholder as any)?.value;
+
+                              return (
+                                <>
+                                  <label
+                                    htmlFor={inputId}
+                                    style={{
+                                      fontSize: '13px',
+                                      fontWeight: 500,
+                                      marginBottom: '4px',
+                                      display: 'block',
+                                    }}
+                                  >
+                                    {childField.label}
+                                    {childField.required && (
+                                      <span style={{ color: 'rgb(var(--color-error))' }}> *</span>
+                                    )}
+                                  </label>
+
+                                  {/* Simple inline renderer for now (supports key field types used by schemas). */}
+                                  {(childField.type === 'text' || childField.type === 'email' || childField.type === 'password') && (
+                                    <input
+                                      id={inputId}
+                                      type={childField.type === 'password' ? 'password' : 'text'}
+                                      value={child[childField.id] || ''}
+                                      onChange={(e) =>
+                                        handleUpdateChild(index, {
+                                          ...child,
+                                          [childField.id]: e.target.value,
+                                        })
+                                      }
+                                      placeholder={placeholder}
+                                      style={{
+                                        width: '100%',
+                                        padding: '8px 12px',
+                                        fontSize: '14px',
+                                        border: '1px solid rgb(var(--color-border))',
+                                        borderRadius: '6px',
+                                      }}
+                                    />
+                                  )}
+
+                                  {childField.type === 'textarea' && (
+                                    <textarea
+                                      id={inputId}
+                                      value={child[childField.id] || ''}
+                                      onChange={(e) =>
+                                        handleUpdateChild(index, {
+                                          ...child,
+                                          [childField.id]: e.target.value,
+                                        })
+                                      }
+                                      placeholder={placeholder}
+                                      rows={3}
+                                      style={{
+                                        width: '100%',
+                                        padding: '8px 12px',
+                                        fontSize: '14px',
+                                        border: '1px solid rgb(var(--color-border))',
+                                        borderRadius: '6px',
+                                        resize: 'vertical',
+                                      }}
+                                    />
+                                  )}
+
+                                  {(childField.type === 'toggle' || childField.type === 'boolean') && (
+                                    <input
+                                      id={inputId}
+                                      type="checkbox"
+                                      checked={Boolean(child[childField.id])}
+                                      onChange={(e) =>
+                                        handleUpdateChild(index, {
+                                          ...child,
+                                          [childField.id]: e.target.checked,
+                                        })
+                                      }
+                                    />
+                                  )}
+
+                                  {childField.type === 'number' && (
+                                    <input
+                                      id={inputId}
+                                      type="number"
+                                      value={child[childField.id] ?? ''}
+                                      onChange={(e) =>
+                                        handleUpdateChild(index, {
+                                          ...child,
+                                          [childField.id]: e.target.value === '' ? undefined : Number(e.target.value),
+                                        })
+                                      }
+                                      placeholder={placeholder}
+                                      style={{
+                                        width: '100%',
+                                        padding: '8px 12px',
+                                        fontSize: '14px',
+                                        border: '1px solid rgb(var(--color-border))',
+                                        borderRadius: '6px',
+                                      }}
+                                    />
+                                  )}
+
+                                  {(childField.type === 'select' || childField.type === 'multiselect') && (
+                                    <select
+                                      id={inputId}
+                                      value={child[childField.id] ?? ''}
+                                      onChange={(e) =>
+                                        handleUpdateChild(index, {
+                                          ...child,
+                                          [childField.id]: e.target.value,
+                                        })
+                                      }
+                                      style={{
+                                        width: '100%',
+                                        padding: '8px 12px',
+                                        fontSize: '14px',
+                                        border: '1px solid rgb(var(--color-border))',
+                                        borderRadius: '6px',
+                                      }}
+                                    >
+                                      <option value="">{placeholder || 'Select...'}</option>
+                                      {Array.isArray((childField as any).options)
+                                        ? (childField as any).options.map((opt: any) => (
+                                            <option key={String(opt.value)} value={opt.value}>
+                                              {opt.label ?? opt.value}
+                                            </option>
+                                          ))
+                                        : null}
+                                    </select>
+                                  )}
+                                </>
+                              );
+                            })()}
                             {childField.helpText && (
                               <div style={{ fontSize: '12px', color: 'rgb(var(--color-text-tertiary))', marginTop: '4px' }}>
                                 {childField.helpText}


### PR DESCRIPTION
Fix nested children config editing so schemas can use non-text fields.

Changes:
- NestedChildrenRenderer: render toggle/boolean, number, and select fields (in addition to text/textarea).
- Add proper label htmlFor/id wiring for accessibility.
- Add regression test verifying toggle edits propagate via onChange.

Tests:
- vitest run NestedChildrenRenderer.test.tsx
- frontend type-check
