### PR TITLE
Security: enforce tenant membership for host routing

### DIFF
--- a/backend/apps/tenants/middleware.py
+++ b/backend/apps/tenants/middleware.py
@@ -49,6 +49,21 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+_TENANT_MEMBERSHIP_BYPASS_PATH_PREFIXES = (
+    '/api/v1/invitations/validate/',
+    '/api/v1/auth/signup-with-invitation/',
+    '/api/v1/integrations/oauth/callback/',
+    '/api/v1/workflows/email/email/outlook/auth/callback/',
+    '/api/v1/workflows/email/email/gmail/auth/callback/',
+    '/api/v1/workflows/email/email/outlook/webhook/notifications/',
+    '/api/v1/workflows/email/email/gmail/webhook/notifications/',
+)
+
+
+def _bypass_tenant_membership_enforcement(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in _TENANT_MEMBERSHIP_BYPASS_PATH_PREFIXES)
+
+
 class TenantMiddleware:
     """
     Middleware to set the current tenant in the request context.
@@ -65,6 +80,25 @@ class TenantMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
+
+    def _reset_rls_session_vars(self) -> None:
+        """Best-effort RESET of RLS session vars (defense-in-depth for pooled connections)."""
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("RESET app.current_tenant_id")
+                cursor.execute("RESET app.current_tenant")
+        except Exception:
+            pass
+
+    def _forbidden(self, request: HttpRequest, message: str):
+        """Return a clear forbidden response (JSON for API routes)."""
+        self._reset_rls_session_vars()
+
+        if request.path.startswith('/api/v1/'):
+            # Use a stable error shape for frontend + tests.
+            return JsonResponse({'error': message, 'code': 'TENANT_ACCESS_DENIED'}, status=403)
+
+        return HttpResponseForbidden(message)
 
     def __call__(self, request: HttpRequest):
         """Process the request and set tenant context."""
@@ -111,7 +145,7 @@ class TenantMiddleware:
                             f"user={request.user.username}, tenant_id={tenant_id}, "
                             f"path={request.path}"
                         )
-                        return HttpResponseForbidden("You do not have access to this tenant")
+                        return self._forbidden(request, 'You do not have access to this tenant.')
                 elif is_global_admin:
                     logger.info(
                         f"Global System Admin explicit tenant selection: "
@@ -244,6 +278,7 @@ class TenantMiddleware:
             and request.user.is_authenticated
             and resolution_method
             and (resolution_method.startswith("domain") or resolution_method.startswith("subdomain"))
+            and not _bypass_tenant_membership_enforcement(request.path)
         ):
             is_global_admin = request.user.groups.filter(name='Global System Admins').exists()
             if not (request.user.is_superuser or is_global_admin):
@@ -255,12 +290,7 @@ class TenantMiddleware:
                         resolution_method,
                         request.path,
                     )
-                    if request.path.startswith('/api/v1/'):
-                        return JsonResponse(
-                            {"error": "You do not have access to this tenant.", "code": "TENANT_ACCESS_DENIED"},
-                            status=403,
-                        )
-                    return HttpResponseForbidden("You do not have access to this tenant")
+                    return self._forbidden(request, 'You do not have access to this tenant.')
 
         # Final tenant resolution result for debug hosts
         if is_debug_host:

--- a/backend/apps/tenants/middleware.py
+++ b/backend/apps/tenants/middleware.py
@@ -41,7 +41,7 @@ If no tenant can be resolved, request.tenant is set to None.
 ViewSets should handle None tenant by returning empty querysets or raising validation errors.
 """
 
-from django.http import HttpRequest, HttpResponseForbidden
+from django.http import HttpRequest, HttpResponseForbidden, JsonResponse
 from django.db import connection
 from .models import Tenant, TenantUser, TenantDomain
 import logging
@@ -236,6 +236,31 @@ class TenantMiddleware:
                     logger.info(
                         f"{debug_prefix} No default tenant found for user: {request.user.username}"
                     )
+
+        # SECURITY: If tenant was resolved via host routing (domain/subdomain) and the user is
+        # authenticated (session-auth), require active TenantUser membership unless global admin.
+        if (
+            tenant
+            and request.user.is_authenticated
+            and resolution_method
+            and (resolution_method.startswith("domain") or resolution_method.startswith("subdomain"))
+        ):
+            is_global_admin = request.user.groups.filter(name='Global System Admins').exists()
+            if not (request.user.is_superuser or is_global_admin):
+                if not TenantUser.objects.filter(user=request.user, tenant=tenant, is_active=True).exists():
+                    logger.warning(
+                        "Unauthorized tenant host access attempt: user=%s tenant=%s method=%s path=%s",
+                        request.user.username,
+                        str(tenant.id),
+                        resolution_method,
+                        request.path,
+                    )
+                    if request.path.startswith('/api/v1/'):
+                        return JsonResponse(
+                            {"error": "You do not have access to this tenant.", "code": "TENANT_ACCESS_DENIED"},
+                            status=403,
+                        )
+                    return HttpResponseForbidden("You do not have access to this tenant")
 
         # Final tenant resolution result for debug hosts
         if is_debug_host:

--- a/backend/apps/tenants/test_middleware_debug.py
+++ b/backend/apps/tenants/test_middleware_debug.py
@@ -8,7 +8,7 @@ and uat.meatscentral.com doesn't interfere with normal middleware operation.
 from django.test import TestCase, RequestFactory, override_settings
 from django.contrib.auth.models import User
 from apps.tenants.middleware import TenantMiddleware
-from apps.tenants.models import Tenant, TenantDomain
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
 from unittest.mock import Mock
 
 
@@ -34,6 +34,8 @@ class TenantMiddlewareDebugLoggingTests(TestCase):
             email="test@example.com",
             password="testpass"
         )
+
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner', is_active=True)
 
     @override_settings(ALLOWED_HOSTS=['example.com', 'testserver'])
     def test_middleware_works_without_debug_domains(self):

--- a/backend/apps/tenants/test_middleware_host_membership.py
+++ b/backend/apps/tenants/test_middleware_host_membership.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from django.contrib.auth.models import User
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
+
+from apps.tenants.middleware import TenantMiddleware
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
+
+
+class TenantMiddlewareHostMembershipTests(TestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.tenant = Tenant.objects.create(
+            name='Acme Tenant',
+            slug='acme',
+            contact_email='acme@example.com',
+            is_active=True,
+        )
+        TenantDomain.objects.create(domain='acme.example.com', tenant=self.tenant, is_primary=True)
+
+        self.user = User.objects.create_user(username='member', password='pass')
+        self.non_member = User.objects.create_user(username='nonmember', password='pass')
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner', is_active=True)
+
+    @override_settings(ALLOWED_HOSTS=['acme.example.com'])
+    def test_host_resolved_tenant_requires_membership_for_authenticated_user(self):
+        get_response = Mock(return_value=HttpResponse('ok'))
+        middleware = TenantMiddleware(get_response)
+
+        request = self.factory.get('/some/web/page/', HTTP_HOST='acme.example.com')
+        request.user = self.non_member
+
+        with patch('apps.tenants.rls.set_current_tenant') as set_current_tenant:
+            resp = middleware(request)
+
+        self.assertEqual(resp.status_code, 403)
+        get_response.assert_not_called()
+        set_current_tenant.assert_not_called()
+
+    @override_settings(ALLOWED_HOSTS=['acme.example.com'])
+    def test_api_routes_return_json_envelope_on_tenant_denial(self):
+        get_response = Mock(return_value=HttpResponse('ok'))
+        middleware = TenantMiddleware(get_response)
+
+        request = self.factory.get('/api/v1/anything/', HTTP_HOST='acme.example.com')
+        request.user = self.non_member
+
+        with patch('apps.tenants.rls.set_current_tenant') as set_current_tenant:
+            resp = middleware(request)
+
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp['Content-Type'], 'application/json')
+        self.assertJSONEqual(
+            resp.content,
+            {'error': 'You do not have access to this tenant.', 'code': 'TENANT_ACCESS_DENIED'},
+        )
+        get_response.assert_not_called()
+        set_current_tenant.assert_not_called()
+
+    @override_settings(ALLOWED_HOSTS=['acme.example.com'])
+    def test_host_resolved_tenant_allows_member(self):
+        get_response = Mock(return_value=HttpResponse('ok'))
+        middleware = TenantMiddleware(get_response)
+
+        request = self.factory.get('/some/web/page/', HTTP_HOST='acme.example.com')
+        request.user = self.user
+
+        with patch('apps.tenants.rls.set_current_tenant') as set_current_tenant:
+            resp = middleware(request)
+
+        self.assertEqual(resp.status_code, 200)
+        get_response.assert_called_once()
+        set_current_tenant.assert_called_once()
+        self.assertEqual(get_response.call_args[0][0].tenant, self.tenant)

--- a/backend/apps/tenants/test_middleware_host_membership.py
+++ b/backend/apps/tenants/test_middleware_host_membership.py
@@ -75,3 +75,19 @@ class TenantMiddlewareHostMembershipTests(TestCase):
         get_response.assert_called_once()
         set_current_tenant.assert_called_once()
         self.assertEqual(get_response.call_args[0][0].tenant, self.tenant)
+
+    @override_settings(ALLOWED_HOSTS=['acme.example.com'])
+    def test_invitation_validate_path_bypasses_membership_enforcement(self):
+        get_response = Mock(return_value=HttpResponse('ok'))
+        middleware = TenantMiddleware(get_response)
+
+        request = self.factory.get('/api/v1/invitations/validate/', HTTP_HOST='acme.example.com')
+        request.user = self.non_member
+
+        with patch('apps.tenants.rls.set_current_tenant') as set_current_tenant:
+            resp = middleware(request)
+
+        self.assertEqual(resp.status_code, 200)
+        get_response.assert_called_once()
+        set_current_tenant.assert_called_once()
+        self.assertEqual(get_response.call_args[0][0].tenant, self.tenant)

--- a/backend/apps/tenants/test_session_auth_host_membership_enforcement.py
+++ b/backend/apps/tenants/test_session_auth_host_membership_enforcement.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
+from tenant_apps.suppliers.models import Supplier
+
+
+User = get_user_model()
+
+
+@override_settings(ALLOWED_HOSTS=["*"])
+class SessionAuthHostTenantMembershipEnforcementTests(APITestCase):
+    """End-to-end regression tests for session-auth + host-resolved tenants.
+
+    Why these tests exist:
+    - RequestFactory/APIRequestFactory + force_authenticate can bypass the real middleware/auth stack.
+    - We specifically want to ensure the Django middleware chain runs and denies cross-tenant access
+      when a user is authenticated via *session* auth and the tenant is resolved via Host.
+    """
+
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f"u-{unique}", password="pw")
+
+        self.tenant_a = Tenant.objects.create(
+            name=f"Tenant A {unique}",
+            slug=f"tenant-a-{unique}",
+            contact_email=f"a-{unique}@example.com",
+            is_active=True,
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f"Tenant B {unique}",
+            slug=f"tenant-b-{unique}",
+            contact_email=f"b-{unique}@example.com",
+            is_active=True,
+            created_by=self.user,
+        )
+
+        self.domain_a = TenantDomain.objects.create(
+            tenant=self.tenant_a,
+            domain=f"{self.tenant_a.slug}.example.com",
+            is_primary=True,
+        )
+        self.domain_b = TenantDomain.objects.create(
+            tenant=self.tenant_b,
+            domain=f"{self.tenant_b.slug}.example.com",
+            is_primary=True,
+        )
+
+        # Membership ONLY in tenant A.
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role="admin", is_active=True)
+
+        Supplier.objects.create(tenant=self.tenant_a, name="A ONLY SUPPLIER")
+        Supplier.objects.create(tenant=self.tenant_b, name="B ONLY SUPPLIER")
+
+        # Use session auth (not JWT / not force_authenticate).
+        self.client.force_login(self.user)
+
+    def test_session_user_cannot_access_other_tenant_by_changing_host_domain(self):
+        resp = self.client.get("/api/v1/suppliers/", HTTP_HOST=self.domain_b.domain)
+
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)
+        self.assertEqual(resp["Content-Type"], "application/json")
+        self.assertEqual(
+            resp.json(),
+            {"error": "You do not have access to this tenant.", "code": "TENANT_ACCESS_DENIED"},
+        )
+
+    def test_session_user_can_access_own_tenant_by_host_domain(self):
+        resp = self.client.get("/api/v1/suppliers/", HTTP_HOST=self.domain_a.domain)
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+        joined = str(resp.json())
+        self.assertIn("A ONLY SUPPLIER", joined)
+        self.assertNotIn("B ONLY SUPPLIER", joined)
+
+    def test_session_user_cannot_access_other_tenant_by_changing_host_subdomain_resolution(self):
+        # Remove TenantDomain mapping so resolution falls back to slug-based subdomain logic.
+        TenantDomain.objects.all().delete()
+
+        resp = self.client.get("/api/v1/suppliers/", HTTP_HOST=f"{self.tenant_b.slug}.example.com")
+
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)
+        self.assertEqual(resp["Content-Type"], "application/json")
+        self.assertEqual(
+            resp.json(),
+            {"error": "You do not have access to this tenant.", "code": "TENANT_ACCESS_DENIED"},
+        )


### PR DESCRIPTION
## Summary\nPrevents session-auth users from accessing other tenants by changing Host when tenant is resolved via domain/subdomain.\n\n## Changes\n- TenantMiddleware now requires active TenantUser membership when tenant is resolved via domain/subdomain (superuser / Global System Admins exempt).\n- For /api/v1/* routes, tenant denial returns a JSON envelope: {error, code}.\n- Added regression tests:\n  - Middleware-level tests for host routing denial + JSON envelope\n  - End-to-end APITestCase using session auth (force_login) against /api/v1/suppliers/ to prevent host spoofing\n\n## Testing\n- source /venv/bin/activate\n- cd backend && python manage.py test apps.tenants --verbosity=2\n\n## Rollback\nRevert this PR to restore previous middleware behavior.