### PR TITLE
Backend: harden tenant form merge/split RBAC

### DIFF
--- a/backend/apps/system/tests/test_workforms_rbac.py
+++ b/backend/apps/system/tests/test_workforms_rbac.py
@@ -7,7 +7,7 @@ from django.test.utils import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from apps.system.models import TenantWorkForm
+from apps.system.models import TenantForm, TenantWorkForm
 from apps.tenants.models import Tenant, TenantDomain, TenantUser
 
 
@@ -43,6 +43,40 @@ class WorkFormsRBACSystemViewSetsTests(APITestCase):
             description='',
             status='draft',
             workflow_definition={'nodes': [], 'edges': []},
+            created_by=self.editor,
+            updated_by=self.editor,
+        )
+
+        self.form_a = TenantForm.objects.create(
+            tenant=self.tenant,
+            name='Form A',
+            description='',
+            type='single_step',
+            form_definition={'entity_type': 'supplier', 'fields': []},
+            created_by=self.editor,
+            updated_by=self.editor,
+        )
+        self.form_b = TenantForm.objects.create(
+            tenant=self.tenant,
+            name='Form B',
+            description='',
+            type='single_step',
+            form_definition={'entity_type': 'supplier', 'fields': []},
+            created_by=self.editor,
+            updated_by=self.editor,
+        )
+        self.multi_form = TenantForm.objects.create(
+            tenant=self.tenant,
+            name='Multi Form',
+            description='',
+            type='multi_step',
+            form_definition={
+                'steps': [
+                    {'name': 'Step 1', 'entity_type': 'supplier', 'fields': []},
+                    {'name': 'Step 2', 'entity_type': 'supplier', 'fields': []},
+                ],
+                'navigation': {'show_progress': True, 'allow_back': True},
+            },
             created_by=self.editor,
             updated_by=self.editor,
         )
@@ -114,3 +148,61 @@ class WorkFormsRBACSystemViewSetsTests(APITestCase):
         )
         # Serializer may perform additional validation; this test only asserts we don't 403.
         self.assertNotEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)
+
+    def test_viewer_cannot_merge_forms(self):
+        self.client.force_login(self.viewer)
+        resp = self.client.post(
+            '/api/v1/tenant-forms/merge/',
+            data={
+                'container_name': 'Merged',
+                'description': '',
+                'source_form_ids': [str(self.form_a.id), str(self.form_b.id)],
+            },
+            format='json',
+            HTTP_HOST=self.domain.domain,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)
+
+    def test_viewer_cannot_split_form(self):
+        self.client.force_login(self.viewer)
+        resp = self.client.post(
+            '/api/v1/tenant-forms/split/',
+            data={
+                'source_form_id': str(self.multi_form.id),
+                'step_index': 0,
+                'new_form_name': 'Split Step',
+                'new_form_description': '',
+            },
+            format='json',
+            HTTP_HOST=self.domain.domain,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)
+
+    def test_editor_can_merge_forms(self):
+        self.client.force_login(self.editor)
+        resp = self.client.post(
+            '/api/v1/tenant-forms/merge/',
+            data={
+                'container_name': 'Merged',
+                'description': '',
+                'source_form_ids': [str(self.form_a.id), str(self.form_b.id)],
+            },
+            format='json',
+            HTTP_HOST=self.domain.domain,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.content)
+
+    def test_editor_can_split_form(self):
+        self.client.force_login(self.editor)
+        resp = self.client.post(
+            '/api/v1/tenant-forms/split/',
+            data={
+                'source_form_id': str(self.multi_form.id),
+                'step_index': 0,
+                'new_form_name': 'Split Step',
+                'new_form_description': '',
+            },
+            format='json',
+            HTTP_HOST=self.domain.domain,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.content)

--- a/backend/apps/system/workform_views.py
+++ b/backend/apps/system/workform_views.py
@@ -708,18 +708,17 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
 
 
 @api_view(['POST'])
-@permission_classes([IsAuthenticated])
+@permission_classes([IsAuthenticated, IsTenantEditorForTenantContext])
 def merge_forms(request):
-    """
-    Merge multiple single-step forms into one multi-step form.
-    
+    """Merge multiple single-step forms into one multi-step form.
+
     POST /api/v1/tenant-forms/merge/
     Body: {
         "container_name": "Multi-Step Form",
         "description": "Optional description",
         "source_form_ids": ["uuid-1", "uuid-2", "uuid-3"]
     }
-    
+
     Response: {
         "id": "new-multi-step-form-uuid",
         "name": "Multi-Step Form",
@@ -728,20 +727,28 @@ def merge_forms(request):
         "deleted_form_ids": ["uuid-1", "uuid-2", "uuid-3"]
     }
     """
+    tenant = _get_request_tenant(request)
+    if not tenant:
+        return Response({"error": "Tenant context required"}, status=status.HTTP_400_BAD_REQUEST)
+
     serializer = FormMergeSerializer(data=request.data, context={'request': request})
-    
+
     if not serializer.is_valid():
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
+
     validated_data = serializer.validated_data
-    
+
     with transaction.atomic():
+        from apps.tenants.rls import set_current_tenant
+
+        set_current_tenant(str(tenant.id))
+
         # Fetch source forms
         source_forms = TenantForm.objects.filter(
-            tenant=request.tenant,
+            tenant=tenant,
             id__in=validated_data['source_form_ids']
         ).order_by('created_at')
-        
+
         # Build multi-step form definition
         steps = []
         for form in source_forms:
@@ -751,7 +758,7 @@ def merge_forms(request):
                 "fields": form.form_definition.get('fields', [])
             }
             steps.append(step_data)
-        
+
         multi_step_definition = {
             "steps": steps,
             "navigation": {
@@ -759,16 +766,16 @@ def merge_forms(request):
                 "allow_back": True
             }
         }
-        
+
         # Create new multi-step form
         merged_form = TenantForm.objects.create(
-            tenant=request.tenant,
+            tenant=tenant,
             name=validated_data['container_name'],
             description=validated_data.get('description', ''),
             type=FormTypeChoices.MULTI_STEP,
             form_definition=multi_step_definition,
             created_by=request.user,
-            updated_by=request.user
+            updated_by=request.user,
         )
         
         # Delete source forms
@@ -786,11 +793,10 @@ def merge_forms(request):
 
 
 @api_view(['POST'])
-@permission_classes([IsAuthenticated])
+@permission_classes([IsAuthenticated, IsTenantEditorForTenantContext])
 def split_form(request):
-    """
-    Split one step out of a multi-step form into a new single-step form.
-    
+    """Split one step out of a multi-step form into a new single-step form.
+
     POST /api/v1/tenant-forms/split/
     Body: {
         "source_form_id": "uuid-123",
@@ -798,7 +804,7 @@ def split_form(request):
         "new_form_name": "Step 2",
         "new_form_description": "Optional"
     }
-    
+
     Response: {
         "source_form_id": "uuid-123",
         "source_remaining_steps": 2,
@@ -806,17 +812,25 @@ def split_form(request):
         "created_form_name": "Step 2"
     }
     """
+    tenant = _get_request_tenant(request)
+    if not tenant:
+        return Response({"error": "Tenant context required"}, status=status.HTTP_400_BAD_REQUEST)
+
     serializer = FormSplitSerializer(data=request.data, context={'request': request})
-    
+
     if not serializer.is_valid():
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
+
     validated_data = serializer.validated_data
-    
+
     with transaction.atomic():
+        from apps.tenants.rls import set_current_tenant
+
+        set_current_tenant(str(tenant.id))
+
         # Fetch source form
         source_form = TenantForm.objects.get(
-            tenant=request.tenant,
+            tenant=tenant,
             id=validated_data['source_form_id']
         )
         


### PR DESCRIPTION
## What
- Tighten RBAC on tenant-form mutation endpoints:
  - `POST /api/v1/tenant-forms/merge/`
  - `POST /api/v1/tenant-forms/split/`
- Resolve tenant via `_get_request_tenant()` (fail closed without tenant context)
- Set RLS session vars (`set_current_tenant`) for transactional writes
- Add regression tests: viewer cannot merge/split; editor can

## Why
These are mutating endpoints and must be editor-only + tenant-safe in shared-schema/RLS mode, including DRF auth flows where middleware may not set `request.tenant` early.

## Testing
- `cd backend && python manage.py test apps.system.tests.test_workforms_rbac --verbosity=2`
