### PR TITLE
WorkForms editor: enforce readOnly + a11y sections

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/ConditionBuilder.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/ConditionBuilder.tsx
@@ -62,6 +62,7 @@ export interface ConditionBuilderProps {
   onChange: (conditions: ConditionRule[], logic: ConditionLogic) => void;
   availableFields?: Array<{ key: string; label: string; type: string }>;
   fieldPrefix?: string; // e.g., "step1." for referencing fields from other steps
+  disabled?: boolean;
 }
 
 // ============================================================================
@@ -200,8 +201,13 @@ const LogicButton = styled.button<{ $active: boolean }>`
   cursor: pointer;
   transition: all 0.15s ease;
   
-  &:hover {
+  &:hover:not(:disabled) {
     background: ${props => props.$active ? 'rgb(var(--color-primary))' : 'rgba(var(--color-primary), 0.1)'};
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
   
   &:not(:last-child) {
@@ -281,9 +287,14 @@ const DeleteButton = styled.button`
   transition: all 0.15s ease;
   flex-shrink: 0;
   
-  &:hover {
+  &:hover:not(:disabled) {
     background: rgba(var(--color-error), 0.1);
     color: rgb(var(--color-error));
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 `;
 
@@ -338,10 +349,15 @@ const AddButton = styled.button`
   cursor: pointer;
   transition: all 0.15s ease;
   
-  &:hover {
+  &:hover:not(:disabled) {
     border-color: rgb(var(--color-primary));
     color: rgb(var(--color-primary));
     background: rgba(var(--color-primary), 0.05);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 `;
 
@@ -359,14 +375,18 @@ export const ConditionBuilder: React.FC<ConditionBuilderProps> = ({
   onChange,
   availableFields = [],
   fieldPrefix = '',
+  disabled = false,
 }) => {
   const [editingConditionId, setEditingConditionId] = useState<string | null>(null);
 
   const handleLogicChange = (newLogic: ConditionLogic) => {
+    if (disabled) return;
     onChange(conditions, newLogic);
   };
 
   const handleAddCondition = () => {
+    if (disabled) return;
+
     const newCondition: ConditionRule = {
       id: `condition-${Date.now()}`,
       field: '',
@@ -378,6 +398,7 @@ export const ConditionBuilder: React.FC<ConditionBuilderProps> = ({
   };
 
   const handleUpdateCondition = (conditionId: string, updates: Partial<ConditionRule>) => {
+    if (disabled) return;
     onChange(
       conditions.map(c => c.id === conditionId ? { ...c, ...updates } : c),
       logic
@@ -385,6 +406,7 @@ export const ConditionBuilder: React.FC<ConditionBuilderProps> = ({
   };
 
   const handleDeleteCondition = (conditionId: string) => {
+    if (disabled) return;
     onChange(conditions.filter(c => c.id !== conditionId), logic);
   };
 
@@ -421,13 +443,17 @@ export const ConditionBuilder: React.FC<ConditionBuilderProps> = ({
           <LogicLabel>Match:</LogicLabel>
           <LogicToggle>
             <LogicButton
+              type="button"
               $active={logic === 'and'}
+              disabled={disabled}
               onClick={() => handleLogicChange('and')}
             >
               ALL (AND)
             </LogicButton>
             <LogicButton
+              type="button"
               $active={logic === 'or'}
+              disabled={disabled}
               onClick={() => handleLogicChange('or')}
             >
               ANY (OR)
@@ -475,6 +501,7 @@ export const ConditionBuilder: React.FC<ConditionBuilderProps> = ({
                           operator: 'equals', // Reset operator when field changes
                           value: '',
                         })}
+                        disabled={disabled}
                       >
                         <option value="">Select a field...</option>
                         {availableFields.map(field => (
@@ -492,7 +519,7 @@ export const ConditionBuilder: React.FC<ConditionBuilderProps> = ({
                         onChange={(e) => handleUpdateCondition(condition.id, { 
                           operator: e.target.value as ConditionOperator 
                         })}
-                        disabled={!condition.field}
+                        disabled={disabled || !condition.field}
                       >
                         {applicableOperators.map(operator => {
                           const def = OPERATOR_DEFINITIONS[operator];
@@ -515,13 +542,16 @@ export const ConditionBuilder: React.FC<ConditionBuilderProps> = ({
                             value: e.target.value 
                           })}
                           placeholder="Enter value..."
+                          disabled={disabled}
                         />
                       </FieldGroup>
                     )}
 
                     <DeleteButton
+                      type="button"
                       onClick={() => handleDeleteCondition(condition.id)}
                       title="Delete condition"
+                      disabled={disabled}
                     >
                       <Trash2 size={16} />
                     </DeleteButton>
@@ -539,7 +569,7 @@ export const ConditionBuilder: React.FC<ConditionBuilderProps> = ({
         </ConditionList>
       )}
 
-      <AddButton onClick={handleAddCondition}>
+      <AddButton type="button" onClick={handleAddCondition} disabled={disabled}>
         <Plus size={16} />
         Add Condition
       </AddButton>

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../config', () => ({
             {
               id: 'basic',
               title: 'Basic Settings',
+              collapsible: true,
               fields: [
                 {
                   id: 'name',
@@ -58,11 +59,12 @@ vi.mock('../config/fieldRenderers/complexRenderers', () => ({
 
 // Mock basic renderers
 vi.mock('../config/fieldRenderers/basicRenderers', () => ({
-  renderTextField: vi.fn(({ field, value, onChange }) => (
+  renderTextField: vi.fn(({ field, value, onChange, disabled }) => (
     <input
       data-testid={`field-${field.id}`}
       value={value || ''}
       onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
     />
   )),
   renderSelectField: vi.fn(() => <select />),
@@ -77,7 +79,12 @@ vi.mock('../hooks/useUpstreamVariables', () => ({
 
 // Mock validation and conditional logic
 vi.mock('../config/validationEngine', () => ({
-  validateField: vi.fn(() => null),
+  validateField: vi.fn((field: any, value: any) => {
+    if (field?.required && (value === undefined || value === null || String(value).trim() === '')) {
+      return 'Required';
+    }
+    return null;
+  }),
 }));
 
 vi.mock('../config/conditionalLogic', () => ({
@@ -330,6 +337,110 @@ describe('DynamicConfigPanel', () => {
       // This would require triggering the Discard button
       // For now, verify handler exists
       expect(mockOnDiscard).toBeDefined();
+    });
+  });
+
+  describe('ReadOnly + Accessibility', () => {
+    it('disables inputs and blocks updates when readOnly=true', () => {
+      const validNode: Node = {
+        id: 'test-node',
+        type: 'form',
+        position: { x: 0, y: 0 },
+        data: {
+          name: 'Test Form',
+          description: 'Test Description',
+        },
+      };
+
+      renderWithProviders(
+        <DynamicConfigPanel
+          node={validNode}
+          nodes={mockNodes}
+          edges={mockEdges}
+          readOnly={true}
+          onUpdateNode={mockOnUpdateNode}
+        />
+      );
+
+      const nameInput = screen.getByTestId('field-name');
+      expect(nameInput).toBeDisabled();
+
+      fireEvent.change(nameInput, { target: { value: 'New Name' } });
+      expect(mockOnUpdateNode).not.toHaveBeenCalled();
+    });
+
+    it('does not clear validation errors on data updates within the same node', async () => {
+      const node: Node = {
+        id: 'test-node',
+        type: 'form',
+        position: { x: 0, y: 0 },
+        data: {
+          name: 'Test Form',
+          description: 'Test Description',
+        },
+      };
+
+      const { rerender } = renderWithProviders(
+        <DynamicConfigPanel node={node} nodes={mockNodes} edges={mockEdges} onUpdateNode={mockOnUpdateNode} />
+      );
+
+      // Trigger a validation error (required name field emptied)
+      fireEvent.change(screen.getByTestId('field-name'), { target: { value: '' } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 errors/i)).toBeInTheDocument();
+      });
+
+      // Simulate an external shadow-state update with the same node id.
+      rerender(
+        <DynamicConfigPanel
+          node={{ ...node, data: { ...node.data, description: 'Updated externally' } }}
+          nodes={mockNodes}
+          edges={mockEdges}
+          onUpdateNode={mockOnUpdateNode}
+        />
+      );
+
+      expect(screen.getByText(/1 errors/i)).toBeInTheDocument();
+    });
+
+    it('renders collapsible section headers as buttons with aria attributes', () => {
+      const validNode: Node = {
+        id: 'test-node',
+        type: 'form',
+        position: { x: 0, y: 0 },
+        data: {
+          name: 'Test Form',
+          description: 'Test Description',
+        },
+      };
+
+      renderWithProviders(
+        <DynamicConfigPanel
+          node={validNode}
+          nodes={mockNodes}
+          edges={mockEdges}
+          onUpdateNode={mockOnUpdateNode}
+        />
+      );
+
+      const headerButton = screen.getByRole('button', { name: /Basic Settings/i });
+      expect(headerButton).toHaveAttribute('aria-expanded', 'true');
+      expect(headerButton).toHaveAttribute('aria-controls');
+
+      const regionId = headerButton.getAttribute('aria-controls');
+      expect(regionId).toBeTruthy();
+
+      const region = document.getElementById(String(regionId));
+      expect(region).toBeTruthy();
+      expect(region).toHaveAttribute('role', 'region');
+      expect(region).toHaveAttribute('aria-labelledby');
+
+      fireEvent.click(headerButton);
+      expect(headerButton).toHaveAttribute('aria-expanded', 'false');
+
+      const regionAfter = document.getElementById(String(regionId));
+      expect(regionAfter).toHaveAttribute('hidden');
     });
   });
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -88,6 +88,9 @@ export interface DynamicConfigPanelProps {
   
   /** All edges in the flow (for context) */
   edges: Edge[];
+
+  /** Read-only mode: prevent any edits/mutations */
+  readOnly?: boolean;
   
   /** Callback to update node data */
   onUpdateNode: (nodeId: string, data: Partial<Node['data']>) => void;
@@ -148,6 +151,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
   node,
   nodes,
   edges,
+  readOnly = false,
   onUpdateNode,
   onApply,
   onDiscard,
@@ -172,6 +176,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
   const [formData, setFormData] = useState<Record<string, any>>(node?.data || {});
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
+  const isReadOnly = Boolean(readOnly);
 
   // Tenant forms cache for schema fields like `formReference`
   const [tenantForms, setTenantForms] = useState<any[]>([]);
@@ -241,13 +246,17 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       });
   }, [schemaNeedsTenantForms]);
 
-  // Reset form data when node changes
+  // Keep local form state in sync with external node.data changes (e.g., Apply/Discard in shadow state).
   useEffect(() => {
     if (node?.data) {
       setFormData(node.data);
-      setErrors({});
     }
   }, [node?.id, node?.data]);
+
+  // Reset validation errors when the selected node changes.
+  useEffect(() => {
+    setErrors({});
+  }, [node?.id]);
 
   // REMOVED: Error panel no longer needed - schemaRegistry always returns a schema
   // Fallback schemas are automatically generated for nodes without explicit schemas
@@ -406,6 +415,8 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     if (!node?.id) return;
 
     const field = findFieldById(schema, fieldId);
+    if (isReadOnly) return;
+    if (field?.readOnly) return;
 
     setFormData((prev) => {
       const semanticNodeType = (((node?.data as any)?.nodeType as string | undefined) || node.type) as string;
@@ -635,6 +646,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
 
   const handleAcceptAutoMap = (suggestion: FieldMappingSuggestion) => {
     if (!node?.id) return;
+    if (isReadOnly) return;
 
     const updatedNode = AutoMappingService.applySuggestion(
       ({ ...node, data: formData } as any),
@@ -667,6 +679,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
 
   const handleApplyAllAutoMap = () => {
     if (!node?.id) return;
+    if (isReadOnly) return;
 
     const updatedNode = AutoMappingService.applyAutoSuggestions(
       ({ ...node, data: formData } as any),
@@ -723,7 +736,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       onChange: (newValue: any) => handleFieldChange(field.id, newValue),
       onFieldChange: (fieldId: string, newValue: any) => handleFieldChange(fieldId, newValue),
       error,
-      disabled: field.disabled || false,
+      disabled: Boolean(isReadOnly || field.disabled || field.readOnly),
       allValues: formData
     };
 
@@ -1073,6 +1086,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
                 }
               }}
               availableFields={availableFields}
+              disabled={commonProps.disabled}
             />
             {error && <ErrorMessage>{error}</ErrorMessage>}
           </div>
@@ -1087,7 +1101,9 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
             <Button
               variant={(field as any).metadata?.variant || 'secondary'}
               fullWidth
+              disabled={commonProps.disabled}
               onClick={() => {
+                if (commonProps.disabled) return;
                 if (!node) {
                   console.warn('[DynamicConfigPanel] Cannot execute button action: node is null');
                   return;
@@ -1166,35 +1182,55 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
     const isCollapsed = collapsedSections.has(section.id);
     const isCollapsible = section.collapsible ?? false;
 
+    const sectionTitleId = `pm-config-section-${section.id}-title`;
+    const sectionRegionId = `pm-config-section-${section.id}-region`;
+
+    const headerContents = (
+      <>
+        {section.icon && (() => {
+          const Icon = section.icon as any;
+          return <Icon size={16} />;
+        })()}
+        <SectionTitle id={sectionTitleId}>{section.title}</SectionTitle>
+        {isCollapsible && (isCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />)}
+      </>
+    );
+
     return (
       <Section key={section.id}>
-        <SectionHeader 
-          onClick={isCollapsible ? () => toggleSection(section.id) : undefined}
-          style={{ cursor: isCollapsible ? 'pointer' : 'default' }}
-        >
-          {section.icon && (() => {
-            const Icon = section.icon as any;
-            return <Icon size={16} />;
-          })()}
-          <SectionTitle>{section.title}</SectionTitle>
-          {isCollapsible && (
-            isCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />
-          )}
-        </SectionHeader>
-        {!isCollapsed && (
-          <SectionContentWrapper>
-            {section.description && (
-              <SectionDescription>{section.description}</SectionDescription>
-            )}
-            {visibleFieldsInSection.length === 0 ? (
-              <SectionEmptyState>
-                No configuration fields are available yet. Adjust earlier selections to unlock additional options.
-              </SectionEmptyState>
-            ) : (
-              section.fields.map(renderField)
-            )}
-          </SectionContentWrapper>
+        {isCollapsible ? (
+          <SectionHeaderButton
+            type="button"
+            onClick={() => toggleSection(section.id)}
+            aria-expanded={!isCollapsed}
+            aria-controls={sectionRegionId}
+          >
+            {headerContents}
+          </SectionHeaderButton>
+        ) : (
+          <SectionHeader>{headerContents}</SectionHeader>
         )}
+
+        <SectionContentWrapper
+          id={sectionRegionId}
+          role="region"
+          aria-labelledby={sectionTitleId}
+          hidden={isCollapsed}
+        >
+          {!isCollapsed && (
+            <>
+              {section.description && <SectionDescription>{section.description}</SectionDescription>}
+
+              {visibleFieldsInSection.length === 0 ? (
+                <SectionEmptyState>
+                  No configuration fields are available yet. Adjust earlier selections to unlock additional options.
+                </SectionEmptyState>
+              ) : (
+                section.fields.map(renderField)
+              )}
+            </>
+          )}
+        </SectionContentWrapper>
       </Section>
     );
   };
@@ -1207,7 +1243,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
       </Header>
       
       <Content>
-        {visibleAutoMapSuggestions.length > 0 && (
+        {!isReadOnly && visibleAutoMapSuggestions.length > 0 && (
           <AutoMapBanner>
             <AutoMapBannerText>
               <AutoMapBannerTitle>Smart suggestions available</AutoMapBannerTitle>
@@ -1219,7 +1255,7 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
           </AutoMapBanner>
         )}
 
-        {visibleAutoMapSuggestions.length > 0 && (
+        {!isReadOnly && visibleAutoMapSuggestions.length > 0 && (
           <MemoAutoMappingSuggestionsPanel
             suggestions={visibleAutoMapSuggestions}
             onAccept={handleAcceptAutoMap}
@@ -1384,6 +1420,32 @@ const SectionDescription = styled.p`
   margin: 0 0 12px 0;
   font-size: 13px;
   color: rgb(var(--color-text-secondary));
+`;
+
+const SectionHeaderButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid rgba(var(--color-primary), 0.5);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 `;
 
 const SectionContentWrapper = styled.div`

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.tsx
@@ -32,6 +32,7 @@ export interface TabbedConfigPanelProps {
   node: Node | null;
   nodes: Node[];
   edges: Edge[];
+  readOnly?: boolean;
   onUpdateNode: (nodeId: string, data: Partial<Node['data']>) => void;
   onClose: () => void;
   onApply?: () => void;
@@ -62,6 +63,7 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
   node,
   nodes,
   edges,
+  readOnly = false,
   onUpdateNode,
   onClose,
   onApply,
@@ -172,6 +174,7 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
                   node={node}
                   nodes={nodes}
                   edges={edges}
+                  readOnly={readOnly}
                   onUpdateNode={onUpdateNode}
                   onApply={onApply}
                   onDiscard={onDiscard}
@@ -206,7 +209,9 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
               >
                 <VisualFormBuilderPanel
                   fields={getResolvedFormFields(node.data)}
+                  readOnly={readOnly}
                   onChange={(newFields) => {
+                    if (readOnly) return;
                     // Dual-model: persist form-builder fields separately from config-time entity picker selections.
                     onUpdateNode(node.id, { formFields: newFields });
                   }}
@@ -222,7 +227,7 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
                 exit={{ opacity: 0, y: -10 }}
                 transition={{ duration: 0.2 }}
               >
-                {showDevToolsToggle && (
+                {showDevToolsToggle && !readOnly && (
                   <DevToolsRow>
                     <DevToolsLabel>
                       <input
@@ -244,7 +249,7 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
                   </DevToolsRow>
                 )}
 
-                {IS_DEV_BUILD && developerMode && (
+                {IS_DEV_BUILD && developerMode && !readOnly && (
                   <DeveloperJsonEditor
                     value={node.data}
                     onApply={(newData) => onUpdateNode(node.id, newData)}
@@ -255,6 +260,7 @@ export const TabbedConfigPanel: React.FC<TabbedConfigPanelProps> = ({
                   node={node}
                   nodes={nodes}
                   edges={edges}
+                  readOnly={readOnly}
                   onUpdateNode={onUpdateNode}
                   onApply={onApply}
                   onDiscard={onDiscard}

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
@@ -37,6 +37,7 @@ export interface TabbedConfigPanelWithShadowProps {
   edges: Edge[];
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
   setEdges: React.Dispatch<React.SetStateAction<Edge[]>>;
+  readOnly?: boolean;
   onClose: () => void;
   onUpdate: (nodeId: string, data: Record<string, any>) => void;
   onTest?: (nodeId: string) => void;
@@ -159,12 +160,14 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
   edges,
   setNodes,
   setEdges,
+  readOnly = false,
   onClose,
   onUpdate,
   onTest,
   onSelectNode,
 }) => {
   const [showCloseConfirmation, setShowCloseConfirmation] = useState(false);
+  const isReadOnly = Boolean(readOnly);
   
   // Use shadow state hook
   const {
@@ -183,12 +186,14 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
 
   // Handle update from inner panel - write to shadow state
   const handleShadowUpdate = useCallback((nodeId: string, data: Record<string, any>) => {
+    if (isReadOnly) return;
     updateShadow(data);
-  }, [updateShadow]);
+  }, [isReadOnly, updateShadow]);
 
   // Handle apply - commit shadow to real config
   const handleApply = useCallback(() => {
     if (!node) return;
+    if (isReadOnly) return;
     
     const sanitized = (sanitizeNodeConfigForPersistence(shadowConfig) || {}) as Record<string, any>;
 
@@ -199,22 +204,28 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
     onUpdate(node.id, sanitized);
     
     console.log('[Shadow State] Applied changes to node:', node.id);
-  }, [node, commitShadow, onUpdate, shadowConfig]);
+  }, [node, isReadOnly, commitShadow, onUpdate, shadowConfig]);
 
   // Handle discard
   const handleDiscard = useCallback(() => {
+    if (isReadOnly) return;
     discardShadow();
     console.log('[Shadow State] Discarded changes');
-  }, [discardShadow]);
+  }, [isReadOnly, discardShadow]);
 
   // Handle close with confirmation if dirty
   const handleClose = useCallback(() => {
+    if (isReadOnly) {
+      onClose();
+      return;
+    }
+
     if (isDirty) {
       setShowCloseConfirmation(true);
     } else {
       onClose();
     }
-  }, [isDirty, onClose]);
+  }, [isReadOnly, isDirty, onClose]);
 
   // Confirm close without saving
   const confirmClose = useCallback(() => {
@@ -229,7 +240,7 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
     <>
       <ShadowWrapper data-tour="config-panel">
         {/* Dirty Indicator Banner */}
-        <DirtyIndicatorBanner $show={isDirty}>
+        <DirtyIndicatorBanner $show={isDirty && !isReadOnly}>
           <AlertCircle size={18} />
           <span>You have unsaved changes</span>
         </DirtyIndicatorBanner>
@@ -240,6 +251,7 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
             node={virtualNode}
             nodes={nodes}
             edges={edges}
+            readOnly={isReadOnly}
             onUpdateNode={handleShadowUpdate}
             onClose={handleClose}
             onApply={handleApply}
@@ -248,7 +260,7 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
         </PanelContent>
 
         {/* Action Bar (Apply/Discard) */}
-        <ActionBar $show={isDirty}>
+        <ActionBar $show={isDirty && !isReadOnly}>
           <SecondaryButton onClick={handleDiscard}>
             Discard Changes
           </SecondaryButton>
@@ -259,7 +271,7 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
       </ShadowWrapper>
 
       {/* Confirmation Modal */}
-      <ConfirmationModal $show={showCloseConfirmation}>
+      <ConfirmationModal $show={showCloseConfirmation && !isReadOnly}>
         <DialogBox>
           <DialogHeader>Unsaved Changes</DialogHeader>
           <DialogMessage>

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -8202,6 +8202,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
               edges={edges}
               setNodes={setNodes}
               setEdges={setEdges}
+              readOnly={readOnly}
               onClose={() => {
                 logger.debug('[Tabbed Config Panel] Closing panel for node:', selectedNode.id);
                 setSelectedNode(null);

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
@@ -51,7 +51,7 @@ export function renderTextField(
           value={value ?? ''}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          disabled={field.disabled || props.disabled}
+          disabled={field.disabled || field.readOnly || props.disabled}
           rows={4}
         />
       ) : (
@@ -81,7 +81,7 @@ export function renderTextField(
             onChange(e.target.value);
           }}
           placeholder={placeholder}
-          disabled={field.disabled || props.disabled}
+          disabled={field.disabled || field.readOnly || props.disabled}
         />
       )}
       {field.helpText && !error && <HelpText>{field.helpText}</HelpText>}
@@ -126,7 +126,7 @@ export function renderSelectField(
             : String((value as any) ?? '')
         }
         onChange={handleChange}
-        disabled={field.disabled || props.disabled}
+        disabled={field.disabled || field.readOnly || props.disabled}
         multiple={isMulti}
       >
         {!field.required && !isMulti && (
@@ -162,7 +162,7 @@ export function renderToggleField(
         <ToggleSwitch
           checked={value || false}
           onChange={(e) => onChange(e.target.checked)}
-          disabled={field.disabled || props.disabled}
+          disabled={field.disabled || field.readOnly || props.disabled}
         />
       </ToggleRow>
       {field.helpText && !error && <HelpText>{field.helpText}</HelpText>}


### PR DESCRIPTION
## What
- Enforces `readOnly` end-to-end for FlowEditor config panels (UnifiedFlowEditor → shadow wrapper → TabbedConfigPanel → DynamicConfigPanel).
- Disables *all* mutation paths in read-only mode (no shadow updates, no dirty banner, no Apply/Discard bar).
- Improves DynamicConfigPanel section accessibility:
  - collapsible headers are real buttons
  - `aria-expanded`/`aria-controls`
  - content uses `role=region` + `aria-labelledby`
- Fixes a major “panel feels broken” bug: validation errors were being cleared on every shadow-data update.

## Why
- Prevents accidental edits in view/monitoring/permission-limited contexts.
- Makes config sections keyboard-operable and screen-reader friendly.
- Keeps validation feedback stable while users type under shadow-state updates.

## Testing
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `cd frontend && npx vitest run src/components/FlowEditor/ConfigPanel/DynamicConfigPanel --reporter=dot`

## Rollback
Revert this PR.
