### PR TITLE
Guardrail: enforce tenant assignment on create

### DIFF
--- a/backend/apps/tenants/test_viewset_tenant_filter_audit.py
+++ b/backend/apps/tenants/test_viewset_tenant_filter_audit.py
@@ -16,6 +16,7 @@ import importlib
 
 from django.test import SimpleTestCase
 from rest_framework.generics import GenericAPIView
+from rest_framework.mixins import CreateModelMixin
 
 
 TENANT_APP_URL_MODULES = [
@@ -83,5 +84,60 @@ class TenantViewSetTenantFilterAuditTests(SimpleTestCase):
             joined = '\n'.join(offenders)
             raise AssertionError(
                 'Tenant-scoped ViewSets must override get_queryset (or inherit a tenant-filtered base).\n'
+                f'Offenders:\n{joined}'
+            )
+
+    def test_tenant_models_do_not_use_unsafe_default_perform_create(self):
+        """Guardrail: tenant-scoped ViewSets must assign tenant on create.
+
+        For shared-schema multi-tenancy, relying on DRF defaults (create + perform_create)
+        can allow cross-tenant writes if the serializer doesn't inject tenant.
+        """
+
+        offenders: list[str] = []
+
+        for mod_path in TENANT_APP_URL_MODULES:
+            mod = importlib.import_module(mod_path)
+
+            routers = []
+            if getattr(mod, 'router', None) is not None:
+                routers.append(getattr(mod, 'router'))
+            for name in dir(mod):
+                if not name.endswith('router'):
+                    continue
+                try:
+                    r = getattr(mod, name)
+                except Exception:
+                    continue
+                if r is not None and r not in routers and hasattr(r, 'registry'):
+                    routers.append(r)
+
+            for router in routers:
+                for prefix, viewset_cls, _basename in getattr(router, 'registry', []):
+                    queryset = getattr(viewset_cls, 'queryset', None)
+                    model = getattr(queryset, 'model', None) if queryset is not None else None
+                    if model is None:
+                        continue
+
+                    if not any(getattr(f, 'name', None) == 'tenant' for f in model._meta.get_fields()):
+                        continue
+
+                    http_methods = set(getattr(viewset_cls, 'http_method_names', []) or [])
+                    if 'post' not in http_methods:
+                        continue
+
+                    if not issubclass(viewset_cls, CreateModelMixin):
+                        continue
+
+                    if (
+                        viewset_cls.create is CreateModelMixin.create
+                        and viewset_cls.perform_create is CreateModelMixin.perform_create
+                    ):
+                        offenders.append(f'{mod_path}:{viewset_cls.__name__} (prefix={prefix}, model={model.__name__})')
+
+        if offenders:
+            joined = '\n'.join(offenders)
+            raise AssertionError(
+                'Tenant-scoped ViewSets must set tenant during create (override create or perform_create).\n'
                 f'Offenders:\n{joined}'
             )

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -1517,7 +1517,7 @@ class TenantFormEntityViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        tenant = getattr(self.request, "tenant", None)
+        tenant = _get_request_tenant(self.request)
         if not tenant:
             return qs.none()
 
@@ -1531,6 +1531,23 @@ class TenantFormEntityViewSet(viewsets.ModelViewSet):
         return qs.prefetch_related(Prefetch("fields", queryset=TenantFormField.objects.order_by("order"))).order_by(
             "order"
         )
+
+    def create(self, request, *args, **kwargs):
+        tenant, error = _require_tenant(request)
+        if error:
+            return error
+        return super().create(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        tenant = _get_request_tenant(self.request)
+        if not tenant:
+            raise ValidationError({'tenant': 'Tenant context is required (X-Tenant-ID header).'})
+
+        form = serializer.validated_data.get('form')
+        if form is not None and getattr(form, 'tenant_id', None) != tenant.id:
+            raise ValidationError({'form': 'Form must belong to the current tenant.'})
+
+        serializer.save(tenant=tenant)
 
     @action(detail=True, methods=["post"])
     def reorder_fields(self, request, pk=None):
@@ -1555,7 +1572,7 @@ class TenantFormFieldViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        tenant = getattr(self.request, "tenant", None)
+        tenant = _get_request_tenant(self.request)
         if not tenant:
             return qs.none()
 
@@ -1567,7 +1584,25 @@ class TenantFormFieldViewSet(viewsets.ModelViewSet):
             qs = qs.filter(form_entity_id=entity_id)
 
         return qs.order_by("order")
-    
+
+    def create(self, request, *args, **kwargs):
+        tenant, error = _require_tenant(request)
+        if error:
+            return error
+        return super().create(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        tenant = _get_request_tenant(self.request)
+        if not tenant:
+            raise ValidationError({'tenant': 'Tenant context is required (X-Tenant-ID header).'})
+
+        entity = serializer.validated_data.get('form_entity')
+        form = getattr(entity, 'form', None) if entity is not None else None
+        if form is not None and getattr(form, 'tenant_id', None) != tenant.id:
+            raise ValidationError({'form_entity': 'Form entity must belong to the current tenant.'})
+
+        serializer.save(tenant=tenant)
+
     @action(detail=True, methods=['get'], url_path='cascade-options')
     def cascade_options(self, request, pk=None):
         """
@@ -1588,7 +1623,7 @@ class TenantFormFieldViewSet(viewsets.ModelViewSet):
         """
         from tenant_apps.workflows.services.cascading import CascadingFieldService
 
-        tenant = getattr(request, 'tenant', None)
+        tenant = _get_request_tenant(request)
         if not tenant:
             return Response(
                 {"error": "Tenant context is required (X-Tenant-ID header)"},
@@ -1635,7 +1670,7 @@ class TenantFormRuleViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        tenant = getattr(self.request, "tenant", None)
+        tenant = _get_request_tenant(self.request)
         if not tenant:
             return qs.none()
 
@@ -1647,6 +1682,23 @@ class TenantFormRuleViewSet(viewsets.ModelViewSet):
             qs = qs.filter(form_id=form_id)
 
         return qs.order_by("order")
+
+    def create(self, request, *args, **kwargs):
+        tenant, error = _require_tenant(request)
+        if error:
+            return error
+        return super().create(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        tenant = _get_request_tenant(self.request)
+        if not tenant:
+            raise ValidationError({'tenant': 'Tenant context is required (X-Tenant-ID header).'})
+
+        form = serializer.validated_data.get('form')
+        if form is not None and getattr(form, 'tenant_id', None) != tenant.id:
+            raise ValidationError({'form': 'Form must belong to the current tenant.'})
+
+        serializer.save(tenant=tenant)
 
 
 # =============================================================================
@@ -2024,7 +2076,7 @@ class TenantWorkflowConditionViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        tenant = getattr(self.request, "tenant", None)
+        tenant = _get_request_tenant(self.request)
         if not tenant:
             return qs.none()
 
@@ -2035,6 +2087,23 @@ class TenantWorkflowConditionViewSet(viewsets.ModelViewSet):
             qs = qs.filter(workflow_id=workflow_id)
 
         return qs.order_by("order")
+
+    def create(self, request, *args, **kwargs):
+        tenant, error = _require_tenant(request)
+        if error:
+            return error
+        return super().create(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        tenant = _get_request_tenant(self.request)
+        if not tenant:
+            raise ValidationError({'tenant': 'Tenant context is required (X-Tenant-ID header).'})
+
+        workflow = serializer.validated_data.get('workflow')
+        if workflow is not None and getattr(workflow, 'tenant_id', None) != tenant.id:
+            raise ValidationError({'workflow': 'Workflow must belong to the current tenant.'})
+
+        serializer.save(tenant=tenant)
 
 
 class TenantWorkflowActionViewSet(viewsets.ModelViewSet):
@@ -2048,7 +2117,7 @@ class TenantWorkflowActionViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        tenant = getattr(self.request, "tenant", None)
+        tenant = _get_request_tenant(self.request)
         if not tenant:
             return qs.none()
 
@@ -2059,6 +2128,23 @@ class TenantWorkflowActionViewSet(viewsets.ModelViewSet):
             qs = qs.filter(workflow_id=workflow_id)
 
         return qs.order_by("order")
+
+    def create(self, request, *args, **kwargs):
+        tenant, error = _require_tenant(request)
+        if error:
+            return error
+        return super().create(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        tenant = _get_request_tenant(self.request)
+        if not tenant:
+            raise ValidationError({'tenant': 'Tenant context is required (X-Tenant-ID header).'})
+
+        workflow = serializer.validated_data.get('workflow')
+        if workflow is not None and getattr(workflow, 'tenant_id', None) != tenant.id:
+            raise ValidationError({'workflow': 'Workflow must belong to the current tenant.'})
+
+        serializer.save(tenant=tenant)
 
 
 class WorkflowExecutionLogViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
## What\n- Add CI guardrail: tenant-scoped ViewSets must **override create/perform_create** (no DRF default tenant-less writes).\n- Fix offenders in tenant_apps.workflows (FormEntity/FormField/FormRule/WorkflowCondition/WorkflowAction) by:\n  - resolving tenant via _get_request_tenant\n  - requiring tenant context on create\n  - validating parent objects belong to the same tenant\n\n## Tests\n- python backend/manage.py test apps.tenants.test_viewset_tenant_filter_audit tenant_apps.workflows.tests.test_available_forms_includes_workforms --verbosity=2\n