### PR TITLE
Admin Studio: fix ChoiceListEditor keyboard save

### DIFF
--- a/frontend/src/apps/admin-studio/components/ChoiceListEditor.test.tsx
+++ b/frontend/src/apps/admin-studio/components/ChoiceListEditor.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SystemChoiceList } from '../../../services/configService';
+
+const mockApiClient = {
+  post: vi.fn(() => Promise.resolve({ data: {} })),
+  patch: vi.fn(() => Promise.resolve({ data: {} })),
+};
+
+const mockConfigService = {
+  getChoiceLists: vi.fn<[], Promise<SystemChoiceList[]>>(),
+  getChoiceList: vi.fn<[string], Promise<SystemChoiceList>>(),
+  clearCache: vi.fn(),
+};
+
+vi.mock('../../../services/apiService', () => ({
+  apiClient: mockApiClient,
+}));
+
+vi.mock('../../../services/configService', () => ({
+  configService: mockConfigService,
+}));
+
+describe('ChoiceListEditor (admin-studio)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Ctrl+S saves the latest edited value (no stale closure in keyboard shortcut handler)', async () => {
+    const list: SystemChoiceList = {
+      id: 1,
+      slug: 'test-list',
+      name: 'Test List',
+      description: 'desc',
+      is_extensible: false,
+      is_reorderable: false,
+      items: [
+        {
+          id: 10,
+          choice_list: 1,
+          value: 'foo',
+          label: 'Foo',
+          description: '',
+          is_system: false,
+          is_active: true,
+          sort_order: 0,
+          metadata: {},
+        },
+      ],
+      created_at: '2020-01-01T00:00:00Z',
+      updated_at: '2020-01-01T00:00:00Z',
+    };
+
+    mockConfigService.getChoiceLists.mockResolvedValue([list]);
+    mockConfigService.getChoiceList.mockResolvedValue(list);
+
+    const { default: ChoiceListEditor } = await import('./ChoiceListEditor');
+
+    render(<ChoiceListEditor listSlug={list.slug} />);
+
+    const valueInput = await screen.findByDisplayValue('foo');
+
+    fireEvent.change(valueInput, { target: { value: 'bar1' } });
+    await screen.findByDisplayValue('bar1');
+
+    // Second edit while `hasChanges` is already true.
+    fireEvent.change(valueInput, { target: { value: 'bar2' } });
+    await screen.findByDisplayValue('bar2');
+
+    fireEvent.keyDown(window, { key: 's', ctrlKey: true });
+
+    await waitFor(() => {
+      expect(mockApiClient.patch).toHaveBeenCalled();
+    });
+
+    const lastCall = mockApiClient.patch.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe('/system/choice-items/10/');
+    expect(lastCall?.[1]).toMatchObject({ value: 'bar2' });
+  });
+});

--- a/frontend/src/apps/admin-studio/components/ChoiceListEditor.tsx
+++ b/frontend/src/apps/admin-studio/components/ChoiceListEditor.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   configService,
-  SystemChoiceList,
+  type SystemChoiceList,
 } from '../../../services/configService';
 import { apiClient } from '../../../services/apiService';
 import { confirmDialog } from '@/utils/uiDialogs';
@@ -48,6 +48,11 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [hasChanges, setHasChanges] = useState(false);
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  // Avoid stale closures in global keyboard listeners.
+  // (The keyboard shortcut effect intentionally does not depend on `items`.)
+  const handleSaveRef = useRef<(() => Promise<void>) | null>(null);
+  const handleAddItemRef = useRef<(() => void) | null>(null);
 
   // Load choice lists on mount
   const loadChoiceLists = useCallback(async () => {
@@ -117,14 +122,14 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
         if (selectedList && hasChanges && !saving) {
-          handleSave();
+          void handleSaveRef.current?.();
         }
       }
       // Ctrl/Cmd + N: Add new item
       else if ((e.ctrlKey || e.metaKey) && e.key === 'n') {
         e.preventDefault();
         if (selectedList) {
-          handleAddItem();
+          handleAddItemRef.current?.();
         }
       }
       // Escape: Close editor or deselect
@@ -167,16 +172,21 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
   };
 
   const handleAddItem = () => {
-    const newItem: EditingItem = {
-      value: '',
-      label: '',
-      is_active: true,
-      sort_order: items.length,
-      is_new: true,
-    };
-    setItems([...items, newItem]);
+    setItems((prevItems) => {
+      const newItem: EditingItem = {
+        value: '',
+        label: '',
+        is_active: true,
+        sort_order: prevItems.length,
+        is_new: true,
+      };
+      return [...prevItems, newItem];
+    });
     setHasChanges(true);
   };
+
+  // Keep ref pointing at the latest implementation for keyboard shortcuts.
+  handleAddItemRef.current = handleAddItem;
 
   const handleItemChange = (index: number, field: keyof EditingItem, value: string | boolean | number) => {
     const newItems = [...items];
@@ -287,7 +297,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
       // Clear cache and reload
       configService.clearCache();
       await loadItems(selectedList.slug);
-      
+
       setSuccessMessage('Changes saved successfully!');
       setTimeout(() => setSuccessMessage(null), 3000);
       setHasChanges(false);
@@ -299,6 +309,9 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
       setSaving(false);
     }
   };
+
+  // Keep ref pointing at the latest implementation for keyboard shortcuts.
+  handleSaveRef.current = handleSave;
 
   const handleExportJson = () => {
     if (!selectedList) return;
@@ -354,7 +367,7 @@ export const ChoiceListEditor: React.FC<ChoiceListEditorProps> = ({
         setHasChanges(true);
         setSuccessMessage(`Imported ${newItems.length} items`);
         setTimeout(() => setSuccessMessage(null), 3000);
-      } catch (err) {
+      } catch {
         setError('Failed to parse JSON file');
       }
     };


### PR DESCRIPTION
## What
- Fix stale-closure bug in global keyboard shortcuts (Ctrl+S / Ctrl+N) by using refs to the latest handlers
- Add a regression unit test ensuring Ctrl+S saves the latest edited value

## Why
Prevents saving an outdated snapshot of items when the editor is already in a dirty state. Also removes the React Hook warning root cause.

## Testing
- `cd frontend && npx vitest run src/apps/admin-studio/components/ChoiceListEditor.test.tsx`
- `npm -C frontend run lint`
