### PR TITLE
FlowEditor: route debug logs through centralized logger

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -16,6 +16,8 @@ import styled from 'styled-components';
 import { Node, Edge } from '@xyflow/react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 
+import { logger } from '@/utils/logger';
+
 // Smart Auto-Map (Phase 7 stabilization)
 import { AutoMappingService, FieldMappingSuggestion } from '../utils/autoMappingService';
 import { AutoMappingSuggestionsPanel } from '../components/AutoMappingSuggestionsPanel';
@@ -209,15 +211,18 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
 
     // Debug logging for schema resolution
     const isFallback = resolvedSchema?.version?.includes('fallback');
-    console.log('[DynamicConfigPanel] Schema resolution:', {
-      nodeType: semanticNodeType,
-      runtimeType: node.type,
-      nodeId: node.id,
-      schemaDisplayName: resolvedSchema?.displayName,
-      isFallback,
-      sectionCount: resolvedSchema?.sections?.length || 0,
+    logger.debug('Schema resolution', {
+      component: 'DynamicConfigPanel',
+      metadata: {
+        nodeType: semanticNodeType,
+        runtimeType: node.type,
+        nodeId: node.id,
+        schemaDisplayName: resolvedSchema?.displayName,
+        isFallback,
+        sectionCount: resolvedSchema?.sections?.length || 0,
+      },
     });
-    
+
     return resolvedSchema;
   }, [node?.type, node?.id, node?.data]);
 
@@ -1218,7 +1223,10 @@ export const DynamicConfigPanel: React.FC<DynamicConfigPanelProps> = ({
                 }
                 // Check if button has FormBuilder action metadata
                 if (field.metadata?.action === 'openFormBuilder') {
-                  console.log('[DynamicConfigPanel] Opening FormBuilder for node:', node.id);
+                  logger.debug('Opening FormBuilder', {
+                    component: 'DynamicConfigPanel',
+                    metadata: { nodeId: node.id },
+                  });
                   openFormBuilder({
                     nodeId: node.id,
                     nodeData: node.data,

--- a/frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPicker.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPicker.tsx
@@ -39,6 +39,8 @@ import {
 } from './SkeletonLoaders';
 import { useTimeout } from '../hooks/useTimeout';
 
+import { logger } from '@/utils/logger';
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -388,7 +390,10 @@ export const EntityFieldPicker: React.FC<EntityFieldPickerProps> = ({
   // Reactive cascade: watch initialEntityType prop changes (uncontrolled mode)
   useEffect(() => {
     if (initialEntityType && initialEntityType !== selectedEntityType) {
-      console.log('[EntityFieldPicker] initialEntityType changed, updating:', initialEntityType);
+      logger.debug('initialEntityType changed, updating', {
+        component: 'EntityFieldPicker',
+        metadata: { initialEntityType },
+      });
       setSelectedEntityType(initialEntityType);
       setSearchTerm('');
       setFieldTypeFilter('all');
@@ -418,7 +423,7 @@ export const EntityFieldPicker: React.FC<EntityFieldPickerProps> = ({
 
   const handleEntityChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const entityType = e.target.value;
-    console.log('[EntityFieldPicker] Entity selected:', entityType);
+    logger.debug('Entity selected', { component: 'EntityFieldPicker', metadata: { entityType } });
     setSelectedEntityType(entityType);
     setSearchTerm('');
     setFieldTypeFilter('all');
@@ -428,21 +433,21 @@ export const EntityFieldPicker: React.FC<EntityFieldPickerProps> = ({
     onFieldsChange([]);
     
     if (onEntityTypeChange) {
-      console.log('[EntityFieldPicker] Notifying parent of entity change');
+      logger.debug('Notifying parent of entity change', { component: 'EntityFieldPicker' });
       onEntityTypeChange(entityType);
     }
   };
   
   // Retry handlers
   const handleRetryEntities = () => {
-    console.log('[EntityFieldPicker] Retrying entity list fetch');
+    logger.debug('Retrying entity list fetch', { component: 'EntityFieldPicker' });
     setRetryCount(prev => prev + 1);
     resetEntitiesTimeout();
     refetchEntities();
   };
   
   const handleRetryFields = () => {
-    console.log('[EntityFieldPicker] Retrying fields fetch');
+    logger.debug('Retrying fields fetch', { component: 'EntityFieldPicker' });
     setRetryCount(prev => prev + 1);
     resetFieldsTimeout();
     refetchFields();

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanelWithShadow.tsx
@@ -21,6 +21,8 @@ import { AlertCircle } from 'lucide-react';
 import { TabbedConfigPanel } from './TabbedConfigPanel';
 import { useNodeShadowState } from '../hooks/useNodeShadowState';
 import { sanitizeNodeConfigForPersistence } from '../utils/nodeDataSanitization';
+
+import { logger } from '@/utils/logger';
 import {
   PrimaryButton,
   SecondaryButton,
@@ -203,14 +205,14 @@ export const TabbedConfigPanelWithShadow: React.FC<TabbedConfigPanelWithShadowPr
     // Also call the original onUpdate to trigger history
     onUpdate(node.id, sanitized);
     
-    console.log('[Shadow State] Applied changes to node:', node.id);
+    logger.debug('Applied changes to node', { component: 'ShadowState', metadata: { nodeId: node.id } });
   }, [node, isReadOnly, commitShadow, onUpdate, shadowConfig]);
 
   // Handle discard
   const handleDiscard = useCallback(() => {
     if (isReadOnly) return;
     discardShadow();
-    console.log('[Shadow State] Discarded changes');
+    logger.debug('Discarded changes', { component: 'ShadowState' });
   }, [isReadOnly, discardShadow]);
 
   // Handle close with confirmation if dirty

--- a/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
@@ -14,6 +14,8 @@ import styled from 'styled-components';
 import { X, ArrowLeft, Save, AlertCircle, Package, Settings, Navigation } from 'lucide-react';
 import { FormSelectionPanel } from '../ConfigPanel';
 
+import { logger } from '@/utils/logger';
+
 // ============================================================================
 // TypeScript Types
 // ============================================================================
@@ -483,7 +485,7 @@ export const FormProcessModal: React.FC<ContainerModalProps> = ({
     formId?: string;
     form?: any;
   }) => {
-    console.log('[FormProcessModal] Selection changed:', selection);
+    logger.debug('Selection changed', { component: 'FormProcessModal', metadata: { selection } });
     setState(prev => ({
       ...prev,
       mode: selection.mode,
@@ -494,10 +496,13 @@ export const FormProcessModal: React.FC<ContainerModalProps> = ({
   }, []);
 
   const handleProceedFromStep1 = useCallback(() => {
-    console.log('[FormProcessModal] Proceeding from step 1:', {
-      mode: state.mode,
-      containerName: state.containerName,
-      selectedWorkflowId: state.selectedWorkflowId
+    logger.debug('Proceeding from step 1', {
+      component: 'FormProcessModal',
+      metadata: {
+        mode: state.mode,
+        containerName: state.containerName,
+        selectedWorkflowId: state.selectedWorkflowId,
+      },
     });
     if (state.mode === 'new' && state.containerName) {
       setState(prev => ({ ...prev, currentStep: 2 }));

--- a/frontend/src/components/FlowEditor/NestedContainer/ContainerContext.tsx
+++ b/frontend/src/components/FlowEditor/NestedContainer/ContainerContext.tsx
@@ -9,6 +9,8 @@
 import React, { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react';
 import { Node, Edge } from '@xyflow/react';
 
+import { logger } from '@/utils/logger';
+
 // ============================================================================
 // TypeScript Interfaces
 // ============================================================================
@@ -78,7 +80,10 @@ export const ContainerContextProvider: React.FC<ContainerContextProviderProps> =
     nodes: Node[],
     edges: Edge[]
   ) => {
-    console.log(`[ContainerContext] Entering container: ${containerId} (${containerName})`);
+    logger.debug('Entering container', {
+      component: 'ContainerContext',
+      metadata: { containerId, containerName },
+    });
     setContainerStack(prev => [...prev, {
       containerId,
       containerName,
@@ -88,12 +93,12 @@ export const ContainerContextProvider: React.FC<ContainerContextProviderProps> =
   }, []);
   
   const exitContainer = useCallback(() => {
-    console.log('[ContainerContext] Exiting container');
+    logger.debug('Exiting container', { component: 'ContainerContext' });
     setContainerStack(prev => prev.slice(0, -1));
   }, []);
   
   const exitToMain = useCallback(() => {
-    console.log('[ContainerContext] Exiting to main canvas');
+    logger.debug('Exiting to main canvas', { component: 'ContainerContext' });
     setContainerStack([]);
   }, []);
   

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
@@ -14,6 +14,8 @@ import styled from 'styled-components';
 import { ConfigField, FieldRendererProps } from '../types';
 import { useEntityList } from '../../../../services/schemaService';  // Fixed path
 
+import { logger } from '@/utils/logger';
+
 // Import shared styled components
 import {
   FormField,
@@ -189,14 +191,17 @@ export function renderEntityTypeSelect(
   // Fetch entity types from backend API (with fallback to hardcoded entities)
   const { data: entities = [], isLoading, error: fetchError } = useEntityList();
 
-  // Debug logging
+  // Debug logging (dev-only)
   React.useEffect(() => {
-    console.log('[EntityTypeSelect] Rendered with:', {
-      isLoading,
-      entityCount: entities.length,
-      entities: entities.map(e => e.label),
-      fetchError: fetchError ? String(fetchError) : null,
-      currentValue: value,
+    logger.debug('Rendered', {
+      component: 'EntityTypeSelect',
+      metadata: {
+        isLoading,
+        entityCount: entities.length,
+        entities: entities.map((e) => e.label),
+        fetchError: fetchError ? String(fetchError) : null,
+        currentValue: value,
+      },
     });
   }, [isLoading, entities, fetchError, value]);
 

--- a/frontend/src/components/FlowEditor/config/schemaRegistry.ts
+++ b/frontend/src/components/FlowEditor/config/schemaRegistry.ts
@@ -11,6 +11,8 @@
 import { NodeConfigSchema, SchemaValidationResult } from './types';
 import type { ConfigField, ValidationRule } from './types';
 
+import { logger } from '@/utils/logger';
+
 /**
  * Singleton registry for node configuration schemas
  */
@@ -283,7 +285,7 @@ class ConfigSchemaRegistry {
   clear(): void {
     this.schemas.clear();
     this.initialized = false;
-    console.log('ConfigSchemaRegistry cleared');
+    logger.debug('ConfigSchemaRegistry cleared', { component: 'ConfigSchemaRegistry' });
   }
 
   /**

--- a/frontend/src/components/FlowEditor/hooks/useAutoMapping.ts
+++ b/frontend/src/components/FlowEditor/hooks/useAutoMapping.ts
@@ -16,6 +16,8 @@ import {
 } from '../utils/autoMappingService';
 import { attachOutputSchemaToNode } from '../utils/outputSchemaInference';
 
+import { logger } from '@/utils/logger';
+
 /**
  * Hook return type
  */
@@ -60,8 +62,8 @@ export function useAutoMapping(): UseAutoMappingReturn {
       );
       
       setSuggestions(mappingSuggestions);
-      
-      console.log('[AutoMapping] Generated suggestions:', mappingSuggestions);
+
+      logger.debug('Generated suggestions', { component: 'AutoMapping', metadata: { mappingSuggestions } });
     } catch (err) {
       console.error('[AutoMapping] Failed to generate suggestions:', err);
       setError(err instanceof Error ? err.message : 'Failed to generate suggestions');
@@ -78,7 +80,7 @@ export function useAutoMapping(): UseAutoMappingReturn {
       return nodes.map(node => {
         if (node.id === nodeId) {
           const updatedNode = AutoMappingService.applySuggestion(node, suggestion);
-          console.log('[AutoMapping] Applied suggestion:', suggestion);
+          logger.debug('Applied suggestion', { component: 'AutoMapping', metadata: { suggestion } });
           return updatedNode;
         }
         return node;
@@ -98,7 +100,7 @@ export function useAutoMapping(): UseAutoMappingReturn {
       return nodes.map(node => {
         if (node.id === nodeId) {
           const updatedNode = AutoMappingService.applyAutoSuggestions(node, suggestions);
-          console.log('[AutoMapping] Applied all auto-suggestions');
+          logger.debug('Applied all auto-suggestions', { component: 'AutoMapping' });
           return updatedNode;
         }
         return node;

--- a/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
@@ -15,6 +15,8 @@ import styled from 'styled-components';
 import { Node } from '@xyflow/react';
 import { X, Smartphone, Monitor, Tablet, RefreshCw, Eye, TestTube2, Eraser, AlertCircle } from 'lucide-react';
 
+import { logger } from '@/utils/logger';
+
 // ============================================================================
 // TypeScript Interfaces
 // ============================================================================
@@ -451,7 +453,7 @@ export const PreviewPanel: React.FC<PreviewPanelProps> = ({
       testData[field.id] = generateTestDataForField(field);
     });
     setFormData(testData);
-    console.log('[PreviewPanel] Test data generated:', testData);
+    logger.debug('Test data generated', { component: 'PreviewPanel', metadata: { testData } });
   }, [formFields, generateTestDataForField]);
   
   /**
@@ -461,7 +463,7 @@ export const PreviewPanel: React.FC<PreviewPanelProps> = ({
     setFormData({});
     setValidationErrors({});
     setTouched({});
-    console.log('[PreviewPanel] Form data cleared');
+    logger.debug('Form data cleared', { component: 'PreviewPanel' });
   }, []);
   
   /**
@@ -546,9 +548,12 @@ export const PreviewPanel: React.FC<PreviewPanelProps> = ({
    */
   useEffect(() => {
     if (isVisible && nodes.length > 0) {
-      console.log('[PreviewPanel] Auto-update: nodes changed', {
-        nodeCount: nodes.length,
-        formNodes: nodes.filter(n => n.type === 'formStep' || n.type === 'formField').length,
+      logger.debug('Auto-update: nodes changed', {
+        component: 'PreviewPanel',
+        metadata: {
+          nodeCount: nodes.length,
+          formNodes: nodes.filter((n) => n.type === 'formStep' || n.type === 'formField').length,
+        },
       });
     }
   }, [nodes, isVisible]);

--- a/frontend/src/components/FlowEditor/utils/nodeSorting.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeSorting.ts
@@ -10,6 +10,8 @@
 
 import { Node } from '@xyflow/react';
 
+import { logger } from '@/utils/logger';
+
 /**
  * Sort nodes topologically to ensure parents appear before children.
  * 
@@ -147,7 +149,7 @@ function verifyNodeOrdering(nodes: Node[]): boolean {
   if (hasOrderingError) {
     console.error('[Node Sort] ❌ Sorting failed - parent-child ordering violated');
   } else {
-    console.log(`[Node Sort] ✅ Successfully sorted ${nodes.length} nodes`);
+    logger.debug(`✅ Successfully sorted ${nodes.length} nodes`, { component: 'NodeSorting' });
   }
 
   return !hasOrderingError;


### PR DESCRIPTION
## Summary
- Replace FlowEditor `console.log` calls with `logger.debug(...)` (dev-gated)
- Reduces lint warning noise and avoids production console spam

## Files
- Config schema registry / field renderers
- Preview panel / FormProcess modal
- Auto-mapping hook / container context
- Node sorting / config panel shadow state

## Testing
- `npm -C frontend run verify-standards`

## Notes
- No behavior changes; logging only.
