### PR TITLE
WorkForms editor: template-aware validation

### DIFF
--- a/frontend/src/components/FlowEditor/config/__tests__/validationEngine.templateVars.test.ts
+++ b/frontend/src/components/FlowEditor/config/__tests__/validationEngine.templateVars.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+
+import { validateField } from '../validationEngine';
+
+describe('validationEngine (template variables)', () => {
+  it('treats {{...}} as valid for email/url/regex validations', () => {
+    const allValues = {};
+
+    expect(
+      validateField(
+        { id: 'to', label: 'To', validation: [{ type: 'email', message: 'bad' }] } as any,
+        '{{customer.email}}',
+        allValues
+      )
+    ).toBeNull();
+
+    expect(
+      validateField(
+        { id: 'url', label: 'URL', validation: [{ type: 'url', message: 'bad' }] } as any,
+        '{{webhook.url}}',
+        allValues
+      )
+    ).toBeNull();
+
+    expect(
+      validateField(
+        { id: 'pattern', label: 'Pattern', validation: [{ type: 'regex', value: '^a$', message: 'bad' }] } as any,
+        '{{value}}',
+        allValues
+      )
+    ).toBeNull();
+  });
+
+  it('allows comma-separated email lists', () => {
+    const allValues = {};
+
+    expect(
+      validateField(
+        { id: 'to', label: 'To', validation: [{ type: 'email', message: 'bad' }] } as any,
+        'a@example.com, b@example.com',
+        allValues
+      )
+    ).toBeNull();
+
+    expect(
+      validateField(
+        { id: 'to', label: 'To', validation: [{ type: 'email', message: 'bad' }] } as any,
+        'a@example.com, not-an-email',
+        allValues
+      )
+    ).toBe('bad');
+  });
+});

--- a/frontend/src/components/FlowEditor/config/validationEngine.ts
+++ b/frontend/src/components/FlowEditor/config/validationEngine.ts
@@ -94,6 +94,10 @@ function validateRule(
     case 'regex':
     case 'pattern':
       if (typeof value === 'string') {
+        // Template variables (e.g. {{customer.email}}) cannot be validated reliably client-side.
+        // Treat them as valid so panels remain usable.
+        if (value.includes('{{') && value.includes('}}')) return null;
+
         const regex = rule.value instanceof RegExp ? rule.value : new RegExp(rule.value);
         if (!regex.test(value)) {
           return rule.message;
@@ -103,8 +107,16 @@ function validateRule(
 
     case 'email':
       if (typeof value === 'string') {
+        if (value.includes('{{') && value.includes('}}')) return null;
+
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(value)) {
+        const parts = value
+          .split(',')
+          .map((p) => p.trim())
+          .filter(Boolean);
+
+        const allValid = parts.length === 0 ? emailRegex.test(value.trim()) : parts.every((p) => emailRegex.test(p));
+        if (!allValid) {
           return rule.message;
         }
       }
@@ -112,6 +124,8 @@ function validateRule(
 
     case 'url':
       if (typeof value === 'string') {
+        if (value.includes('{{') && value.includes('}}')) return null;
+
         try {
           new URL(value);
           return null;


### PR DESCRIPTION
Fix action panel validation rejecting template variables.

Changes:
- validationEngine: treat strings containing {{...}} as valid for email/url/regex validations.
- email validation: allow comma-separated lists.
- Add unit tests.

Tests:
- vitest run validationEngine.templateVars.test
- frontend type-check
