### PR TITLE
Fix WorkForms QuickActions/test 500s

### DIFF
--- a/backend/apps/system/models/tenant_workform.py
+++ b/backend/apps/system/models/tenant_workform.py
@@ -327,22 +327,45 @@ class TenantWorkForm(models.Model):
         }
     
     def get_node_count(self):
-        """Get total number of nodes in this workflow."""
-        return len(self.workflow_definition.get('nodes', []))
+        """Get total number of nodes in this workflow.
+
+        Defensive: historical/legacy payloads may persist non-dict JSON values.
+        """
+        wf = self.workflow_definition
+        if not isinstance(wf, dict):
+            return 0
+        nodes = wf.get('nodes', [])
+        return len(nodes) if isinstance(nodes, list) else 0
     
     def get_edge_count(self):
-        """Get total number of edges in this workflow."""
-        return len(self.workflow_definition.get('edges', []))
+        """Get total number of edges in this workflow.
+
+        Defensive: historical/legacy payloads may persist non-dict JSON values.
+        """
+        wf = self.workflow_definition
+        if not isinstance(wf, dict):
+            return 0
+        edges = wf.get('edges', [])
+        return len(edges) if isinstance(edges, list) else 0
     
     def get_node_types_summary(self):
-        """
-        Get summary of node types used in this workflow.
-        
+        """Get summary of node types used in this workflow.
+
         Returns:
             dict: {"formStep": 3, "actionEmail": 1, "conditionIf": 2, ...}
         """
-        summary = {}
-        for node in self.workflow_definition.get('nodes', []):
+        wf = self.workflow_definition
+        if not isinstance(wf, dict):
+            return {}
+
+        nodes = wf.get('nodes', [])
+        if not isinstance(nodes, list):
+            return {}
+
+        summary: dict[str, int] = {}
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
             node_type = node.get('type', 'unknown')
             summary[node_type] = summary.get(node_type, 0) + 1
         return summary

--- a/backend/apps/system/workform_views.py
+++ b/backend/apps/system/workform_views.py
@@ -7,6 +7,8 @@ CRUD operations, merge/split, clone, and validation.
 Phase 1.4-1.7 of WF-ENH-2026-Q1
 Created: 2026-02-06
 """
+import logging
+
 from django.db import transaction, models
 from django.utils import timezone
 from rest_framework import viewsets, status
@@ -26,6 +28,9 @@ from apps.system.workform_serializers import (
     FormSplitSerializer,
     WorkFormCloneSerializer,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_request_tenant(request):
@@ -451,6 +456,10 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=['post'])
     def execute(self, request, pk=None):
         """Execute a TenantWorkForm and create a persisted execution record."""
+        tenant = _get_request_tenant(request)
+        if not tenant:
+            return Response({"error": "Tenant context required"}, status=status.HTTP_400_BAD_REQUEST)
+
         workform = self.get_object()
         if not self._can_execute_workform(workform):
             return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
@@ -458,20 +467,35 @@ class TenantWorkFormViewSet(viewsets.ModelViewSet):
         initial_data = request.data.get('initial_data') if isinstance(request.data, dict) else None
         initial_data = initial_data if isinstance(initial_data, dict) else {}
 
+        from apps.tenants.rls import set_current_tenant
         from tenant_apps.workflows.models import TenantWorkFormExecution, TenantWorkFormExecutionStatus
 
-        execution = TenantWorkFormExecution.objects.create(
-            tenant=request.tenant,
-            workform=workform,
-            status=TenantWorkFormExecutionStatus.IN_PROGRESS,
-            initial_data=initial_data,
-            started_by=request.user,
-            started_at=timezone.now(),
-        )
+        # Ensure RLS session vars are asserted for this connection before writing.
+        rls = set_current_tenant(str(tenant.id))
+        if not rls.ok:
+            logger.warning('RLS: failed to set session vars for tenant=%s: %s', tenant.id, rls.error)
+            return Response({"error": "Tenant context unavailable"}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
-        from apps.system.tasks import execute_workform_execution
+        try:
+            with transaction.atomic():
+                execution = TenantWorkFormExecution.objects.create(
+                    tenant=tenant,
+                    workform=workform,
+                    status=TenantWorkFormExecutionStatus.IN_PROGRESS,
+                    initial_data=initial_data,
+                    started_by=request.user,
+                    started_at=timezone.now(),
+                )
 
-        execute_workform_execution.delay(execution_id=str(execution.id), tenant_id=str(request.tenant.id))
+                from apps.system.tasks import execute_workform_execution
+
+                execute_workform_execution.delay(execution_id=str(execution.id), tenant_id=str(tenant.id))
+        except Exception as e:
+            logger.exception('Failed to enqueue workform execution: %s', e)
+            return Response(
+                {"error": "Execution service unavailable"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
 
         return Response(
             {

--- a/backend/tenant_apps/workflows/tests/test_available_forms_includes_workforms.py
+++ b/backend/tenant_apps/workflows/tests/test_available_forms_includes_workforms.py
@@ -56,6 +56,16 @@ class AvailableFormsIncludesWorkformsTests(APITestCase):
             updated_by=self.user,
         )
 
+        # Regression: malformed JSON payloads should not 500 available-forms.
+        self.malformed_workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='Malformed WF',
+            status='active',
+            workflow_definition='oops',
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
         self.other_workform = TenantWorkForm.objects.create(
             tenant=self.other_tenant,
             name='Other Tenant WF',
@@ -77,4 +87,8 @@ class AvailableFormsIncludesWorkformsTests(APITestCase):
 
         self.assertIn(('form', str(self.form.id)), seen)
         self.assertIn(('workflow', str(self.workform.id)), seen)
+        self.assertIn(('workflow', str(self.malformed_workform.id)), seen)
         self.assertNotIn(('workflow', str(self.other_workform.id)), seen)
+
+        malformed_row = next(r for r in rows if r.get('id') == str(self.malformed_workform.id))
+        self.assertEqual(malformed_row.get('node_count'), 0)

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -24,6 +24,8 @@ from drf_spectacular.utils import OpenApiTypes, extend_schema
 
 logger = logging.getLogger(__name__)
 
+from apps.tenants.models import Tenant, TenantUser
+
 from .models import (
     FormStatus,
     FormStatusHistory,
@@ -78,8 +80,55 @@ from .services.form_process_persistence import FormProcessPersistenceService
 # =============================================================================
 
 
+def _get_request_tenant(request):
+    """Return resolved tenant, supporting both middleware and DRF-auth flows.
+
+    In normal requests, TenantAware authentication sets request.tenant and asserts
+    RLS session vars. For tests (force_authenticate) and edge cases, we also support
+    late resolution from the X-Tenant-ID header with membership validation.
+    """
+
+    django_request = getattr(request, '_request', None)
+    tenant = getattr(request, 'tenant', None) or getattr(django_request, 'tenant', None)
+    if tenant:
+        return tenant
+
+    tenant_id = None
+    if hasattr(request, 'headers'):
+        tenant_id = request.headers.get('X-Tenant-ID')
+    if not tenant_id and django_request is not None and hasattr(django_request, 'headers'):
+        tenant_id = django_request.headers.get('X-Tenant-ID')
+
+    user = getattr(request, 'user', None) or getattr(django_request, 'user', None)
+    if not tenant_id or not user or not getattr(user, 'is_authenticated', False):
+        return None
+
+    try:
+        tenant = Tenant.objects.get(id=tenant_id, is_active=True)
+    except (Tenant.DoesNotExist, ValueError):
+        return None
+
+    is_global_admin = user.groups.filter(name='Global System Admins').exists()
+    if not (user.is_superuser or is_global_admin):
+        if not TenantUser.objects.filter(user=user, tenant=tenant, is_active=True).exists():
+            return None
+
+    # Cache for later uses during this request lifecycle.
+    try:
+        setattr(request, 'tenant', tenant)
+    except Exception:
+        pass
+    try:
+        if django_request is not None:
+            setattr(django_request, 'tenant', tenant)
+    except Exception:
+        pass
+
+    return tenant
+
+
 def _require_tenant(request):
-    tenant = getattr(request, 'tenant', None)
+    tenant = _get_request_tenant(request)
     if not tenant:
         return None, Response(
             {'error': 'Tenant context is required (X-Tenant-ID header).'},
@@ -2730,7 +2779,7 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
         WorkForms (apps.system.TenantWorkForm) are added in `list()` as a second query
         to avoid cross-model unions.
         """
-        tenant = getattr(self.request, 'tenant', None)
+        tenant = _get_request_tenant(self.request)
         if not tenant:
             return TenantForm.objects.none()
 
@@ -2745,7 +2794,7 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
         """Tenant-scoped WorkForms for Quick Actions."""
         from apps.system.models import TenantWorkForm
 
-        tenant = getattr(request, 'tenant', None)
+        tenant = _get_request_tenant(request)
         if not tenant:
             return TenantWorkForm.objects.none()
 


### PR DESCRIPTION
## What
- Prevent `/api/v1/workflows/available-forms/` from 500ing when any WorkForm has a malformed `workflow_definition` payload.
- Ensure `/api/v1/tenant-workforms/{id}/execute/` asserts tenant + RLS context before writing execution records, and returns a clear 503 if enqueue fails (instead of a 500).
- Add late X-Tenant-ID tenant resolution for `available-forms` to support DRF force_authenticate + token flows.

## Why
Quick Actions and in-editor WorkForm testing were failing due to backend 500s.

## Testing
- `python manage.py test tenant_apps.workflows.tests.test_available_forms_includes_workforms apps.system.tests.test_tenant_workform_execute_permissions --verbosity=2`
