### PR TITLE
System WorkForms: enforce editor RBAC + active-member execute

### DIFF
--- a/backend/apps/system/permissions.py
+++ b/backend/apps/system/permissions.py
@@ -5,12 +5,13 @@ from rest_framework import permissions
 from apps.tenants.models import TenantUser
 
 
-class IsTenantAdminOrOwnerForTenantContext(permissions.BasePermission):
-    """Allow unsafe methods only for tenant admins/owners in request.tenant.
+def _get_request_tenant(request):
+    django_request = getattr(request, '_request', None)
+    return getattr(request, 'tenant', None) or getattr(django_request, 'tenant', None)
 
-    This is used by tenant-scoped resources that are not Tenant objects themselves
-    (e.g., TenantProductPreference).
-    """
+
+class IsTenantAdminOrOwnerForTenantContext(permissions.BasePermission):
+    """Allow unsafe methods only for tenant admins/owners in the tenant context."""
 
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
@@ -22,7 +23,7 @@ class IsTenantAdminOrOwnerForTenantContext(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        tenant = getattr(request, 'tenant', None)
+        tenant = _get_request_tenant(request)
         if not tenant:
             return False
 
@@ -48,5 +49,101 @@ class IsTenantAdminOrOwnerForTenantContext(permissions.BasePermission):
             tenant_id=obj.tenant_id,
             user=request.user,
             role__in=['owner', 'admin'],
+            is_active=True,
+        ).exists()
+
+
+class IsTenantEditorForTenantContext(permissions.BasePermission):
+    """Allow unsafe WorkForms/FormBuilder mutations only for tenant editors."""
+
+    editor_roles = ['owner', 'admin', 'manager']
+
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser or request.user.is_staff:
+            return True
+
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        django_request = getattr(request, '_request', None)
+        tenant_user = getattr(request, 'tenant_user', None) or getattr(django_request, 'tenant_user', None)
+        if tenant_user is not None:
+            return getattr(tenant_user, 'role', None) in self.editor_roles
+
+        tenant = _get_request_tenant(request)
+        if not tenant:
+            return False
+
+        return TenantUser.objects.filter(
+            tenant=tenant,
+            user=request.user,
+            role__in=self.editor_roles,
+            is_active=True,
+        ).exists()
+
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_superuser or request.user.is_staff:
+            return True
+
+        if request.method in permissions.SAFE_METHODS:
+            return getattr(obj, 'tenant_id', None) is not None and TenantUser.objects.filter(
+                tenant_id=obj.tenant_id,
+                user=request.user,
+                is_active=True,
+            ).exists()
+
+        django_request = getattr(request, '_request', None)
+        tenant_user = getattr(request, 'tenant_user', None) or getattr(django_request, 'tenant_user', None)
+        if tenant_user is not None and getattr(obj, 'tenant_id', None) == getattr(tenant_user, 'tenant_id', None):
+            return getattr(tenant_user, 'role', None) in self.editor_roles
+
+        return getattr(obj, 'tenant_id', None) is not None and TenantUser.objects.filter(
+            tenant_id=obj.tenant_id,
+            user=request.user,
+            role__in=self.editor_roles,
+            is_active=True,
+        ).exists()
+
+
+class IsActiveTenantMemberForTenantContext(permissions.BasePermission):
+    """Allow actions only for active tenant members in the tenant context.
+
+    This permission is intended for actions like workform execution.
+    """
+
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser or request.user.is_staff:
+            return True
+
+        tenant = _get_request_tenant(request)
+        if not tenant and hasattr(request, 'headers'):
+            tenant_id = request.headers.get('X-Tenant-ID')
+            if tenant_id:
+                try:
+                    tu = TenantUser.objects.select_related('tenant').get(
+                        tenant_id=tenant_id,
+                        user=request.user,
+                        is_active=True,
+                    )
+                    tenant = tu.tenant
+                    setattr(request, 'tenant', tenant)
+                    django_request = getattr(request, '_request', None)
+                    if django_request is not None:
+                        setattr(django_request, 'tenant', tenant)
+                except TenantUser.DoesNotExist:
+                    return False
+
+        if not tenant:
+            return False
+
+        return TenantUser.objects.filter(
+            tenant=tenant,
+            user=request.user,
             is_active=True,
         ).exists()

--- a/backend/apps/system/tests/test_workforms_rbac.py
+++ b/backend/apps/system/tests/test_workforms_rbac.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.system.models import TenantWorkForm
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
+
+
+User = get_user_model()
+
+
+@override_settings(ALLOWED_HOSTS=['*'])
+class WorkFormsRBACSystemViewSetsTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+        )
+        self.domain = TenantDomain.objects.create(
+            tenant=self.tenant,
+            domain=f'{self.tenant.slug}.example.com',
+            is_primary=True,
+        )
+
+        self.viewer = User.objects.create_user(username=f'viewer-{unique}', password='pw')
+        self.editor = User.objects.create_user(username=f'editor-{unique}', password='pw')
+
+        TenantUser.objects.create(tenant=self.tenant, user=self.viewer, role='user', is_active=True)
+        TenantUser.objects.create(tenant=self.tenant, user=self.editor, role='manager', is_active=True)
+
+        self.workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='Existing WF',
+            description='',
+            status='draft',
+            workflow_definition={'nodes': [], 'edges': []},
+            created_by=self.editor,
+            updated_by=self.editor,
+        )
+
+    def test_viewer_can_list_workforms(self):
+        self.client.force_login(self.viewer)
+        resp = self.client.get('/api/v1/tenant-workforms/', HTTP_HOST=self.domain.domain)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+    def test_viewer_cannot_create_workform(self):
+        self.client.force_login(self.viewer)
+        resp = self.client.post(
+            '/api/v1/tenant-workforms/',
+            data={
+                'name': 'New WF',
+                'description': '',
+                'status': 'draft',
+                'workflow_definition': {'nodes': [], 'edges': []},
+            },
+            format='json',
+            HTTP_HOST=self.domain.domain,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)
+
+    def test_editor_can_create_workform(self):
+        self.client.force_login(self.editor)
+        resp = self.client.post(
+            '/api/v1/tenant-workforms/',
+            data={
+                'name': 'New WF',
+                'description': '',
+                'status': 'draft',
+                'workflow_definition': {'nodes': [], 'edges': []},
+            },
+            format='json',
+            HTTP_HOST=self.domain.domain,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.content)
+
+    def test_viewer_cannot_create_tenant_form(self):
+        self.client.force_login(self.viewer)
+        resp = self.client.post(
+            '/api/v1/tenant-forms/',
+            data={
+                'name': 'New Form',
+                'description': '',
+                'type': 'single_step',
+                'entity_type': 'supplier',
+                'schema': {'fields': []},
+            },
+            format='json',
+            HTTP_HOST=self.domain.domain,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)
+
+    def test_editor_can_create_tenant_form(self):
+        self.client.force_login(self.editor)
+        resp = self.client.post(
+            '/api/v1/tenant-forms/',
+            data={
+                'name': 'New Form',
+                'description': '',
+                'type': 'single_step',
+                'entity_type': 'supplier',
+                'schema': {'fields': []},
+            },
+            format='json',
+            HTTP_HOST=self.domain.domain,
+        )
+        # Serializer may perform additional validation; this test only asserts we don't 403.
+        self.assertNotEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)

--- a/backend/apps/system/workform_views.py
+++ b/backend/apps/system/workform_views.py
@@ -12,8 +12,11 @@ from django.utils import timezone
 from rest_framework import viewsets, status
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
+
+from apps.system.permissions import IsTenantEditorForTenantContext, IsActiveTenantMemberForTenantContext
 from rest_framework.response import Response
 from apps.system.models import TenantForm, TenantWorkForm, FormTypeChoices
+from apps.tenants.models import Tenant, TenantUser
 from apps.system.workform_serializers import (
     TenantFormSerializer,
     TenantFormListSerializer,
@@ -23,6 +26,54 @@ from apps.system.workform_serializers import (
     FormSplitSerializer,
     WorkFormCloneSerializer,
 )
+
+
+def _get_request_tenant(request):
+    """Return resolved tenant, supporting both middleware and DRF-auth flows.
+
+    TenantMiddleware resolves tenant early when request.user is already authenticated.
+    For DRF token auth (and tests using force_authenticate), authentication happens
+    after middleware, so we also support late resolution from the X-Tenant-ID header.
+    """
+
+    django_request = getattr(request, '_request', None)
+    tenant = getattr(request, 'tenant', None) or getattr(django_request, 'tenant', None)
+    if tenant:
+        return tenant
+
+    tenant_id = None
+    if hasattr(request, 'headers'):
+        tenant_id = request.headers.get('X-Tenant-ID')
+    if not tenant_id and django_request is not None and hasattr(django_request, 'headers'):
+        tenant_id = django_request.headers.get('X-Tenant-ID')
+
+    user = getattr(request, 'user', None) or getattr(django_request, 'user', None)
+    if not tenant_id or not user or not getattr(user, 'is_authenticated', False):
+        return None
+
+    try:
+        tenant = Tenant.objects.get(id=tenant_id, is_active=True)
+    except (Tenant.DoesNotExist, ValueError):
+        return None
+
+    is_global_admin = user.groups.filter(name='Global System Admins').exists()
+    if not (user.is_superuser or is_global_admin):
+        if not TenantUser.objects.filter(user=user, tenant=tenant, is_active=True).exists():
+            return None
+
+    # Cache for later uses during this request lifecycle.
+    try:
+        setattr(request, 'tenant', tenant)
+    except Exception:
+        pass
+    try:
+        if django_request is not None:
+            setattr(django_request, 'tenant', tenant)
+    except Exception:
+        pass
+
+    return tenant
+
 
 
 class TenantFormViewSet(viewsets.ModelViewSet):
@@ -41,11 +92,23 @@ class TenantFormViewSet(viewsets.ModelViewSet):
     - entity_type: supplier | customer | etc.
     """
     permission_classes = [IsAuthenticated]
+
+    def get_permissions(self):
+        # Allow any authenticated tenant member to read forms.
+        if self.action in {'list', 'retrieve', 'get_usage'}:
+            return [IsAuthenticated()]
+
+        # Form mutations are editor-only.
+        return [IsAuthenticated(), IsTenantEditorForTenantContext()]
     
     def get_queryset(self):
         """Filter forms by tenant."""
-        queryset = TenantForm.objects.filter(tenant=self.request.tenant)
-        
+        tenant = _get_request_tenant(self.request)
+        if not tenant:
+            return TenantForm.objects.none()
+
+        queryset = TenantForm.objects.filter(tenant=tenant)
+
         # Filter by type
         form_type = self.request.query_params.get('type')
         if form_type:
@@ -83,7 +146,7 @@ class TenantFormViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         """Assign tenant and creator on creation."""
         serializer.save(
-            tenant=self.request.tenant,
+            tenant=_get_request_tenant(self.request),
             created_by=self.request.user,
             updated_by=self.request.user
         )
@@ -183,11 +246,35 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
     - status: draft | active | archived
     """
     permission_classes = [IsAuthenticated]
+
+    def get_permissions(self):
+        # Read-like operations are allowed for any authenticated tenant member.
+        if self.action in {
+            'list',
+            'retrieve',
+            'usage',
+            'validate',
+            'list_containers',
+            'container_detail',
+        }:
+            return [IsAuthenticated()]
+
+        # Execution is allowed for any active tenant member; additional checks are performed
+        # in _can_execute_workform().
+        if self.action in {'execute'}:
+            return [IsAuthenticated(), IsActiveTenantMemberForTenantContext()]
+
+        # Mutations are editor-only (creator/owner/admin logic is enforced in the view methods too).
+        return [IsAuthenticated(), IsTenantEditorForTenantContext()]
     
     def get_queryset(self):
         """Filter workflows by tenant."""
-        queryset = TenantWorkForm.objects.filter(tenant=self.request.tenant)
-        
+        tenant = _get_request_tenant(self.request)
+        if not tenant:
+            return TenantWorkForm.objects.none()
+
+        queryset = TenantWorkForm.objects.filter(tenant=tenant)
+
         # Filter by status (support comma-separated list)
         workflow_status = self.request.query_params.get('status')
         if workflow_status:
@@ -237,7 +324,7 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         """Assign tenant and creator on creation."""
         serializer.save(
-            tenant=self.request.tenant,
+            tenant=_get_request_tenant(self.request),
             created_by=self.request.user,
             updated_by=self.request.user
         )


### PR DESCRIPTION
## Summary
- Enforce editor-only mutations for TenantWorkForm/TenantForm system viewsets.
- Require active tenant membership for workform execute.
- Resolve tenant context reliably for DRF-auth flows using X-Tenant-ID (fail-closed when missing/unauthorized).
- Add RBAC regression tests for list/create on forms/workforms.

## Testing
- `python manage.py test apps.system --verbosity=2`

## Notes
- Keeps list endpoints fail-closed (missing tenant context returns empty list per existing tests).
