### PR TITLE
WorkForms: validate activation on create

### DIFF
--- a/backend/apps/system/tests/test_workform_runtime_support_validation.py
+++ b/backend/apps/system/tests/test_workform_runtime_support_validation.py
@@ -7,12 +7,15 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from apps.system.models import TenantWorkForm
-from apps.tenants.models import Tenant, TenantUser
+from django.test.utils import override_settings
+
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
 
 
 User = get_user_model()
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class WorkFormRuntimeSupportValidationTests(APITestCase):
     def setUp(self):
         unique = uuid.uuid4().hex[:8]
@@ -29,6 +32,14 @@ class WorkFormRuntimeSupportValidationTests(APITestCase):
         )
 
         TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        domain = TenantDomain.objects.create(
+            tenant=self.tenant,
+            domain=f'{self.tenant.slug}.example.com',
+            is_primary=True,
+        )
+        # TenantMiddleware resolves tenant from host (force_authenticate doesn't run through middleware auth).
+        self.client.defaults['HTTP_HOST'] = domain.domain
 
         self.workform = TenantWorkForm.objects.create(
             tenant=self.tenant,
@@ -80,3 +91,34 @@ class WorkFormRuntimeSupportValidationTests(APITestCase):
         self.assertEqual(payload.get('error'), 'workform_validation_failed')
         self.assertIn('runtime', payload)
         self.assertFalse(payload['runtime'].get('valid', True))
+
+    def test_create_active_is_blocked_when_runtime_invalid(self):
+        resp = self.client.post(
+            '/api/v1/tenant-workforms/',
+            data={
+                'name': 'WF create',
+                'description': '',
+                'status': 'active',
+                'workflow_definition': {
+                    'nodes': [
+                        {'id': 't1', 'type': 'triggerManual', 'data': {'label': 'Manual Trigger'}},
+                        {'id': 'bad', 'type': 'actionHttp', 'data': {'label': 'HTTP Request'}},
+                        {'id': 'end', 'type': 'end', 'data': {'label': 'End'}},
+                    ],
+                    'edges': [
+                        {'id': 'e1', 'source': 't1', 'target': 'bad', 'type': 'default'},
+                        {'id': 'e2', 'source': 'bad', 'target': 'end', 'type': 'default'},
+                    ],
+                },
+            },
+            format='json',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.content)
+        payload = resp.json()
+        self.assertEqual(payload.get('error'), 'workform_validation_failed')
+        self.assertIn('runtime', payload)
+        self.assertFalse(payload['runtime'].get('valid', True))
+
+        self.assertFalse(TenantWorkForm.objects.filter(tenant=self.tenant, name='WF create').exists())

--- a/backend/apps/system/workform_views.py
+++ b/backend/apps/system/workform_views.py
@@ -210,7 +210,30 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
         if self.action == 'list':
             return TenantWorkFormListSerializer
         return TenantWorkFormSerializer
-    
+
+    def create(self, request, *args, **kwargs):
+        if not getattr(request, 'tenant', None):
+            return Response({'error': 'Tenant context missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        requested_status = request.data.get('status') if isinstance(request.data, dict) else None
+        requested_status = str(requested_status) if requested_status is not None else None
+
+        # Prevent bypass: creating with status=active must be validated the same as activation on update.
+        if requested_status == 'active':
+            serializer = self.get_serializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+
+            candidate = TenantWorkForm(**serializer.validated_data)
+            candidate.tenant = request.tenant
+            candidate.created_by = request.user
+            candidate.updated_by = request.user
+
+            gate = self._validate_before_activation(candidate, 'active', allow_already_active=False)
+            if gate is not None:
+                return gate
+
+        return super().create(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         """Assign tenant and creator on creation."""
         serializer.save(
@@ -277,12 +300,19 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
         except Exception:
             return False
 
-    def _validate_before_activation(self, workform: TenantWorkForm, requested_status: str | None):
+    def _validate_before_activation(
+        self,
+        workform: TenantWorkForm,
+        requested_status: str | None,
+        *,
+        allow_already_active: bool = True,
+    ):
         if requested_status != 'active':
             return None
 
         # Backward compatibility: do not block updates to already-active WorkForms.
-        if workform.status == 'active':
+        # (But allow callers like create() to force validation when status is requested as active.)
+        if allow_already_active and workform.status == 'active':
             return None
 
         refs = workform.validate_form_references()


### PR DESCRIPTION
Deliverables:
- Creating TenantWorkForm with status=active now runs activation validation (references + runtime support)
- Invalid WorkForms cannot be created as active; returns 400 workform_validation_failed
- Adds integration test covering create-path activation gate

Testing:
- python manage.py test apps.system.tests.test_workform_runtime_support_validation --verbosity=2

Rollback:
- Revert PR.