### PR TITLE
Security: tenant-scoped workflow webhook receiver

### DIFF
--- a/backend/projectmeats/urls.py
+++ b/backend/projectmeats/urls.py
@@ -16,6 +16,7 @@ from drf_spectacular.views import (
 from .health import health_check, health_detailed, ready_check, health_workforms
 from apps.core.admin_site import admin_site
 from tenant_apps.workflows.views import SuggestNodesView
+from tenant_apps.workflows.views_triggers import TenantScopedWebhookReceiverAPIView
 
 # Keep default admin for backwards compatibility, but use custom site as primary
 admin.site.site_header = '🥩 Meats Central Admin'
@@ -36,6 +37,14 @@ urlpatterns = [
     # API v1 endpoints
     path("api/v1/system/", include("apps.system.urls")),  # NEW: Centralized config system (v2.0 Wave 1)
     path("api/v1/", include("apps.tenants.urls")),  # Multi-tenancy endpoints (shared)
+
+    # Canonical public workflow webhook receiver (tenant selected via path).
+    path(
+        "api/v1/tenants/<uuid:tenant_id>/workflows/webhooks/<uuid:workflow_id>/<str:webhook_token>/",
+        TenantScopedWebhookReceiverAPIView.as_view(),
+        name="tenant-workflow-webhook-receiver",
+    ),
+
     path('api/v1/integrations/', include('integrations.urls')),
     path("api/v1/workflows/email/", include("apps.email_integration.urls")),  # Email integration & webhooks
     # NOTE: accounts_receivables DELETED in v2.0 Wave 1 (merged into invoices/accounting)

--- a/backend/tenant_apps/workflows/tests/test_webhook_receiver_tenant_path.py
+++ b/backend/tenant_apps/workflows/tests/test_webhook_receiver_tenant_path.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.workflows.models import TenantWorkflow, TriggerType, WorkflowStatus
+
+
+class WorkflowWebhookTenantPathTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        self.client = APIClient()
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        self.other_tenant = Tenant.objects.create(
+            name=f'Other {unique}',
+            slug=f'other-{unique}',
+            contact_email=f'other-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        self.webhook_token = 'tok_' + uuid.uuid4().hex
+        self.webhook_secret = 'sec_' + uuid.uuid4().hex
+
+        self.workflow = TenantWorkflow.objects.create(
+            tenant=self.tenant,
+            name='WF',
+            status=WorkflowStatus.ACTIVE,
+            trigger_type=TriggerType.WEBHOOK,
+            trigger_config={
+                'webhook_token': self.webhook_token,
+                'webhook_secret': self.webhook_secret,
+                'webhook_auth': 'token',
+                'webhook_method': ['POST'],
+            },
+            created_by=self.user,
+        )
+
+    @patch('tenant_apps.workflows.views_triggers.set_current_tenant')
+    @patch('tenant_apps.workflows.views_triggers.execute_workflow')
+    def test_tenant_scoped_webhook_executes_and_sets_rls(self, execute_workflow, set_current_tenant):
+        set_current_tenant.return_value = SimpleNamespace(ok=True)
+        execute_workflow.return_value = SimpleNamespace(id=uuid.uuid4(), status='success')
+
+        url = (
+            f'/api/v1/tenants/{self.tenant.id}/workflows/webhooks/'
+            f'{self.workflow.id}/{self.webhook_token}/'
+        )
+
+        resp = self.client.post(
+            url,
+            data={'hello': 'world'},
+            format='json',
+            HTTP_AUTHORIZATION=f'Bearer {self.webhook_secret}',
+        )
+
+        self.assertEqual(resp.status_code, 200, resp.content)
+        set_current_tenant.assert_called_with(str(self.tenant.id))
+        execute_workflow.assert_called()
+
+    @patch('tenant_apps.workflows.views_triggers.set_current_tenant')
+    @patch('tenant_apps.workflows.views_triggers.execute_workflow')
+    def test_tenant_mismatch_fails_closed(self, execute_workflow, set_current_tenant):
+        set_current_tenant.return_value = SimpleNamespace(ok=True)
+        execute_workflow.return_value = SimpleNamespace(id=uuid.uuid4(), status='success')
+
+        url = (
+            f'/api/v1/tenants/{self.other_tenant.id}/workflows/webhooks/'
+            f'{self.workflow.id}/{self.webhook_token}/'
+        )
+
+        resp = self.client.post(
+            url,
+            data={'hello': 'world'},
+            format='json',
+            HTTP_AUTHORIZATION=f'Bearer {self.webhook_secret}',
+        )
+
+        self.assertEqual(resp.status_code, 404)
+        execute_workflow.assert_not_called()
+
+    @patch('tenant_apps.workflows.views_triggers.set_current_tenant')
+    @patch('tenant_apps.workflows.views_triggers.execute_workflow')
+    def test_invalid_token_fails_closed(self, execute_workflow, set_current_tenant):
+        set_current_tenant.return_value = SimpleNamespace(ok=True)
+        execute_workflow.return_value = SimpleNamespace(id=uuid.uuid4(), status='success')
+
+        url = (
+            f'/api/v1/tenants/{self.tenant.id}/workflows/webhooks/'
+            f'{self.workflow.id}/wrong-token/'
+        )
+
+        resp = self.client.post(
+            url,
+            data={'hello': 'world'},
+            format='json',
+            HTTP_AUTHORIZATION=f'Bearer {self.webhook_secret}',
+        )
+
+        self.assertEqual(resp.status_code, 404)
+        execute_workflow.assert_not_called()
+
+    @patch('tenant_apps.workflows.views_triggers.set_current_tenant')
+    @patch('tenant_apps.workflows.views_triggers.execute_workflow')
+    def test_legacy_webhook_endpoint_still_executes(self, execute_workflow, set_current_tenant):
+        set_current_tenant.return_value = SimpleNamespace(ok=True)
+        execute_workflow.return_value = SimpleNamespace(id=uuid.uuid4(), status='success')
+
+        url = f'/api/v1/workflows/webhooks/{self.workflow.id}/{self.webhook_token}/'
+
+        resp = self.client.post(
+            url,
+            data={'hello': 'world'},
+            format='json',
+            HTTP_AUTHORIZATION=f'Bearer {self.webhook_secret}',
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        set_current_tenant.assert_called_with(str(self.tenant.id))
+        execute_workflow.assert_called()

--- a/backend/tenant_apps/workflows/views_triggers.py
+++ b/backend/tenant_apps/workflows/views_triggers.py
@@ -19,7 +19,105 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.tenants.models import TenantUser
+from apps.tenants.rls import set_current_tenant
+
 from .models import TenantWorkflow
+from .services.workflow_executor import execute_workflow
+
+
+def _set_tenant_context(request, tenant) -> None:
+    request.tenant = tenant
+
+    result = set_current_tenant(str(tenant.id))
+    if result.ok:
+        # Allow TenantMiddleware to clean up RLS session vars at the end of the request.
+        setattr(request, '_rls_set', True)
+
+
+def _enforce_membership_if_authenticated(request, tenant):
+    if not request.user or not request.user.is_authenticated:
+        return None
+
+    if request.user.is_superuser or request.user.is_staff:
+        return None
+
+    if not TenantUser.objects.filter(tenant=tenant, user=request.user, is_active=True).exists():
+        return Response({'error': 'Tenant membership required'}, status=status.HTTP_403_FORBIDDEN)
+
+    return None
+
+
+def _webhook_not_found() -> Response:
+    # Uniform not-found to reduce enumeration signal.
+    return Response({'error': 'Not found'}, status=status.HTTP_404_NOT_FOUND)
+
+
+def _process_workflow_webhook(request, workflow: TenantWorkflow, webhook_token: str) -> Response:
+    """Shared workflow webhook receiver logic (legacy + tenant-scoped endpoints)."""
+
+    # Set request tenant context + RLS session variables.
+    tenant = workflow.tenant
+    if not tenant or not getattr(tenant, 'is_active', True):
+        return _webhook_not_found()
+
+    _set_tenant_context(request, tenant)
+
+    membership_error = _enforce_membership_if_authenticated(request, tenant)
+    if membership_error is not None:
+        return membership_error
+
+    # Verify workflow is active and webhook-triggered
+    if workflow.status != 'active':
+        return Response({'error': 'Workflow is not active'}, status=status.HTTP_400_BAD_REQUEST)
+
+    if workflow.trigger_type != 'webhook':
+        return Response({'error': 'Workflow is not configured for webhook triggers'}, status=status.HTTP_400_BAD_REQUEST)
+
+    trigger_config = workflow.trigger_config or {}
+
+    # Verify webhook token (fail closed; no existence signal)
+    expected_token = str(trigger_config.get('webhook_token') or '')
+    if not expected_token or not hmac.compare_digest(expected_token, str(webhook_token or '')):
+        return _webhook_not_found()
+
+    # Verify authentication if required
+    auth_method = trigger_config.get('webhook_auth', 'token')
+    if auth_method != 'none':
+        if auth_method == 'token':
+            auth_header = request.headers.get('Authorization', '')
+            expected_auth = f"Bearer {trigger_config.get('webhook_secret', '')}"
+            if not hmac.compare_digest(auth_header, expected_auth):
+                return _webhook_not_found()
+
+        elif auth_method == 'hmac':
+            signature = request.headers.get('X-Webhook-Signature', '')
+            secret = str(trigger_config.get('webhook_secret', '')).encode()
+            expected_signature = hmac.new(secret, request.body, hashlib.sha256).hexdigest()
+
+            if not hmac.compare_digest(signature, expected_signature):
+                return _webhook_not_found()
+
+    try:
+        execution_log = execute_workflow(workflow, request.data)
+
+        return Response(
+            {
+                'message': 'Webhook received and workflow executed successfully',
+                'execution_id': str(getattr(execution_log, 'id', '')),
+                'status': getattr(execution_log, 'status', 'completed'),
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    except Exception as e:
+        return Response(
+            {
+                'error': 'Workflow execution failed',
+                'message': str(e),
+            },
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 class WorkflowWebhookAPIView(APIView):
@@ -55,21 +153,40 @@ class WorkflowWebhookAPIView(APIView):
         
         trigger_config = workflow.trigger_config or {}
         
-        # Generate webhook URL if not exists
-        if not trigger_config.get('webhook_url'):
-            webhook_token = secrets.token_urlsafe(32)
-            webhook_url = f"{request.build_absolute_uri('/api/v1/webhooks/')}{workflow.id}/{webhook_token}/"
-            
-            trigger_config['webhook_url'] = webhook_url
-            trigger_config['webhook_token'] = webhook_token
+        # Ensure webhook credentials exist and URLs reflect the current canonical route.
+        needs_save = False
+
+        if not trigger_config.get('webhook_token'):
+            trigger_config['webhook_token'] = secrets.token_urlsafe(32)
+            needs_save = True
+        if not trigger_config.get('webhook_secret'):
             trigger_config['webhook_secret'] = secrets.token_urlsafe(32)
-            
+            needs_save = True
+
+        webhook_token = trigger_config['webhook_token']
+
+        webhook_url = request.build_absolute_uri(
+            f"/api/v1/tenants/{request.tenant.id}/workflows/webhooks/{workflow.id}/{webhook_token}/"
+        )
+        legacy_webhook_url = request.build_absolute_uri(
+            f"/api/v1/workflows/webhooks/{workflow.id}/{webhook_token}/"
+        )
+
+        if trigger_config.get('webhook_url') != webhook_url:
+            trigger_config['webhook_url'] = webhook_url
+            needs_save = True
+        if trigger_config.get('legacy_webhook_url') != legacy_webhook_url:
+            trigger_config['legacy_webhook_url'] = legacy_webhook_url
+            needs_save = True
+
+        if needs_save:
             workflow.trigger_config = trigger_config
             workflow.save(update_fields=['trigger_config', 'updated_at'])
         
         return Response({
             "workflow_id": str(workflow.id),
             "webhook_url": trigger_config.get('webhook_url'),
+            "legacy_webhook_url": trigger_config.get('legacy_webhook_url'),
             "webhook_secret": trigger_config.get('webhook_secret'),
             "auth_method": trigger_config.get('webhook_auth', 'token'),
             "allowed_methods": trigger_config.get('webhook_method', ['POST']),
@@ -94,12 +211,19 @@ class WorkflowWebhookAPIView(APIView):
         
         # Generate new webhook credentials
         webhook_token = secrets.token_urlsafe(32)
-        webhook_url = f"{request.build_absolute_uri('/api/v1/webhooks/')}{workflow.id}/{webhook_token}/"
         webhook_secret = secrets.token_urlsafe(32)
-        
+
+        webhook_url = request.build_absolute_uri(
+            f"/api/v1/tenants/{request.tenant.id}/workflows/webhooks/{workflow.id}/{webhook_token}/"
+        )
+        legacy_webhook_url = request.build_absolute_uri(
+            f"/api/v1/workflows/webhooks/{workflow.id}/{webhook_token}/"
+        )
+
         trigger_config = workflow.trigger_config or {}
         trigger_config.update({
             'webhook_url': webhook_url,
+            'legacy_webhook_url': legacy_webhook_url,
             'webhook_token': webhook_token,
             'webhook_secret': webhook_secret,
             'webhook_auth': request.data.get('auth_method', 'token'),
@@ -113,6 +237,7 @@ class WorkflowWebhookAPIView(APIView):
             "message": "Webhook URL generated successfully",
             "workflow_id": str(workflow.id),
             "webhook_url": webhook_url,
+            "legacy_webhook_url": legacy_webhook_url,
             "webhook_secret": webhook_secret,
             "auth_method": trigger_config['webhook_auth'],
             "allowed_methods": trigger_config['webhook_method'],
@@ -134,6 +259,7 @@ class WorkflowWebhookAPIView(APIView):
         # Clear webhook configuration
         trigger_config = workflow.trigger_config or {}
         trigger_config.pop('webhook_url', None)
+        trigger_config.pop('legacy_webhook_url', None)
         trigger_config.pop('webhook_token', None)
         trigger_config.pop('webhook_secret', None)
         
@@ -145,112 +271,42 @@ class WorkflowWebhookAPIView(APIView):
         })
 
 
-class WebhookReceiverAPIView(APIView):
+class TenantScopedWebhookReceiverAPIView(APIView):
+    """Canonical public workflow webhook receiver.
+
+    POST /api/v1/tenants/{tenant_id}/workflows/webhooks/{workflow_id}/{webhook_token}/
+
+    Tenant selection is via path param only (public endpoints must not honor X-Tenant-ID).
     """
-    Webhook receiver endpoint.
-    
-    POST /api/v1/webhooks/{workflow_id}/{webhook_token}/ - Receive webhook
-    
-    Public endpoint (no authentication required - uses webhook token).
-    """
-    
+
     permission_classes = [AllowAny]
-    
+    authentication_classes = []
+
+    def post(self, request, tenant_id, workflow_id, webhook_token):
+        try:
+            workflow = TenantWorkflow.objects.select_related('tenant').get(id=workflow_id, tenant_id=tenant_id)
+        except TenantWorkflow.DoesNotExist:
+            return _webhook_not_found()
+
+        return _process_workflow_webhook(request, workflow, webhook_token)
+
+
+class WebhookReceiverAPIView(APIView):
+    """Legacy public workflow webhook receiver (kept for backwards compatibility).
+
+    POST /api/v1/workflows/webhooks/{workflow_id}/{webhook_token}/
+    """
+
+    permission_classes = [AllowAny]
+    authentication_classes = []
+
     def post(self, request, workflow_id, webhook_token):
-        """Receive and process webhook."""
         try:
             workflow = TenantWorkflow.objects.select_related('tenant').get(id=workflow_id)
         except TenantWorkflow.DoesNotExist:
-            return Response(
-                {"error": "Workflow not found"},
-                status=status.HTTP_404_NOT_FOUND
-            )
-        
-        # Verify workflow is active and webhook-triggered
-        if workflow.status != 'active':
-            return Response(
-                {"error": "Workflow is not active"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        if workflow.trigger_type != 'webhook':
-            return Response(
-                {"error": "Workflow is not configured for webhook triggers"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        trigger_config = workflow.trigger_config or {}
-        
-        # Verify webhook token
-        if trigger_config.get('webhook_token') != webhook_token:
-            return Response(
-                {"error": "Invalid webhook token"},
-                status=status.HTTP_403_FORBIDDEN
-            )
-        
-        # Verify HTTP method
-        allowed_methods = trigger_config.get('webhook_method', ['POST'])
-        if request.method not in allowed_methods:
-            return Response(
-                {"error": f"Method {request.method} not allowed"},
-                status=status.HTTP_405_METHOD_NOT_ALLOWED
-            )
-        
-        # Verify authentication if required
-        auth_method = trigger_config.get('webhook_auth', 'token')
-        if auth_method != 'none':
-            if auth_method == 'token':
-                auth_header = request.headers.get('Authorization', '')
-                expected_token = f"Bearer {trigger_config.get('webhook_secret', '')}"
-                if auth_header != expected_token:
-                    return Response(
-                        {"error": "Invalid authorization token"},
-                        status=status.HTTP_403_FORBIDDEN
-                    )
-            
-            elif auth_method == 'hmac':
-                signature = request.headers.get('X-Webhook-Signature', '')
-                secret = trigger_config.get('webhook_secret', '').encode()
-                expected_signature = hmac.new(
-                    secret,
-                    request.body,
-                    hashlib.sha256
-                ).hexdigest()
-                
-                if not hmac.compare_digest(signature, expected_signature):
-                    return Response(
-                        {"error": "Invalid HMAC signature"},
-                        status=status.HTTP_403_FORBIDDEN
-                    )
-        
-        # Execute workflow using execution engine
-        from .services.workflow_executor import execute_workflow
-        
-        try:
-            execution_log = execute_workflow(workflow, request.data)
-            
-            # Update workflow stats
-            workflow.last_run_at = timezone.now()
-            workflow.run_count += 1
-            workflow.save(update_fields=['last_run_at', 'run_count'])
-            
-            return Response({
-                "message": "Webhook received and workflow executed successfully",
-                "execution_id": str(execution_log.id),
-                "status": "completed"
-            }, status=status.HTTP_200_OK)
-            
-        except Exception as e:
-            execution_log.status = 'failed'
-            execution_log.error_message = str(e)
-            execution_log.completed_at = timezone.now()
-            execution_log.save(update_fields=['status', 'error_message', 'completed_at'])
-            
-            return Response({
-                "error": "Workflow execution failed",
-                "execution_id": str(execution_log.id),
-                "message": str(e)
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return _webhook_not_found()
+
+        return _process_workflow_webhook(request, workflow, webhook_token)
 
 
 class ManualTriggerAPIView(APIView):


### PR DESCRIPTION
## What
- Adds canonical public workflow webhook receiver scoped by tenant in the URL path:
  - `POST /api/v1/tenants/{tenant_id}/workflows/webhooks/{workflow_id}/{webhook_token}/`
- Keeps legacy receiver working:
  - `POST /api/v1/workflows/webhooks/{workflow_id}/{webhook_token}/`
- Receiver explicitly sets `request.tenant` and calls `set_current_tenant()` (RLS) before any workflow work.
- Fixes webhook URL generation (previously emitted a non-existent `/api/v1/webhooks/...` base) and returns both canonical + legacy URLs.
- Webhook receivers set `authentication_classes = []` so `Authorization: Bearer <webhook_secret>` is treated as webhook auth, not JWT.

## Why
- Public endpoints must not accept tenant context via headers; tenant-id-in-path is the canonical safe selector.
- Ensures RLS policies have the correct tenant session context for webhook-triggered execution.
- Makes generated webhook URLs actually routable.

## Acceptance criteria
- Tenant-scoped endpoint fails closed on tenant mismatch and token mismatch.
- Legacy endpoint remains functional.

## Testing
- `cd backend && python manage.py makemigrations --check`
- `cd backend && python manage.py test tenant_apps.workflows.tests.test_webhook_receiver_tenant_path --verbosity=2 --keepdb`

## Rollback
Revert this PR (legacy endpoint still exists).
