### PR TITLE
WorkForms editor: normalize fieldMappings

### DIFF
--- a/frontend/src/components/FlowEditor/config/fieldRenderers/complexRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/complexRenderers.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components';
 import { ConfigField, FieldRenderProps } from '../types';
 import EntityFieldPicker, { SelectedField } from '../../ConfigPanel/EntityFieldPicker';
 import FieldMappingPanel from '../../ConfigPanel/FieldMappingPanel';
+import { normalizeFieldMappings } from '../../utils/fieldMappingsAdapter';
 import { VariablePicker, type Variable as VariableOption } from '../../components/VariablePicker';
 import ValidationRuleBuilder from '../../ConfigPanel/ValidationRuleBuilder';
 
@@ -159,11 +160,14 @@ export function renderFieldMapping(props: FieldRenderProps): React.ReactElement 
   }));
 
   // Coerce mappings to the array shape expected by FieldMappingPanel.
-  const mappings = Array.isArray(value)
+  // Older nodes may store AutoMappingService suggestions directly; normalize them.
+  const rawMappings = Array.isArray(value)
     ? value
     : Array.isArray(field.defaultValue)
       ? (field.defaultValue as any)
       : [];
+
+  const mappings = normalizeFieldMappings(rawMappings);
 
   return (
     <FieldContainer>

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -799,7 +799,11 @@ export const createRecordSchema: NodeConfigSchema = {
               message: 'All mappings must have both target field and source value',
               validator: (value: any) => {
                 if (!value || value.length === 0) return true;
-                const hasMissingMappings = value.some((m: any) => !m.targetField || !m.sourceExpression);
+                const hasMissingMappings = value.some((m: any) => {
+                  const hasTarget = Boolean(m?.entityField || m?.targetField || m?.targetFieldName);
+                  const hasSource = Boolean(m?.formFieldId || m?.sourceExpression || m?.sourceFieldName);
+                  return !hasTarget || !hasSource;
+                });
                 return !hasMissingMappings;
               },
             },

--- a/frontend/src/components/FlowEditor/utils/__tests__/fieldMappingsAdapter.test.ts
+++ b/frontend/src/components/FlowEditor/utils/__tests__/fieldMappingsAdapter.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+
+import { normalizeFieldMappings } from '../fieldMappingsAdapter';
+
+describe('fieldMappingsAdapter', () => {
+  it('normalizes legacy AutoMappingService shape into FieldMappingPanel shape', () => {
+    const out = normalizeFieldMappings([
+      {
+        id: 's1',
+        targetFieldName: 'email',
+        sourceNodeId: 'n1',
+        sourceFieldName: 'email',
+      },
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      id: 's1',
+      entityField: 'email',
+      formFieldId: 'n1.email',
+      transformation: { type: 'direct' },
+      autoPopulate: {
+        sourceStep: 'n1',
+        sourceField: 'email',
+        mode: 'copy',
+      },
+    });
+  });
+});

--- a/frontend/src/components/FlowEditor/utils/fieldMappingsAdapter.ts
+++ b/frontend/src/components/FlowEditor/utils/fieldMappingsAdapter.ts
@@ -1,0 +1,56 @@
+import type { FieldMapping } from '../ConfigPanel/FieldMappingPanel';
+
+export type LegacyAutoMapping = {
+  id?: string;
+  targetFieldName?: string;
+  sourceNodeId?: string;
+  sourceFieldName?: string;
+  mode?: string;
+  autoPopulate?: boolean;
+};
+
+function isLegacyAutoMapping(
+  value: any
+): value is LegacyAutoMapping & {
+  targetFieldName: string;
+  sourceNodeId: string;
+  sourceFieldName: string;
+} {
+  return (
+    value &&
+    typeof value === 'object' &&
+    typeof value.targetFieldName === 'string' &&
+    typeof value.sourceNodeId === 'string' &&
+    typeof value.sourceFieldName === 'string'
+  );
+}
+
+/**
+ * Normalize various stored mapping shapes into the canonical FieldMappingPanel shape.
+ *
+ * This is intentionally additive/backwards compatible: older workflows might store
+ * AutoMappingService suggestions directly under `fieldMappings`.
+ */
+export function normalizeFieldMappings(input: unknown): FieldMapping[] {
+  if (!Array.isArray(input)) return [];
+
+  return (input as any[]).map((m) => {
+    if (isLegacyAutoMapping(m)) {
+      const formFieldId = String((m as any).formFieldId ?? `${m.sourceNodeId}.${m.sourceFieldName}`);
+      return {
+        id: String(m.id ?? `${m.sourceNodeId}_${m.sourceFieldName}_${m.targetFieldName}`),
+        formFieldId,
+        entityField: String(m.targetFieldName),
+        transformation: { type: 'direct' },
+        autoPopulate: {
+          sourceStep: String(m.sourceNodeId),
+          sourceField: String(m.sourceFieldName),
+          mode: 'copy',
+        },
+      } satisfies FieldMapping;
+    }
+
+    // Assume already canonical; callers still need to validate at runtime.
+    return m as FieldMapping;
+  });
+}


### PR DESCRIPTION
Fix broken field mapping UI when Auto-Mapping suggestions are stored in legacy shape.

Changes:
- Add normalizeFieldMappings adapter to coerce AutoMappingService mapping objects into FieldMappingPanel shape.
- Use adapter in renderFieldMapping so mappings render/edit correctly.
- Fix createRecordSchema validator to accept canonical mapping keys (entityField/formFieldId) and legacy keys.
- Add unit test for adapter.

Tests:
- vitest run fieldMappingsAdapter.test
- frontend type-check
