### PR TITLE
CI: digest-pin workflow service images

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -46,7 +46,8 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        # Digest-pinned (multi-arch manifest) for deterministic CI
+        image: postgres:15@sha256:3e43515057e113ee741fca2f621f15300be34a6d4a8dfcf2e20651288c8272f3
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -102,7 +103,8 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        # Digest-pinned (multi-arch manifest) for deterministic CI
+        image: postgres:15@sha256:3e43515057e113ee741fca2f621f15300be34a6d4a8dfcf2e20651288c8272f3
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -349,7 +349,8 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: pgvector/pgvector:pg15
+        # Digest-pinned (multi-arch manifest) for deterministic CI
+        image: pgvector/pgvector:pg15@sha256:7f5681e45237acdf546cf7cdc0dfc0ed7752ede857fda6e54f6ea21b936f8742
         env:
           POSTGRES_DB: projectmeats_test
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Deliverables:
- Digest-pin workflow service images for deterministic CI:
  - postgres:15@sha256:3e43515057e113ee741fca2f621f15300be34a6d4a8dfcf2e20651288c8272f3
  - pgvector/pgvector:pg15@sha256:7f5681e45237acdf546cf7cdc0dfc0ed7752ede857fda6e54f6ea21b936f8742

Testing:
- bash .github/scripts/check_infrastructure.sh

Rollback:
- Revert to tag-only images if digest causes CI service startup issues.