### PR TITLE
Workflows: set RLS before tenant webhook lookup

### DIFF
--- a/backend/tenant_apps/workflows/tests/test_webhook_receiver_tenant_path.py
+++ b/backend/tenant_apps/workflows/tests/test_webhook_receiver_tenant_path.py
@@ -56,7 +56,13 @@ class WorkflowWebhookTenantPathTests(TestCase):
     @patch('tenant_apps.workflows.views_triggers.set_current_tenant')
     @patch('tenant_apps.workflows.views_triggers.execute_workflow')
     def test_tenant_scoped_webhook_executes_and_sets_rls(self, execute_workflow, set_current_tenant):
-        set_current_tenant.return_value = SimpleNamespace(ok=True)
+        events: list[str] = []
+
+        def set_side_effect(tid: str):
+            events.append('set_current_tenant')
+            return SimpleNamespace(ok=True)
+
+        set_current_tenant.side_effect = set_side_effect
         execute_workflow.return_value = SimpleNamespace(id=uuid.uuid4(), status='success')
 
         url = (
@@ -64,16 +70,30 @@ class WorkflowWebhookTenantPathTests(TestCase):
             f'{self.workflow.id}/{self.webhook_token}/'
         )
 
-        resp = self.client.post(
-            url,
-            data={'hello': 'world'},
-            format='json',
-            HTTP_AUTHORIZATION=f'Bearer {self.webhook_secret}',
-        )
+        orig_select_related = TenantWorkflow.objects.select_related
+
+        def select_related_spy(*args, **kwargs):
+            events.append('workflow_select_related')
+            return orig_select_related(*args, **kwargs)
+
+        with patch('tenant_apps.workflows.views_triggers.TenantWorkflow.objects.select_related', side_effect=select_related_spy):
+            resp = self.client.post(
+                url,
+                data={'hello': 'world'},
+                format='json',
+                HTTP_AUTHORIZATION=f'Bearer {self.webhook_secret}',
+                # Public endpoints must not honor X-Tenant-ID; path param is canonical.
+                HTTP_X_TENANT_ID=str(self.other_tenant.id),
+            )
 
         self.assertEqual(resp.status_code, 200, resp.content)
         set_current_tenant.assert_called_with(str(self.tenant.id))
         execute_workflow.assert_called()
+
+        # Critical: RLS tenant context must be set BEFORE hitting tenant-scoped ORM.
+        self.assertIn('set_current_tenant', events)
+        self.assertIn('workflow_select_related', events)
+        self.assertLess(events.index('set_current_tenant'), events.index('workflow_select_related'))
 
     @patch('tenant_apps.workflows.views_triggers.set_current_tenant')
     @patch('tenant_apps.workflows.views_triggers.execute_workflow')

--- a/backend/tenant_apps/workflows/views_triggers.py
+++ b/backend/tenant_apps/workflows/views_triggers.py
@@ -19,7 +19,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.tenants.models import TenantUser
+from apps.tenants.models import Tenant, TenantUser
 from apps.tenants.rls import set_current_tenant
 
 from .models import TenantWorkflow
@@ -56,12 +56,13 @@ def _webhook_not_found() -> Response:
 def _process_workflow_webhook(request, workflow: TenantWorkflow, webhook_token: str) -> Response:
     """Shared workflow webhook receiver logic (legacy + tenant-scoped endpoints)."""
 
-    # Set request tenant context + RLS session variables.
+    # Ensure request has tenant+RLS context before any tenant-scoped access.
     tenant = workflow.tenant
     if not tenant or not getattr(tenant, 'is_active', True):
         return _webhook_not_found()
 
-    _set_tenant_context(request, tenant)
+    if getattr(request, 'tenant', None) is None or str(getattr(request.tenant, 'id', '')) != str(tenant.id):
+        _set_tenant_context(request, tenant)
 
     membership_error = _enforce_membership_if_authenticated(request, tenant)
     if membership_error is not None:
@@ -283,6 +284,14 @@ class TenantScopedWebhookReceiverAPIView(APIView):
     authentication_classes = []
 
     def post(self, request, tenant_id, workflow_id, webhook_token):
+        try:
+            tenant = Tenant.objects.get(id=tenant_id, is_active=True)
+        except Tenant.DoesNotExist:
+            return _webhook_not_found()
+
+        # Set tenant/RLS context BEFORE touching tenant-scoped workflow tables (FORCE RLS).
+        _set_tenant_context(request, tenant)
+
         try:
             workflow = TenantWorkflow.objects.select_related('tenant').get(id=workflow_id, tenant_id=tenant_id)
         except TenantWorkflow.DoesNotExist:


### PR DESCRIPTION
Deliverables:
- Tenant-id-in-path workflow webhook receiver sets tenant + RLS context before ORM access (FORCE RLS safe)
- Avoid redundant tenant/RLS re-setting when already in correct context
- Regression test asserts call order; X-Tenant-ID header is ignored

Testing:
- python manage.py test tenant_apps.workflows.tests.test_webhook_receiver_tenant_path --verbosity=2

Rollback:
- Revert PR.