### PR TITLE
Mobile: align WorkForms API contract

### DIFF
--- a/mobile/src/__tests__/ApiService.test.ts
+++ b/mobile/src/__tests__/ApiService.test.ts
@@ -166,7 +166,10 @@ describe('ApiService – workforms', () => {
           description: 'Desc',
           status: 'active',
           node_count: 3,
-          created_at: '2026-01-01T00:00:00Z',
+          edge_count: 2,
+          version: 1,
+          execution_count: 0,
+          last_executed_at: null,
           updated_at: '2026-01-02T00:00:00Z',
         },
       ],
@@ -176,7 +179,9 @@ describe('ApiService – workforms', () => {
     const result = await ApiService.getWorkForms();
     expect(result.count).toBe(2);
     expect(result.results[0].name).toBe('Intake');
+    expect(result.results[0].status).toBe('active');
     expect(result.results[0].is_active).toBe(true);
+    expect(result.results[0].edge_count).toBe(2);
     expect(internalApi.get).toHaveBeenCalledWith('/tenant-workforms/');
   });
 
@@ -186,15 +191,21 @@ describe('ApiService – workforms', () => {
       name: 'Intake',
       description: 'Desc',
       status: 'draft',
-      node_count: 3,
-      created_at: '2026-01-01T00:00:00Z',
+      workflow_definition: {
+        nodes: [{ id: 'n1' }],
+        edges: [],
+      },
+      form_references: [],
       updated_at: '2026-01-02T00:00:00Z',
     };
     internalApi.get.mockResolvedValueOnce({ data: mockForm });
 
     const result = await ApiService.getWorkForm('wf-1');
     expect(result.id).toBe('wf-1');
+    expect(result.status).toBe('draft');
     expect(result.is_active).toBe(false);
+    expect(result.node_count).toBe(1);
+    expect(result.workflow_definition?.nodes?.length).toBe(1);
     expect(internalApi.get).toHaveBeenCalledWith('/tenant-workforms/wf-1/');
   });
 });

--- a/mobile/src/__tests__/openapi.contract.test.ts
+++ b/mobile/src/__tests__/openapi.contract.test.ts
@@ -122,5 +122,27 @@ describe('OpenAPI contract – mobile ApiService', () => {
     internalApi.post.mockResolvedValue({ data: { message: 'ok' } });
     await ApiService.logout();
     expectExists('/auth/logout/', 'post');
+
+    internalApi.get.mockResolvedValue({
+      data: {
+        count: 0,
+        results: [],
+      },
+    });
+    await ApiService.getWorkForms();
+    expectExists('/tenant-workforms/', 'get');
+
+    internalApi.get.mockResolvedValue({
+      data: {
+        id: 'wf-1',
+        name: 'WF',
+        status: 'draft',
+        workflow_definition: { nodes: [], edges: [] },
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    });
+    await ApiService.getWorkForm('wf-1');
+    // OpenAPI uses a templated path for detail routes.
+    expectExists('/tenant-workforms/{id}/', 'get');
   });
 });

--- a/mobile/src/__tests__/types.test.ts
+++ b/mobile/src/__tests__/types.test.ts
@@ -4,7 +4,6 @@ import {
   TenantInvite,
   InviteAcceptRequest,
   WorkForm,
-  WorkFormNode,
   RootStackParamList,
 } from '../types';
 
@@ -84,38 +83,33 @@ describe('WorkForm type', () => {
     const form: WorkForm = {
       id: 'wf-1',
       name: 'Intake Form',
-      tenant: 'tenant-1',
+      status: 'active',
       is_active: true,
       node_count: 5,
-      created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-01-02T00:00:00Z',
     };
     expect(form.is_active).toBe(true);
+    expect(form.status).toBe('active');
     expect(form.node_count).toBe(5);
     expect(form.description).toBeUndefined();
-    expect(form.nodes).toBeUndefined();
+    expect(form.workflow_definition).toBeUndefined();
   });
 
-  it('should accept optional nodes array', () => {
-    const node: WorkFormNode = {
-      id: 'n-1',
-      type: 'text_field',
-      label: 'Name',
-      position: { x: 0, y: 0 },
-      data: {},
-    };
+  it('should accept optional workflow_definition on detail responses', () => {
     const form: WorkForm = {
       id: 'wf-2',
-      name: 'Form with Nodes',
-      tenant: 'tenant-1',
-      is_active: true,
+      name: 'Form with Definition',
+      status: 'draft',
+      is_active: false,
       node_count: 1,
-      nodes: [node],
-      created_at: '',
-      updated_at: '',
+      updated_at: '2026-01-02T00:00:00Z',
+      workflow_definition: {
+        nodes: [{ id: 'n-1' }],
+        edges: [],
+      },
     };
-    expect(form.nodes).toHaveLength(1);
-    expect(form.nodes![0].type).toBe('text_field');
+
+    expect(form.workflow_definition?.nodes).toHaveLength(1);
   });
 });
 

--- a/mobile/src/services/ApiService.ts
+++ b/mobile/src/services/ApiService.ts
@@ -297,10 +297,14 @@ class ApiServiceClass {
         id: String(row.id),
         name: String(row.name ?? ''),
         description: row.description ?? undefined,
-        tenant: String(row.tenant ?? ''),
+        status: String(row.status ?? 'draft'),
         is_active: String(row.status ?? '').toLowerCase() === 'active',
         node_count: Number(row.node_count ?? 0),
-        created_at: String(row.created_at ?? ''),
+        edge_count: row.edge_count !== undefined ? Number(row.edge_count) : undefined,
+        version: row.version !== undefined ? Number(row.version) : undefined,
+        execution_count: row.execution_count !== undefined ? Number(row.execution_count) : undefined,
+        last_executed_at: row.last_executed_at ?? null,
+        created_at: row.created_at ?? undefined,
         updated_at: String(row.updated_at ?? ''),
       })),
     };
@@ -310,16 +314,23 @@ class ApiServiceClass {
     const response = await this.api.get(`/tenant-workforms/${id}/`);
     const row = response.data;
 
+    const definition = row.workflow_definition;
+
     return {
       id: String(row.id),
       name: String(row.name ?? ''),
       description: row.description ?? undefined,
-      tenant: String(row.tenant ?? ''),
+      status: String(row.status ?? 'draft'),
       is_active: String(row.status ?? '').toLowerCase() === 'active',
-      node_count: Number(row.node_count ?? 0),
-      nodes: Array.isArray(row.nodes) ? row.nodes : undefined,
-      created_at: String(row.created_at ?? ''),
+      node_count: Number(row.node_count ?? (Array.isArray(definition?.nodes) ? definition.nodes.length : 0)),
+      edge_count: row.edge_count !== undefined ? Number(row.edge_count) : undefined,
+      version: row.version !== undefined ? Number(row.version) : undefined,
+      execution_count: row.execution_count !== undefined ? Number(row.execution_count) : undefined,
+      last_executed_at: row.last_executed_at ?? null,
+      created_at: row.created_at ?? undefined,
       updated_at: String(row.updated_at ?? ''),
+      workflow_definition: definition && typeof definition === 'object' ? definition : undefined,
+      form_references: Array.isArray(row.form_references) ? row.form_references : undefined,
     };
   }
 }

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -151,26 +151,36 @@ export interface InviteAcceptRequest {
   last_name?: string;
 }
 
-// WorkForms types (mobile parity with web Workform Editor)
-export interface WorkFormNode {
-  id: string;
-  type: string;
-  label: string;
-  description?: string;
-  position: { x: number; y: number };
-  data: Record<string, any>;
+// WorkForms types (mobile contract aligned with backend serializers)
+export type WorkFormStatus = 'draft' | 'active' | 'archived' | string;
+
+export interface WorkflowDefinition {
+  nodes: any[];
+  edges: any[];
+  viewport?: {
+    x: number;
+    y: number;
+    zoom: number;
+  };
 }
 
 export interface WorkForm {
   id: string;
   name: string;
   description?: string;
-  tenant: string;
+  status: WorkFormStatus;
+  // Convenience field computed client-side
   is_active: boolean;
   node_count: number;
-  nodes?: WorkFormNode[];
-  created_at: string;
+  edge_count?: number;
+  version?: number;
+  execution_count?: number;
+  last_executed_at?: string | null;
+  created_at?: string;
   updated_at: string;
+  // Detail-only fields
+  workflow_definition?: WorkflowDefinition;
+  form_references?: string[];
 }
 
 // Common entity types (shared with backend)


### PR DESCRIPTION
Aligns mobile WorkForms types + ApiService mapping to backend serializers (status + workflow_definition) and adds OpenAPI contract assertions for /tenant-workforms list/detail.

Tests:
- mobile: jest (ApiService + OpenAPI contract + types)
- mobile: tsc --noEmit