### PR TITLE
WorkForms: publish-time schema validation parity

### DIFF
--- a/frontend/src/components/FlowEditor/config/__tests__/validationEngine.requiredEmptyObject.test.ts
+++ b/frontend/src/components/FlowEditor/config/__tests__/validationEngine.requiredEmptyObject.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+
+import { validateField } from '../validationEngine';
+
+describe('validationEngine (required rule)', () => {
+  it('treats empty plain objects as empty for required validation', () => {
+    const allValues = {};
+
+    expect(
+      validateField(
+        {
+          id: 'headers',
+          label: 'Headers',
+          validation: [{ type: 'required', message: 'required' }],
+        } as any,
+        {},
+        allValues
+      )
+    ).toBe('required');
+
+    expect(
+      validateField(
+        {
+          id: 'headers',
+          label: 'Headers',
+          validation: [{ type: 'required', message: 'required' }],
+        } as any,
+        { Authorization: 'Bearer x' },
+        allValues
+      )
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/FlowEditor/config/validationEngine.ts
+++ b/frontend/src/components/FlowEditor/config/validationEngine.ts
@@ -59,6 +59,16 @@ function validateRule(
       if (Array.isArray(value) && value.length === 0) {
         return rule.message;
       }
+      // Treat empty plain objects as empty (e.g., keyValueMode='record' fields).
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        (value as any).constructor === Object &&
+        Object.keys(value as any).length === 0
+      ) {
+        return rule.message;
+      }
       return null;
 
     case 'minLength':

--- a/frontend/src/components/FlowEditor/utils/__tests__/validationEngine.schemaParity.test.ts
+++ b/frontend/src/components/FlowEditor/utils/__tests__/validationEngine.schemaParity.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+
+import { validateWorkflow } from '../validationEngine';
+
+describe('workflow validationEngine (schema parity)', () => {
+  it('blocks publish when schema-required fields are missing (generic actionType inference)', () => {
+    const nodes: Node[] = [
+      {
+        id: 't1',
+        type: 'trigger',
+        position: { x: 0, y: 0 },
+        data: {},
+      } as any,
+      {
+        id: 'a1',
+        type: 'action',
+        position: { x: 100, y: 0 },
+        data: {
+          actionType: 'http',
+        },
+      } as any,
+    ];
+
+    const edges: Edge[] = [
+      {
+        id: 'e1',
+        source: 't1',
+        target: 'a1',
+      } as any,
+    ];
+
+    const result = validateWorkflow(nodes, edges);
+
+    expect(result.isValid).toBe(false);
+    expect(result.issues.some((i) => i.nodeId === 'a1' && i.message === 'URL is required')).toBe(true);
+
+    // Trigger defaults to manual, so schedule-only required fields must not block.
+    expect(result.issues.some((i) => i.message === 'Interval is required')).toBe(false);
+  });
+});

--- a/frontend/src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts
+++ b/frontend/src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts
@@ -45,4 +45,49 @@ describe('prepareWorkflowForSave (sanitization)', () => {
     expect(preparedNodeData.config?.configStatus).toBeUndefined();
     expect(preparedNodeData.config?._upstreamVariables).toBeUndefined();
   });
+
+  it('materializes non-empty schema defaults into persisted node.data', () => {
+    const nodes: Node[] = [
+      {
+        id: 't1',
+        type: 'trigger',
+        position: { x: 0, y: 0 },
+        data: {},
+      } as any,
+      {
+        id: 'a1',
+        type: 'action',
+        position: { x: 100, y: 0 },
+        data: {
+          actionType: 'http',
+        },
+      } as any,
+      {
+        id: 'a2',
+        type: 'action',
+        position: { x: 200, y: 0 },
+        data: {
+          actionType: 'http',
+          method: 'POST',
+        },
+      } as any,
+    ];
+
+    const edges: Edge[] = [];
+
+    const prepared = prepareWorkflowForSave(nodes, edges);
+    const triggerData = prepared.nodes.find((n) => n.id === 't1')!.data as any;
+    const actionData = prepared.nodes.find((n) => n.id === 'a1')!.data as any;
+    const action2Data = prepared.nodes.find((n) => n.id === 'a2')!.data as any;
+
+    // Trigger defaults are persisted so the saved payload reflects what the panel shows.
+    expect(triggerData.type).toBe('manual');
+
+    // actionHTTP defaults
+    expect(actionData.method).toBe('GET');
+    expect(actionData.headers).toEqual(expect.objectContaining({ 'Content-Type': 'application/json' }));
+
+    // Existing values must not be overwritten.
+    expect(action2Data.method).toBe('POST');
+  });
 });

--- a/frontend/src/components/FlowEditor/utils/validationEngine.ts
+++ b/frontend/src/components/FlowEditor/utils/validationEngine.ts
@@ -17,6 +17,14 @@
 
 import { Node, Edge } from '@xyflow/react';
 
+// Ensure schemas are registered before any publish-time validation runs.
+import '../config/nodeConfigSchemas';
+
+import { schemaRegistry } from '../config/schemaRegistry';
+import { evaluateCondition } from '../config/conditionalLogic';
+import { validateField } from '../config/validationEngine';
+import type { ConfigField } from '../config/types';
+
 export type ValidationSeverity = 'error' | 'warning' | 'info';
 
 export interface ValidationIssue {
@@ -141,11 +149,77 @@ export function validateWorkflow(nodes: Node[], edges: Edge[]): ValidationResult
 /**
  * Validates a single node's configuration
  */
+const _resolveSchemaNodeType = (node: Node): string => {
+  const data = (node.data || {}) as any;
+  if (typeof data.nodeType === 'string' && data.nodeType.trim()) return data.nodeType;
+
+  // Generic action nodes can be discriminated by actionType.
+  if (node.type === 'action' && typeof data.actionType === 'string' && data.actionType.trim()) {
+    const at = data.actionType.trim();
+    const map: Record<string, string> = {
+      email: 'actionEmail',
+      http: 'actionHTTP',
+      sms: 'actionSMS',
+      notify: 'actionNotify',
+      notification: 'actionNotify',
+      script: 'actionScript',
+      createRecord: 'actionCreateRecord',
+      updateRecord: 'actionUpdateRecord',
+      deleteRecord: 'actionDeleteRecord',
+    };
+    return map[at] || `action${at.charAt(0).toUpperCase()}${at.slice(1)}`;
+  }
+
+  // If the node.type already matches a schema nodeType, this will work.
+  return node.type || 'unknown';
+};
+
+const _checkIsVisible = (item: any, data: Record<string, any>): boolean => {
+  const cond = item?.conditional || item?.visibilityCondition || item?.showIf;
+  if (!cond) return true;
+
+  if (typeof cond === 'function') {
+    try {
+      return Boolean(cond(data));
+    } catch {
+      return true;
+    }
+  }
+
+  return evaluateCondition(cond, data);
+};
+
+const _materializeEffectiveValues = (
+  node: Node,
+  schemaFields: ConfigField[]
+): Record<string, any> => {
+  const raw = ((node.data as any) || {}) as Record<string, any>;
+  const out: Record<string, any> = { ...raw };
+
+  // Minimal alias/sync rules to match config panel behavior.
+  if (out.type === undefined && out.triggerType !== undefined) out.type = out.triggerType;
+  if (out.triggerType === undefined && out.type !== undefined) out.triggerType = out.type;
+
+  if (out.entityType === undefined && out.entity !== undefined) out.entityType = out.entity;
+  if (out.entity === undefined && out.entityType !== undefined) out.entity = out.entityType;
+
+  if (out.fieldMappings === undefined && out.fields !== undefined) out.fieldMappings = out.fields;
+  if (out.fields === undefined && out.fieldMappings !== undefined) out.fields = out.fieldMappings;
+
+  // Apply schema defaults for validation computation (only when truly missing).
+  for (const field of schemaFields) {
+    if (out[field.id] === undefined && (field as any).defaultValue !== undefined) {
+      out[field.id] = (field as any).defaultValue;
+    }
+  }
+
+  return out;
+};
+
 export function validateNodeConfig(node: Node): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
-  
-  // Basic validation without schema dependency
-  // Type-specific validations
+
+  // Existing lightweight type-specific checks
   if (node.type === 'form' || node.type === 'formProcessGroup' || node.type === 'formBook') {
     const fields = Array.isArray((node.data as any)?.fields) ? (node.data as any).fields : [];
     if (fields.length === 0) {
@@ -159,7 +233,7 @@ export function validateNodeConfig(node: Node): ValidationIssue[] {
       });
     }
   }
-  
+
   if (node.type === 'conditionIf') {
     const rules = Array.isArray((node.data as any)?.rules) ? (node.data as any).rules : [];
     if (rules.length === 0) {
@@ -173,9 +247,9 @@ export function validateNodeConfig(node: Node): ValidationIssue[] {
       });
     }
   }
-  
+
   if (node.type?.startsWith('action')) {
-    const actionType = node.data.actionType;
+    const actionType = (node.data as any)?.actionType;
     if (!actionType) {
       issues.push({
         id: `no-action-type-${node.id}`,
@@ -187,7 +261,35 @@ export function validateNodeConfig(node: Node): ValidationIssue[] {
       });
     }
   }
-  
+
+  // Schema-driven validation (publish-time parity)
+  const schemaNodeType = _resolveSchemaNodeType(node);
+  const schema = schemaRegistry.getSchema(schemaNodeType);
+
+  const schemaFields: ConfigField[] = (schema.sections || []).flatMap((s: any) => (s?.fields || []) as ConfigField[]);
+  const effective = _materializeEffectiveValues(node, schemaFields);
+
+  for (const section of schema.sections || []) {
+    if (!_checkIsVisible(section, effective)) continue;
+
+    for (const field of (section.fields || []) as ConfigField[]) {
+      if (!_checkIsVisible(field, effective)) continue;
+
+      const value = effective[field.id];
+      const err = validateField(field, value, effective);
+      if (!err) continue;
+
+      issues.push({
+        id: `schema-${node.id}-${field.id}`,
+        nodeId: node.id,
+        severity: 'error',
+        message: err,
+        suggestion: `Open the config panel and fix “${field.label || field.id}”.`,
+        category: 'config',
+      });
+    }
+  }
+
   return issues;
 }
 

--- a/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
+++ b/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
@@ -18,6 +18,12 @@ import { sortNodesTopologically } from './nodeSorting';
 import { sanitizeNodeDataForPersistence } from './nodeDataSanitization';
 import { apiClient } from '../../../services/apiService';
 
+// Ensure schemas are registered so defaults can be materialized.
+import '../config/nodeConfigSchemas';
+
+import { schemaRegistry } from '../config/schemaRegistry';
+import type { ConfigField } from '../config/types';
+
 // ============================================================================
 // TypeScript Interfaces
 // ============================================================================
@@ -151,11 +157,66 @@ export const prepareWorkflowForSave = (
   // This also prevents "disappearing" nodes when reloading persisted workflows.
   const sortedNodes = sortNodesTopologically(nodesCopy);
   
+  const resolveSchemaNodeType = (node: Node): string => {
+    const data = (node.data || {}) as any;
+    if (typeof data.nodeType === 'string' && data.nodeType.trim()) return data.nodeType;
+
+    if (node.type === 'action' && typeof data.actionType === 'string' && data.actionType.trim()) {
+      const at = data.actionType.trim();
+      const map: Record<string, string> = {
+        email: 'actionEmail',
+        http: 'actionHTTP',
+        sms: 'actionSMS',
+        notify: 'actionNotify',
+        notification: 'actionNotify',
+        script: 'actionScript',
+        createRecord: 'actionCreateRecord',
+        updateRecord: 'actionUpdateRecord',
+        deleteRecord: 'actionDeleteRecord',
+      };
+      return map[at] || `action${at.charAt(0).toUpperCase()}${at.slice(1)}`;
+    }
+
+    return node.type || 'unknown';
+  };
+
+  const materializeDefaultsForNode = (node: Node): void => {
+    const schemaNodeType = resolveSchemaNodeType(node);
+    const schema = schemaRegistry.getSchema(schemaNodeType);
+
+    const fields: ConfigField[] = (schema.sections || []).flatMap((s: any) => (s?.fields || []) as ConfigField[]);
+    const data = (node.data || {}) as any;
+
+    // Minimal sync rules for legacy compatibility.
+    if (data.type === undefined && data.triggerType !== undefined) data.type = data.triggerType;
+    if (data.triggerType === undefined && data.type !== undefined) data.triggerType = data.type;
+
+    if (data.entityType === undefined && data.entity !== undefined) data.entityType = data.entity;
+    if (data.entity === undefined && data.entityType !== undefined) data.entity = data.entityType;
+
+    if (data.fieldMappings === undefined && data.fields !== undefined) data.fieldMappings = data.fields;
+    if (data.fields === undefined && data.fieldMappings !== undefined) data.fields = data.fieldMappings;
+
+    for (const field of fields) {
+      const dv = (field as any).defaultValue;
+      if (dv === undefined) continue;
+      if (typeof dv === 'string' && dv.length === 0) continue;
+      if (data[field.id] === undefined) {
+        data[field.id] = dv;
+      }
+    }
+
+    node.data = data;
+  };
+
   // Ensure all nodes have proper parentId metadata (React Flow v11+)
   // (This is already set by React Flow, but we verify it's serialized)
   for (const node of sortedNodes) {
     // Strip UI-only keys before persistence (shadowConfig, dirty flags, debug flags, etc).
     node.data = sanitizeNodeDataForPersistence(node.data);
+
+    // Materialize schema defaults so "looks set" == "is persisted".
+    materializeDefaultsForNode(node);
 
     if (node.parentId) {
       // Ensure extent is serialized


### PR DESCRIPTION
Deliverables:
- Publish-time schema-driven required validation parity (including generic action nodes via actionType inference)
- Save-time materialization of non-empty schema defaults so persisted config matches UI defaults
- Required validation treats empty objects as empty (keyValue record mode)

Testing:
- npx vitest run src/components/FlowEditor/utils/__tests__/validationEngine.schemaParity.test.ts   src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts   src/components/FlowEditor/config/__tests__/validationEngine.requiredEmptyObject.test.ts

Risk / rollback:
- Additive-only; revert PR to restore prior behavior.