### PR TITLE
WorkForms editor: fix document template field

### DIFF
--- a/frontend/src/components/FlowEditor/config/__tests__/schemaRegistry.actionSchemas.test.ts
+++ b/frontend/src/components/FlowEditor/config/__tests__/schemaRegistry.actionSchemas.test.ts
@@ -32,4 +32,14 @@ describe('schemaRegistry action schemas', () => {
     expect(updateFieldIds.has('recordId')).toBe(true);
     expect(updateFieldIds.has('fieldMappings')).toBe(true);
   });
+
+  it('keeps documentGenerate template field usable (no stuck loading select)', () => {
+    const schema = schemaRegistry.getSchema('documentGenerate');
+    const templateField = schema.sections
+      .flatMap((s) => s.fields ?? [])
+      .find((f) => f.id === 'templateId');
+
+    expect(templateField).toBeDefined();
+    expect((templateField as any).type).toBe('text');
+  });
 });

--- a/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
+++ b/frontend/src/components/FlowEditor/config/nodeConfigSchemas.ts
@@ -1402,24 +1402,16 @@ export const documentGenerateSchema: NodeConfigSchema = {
         },
         {
           id: 'templateId',
-          type: 'select',
-          label: 'Template',
-          placeholder: 'Select template...',
-          helpText: 'Pre-configured document template',
+          type: 'text',
+          label: 'Template ID',
+          placeholder: 'Paste a template ID...',
+          helpText: 'Template Library integration is not yet available here. Paste the template ID for now.',
           required: true,
-          options: [
-            {
-              value: '__loading__',
-              label: 'Loading Templates...',
-              disabled: true,
-            },
-          ],
           conditional: {
             field: 'templateSource',
             operator: 'equals',
             value: 'library'
           },
-          // Options loaded dynamically from API
           validation: [{ type: 'required', message: 'Template is required' }]
         },
         {


### PR DESCRIPTION
Document Generate schema had a template select that never loads options, leaving the UI stuck at "Loading Templates...".

Changes:
- Switch documentGenerate.templateId to a text field (usable immediately) until template library API is implemented.
- Add schema regression test ensuring templateId is not a stuck select.

Tests:
- vitest run schemaRegistry.actionSchemas.test.ts
- frontend type-check
