### PR TITLE
WorkForms editor: a11y nested children

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.test.tsx
@@ -34,4 +34,31 @@ describe('NestedChildrenRenderer', () => {
 
     expect(onChange).toHaveBeenCalledWith([{ label: 'A', disabled: true }]);
   });
+
+  it('allows keyboard toggle of child expansion', () => {
+    render(
+      <NestedChildrenRenderer
+        field={{
+          id: 'options',
+          label: 'Options',
+          type: 'nested-children',
+          itemSchema: {
+            fields: [
+              { id: 'label', label: 'Label', type: 'text' },
+              { id: 'disabled', label: 'Disabled', type: 'toggle' },
+            ],
+          },
+        } as any}
+        value={[{ label: 'A', disabled: false }, { label: 'B', disabled: false }]}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText('Disabled')).toBeNull();
+
+    const header = screen.getByLabelText('Toggle item 1');
+    fireEvent.keyDown(header, { key: 'Enter' });
+
+    expect(screen.getByLabelText('Disabled')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NestedChildrenRenderer.tsx
@@ -62,9 +62,14 @@ const ChildHeader = styled.div`
   background: rgba(var(--color-primary), 0.03);
   cursor: pointer;
   user-select: none;
-  
+
   &:hover {
     background: rgba(var(--color-primary), 0.06);
+  }
+
+  &:focus {
+    outline: 2px solid rgba(var(--color-primary), 0.35);
+    outline-offset: 2px;
   }
 `;
 
@@ -110,7 +115,7 @@ const Actions = styled.div`
   gap: 4px;
 `;
 
-const IconButton = styled.button`
+const IconButton = styled.button.attrs({ type: 'button' })`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -122,12 +127,12 @@ const IconButton = styled.button`
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
-  
+
   &:hover {
     background: rgba(var(--color-primary), 0.1);
     color: rgb(var(--color-primary));
   }
-  
+
   &:active {
     transform: scale(0.95);
   }
@@ -145,7 +150,7 @@ const ChildContent = styled.div`
   border-top: 1px solid rgb(var(--color-border));
 `;
 
-const AddButton = styled.button`
+const AddButton = styled.button.attrs({ type: 'button' })`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -159,13 +164,13 @@ const AddButton = styled.button`
   font-weight: 500;
   cursor: pointer;
   transition: all 0.15s ease;
-  
+
   &:hover {
     border-color: rgb(var(--color-primary));
     background: rgba(var(--color-primary), 0.03);
     color: rgb(var(--color-primary));
   }
-  
+
   &:active {
     transform: scale(0.98);
   }
@@ -298,7 +303,19 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
             
             return (
               <ChildItem key={index} $expanded={isExpanded}>
-                <ChildHeader onClick={() => toggleExpanded(index)}>
+                <ChildHeader
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={isExpanded}
+                  aria-label={`Toggle item ${index + 1}`}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      toggleExpanded(index);
+                    }
+                  }}
+                  onClick={() => toggleExpanded(index)}
+                >
                   <DragHandle onClick={(e) => e.stopPropagation()}>
                     <GripVertical size={16} />
                   </DragHandle>
@@ -313,7 +330,7 @@ export const NestedChildrenRenderer: React.FC<NestedChildrenRendererProps> = ({
                   </ChildTitle>
                   
                   <Actions>
-                    <DeleteButton onClick={(e) => handleRemoveChild(index, e)}>
+                    <DeleteButton aria-label={`Delete item ${index + 1}`} onClick={(e) => handleRemoveChild(index, e)}>
                       <Trash2 size={16} />
                     </DeleteButton>
                   </Actions>


### PR DESCRIPTION
Improve accessibility for NestedChildrenRenderer (used by nested-children schemas like Form Field options).

Changes:
- Make child headers keyboard accessible (role=button, tabIndex, Enter/Space handling, aria-expanded).
- Add aria-labels for toggle/delete actions and ensure icon buttons are type=button.
- Add regression test for keyboard expansion.

Tests:
- vitest run NestedChildrenRenderer.test.tsx
- frontend type-check
