### PR TITLE
Workflows: legacy webhook fails closed without tenant context

### DIFF
--- a/backend/tenant_apps/workflows/tests/test_webhook_receiver_tenant_path.py
+++ b/backend/tenant_apps/workflows/tests/test_webhook_receiver_tenant_path.py
@@ -6,12 +6,14 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.test.utils import override_settings
 from rest_framework.test import APIClient
 
-from apps.tenants.models import Tenant, TenantUser
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
 from tenant_apps.workflows.models import TenantWorkflow, TriggerType, WorkflowStatus
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class WorkflowWebhookTenantPathTests(TestCase):
     def setUp(self):
         unique = uuid.uuid4().hex[:8]
@@ -35,6 +37,12 @@ class WorkflowWebhookTenantPathTests(TestCase):
         )
 
         TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        self.tenant_domain = TenantDomain.objects.create(
+            tenant=self.tenant,
+            domain=f'{self.tenant.slug}.example.com',
+            is_primary=True,
+        )
 
         self.webhook_token = 'tok_' + uuid.uuid4().hex
         self.webhook_secret = 'sec_' + uuid.uuid4().hex
@@ -150,6 +158,7 @@ class WorkflowWebhookTenantPathTests(TestCase):
             data={'hello': 'world'},
             format='json',
             HTTP_AUTHORIZATION=f'Bearer {self.webhook_secret}',
+            HTTP_HOST=self.tenant_domain.domain,
         )
 
         self.assertEqual(resp.status_code, 200)

--- a/backend/tenant_apps/workflows/views_triggers.py
+++ b/backend/tenant_apps/workflows/views_triggers.py
@@ -310,8 +310,17 @@ class WebhookReceiverAPIView(APIView):
     authentication_classes = []
 
     def post(self, request, workflow_id, webhook_token):
+        # Legacy endpoint has no tenant_id in the path.
+        # Fail closed unless tenant context is resolvable by middleware/domain.
+        tenant = getattr(request, 'tenant', None)
+        if not tenant or not getattr(tenant, 'is_active', True):
+            return _webhook_not_found()
+
+        # Set tenant/RLS context BEFORE touching tenant-scoped workflow tables (FORCE RLS).
+        _set_tenant_context(request, tenant)
+
         try:
-            workflow = TenantWorkflow.objects.select_related('tenant').get(id=workflow_id)
+            workflow = TenantWorkflow.objects.select_related('tenant').get(id=workflow_id, tenant_id=tenant.id)
         except TenantWorkflow.DoesNotExist:
             return _webhook_not_found()
 


### PR DESCRIPTION
Deliverables:
- Legacy workflow webhook receiver fails closed unless tenant context is resolvable (domain/middleware)
- Sets tenant/RLS context before ORM lookup; scopes workflow lookup by request.tenant

Testing:
- python manage.py test tenant_apps.workflows.tests.test_webhook_receiver_tenant_path --verbosity=2

Rollback:
- Revert PR.