### PR TITLE
Security: harden OAuth callbacks

### DIFF
--- a/backend/apps/email_integration/tests/test_oauth_security.py
+++ b/backend/apps/email_integration/tests/test_oauth_security.py
@@ -1,0 +1,74 @@
+from django.contrib.auth.models import User
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.tenants.models import Tenant, TenantUser
+from apps.email_integration.models import EmailAccount
+from apps.email_integration.views.oauth_views import _sign_oauth_state
+
+
+class EmailOAuthSecurityTests(APITestCase):
+    EMAIL_PREFIX = '/api/v1/workflows/email/email'
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='email-oauth', password='pass123')
+        self.tenant_a = Tenant.objects.create(
+            name='Tenant A',
+            slug='tenant-a',
+            contact_email='a@example.com',
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name='Tenant B',
+            slug='tenant-b',
+            contact_email='b@example.com',
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role='owner', is_active=True)
+
+    def test_outlook_auth_init_requires_auth(self):
+        resp = self.client.get(f'{self.EMAIL_PREFIX}/outlook/auth/init/')
+        self.assertIn(resp.status_code, {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN})
+
+    def test_gmail_auth_init_requires_auth(self):
+        resp = self.client.get(f'{self.EMAIL_PREFIX}/gmail/auth/init/')
+        self.assertIn(resp.status_code, {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN})
+
+    @override_settings(FRONTEND_URL='http://frontend.test')
+    def test_outlook_callback_rejects_without_expected_state(self):
+        state = _sign_oauth_state(
+            {
+                'user_id': self.user.id,
+                'tenant_id': str(self.tenant_a.id),
+                'provider': 'outlook',
+                'nonce': 'n',
+            }
+        )
+
+        resp = self.client.get(f'{self.EMAIL_PREFIX}/outlook/auth/callback/?code=abc&state={state}')
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn('oauth_error=invalid_state', resp['Location'])
+        self.assertEqual(EmailAccount.objects.count(), 0)
+
+    @override_settings(FRONTEND_URL='http://frontend.test')
+    def test_gmail_callback_rejects_tenant_mismatch(self):
+        state = _sign_oauth_state(
+            {
+                'user_id': self.user.id,
+                'tenant_id': str(self.tenant_b.id),
+                'provider': 'gmail',
+                'nonce': 'n',
+            }
+        )
+
+        session = self.client.session
+        session['oauth_state_gmail'] = state
+        session['oauth_tenant_gmail'] = str(self.tenant_b.id)
+        session['oauth_nonce_gmail'] = 'n'
+        session.save()
+
+        resp = self.client.get(f'{self.EMAIL_PREFIX}/gmail/auth/callback/?code=abc&state={state}')
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn('oauth_error=tenant_denied', resp['Location'])
+        self.assertEqual(EmailAccount.objects.count(), 0)

--- a/backend/apps/email_integration/views/oauth_views.py
+++ b/backend/apps/email_integration/views/oauth_views.py
@@ -8,10 +8,12 @@ Created: 2026-02-23 - Email Integration Phase 2
 """
 
 import logging
+import secrets
 from datetime import timedelta
+
 from django.conf import settings
 from django.core import signing
-from django.core.signing import BadSignature, SignatureExpired
+from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
 from django.shortcuts import redirect
 from django.utils import timezone
 from django.http import JsonResponse
@@ -26,6 +28,63 @@ logger = logging.getLogger(__name__)
 
 OAUTH_STATE_SALT = 'email_integration.oauth_state'
 OAUTH_STATE_MAX_AGE_SECONDS = 10 * 60
+
+_EMAIL_OAUTH_COOKIE_PREFIX = 'pm_email_oauth'
+_EMAIL_OAUTH_COOKIE_PATH = '/api/v1/workflows/email/email/'
+_EMAIL_SIGNER = TimestampSigner(salt='pm.email_integration.oauth.cookie')
+
+
+def _email_oauth_cookie_name(key: str, provider: str) -> str:
+    return f'{_EMAIL_OAUTH_COOKIE_PREFIX}_{key}_{provider}'
+
+
+def _set_signed_email_oauth_cookie(response: JsonResponse, *, name: str, value: str, request) -> None:
+    secure = bool(getattr(settings, 'SESSION_COOKIE_SECURE', False)) or request.is_secure()
+
+    response.set_cookie(
+        name,
+        _EMAIL_SIGNER.sign(value),
+        max_age=OAUTH_STATE_MAX_AGE_SECONDS,
+        httponly=True,
+        secure=secure,
+        samesite='Lax',
+        path=_EMAIL_OAUTH_COOKIE_PATH,
+    )
+
+
+def _get_signed_email_oauth_cookie(request, *, name: str) -> str | None:
+    signed = request.COOKIES.get(name)
+    if not signed:
+        return None
+
+    try:
+        return _EMAIL_SIGNER.unsign(signed, max_age=OAUTH_STATE_MAX_AGE_SECONDS)
+    except (BadSignature, SignatureExpired):
+        return None
+
+
+def _clear_email_oauth_state(request, response: JsonResponse, provider: str) -> None:
+    request.session.pop(f'oauth_state_{provider}', None)
+    request.session.pop(f'oauth_tenant_{provider}', None)
+    request.session.pop(f'oauth_nonce_{provider}', None)
+    response.delete_cookie(_email_oauth_cookie_name('state', provider), path=_EMAIL_OAUTH_COOKIE_PATH)
+    response.delete_cookie(_email_oauth_cookie_name('tenant', provider), path=_EMAIL_OAUTH_COOKIE_PATH)
+    response.delete_cookie(_email_oauth_cookie_name('nonce', provider), path=_EMAIL_OAUTH_COOKIE_PATH)
+
+
+def _consume_email_oauth_nonce(request, provider: str, nonce: str) -> bool:
+    if not nonce:
+        return False
+
+    expected = request.session.get(f'oauth_nonce_{provider}') or _get_signed_email_oauth_cookie(
+        request,
+        name=_email_oauth_cookie_name('nonce', provider),
+    )
+    if not expected or expected != nonce:
+        return False
+
+    request.session.pop(f'oauth_nonce_{provider}', None)
+    return True
 
 
 def _sign_oauth_state(payload: dict) -> str:
@@ -78,7 +137,20 @@ def outlook_auth_init(request):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        state = _sign_oauth_state({'user_id': request.user.id, 'tenant_id': str(tenant.id), 'provider': 'outlook'})
+        nonce = secrets.token_urlsafe(16)
+        request.session['oauth_nonce_outlook'] = nonce
+
+        state = _sign_oauth_state(
+            {
+                'user_id': request.user.id,
+                'tenant_id': str(tenant.id),
+                'provider': 'outlook',
+                'nonce': nonce,
+            }
+        )
+
+        request.session['oauth_state_outlook'] = state
+        request.session['oauth_tenant_outlook'] = str(tenant.id)
         
         auth_url = msal_app.get_authorization_request_url(
             scopes=scopes,
@@ -87,10 +159,26 @@ def outlook_auth_init(request):
             prompt="select_account",  # Mitigates msaidpvalidate 400 errors and enforces clean session selection
         )
         
-        return JsonResponse({
-            'auth_url': auth_url,
-            'provider': 'outlook'
-        })
+        response = JsonResponse({'auth_url': auth_url, 'provider': 'outlook'})
+        _set_signed_email_oauth_cookie(
+            response,
+            name=_email_oauth_cookie_name('state', 'outlook'),
+            value=state,
+            request=request,
+        )
+        _set_signed_email_oauth_cookie(
+            response,
+            name=_email_oauth_cookie_name('tenant', 'outlook'),
+            value=str(tenant.id),
+            request=request,
+        )
+        _set_signed_email_oauth_cookie(
+            response,
+            name=_email_oauth_cookie_name('nonce', 'outlook'),
+            value=nonce,
+            request=request,
+        )
+        return response
         
     except Exception as e:
         logger.error(f"Outlook OAuth init failed: {str(e)}")
@@ -103,36 +191,66 @@ def outlook_auth_init(request):
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def outlook_auth_callback(request):
+    """Handle Outlook OAuth2 callback.
+
+    Security requirements:
+    - Callback must be bound to the browser that initiated OAuth (expected_state in session/cookie).
+    - Signed state must include tenant_id + user_id + provider + nonce.
+    - Best-effort replay protection via nonce consumption.
     """
-    Handle Outlook OAuth2 callback.
-    Exchange code for tokens and create EmailAccount.
-    """
-    from msal import ConfidentialClientApplication
-    import requests
-    
+
     code = request.GET.get('code')
     state = request.GET.get('state')
     error = request.GET.get('error')
-    
+
     if error:
         logger.error(f"Outlook OAuth error: {error}")
         return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error={error}")
-    
+
     if not code or not state:
         return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=missing_params")
-    
+
+    expected_state = request.session.get('oauth_state_outlook') or _get_signed_email_oauth_cookie(
+        request,
+        name=_email_oauth_cookie_name('state', 'outlook'),
+    )
+    if state != expected_state:
+        response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+        _clear_email_oauth_state(request, response, 'outlook')
+        return response
+
     try:
         try:
             payload = _unsign_oauth_state(state)
         except SignatureExpired:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=state_expired")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=state_expired")
+            _clear_email_oauth_state(request, response, 'outlook')
+            return response
         except BadSignature:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+            _clear_email_oauth_state(request, response, 'outlook')
+            return response
 
         user_id = payload.get('user_id')
         tenant_id = payload.get('tenant_id')
-        if not user_id or not tenant_id:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+        provider = payload.get('provider')
+        nonce = str(payload.get('nonce') or '')
+
+        if not user_id or not tenant_id or provider != 'outlook' or not nonce:
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+            _clear_email_oauth_state(request, response, 'outlook')
+            return response
+
+        header_tenant = request.headers.get('X-Tenant-ID')
+        if header_tenant and header_tenant != str(tenant_id):
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=tenant_mismatch")
+            _clear_email_oauth_state(request, response, 'outlook')
+            return response
+
+        if not _consume_email_oauth_nonce(request, 'outlook', nonce):
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=replayed_state")
+            _clear_email_oauth_state(request, response, 'outlook')
+            return response
 
         from django.contrib.auth import get_user_model
         from apps.tenants.models import Tenant, TenantUser
@@ -141,59 +259,64 @@ def outlook_auth_callback(request):
         user = User.objects.get(id=int(user_id))
         tenant = Tenant.objects.filter(id=tenant_id, is_active=True).first()
         if not tenant:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_tenant")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_tenant")
+            _clear_email_oauth_state(request, response, 'outlook')
+            return response
 
         if not TenantUser.objects.filter(tenant=tenant, user=user, is_active=True).exists():
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=tenant_denied")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=tenant_denied")
+            _clear_email_oauth_state(request, response, 'outlook')
+            return response
 
-        # Exchange code for tokens
+        # Imports below must only occur after state/membership gates so tests can run without
+        # provider libraries installed.
+        from msal import ConfidentialClientApplication
+        import requests
+
         client_id = settings.MICROSOFT_CLIENT_ID
         client_secret = settings.MICROSOFT_CLIENT_SECRET
         redirect_uri = settings.MICROSOFT_REDIRECT_URI
-        
-        tenant_id = getattr(settings, 'MICROSOFT_TENANT_ID', 'common')
-        authority = f"https://login.microsoftonline.com/{tenant_id}"
+
+        microsoft_tenant_id = getattr(settings, 'MICROSOFT_TENANT_ID', 'common')
+        authority = f"https://login.microsoftonline.com/{microsoft_tenant_id}"
 
         msal_app = ConfidentialClientApplication(
             client_id,
             authority=authority,
             client_credential=client_secret,
         )
-        
+
         scopes = [
-            "https://graph.microsoft.com/Mail.Read",
-            "https://graph.microsoft.com/Mail.Send",
-            "https://graph.microsoft.com/User.Read"
+            'https://graph.microsoft.com/Mail.Read',
+            'https://graph.microsoft.com/Mail.Send',
+            'https://graph.microsoft.com/User.Read',
         ]
-        
+
         result = msal_app.acquire_token_by_authorization_code(
             code,
             scopes=scopes,
-            redirect_uri=redirect_uri
+            redirect_uri=redirect_uri,
         )
-        
+
         if 'error' in result:
             logger.error(f"Token exchange failed: {result.get('error_description')}")
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=token_failed")
-        
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=token_failed")
+            _clear_email_oauth_state(request, response, 'outlook')
+            return response
+
         access_token = result.get('access_token')
         refresh_token = result.get('refresh_token')
         expires_in = result.get('expires_in', 3600)
-        
-        # Get user profile
+
         headers = {'Authorization': f'Bearer {access_token}'}
-        profile_response = requests.get(
-            'https://graph.microsoft.com/v1.0/me',
-            headers=headers
-        )
+        profile_response = requests.get('https://graph.microsoft.com/v1.0/me', headers=headers)
         profile_data = profile_response.json()
-        
+
         email_address = profile_data.get('mail') or profile_data.get('userPrincipalName')
         display_name = profile_data.get('displayName', '')
         provider_user_id = profile_data.get('id')
-        
-        # Create or update EmailAccount
-        email_account, created = EmailAccount.objects.update_or_create(
+
+        EmailAccount.objects.update_or_create(
             user=user,
             provider='outlook',
             email_address=email_address,
@@ -204,17 +327,21 @@ def outlook_auth_callback(request):
                 'provider_user_id': provider_user_id,
                 'display_name': display_name,
                 'status': 'active',
-                'last_synced_at': timezone.now()
-            }
+                'last_synced_at': timezone.now(),
+            },
         )
-        
-        logger.info(f"Outlook account {'created' if created else 'updated'}: {email_address}")
-        
-        return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_success=outlook&email={email_address}")
-        
+
+        logger.info(f"Outlook account updated: {email_address}")
+
+        response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_success=outlook&email={email_address}")
+        _clear_email_oauth_state(request, response, 'outlook')
+        return response
+
     except Exception as e:
         logger.error(f"Outlook callback failed: {str(e)}")
-        return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=callback_failed")
+        response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=callback_failed")
+        _clear_email_oauth_state(request, response, 'outlook')
+        return response
 
 
 # ============================================================================
@@ -272,19 +399,48 @@ def gmail_auth_init(request):
             redirect_uri=redirect_uri
         )
 
-        state = _sign_oauth_state({'user_id': request.user.id, 'tenant_id': str(tenant.id), 'provider': 'gmail'})
-        
+        nonce = secrets.token_urlsafe(16)
+        request.session['oauth_nonce_gmail'] = nonce
+
+        state = _sign_oauth_state(
+            {
+                'user_id': request.user.id,
+                'tenant_id': str(tenant.id),
+                'provider': 'gmail',
+                'nonce': nonce,
+            }
+        )
+
+        request.session['oauth_state_gmail'] = state
+        request.session['oauth_tenant_gmail'] = str(tenant.id)
+
         auth_url, _ = flow.authorization_url(
             access_type='offline',
             include_granted_scopes='true',
             state=state,
-            prompt='consent'  # Force consent to get refresh token
+            prompt='consent',  # Force consent to get refresh token
         )
-        
-        return JsonResponse({
-            'auth_url': auth_url,
-            'provider': 'gmail'
-        })
+
+        response = JsonResponse({'auth_url': auth_url, 'provider': 'gmail'})
+        _set_signed_email_oauth_cookie(
+            response,
+            name=_email_oauth_cookie_name('state', 'gmail'),
+            value=state,
+            request=request,
+        )
+        _set_signed_email_oauth_cookie(
+            response,
+            name=_email_oauth_cookie_name('tenant', 'gmail'),
+            value=str(tenant.id),
+            request=request,
+        )
+        _set_signed_email_oauth_cookie(
+            response,
+            name=_email_oauth_cookie_name('nonce', 'gmail'),
+            value=nonce,
+            request=request,
+        )
+        return response
         
     except Exception as e:
         logger.error(f"Gmail OAuth init failed: {str(e)}")
@@ -297,36 +453,60 @@ def gmail_auth_init(request):
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def gmail_auth_callback(request):
-    """
-    Handle Gmail OAuth2 callback.
-    Exchange code for tokens and create EmailAccount.
-    """
-    from google_auth_oauthlib.flow import Flow
-    from googleapiclient.discovery import build
-    
+    """Handle Gmail OAuth2 callback (tenant-safe)."""
+
     code = request.GET.get('code')
     state = request.GET.get('state')
     error = request.GET.get('error')
-    
+
     if error:
         logger.error(f"Gmail OAuth error: {error}")
         return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error={error}")
-    
+
     if not code or not state:
         return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=missing_params")
-    
+
+    expected_state = request.session.get('oauth_state_gmail') or _get_signed_email_oauth_cookie(
+        request,
+        name=_email_oauth_cookie_name('state', 'gmail'),
+    )
+    if state != expected_state:
+        response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+        _clear_email_oauth_state(request, response, 'gmail')
+        return response
+
     try:
         try:
             payload = _unsign_oauth_state(state)
         except SignatureExpired:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=state_expired")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=state_expired")
+            _clear_email_oauth_state(request, response, 'gmail')
+            return response
         except BadSignature:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+            _clear_email_oauth_state(request, response, 'gmail')
+            return response
 
         user_id = payload.get('user_id')
         tenant_id = payload.get('tenant_id')
-        if not user_id or not tenant_id:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+        provider = payload.get('provider')
+        nonce = str(payload.get('nonce') or '')
+
+        if not user_id or not tenant_id or provider != 'gmail' or not nonce:
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_state")
+            _clear_email_oauth_state(request, response, 'gmail')
+            return response
+
+        header_tenant = request.headers.get('X-Tenant-ID')
+        if header_tenant and header_tenant != str(tenant_id):
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=tenant_mismatch")
+            _clear_email_oauth_state(request, response, 'gmail')
+            return response
+
+        if not _consume_email_oauth_nonce(request, 'gmail', nonce):
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=replayed_state")
+            _clear_email_oauth_state(request, response, 'gmail')
+            return response
 
         from django.contrib.auth import get_user_model
         from apps.tenants.models import Tenant, TenantUser
@@ -335,29 +515,37 @@ def gmail_auth_callback(request):
         user = User.objects.get(id=int(user_id))
         tenant = Tenant.objects.filter(id=tenant_id, is_active=True).first()
         if not tenant:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_tenant")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=invalid_tenant")
+            _clear_email_oauth_state(request, response, 'gmail')
+            return response
 
         if not TenantUser.objects.filter(tenant=tenant, user=user, is_active=True).exists():
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=tenant_denied")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=tenant_denied")
+            _clear_email_oauth_state(request, response, 'gmail')
+            return response
+
+        from google_auth_oauthlib.flow import Flow
+        from googleapiclient.discovery import build
 
         client_id = str(getattr(settings, 'GOOGLE_CLIENT_ID', '') or '').strip()
         client_secret = str(getattr(settings, 'GOOGLE_CLIENT_SECRET', '') or '').strip()
         redirect_uri = str(getattr(settings, 'GOOGLE_REDIRECT_URI', '') or '').strip()
 
         if not client_id or not client_secret or not redirect_uri:
-            return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=not_configured")
+            response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=not_configured")
+            _clear_email_oauth_state(request, response, 'gmail')
+            return response
 
-        # Exchange code for tokens
         client_config = {
-            "web": {
-                "client_id": client_id,
-                "client_secret": client_secret,
-                "redirect_uris": [redirect_uri],
-                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                "token_uri": "https://oauth2.googleapis.com/token",
+            'web': {
+                'client_id': client_id,
+                'client_secret': client_secret,
+                'redirect_uris': [redirect_uri],
+                'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                'token_uri': 'https://oauth2.googleapis.com/token',
             }
         }
-        
+
         flow = Flow.from_client_config(
             client_config,
             scopes=[
@@ -366,22 +554,19 @@ def gmail_auth_callback(request):
                 'https://www.googleapis.com/auth/userinfo.email',
             ],
             redirect_uri=redirect_uri,
-            state=state
+            state=state,
         )
-        
+
         flow.fetch_token(code=code)
         credentials = flow.credentials
-        
-        # Get user email
+
         service = build('gmail', 'v1', credentials=credentials)
         profile = service.users().getProfile(userId='me').execute()
         email_address = profile.get('emailAddress')
-        
-        # Calculate token expiration
-        expires_in = 3600  # Default 1 hour
-        
-        # Create or update EmailAccount
-        email_account, created = EmailAccount.objects.update_or_create(
+
+        expires_in = 3600
+
+        EmailAccount.objects.update_or_create(
             user=user,
             provider='gmail',
             email_address=email_address,
@@ -392,17 +577,19 @@ def gmail_auth_callback(request):
                 'provider_user_id': email_address,
                 'display_name': email_address.split('@')[0],
                 'status': 'active',
-                'last_synced_at': timezone.now()
-            }
+                'last_synced_at': timezone.now(),
+            },
         )
-        
-        logger.info(f"Gmail account {'created' if created else 'updated'}: {email_address}")
-        
-        return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_success=gmail&email={email_address}")
-        
+
+        response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_success=gmail&email={email_address}")
+        _clear_email_oauth_state(request, response, 'gmail')
+        return response
+
     except Exception as e:
         logger.error(f"Gmail callback failed: {str(e)}")
-        return redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=callback_failed")
+        response = redirect(f"{settings.FRONTEND_URL}/cockpit?oauth_error=callback_failed")
+        _clear_email_oauth_state(request, response, 'gmail')
+        return response
 
 
 # ============================================================================

--- a/backend/apps/integrations/tests.py
+++ b/backend/apps/integrations/tests.py
@@ -127,6 +127,7 @@ class IntegrationsOAuthSecurityTests(APITestCase):
         session = self.client.session
         session['oauth_state_microsoft'] = state
         session['oauth_tenant_microsoft'] = str(self.tenant.id)
+        session['oauth_nonce_microsoft'] = 'n'
         session.save()
 
         with patch('integrations.views.oauth.MicrosoftGraphProvider') as mocked_provider:
@@ -139,6 +140,84 @@ class IntegrationsOAuthSecurityTests(APITestCase):
         self.assertFalse(
             ExternalAuthProvider.objects.filter(tenant=self.tenant, provider_type='microsoft').exists()
         )
+        mocked_provider.assert_not_called()
+
+    def test_oauth_callback_rejects_tenant_header_mismatch(self):
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner', is_active=True)
+
+        state = signing.dumps(
+            {
+                'tenant_id': str(self.tenant.id),
+                'user_id': str(self.user.id),
+                'provider': 'microsoft',
+                'nonce': 'n',
+            },
+            salt='pm.integrations.oauth.state',
+        )
+
+        session = self.client.session
+        session['oauth_state_microsoft'] = state
+        session['oauth_tenant_microsoft'] = str(self.tenant.id)
+        session['oauth_nonce_microsoft'] = 'n'
+        session.save()
+
+        with patch('integrations.views.oauth.MicrosoftGraphProvider') as mocked_provider:
+            resp = self.client.get(
+                f'/api/v1/integrations/oauth/callback/microsoft/?code=abc&state={state}',
+                HTTP_X_TENANT_ID='00000000-0000-0000-0000-000000000000',
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn('error=tenant_mismatch', resp['Location'])
+        mocked_provider.assert_not_called()
+
+    def test_oauth_callback_rejects_replayed_state(self):
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner', is_active=True)
+
+
+        state = signing.dumps(
+            {
+                'tenant_id': str(self.tenant.id),
+                'user_id': str(self.user.id),
+                'provider': 'microsoft',
+                'nonce': 'n',
+            },
+            salt='pm.integrations.oauth.state',
+        )
+
+        token_response = SimpleNamespace(access_token='access', refresh_token='refresh', expires_in=3600)
+        user_info = {'email': 'connected@example.com', 'name': 'Connected User'}
+        mocked_instance = SimpleNamespace(
+            exchange_code=lambda code, redirect_uri: token_response,
+            get_user_info=lambda access_token: user_info,
+        )
+
+        session = self.client.session
+        session['oauth_state_microsoft'] = state
+        session['oauth_tenant_microsoft'] = str(self.tenant.id)
+        session['oauth_nonce_microsoft'] = 'n'
+        session.save()
+
+        with patch('integrations.views.oauth.MicrosoftGraphProvider', return_value=mocked_instance):
+            resp1 = self.client.get(f'/api/v1/integrations/oauth/callback/microsoft/?code=abc&state={state}')
+
+        self.assertEqual(resp1.status_code, 302)
+        self.assertIn('success=connected', resp1['Location'])
+
+        # Simulate a second attempt where an attacker replays the same state but the browser/session
+        # still presents it (e.g., cookie re-send). Nonce consumption must fail closed.
+        session = self.client.session
+        session['oauth_state_microsoft'] = state
+        session['oauth_tenant_microsoft'] = str(self.tenant.id)
+        # Note: oauth_nonce_microsoft is intentionally NOT set. The nonce was already consumed
+        # by the first callback and must fail closed on replay.
+        session.save()
+
+        with patch('integrations.views.oauth.MicrosoftGraphProvider') as mocked_provider:
+            resp2 = self.client.get(f'/api/v1/integrations/oauth/callback/microsoft/?code=abc&state={state}')
+
+        self.assertEqual(resp2.status_code, 302)
+        self.assertIn('error=replayed_state', resp2['Location'])
         mocked_provider.assert_not_called()
 
     def test_oauth_callback_persists_tokens_for_member(self):
@@ -157,6 +236,7 @@ class IntegrationsOAuthSecurityTests(APITestCase):
         session = self.client.session
         session['oauth_state_microsoft'] = state
         session['oauth_tenant_microsoft'] = str(self.tenant.id)
+        session['oauth_nonce_microsoft'] = 'n'
         session.save()
 
         token_response = SimpleNamespace(access_token='access', refresh_token='refresh', expires_in=3600)

--- a/backend/apps/integrations/views.py
+++ b/backend/apps/integrations/views.py
@@ -155,6 +155,12 @@ def oauth_callback(request, provider_type):
     # Validate signed state for CSRF protection + identity binding.
     state = request.GET.get('state')
 
+    expected_state = request.session.get(f'oauth_state_{provider_type}')
+    if not expected_state or state != expected_state:
+        request.session.pop(f'oauth_state_{provider_type}', None)
+        request.session.pop(f'oauth_tenant_{provider_type}', None)
+        return redirect('/settings?error=invalid_state')
+
     try:
         state_payload = signing.loads(state or '', salt='integrations.oauth.state', max_age=15 * 60)
     except Exception:

--- a/backend/integrations/views/oauth.py
+++ b/backend/integrations/views/oauth.py
@@ -63,6 +63,28 @@ def _get_signed_oauth_cookie(request, *, name: str) -> str | None:
 def _clear_oauth_cookies(response, provider: str) -> None:
     response.delete_cookie(_oauth_cookie_name('state', provider), path=_OAUTH_COOKIE_PATH)
     response.delete_cookie(_oauth_cookie_name('tenant', provider), path=_OAUTH_COOKIE_PATH)
+    response.delete_cookie(_oauth_cookie_name('nonce', provider), path=_OAUTH_COOKIE_PATH)
+
+
+def _consume_oauth_nonce(request, provider: str, nonce: str) -> bool:
+    """Nonce replay protection without requiring a shared cache.
+
+    We bind nonce to the initiating browser via session and a signed httpOnly cookie.
+    Callback must present the same nonce exactly once.
+    """
+
+    if not nonce:
+        return False
+
+    expected = request.session.get(f'oauth_nonce_{provider}') or _get_signed_oauth_cookie(
+        request,
+        name=_oauth_cookie_name('nonce', provider),
+    )
+    if not expected or expected != nonce:
+        return False
+
+    request.session.pop(f'oauth_nonce_{provider}', None)
+    return True
 
 
 class OAuthAuthorizeView(APIView):
@@ -136,6 +158,8 @@ class OAuthAuthorizeView(APIView):
         # - Session cookie may be blocked on cross-site redirects.
         # - Signed state provides integrity and lets us enforce tenant membership.
         nonce = secrets.token_urlsafe(16)
+        request.session[f'oauth_nonce_{provider}'] = nonce
+
         state = signing.dumps(
             {
                 'tenant_id': str(tenant.id),
@@ -220,6 +244,12 @@ class OAuthAuthorizeView(APIView):
             value=str(tenant.id),
             request=request,
         )
+        _set_signed_oauth_cookie(
+            response,
+            name=_oauth_cookie_name('nonce', provider),
+            value=nonce,
+            request=request,
+        )
         return response
 
 
@@ -255,6 +285,8 @@ class OAuthCallbackView(APIView):
             name=_oauth_cookie_name('state', provider),
         )
         if not state or state != expected_state:
+            request.session.pop(f'oauth_state_{provider}', None)
+            request.session.pop(f'oauth_tenant_{provider}', None)
             response = redirect(f'/settings/email-integrations?error=invalid_state&provider={quote(provider)}')
             _clear_oauth_cookies(response, provider)
             return response
@@ -269,8 +301,35 @@ class OAuthCallbackView(APIView):
 
         tenant_id = str(state_payload.get('tenant_id') or '')
         user_id = str(state_payload.get('user_id') or '')
-        if not tenant_id or not user_id:
+        state_provider = str(state_payload.get('provider') or '')
+        nonce = str(state_payload.get('nonce') or '')
+
+        if not tenant_id or not user_id or not nonce:
+            request.session.pop(f'oauth_state_{provider}', None)
+            request.session.pop(f'oauth_tenant_{provider}', None)
             response = redirect(f'/settings/email-integrations?error=invalid_state&provider={quote(provider)}')
+            _clear_oauth_cookies(response, provider)
+            return response
+
+        if state_provider and state_provider != provider:
+            request.session.pop(f'oauth_state_{provider}', None)
+            request.session.pop(f'oauth_tenant_{provider}', None)
+            response = redirect(f'/settings/email-integrations?error=invalid_state&provider={quote(provider)}')
+            _clear_oauth_cookies(response, provider)
+            return response
+
+        header_tenant = request.headers.get('X-Tenant-ID')
+        if header_tenant and header_tenant != tenant_id:
+            request.session.pop(f'oauth_state_{provider}', None)
+            request.session.pop(f'oauth_tenant_{provider}', None)
+            response = redirect(f'/settings/email-integrations?error=tenant_mismatch&provider={quote(provider)}')
+            _clear_oauth_cookies(response, provider)
+            return response
+
+        if not _consume_oauth_nonce(request, provider, nonce):
+            request.session.pop(f'oauth_state_{provider}', None)
+            request.session.pop(f'oauth_tenant_{provider}', None)
+            response = redirect(f'/settings/email-integrations?error=replayed_state&provider={quote(provider)}')
             _clear_oauth_cookies(response, provider)
             return response
 


### PR DESCRIPTION
## What
- Hardened OAuth callbacks for email integration (Gmail/Outlook) to require `state` to match an **expected** browser-bound value (session or signed httpOnly cookie).
- Added **nonce single-use** enforcement without relying on cache backends (session/cookie consume-once).
- Enforced provider match and rejected `X-Tenant-ID` header mismatches on callback endpoints.
- Hardened legacy integrations callback handler (defense-in-depth) to require expected_state.

## Why
Prevents OAuth misbinding / login-CSRF style attacks where a valid signed `state` could be replayed or used from the wrong browser context, and reduces cross-tenant footguns on public callbacks.

## Testing
- `cd backend && python manage.py test apps.integrations apps.email_integration --keepdb`

## Rollback
Revert this PR to restore prior callback behavior (no schema changes).
