### PR TITLE
FlowEditor: fix HelpModal hook safety

### DIFF
--- a/frontend/src/components/FlowEditor/HelpModal.tsx
+++ b/frontend/src/components/FlowEditor/HelpModal.tsx
@@ -261,26 +261,32 @@ const Footer = styled.div`
 // ============================================================================
 
 export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
-  if (!isOpen) return null;
+  const handleOverlayClick = React.useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
 
-  const handleOverlayClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      onClose();
-    }
-  };
+  const handleKeyDown = React.useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose]
+  );
 
   React.useEffect(() => {
-    if (isOpen) {
-      document.addEventListener('keydown', handleKeyDown as any);
-      return () => document.removeEventListener('keydown', handleKeyDown as any);
-    }
-  }, [isOpen]);
+    if (!isOpen) return;
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown, isOpen]);
+
+  if (!isOpen) return null;
 
   return (
     <Overlay onClick={handleOverlayClick}>

--- a/frontend/src/components/FlowEditor/__tests__/HelpModal.test.tsx
+++ b/frontend/src/components/FlowEditor/__tests__/HelpModal.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { HelpModal } from '../HelpModal';
+
+describe('HelpModal', () => {
+  it('does not render when closed', () => {
+    render(<HelpModal isOpen={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape when open', () => {
+    const onClose = vi.fn();
+    render(<HelpModal isOpen={true} onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on overlay click but not on modal click', () => {
+    const onClose = vi.fn();
+    render(<HelpModal isOpen={true} onClose={onClose} />);
+
+    const dialog = screen.getByRole('dialog');
+    const overlay = dialog.parentElement;
+    expect(overlay).toBeTruthy();
+
+    fireEvent.click(dialog);
+    expect(onClose).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(overlay as Element);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What
- Fix HelpModal to follow React hook rules (no conditional hook calls)
- Use typed keydown listener without `as any` casts
- Add regression tests for Escape + overlay click behavior

## Why
Prevents subtle hook-order bugs and makes the modal event wiring safer + test-covered.

## Testing
- `cd frontend && npx vitest run src/components/FlowEditor/__tests__/HelpModal.test.tsx`
- `npm -C frontend run verify-standards`
