### PR TITLE
CI: enforce RLS audit coverage

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -18,7 +18,7 @@ This directory contains validation and automation scripts used by GitHub Actions
 2. Migration plan is valid (`migrate --plan`)
 3. No migration conflicts (`showmigrations`)
 4. Python syntax in all migration files
-5. RLS policy SQL is present in newly-changed tenant-aware `CreateModel` migrations (requires `ENABLE ROW LEVEL SECURITY` + `CREATE POLICY`)
+5. RLS policy SQL is present in newly-changed tenant-aware `CreateModel` migrations (requires `ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY` + `CREATE POLICY`)
 6. Migration dependencies are consistent
 7. Migrations work on fresh database (CI only)
 

--- a/.github/scripts/validate-migrations.sh
+++ b/.github/scripts/validate-migrations.sh
@@ -72,17 +72,26 @@ echo ""
 echo "Step 5: Enforcing RLS policy for new tenant-aware tables..."
 
 # Only enforce on migrations changed in this branch to avoid failing legacy history.
+# Keep deterministic by resolving the PR base ref in CI (shallow checkouts often lack origin/<branch>).
 BASE_REF=${GITHUB_BASE_REF:-development}
 BASE_REV=""
 
-if git -C "$REPO_ROOT" rev-parse --verify "origin/$BASE_REF" >/dev/null 2>&1; then
-    BASE_REV="origin/$BASE_REF"
-elif git -C "$REPO_ROOT" rev-parse --verify "upstream/$BASE_REF" >/dev/null 2>&1; then
-    BASE_REV="upstream/$BASE_REF"
+if [ -n "${CI:-}" ]; then
+    # Prefer fetching the base branch explicitly (works with actions/checkout default depth).
+    if git -C "$REPO_ROOT" fetch --no-tags --depth=1 origin "$BASE_REF" >/dev/null 2>&1; then
+        BASE_REV=$(git -C "$REPO_ROOT" rev-parse FETCH_HEAD)
+    fi
+else
+    # Local/dev usage: fall back to existing remotes if present.
+    if git -C "$REPO_ROOT" rev-parse --verify "origin/$BASE_REF" >/dev/null 2>&1; then
+        BASE_REV="origin/$BASE_REF"
+    elif git -C "$REPO_ROOT" rev-parse --verify "upstream/$BASE_REF" >/dev/null 2>&1; then
+        BASE_REV="upstream/$BASE_REF"
+    fi
 fi
 
 if [ -z "$BASE_REV" ]; then
-    echo "⚠️  Skipping RLS enforcement (could not resolve base ref origin/$BASE_REF or upstream/$BASE_REF)"
+    echo "⚠️  Skipping RLS enforcement (could not resolve base ref '$BASE_REF')"
 else
     CHANGED_MIGRATIONS=$(git -C "$REPO_ROOT" diff --name-only "$BASE_REV"...HEAD | \
         grep -E '^backend/(apps|tenant_apps)/.+/migrations/.+\.py$' | \
@@ -100,9 +109,9 @@ else
             # Only require RLS when a tenant-aware table is created.
             # Heuristic: CreateModel + a tenant FK field tuple exists in the migration file.
             if grep -q "CreateModel(" "$REPO_ROOT/$file" && grep -q "('tenant'," "$REPO_ROOT/$file"; then
-                if ! grep -q "ENABLE ROW LEVEL SECURITY" "$REPO_ROOT/$file" || ! grep -q "CREATE POLICY" "$REPO_ROOT/$file"; then
+                if ! grep -q "ENABLE ROW LEVEL SECURITY" "$REPO_ROOT/$file" || ! grep -q "FORCE ROW LEVEL SECURITY" "$REPO_ROOT/$file" || ! grep -q "CREATE POLICY" "$REPO_ROOT/$file"; then
                     echo "❌ Missing RLS policy SQL in: $file"
-                    echo "   Expected to find both: 'ENABLE ROW LEVEL SECURITY' and 'CREATE POLICY'"
+                    echo "   Expected to find all of: 'ENABLE ROW LEVEL SECURITY', 'FORCE ROW LEVEL SECURITY', and 'CREATE POLICY'"
                     RLS_ERRORS=$((RLS_ERRORS + 1))
                 fi
             fi

--- a/backend/apps/core/management/commands/audit_rls_compliance.py
+++ b/backend/apps/core/management/commands/audit_rls_compliance.py
@@ -112,9 +112,13 @@ class Command(BaseCommand):
 
         # Non-TenantAwareModel tables that must still have RLS enabled.
         must_have = {
+            # System WorkForms (tenant-bearing tables in apps.system)
             "system.TenantForm",
             "system.TenantWorkForm",
+
+            # Integrations (tenant-bearing tables in apps.integrations)
             "integrations.ExternalAuthProvider",
+            "integrations.EmailLog",
         }
         for label in sorted(must_have):
             try:

--- a/backend/apps/core/tests/test_audit_rls_compliance.py
+++ b/backend/apps/core/tests/test_audit_rls_compliance.py
@@ -13,3 +13,4 @@ class AuditRlsComplianceCommandTest(SimpleTestCase):
         self.assertIn("system.TenantForm", labels)
         self.assertIn("system.TenantWorkForm", labels)
         self.assertIn("integrations.ExternalAuthProvider", labels)
+        self.assertIn("integrations.EmailLog", labels)


### PR DESCRIPTION
## What
- Tightens CI migration validation to require tenant-aware `CreateModel` migrations include RLS SQL:
  - `ENABLE ROW LEVEL SECURITY`
  - `FORCE ROW LEVEL SECURITY`
  - `CREATE POLICY`
- Makes the diff-based RLS lint deterministic in CI by fetching the PR base ref (works with shallow checkouts).
- Extends `audit_rls_compliance` coverage to include `integrations.EmailLog` (tenant-bearing, non-TenantAwareModel).
- Adds a small regression test locking the audited allowlist.

## Why
Defense-in-depth: prevents new tenant-bearing tables from landing without RLS and ensures our CI RLS audit covers tenant-scoped integrations tables.

## Testing
- `cd backend && python manage.py test apps.core.tests.test_audit_rls_compliance --keepdb`

## Rollback
Revert this PR to restore the previous lint/audit scope.
