### PR TITLE
Frontend: remove remaining console.log calls (batch 2)

### DIFF
--- a/frontend/src/apps/admin-studio/pages/Editor.tsx
+++ b/frontend/src/apps/admin-studio/pages/Editor.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import SchemaEditor from '../components/SchemaEditorSimple';
 import { adminClient } from '@/services/apiService';
 import { confirmDialog, showAlert } from '@/utils/uiDialogs';
+import { logger } from '@/utils/logger';
 // Use UnifiedFlowEditor instead of WorkflowCanvas
 import { UnifiedFlowEditor } from '../../../components/FlowEditor';
 import { VersionHistory } from '../components/VersionHistory';
@@ -259,7 +260,7 @@ const Editor: React.FC<EditorProps> = () => {
             readOnly={false}
             editorMode="visual"
             onSave={(nodes, edges) => {
-              console.log('Workflow saved:', { nodes, edges });
+              logger.debug('Workflow saved:', { nodes, edges });
               // TODO: Integrate with backend persistence
             }}
           />

--- a/frontend/src/hooks/useTokenRefresh.ts
+++ b/frontend/src/hooks/useTokenRefresh.ts
@@ -30,6 +30,7 @@ import {
   needsRefresh,
   isUsingJwt 
 } from '../services/jwtService';
+import { logger } from '@/utils/logger';
 
 interface TokenRefreshOptions {
   /** Refresh token this many ms before expiry (default: 5 minutes) */
@@ -73,7 +74,7 @@ export function useTokenRefresh(options: TokenRefreshOptions = {}) {
   
   const log = useCallback((...args: any[]) => {
     if (opts.debug) {
-      console.log('[TokenRefresh]', ...args);
+      logger.debug('[TokenRefresh]', args);
     }
   }, [opts.debug]);
 
@@ -132,7 +133,7 @@ export function useTokenRefresh(options: TokenRefreshOptions = {}) {
         opts.onExpired();
       }
     } catch (error) {
-      console.error('[TokenRefresh] Refresh error:', error);
+      logger.error('[TokenRefresh] Refresh error:', error);
       opts.onExpired();
     }
   }, [log, opts, scheduleRefresh]);


### PR DESCRIPTION
## What
- Replace remaining `console.log` usage in:
  - `useTokenRefresh` debug logging
  - Admin Studio Editor canvas `onSave` handler

## Why
Keeps production consoles clean while preserving useful debug output via the centralized logger.

## Testing
- `npm -C frontend run verify-standards`
