### PR TITLE
Frontend: replace console.log noise with logger

### DIFF
--- a/frontend/src/components/Navigation/CommandPalette.tsx
+++ b/frontend/src/components/Navigation/CommandPalette.tsx
@@ -19,6 +19,7 @@ import { apiClient } from '../../services/apiService';
 import { useNavigate } from 'react-router-dom';
 import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
 import { EntityDetailModal } from '../Shared/EntityDetailModal';
+import { logger } from '@/utils/logger';
 
 // ============================================================================
 // TypeScript Interfaces
@@ -530,7 +531,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
       const response = await apiClient.get('search/recent/', { params: { limit: 5 } });
       setRecentItems(response.data.items || []);
     } catch (err) {
-      console.error('Failed to fetch recent items:', err);
+      logger.error('Failed to fetch recent items:', err);
     }
   };
 
@@ -556,7 +557,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
       setIsLoading(true);
       try {
         // Use ranked search API
-        console.log('[CommandPalette] API Request:', {
+        logger.debug('[CommandPalette] API Request:', {
           url: 'system/search/ranked/',
           params: { q: query, date_range: dateRange, limit: 8 },
         });
@@ -569,12 +570,11 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
           }
         });
         
-        console.log('[CommandPalette] API Response:', {
+        logger.debug('[CommandPalette] API Response:', {
           query: response.data.query,
           total: response.data.total,
           counts: response.data.counts,
           resultsCount: response.data.results?.length || 0,
-          results: response.data.results,
         });
         
         const fetchedResults = response.data.results;
@@ -586,14 +586,14 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
         setTotalCount(response.data.total || fetchedResults.length);
         setSelectedIndex(0);
         
-        console.log('[CommandPalette] Ranked search completed:', {
+        logger.debug('[CommandPalette] Ranked search completed:', {
           query,
           dateRange,
           resultsCount: fetchedResults.length,
           topScore: fetchedResults[0]?.score,
         });
       } catch (err) {
-        console.error('[CommandPalette] Search failed:', err);
+        logger.error('[CommandPalette] Search failed:', err);
         setResults([]);
         setTotalCount(0);
       } finally {
@@ -860,7 +860,10 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
           entityId={selectedEntity.id}
           onExpandEntity={(entity) => {
             // Keep modal open but load relational data for expanded view
-            console.log('[CommandPalette] Expanding entity:', entity);
+            logger.debug('[CommandPalette] Expanding entity:', {
+              id: entity?.id,
+              type: entity?.type,
+            });
             setSelectedEntity(null); // Close detail modal
             // Trigger search with entity context for mind-map view
             handleSelect({

--- a/frontend/src/hooks/useWorkFormPermissions.ts
+++ b/frontend/src/hooks/useWorkFormPermissions.ts
@@ -15,6 +15,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../services/apiService';
+import { logger } from '@/utils/logger';
 
 export interface WorkFormPermissions {
   can_create: boolean;
@@ -37,29 +38,29 @@ export function useWorkFormPermissions() {
   const query = useQuery<WorkFormPermissions>({
     queryKey: ['workforms', 'permissions'],
     queryFn: async () => {
-      console.log('[useWorkFormPermissions] Fetching permissions...');
+      logger.debug('[useWorkFormPermissions] Fetching permissions...');
       try {
         const response = await apiClient.get('/workflows/permissions/');
-        console.log('[useWorkFormPermissions] SUCCESS - Response:', response.data);
+        logger.debug('[useWorkFormPermissions] SUCCESS - Response:', response.data);
         return response.data;
       } catch (error: any) {
-        console.error('[useWorkFormPermissions] FAILED - Error:', {
+        logger.error('[useWorkFormPermissions] FAILED - Error:', {
           status: error.response?.status,
           data: error.response?.data,
           message: error.message,
-          error
+          error,
         });
-        
+
         // If 401, let the axios interceptor handle it (token refresh or redirect to login)
         // Don't catch 401 errors - they need to propagate for proper auth handling
         if (error.response?.status === 401) {
-          console.warn('[useWorkFormPermissions] 401 Unauthorized - token expired or invalid');
+          logger.warn('[useWorkFormPermissions] 401 Unauthorized - token expired or invalid');
           throw error; // Let axios interceptor handle token refresh/redirect
         }
-        
+
         // For other errors (network, 500, etc), return default permissions
         const defaults = getDefaultPermissions();
-        console.warn('[useWorkFormPermissions] Returning default permissions:', defaults);
+        logger.warn('[useWorkFormPermissions] Returning default permissions:', defaults);
         return defaults;
       }
     },
@@ -76,11 +77,11 @@ export function useWorkFormPermissions() {
     placeholderData: getDefaultPermissions(),
   });
 
-  console.log('[useWorkFormPermissions] Query state:', {
+  logger.debug('[useWorkFormPermissions] Query state:', {
     isLoading: query.isLoading,
     isError: query.isError,
     data: query.data,
-    error: query.error
+    error: query.error,
   });
 
   return {

--- a/frontend/src/services/quickActionsService.ts
+++ b/frontend/src/services/quickActionsService.ts
@@ -6,6 +6,7 @@
  */
 import axios, { CancelTokenSource } from 'axios';
 import { apiClient } from './apiService';
+import { logger } from '@/utils/logger';
 
 // Cancel token manager for request cancellation
 class CancelTokenManager {
@@ -238,27 +239,27 @@ export const formSubmissionService = {
     const source = cancelTokenManager.create(cancelKey);
     
     try {
-      console.log('[autoSave] Saving:', { submissionId, stepId, fieldKey, valueType: typeof value });
+      logger.debug('[autoSave] Saving:', { submissionId, stepId, fieldKey, valueType: typeof value });
       const response = await apiClient.post(
         `/workflows/form-submissions/${submissionId}/auto_save/`, 
         { step_id: stepId, field_key: fieldKey, value },
         { cancelToken: source.token }
       );
       cancelTokenManager.remove(cancelKey);
-      console.log('[autoSave] Success:', response.data);
+      logger.debug('[autoSave] Success:', response.data);
       return response.data;
     } catch (err: any) {
       cancelTokenManager.remove(cancelKey);
       
       if (axios.isCancel(err)) {
-        console.log('[autoSave] Cancelled:', { submissionId, stepId, fieldKey });
+        logger.debug('[autoSave] Cancelled:', { submissionId, stepId, fieldKey });
         // Mark error with __CANCEL__ for easier detection
         const cancelError = new Error('Request cancelled');
         (cancelError as any).__CANCEL__ = true;
         throw cancelError;
       }
       
-      console.error('[autoSave] Error:', {
+      logger.error('[autoSave] Error:', {
         submissionId,
         stepId,
         fieldKey,


### PR DESCRIPTION
## What
- Replace runtime `console.log` noise with centralized `logger.debug()` in:
  - `useWorkFormPermissions`
  - `quickActionsService.autoSave`
  - `CommandPalette`
- Route errors through `logger.error()` for consistent prod handling

## Why
Reduces noisy production consoles while keeping useful debug output available in development.

## Testing
- `npm -C frontend run verify-standards`
