### PR TITLE
CI: stop pushing latest tags

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,15 +2,10 @@ version: '3.8'
 
 services:
   app:
-    # Use pre-built image from GitHub Container Registry
-    # This ensures consistent environment across all Codespaces instances
-    image: ghcr.io/meats-central/projectmeats/app:latest
-    
-    # Build configuration (commented out - using GHCR image instead)
-    # Uncomment these lines if you need to build locally:
-    # build:
-    #   context: ..
-    #   dockerfile: .devcontainer/Dockerfile.dev
+    # Build locally (deterministic, avoids mutable registry tags like :latest)
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile.dev
     
     volumes:
       - ..:/workspaces/ProjectMeats:cached

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -136,14 +136,14 @@ jobs:
 
 ### Immutable Tagging Pattern
 ```yaml
-# ✅ CORRECT: Use SHA for deployments
+# ✅ CORRECT: Use immutable SHA tags for deployments
 tags: |
   ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.ENV }}-${{ github.sha }}
-  ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.ENV }}-latest
 
-# ❌ WRONG: Never use only -latest for production
+# ❌ WRONG: Never push/deploy mutable latest tags
 tags: |
   ${{ env.REGISTRY }}/${{ env.IMAGE }}:latest
+  ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.ENV }}-latest
 ```
 
 ### Environment Prefixes

--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest
             type=sha,prefix=sha-
 
       - name: Build and push Docker image


### PR DESCRIPTION
Deliverables:
- build-dev-image workflow no longer generates/pushes :latest (sha-* tags only)
- devcontainer builds locally to avoid relying on registry :latest
- workflow instructions updated to match no-latest policy

Testing:
- bash .github/scripts/check_infrastructure.sh

Risk / rollback:
- Low risk; revert PR to restore :latest usage.