### PR TITLE
Frontend: remove console.log from Sentry init

### DIFF
--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -12,6 +12,8 @@
  */
 
 import * as Sentry from '@sentry/react';
+
+import { logger } from '@/utils/logger';
 import { useEffect } from 'react';
 import {
   createRoutesFromChildren,
@@ -166,7 +168,10 @@ export const initSentry = (config?: SentryConfig): void => {
     debug: environment === 'development',
   });
   
-  console.log(`[Sentry] Initialized for ${environment} (release: ${release})`);
+  logger.debug('Initialized', {
+    component: 'Sentry',
+    metadata: { environment, release },
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary
- Replace Sentry init `console.log` with centralized `logger.debug` (dev-gated)

## Testing
- `npm -C frontend run verify-standards`
