### PR TITLE
Fix tenant assignment in split_form

### DIFF
--- a/backend/apps/system/tests/test_workforms_rbac.py
+++ b/backend/apps/system/tests/test_workforms_rbac.py
@@ -206,3 +206,9 @@ class WorkFormsRBACSystemViewSetsTests(APITestCase):
             HTTP_HOST=self.domain.domain,
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.content)
+
+        created_form_id = resp.json().get('created_form_id')
+        self.assertTrue(created_form_id, resp.content)
+
+        created = TenantForm.objects.get(id=created_form_id)
+        self.assertEqual(created.tenant_id, self.tenant.id)

--- a/backend/apps/system/workform_views.py
+++ b/backend/apps/system/workform_views.py
@@ -877,13 +877,13 @@ def split_form(request):
         }
         
         new_form = TenantForm.objects.create(
-            tenant=request.tenant,
+            tenant=tenant,
             name=validated_data['new_form_name'],
             description=validated_data.get('new_form_description', ''),
             type=FormTypeChoices.SINGLE_STEP,
             form_definition=single_step_definition,
             created_by=request.user,
-            updated_by=request.user
+            updated_by=request.user,
         )
         
         # Update source form (remove the split step)


### PR DESCRIPTION
## What
- Fix `split_form` to create the extracted TenantForm with the resolved tenant (not `request.tenant`).
- Add a regression assertion ensuring the created form belongs to the correct tenant.

## Why
Prevents incorrect tenant assignment in edge request flows and aligns writes with the resolved tenant context.

## Testing
- `python manage.py test apps.system.tests.test_workforms_rbac --verbosity=2`
