### PR TITLE
Workflows: require tenant context for QuickActions PUT

### DIFF
--- a/backend/tenant_apps/workflows/tests/test_quick_actions_put.py
+++ b/backend/tenant_apps/workflows/tests/test_quick_actions_put.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.system.models import TenantWorkForm
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.workflows.models import FormStatus, TenantForm
+
+
+User = get_user_model()
+
+
+class QuickActionsPutTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+        self.client.force_authenticate(self.user)
+
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        self.form = TenantForm.objects.create(
+            tenant=self.tenant,
+            name='QA Form',
+            status=FormStatus.ACTIVE,
+            created_by=self.user,
+        )
+        self.workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='QA WorkForm',
+            status='active',
+            workflow_definition={'nodes': [], 'edges': []},
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+    def test_put_requires_tenant_context(self):
+        resp = self.client.put('/api/v1/workflows/quick-actions/', data={'items': []}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.content)
+
+    def test_put_accepts_valid_form_and_workflow_targets(self):
+        payload = {
+            'items': [
+                {'id': 'qa-form', 'type': 'form', 'form_id': str(self.form.id), 'label': 'QA Form', 'order': 0},
+                {
+                    'id': 'qa-workflow',
+                    'type': 'workflow',
+                    'workflow_id': str(self.workform.id),
+                    'label': 'QA WorkForm',
+                    'order': 1,
+                },
+            ]
+        }
+
+        resp = self.client.put(
+            '/api/v1/workflows/quick-actions/',
+            data=payload,
+            format='json',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+        body = resp.json()
+        self.assertTrue(body.get('success'))
+
+        items = body.get('items')
+        self.assertEqual(len(items), 2)
+
+        # Stored/returned IDs should be strings (JSON safe).
+        self.assertEqual(items[0]['type'], 'form')
+        self.assertEqual(items[0]['form_id'], str(self.form.id))
+
+        self.assertEqual(items[1]['type'], 'workflow')
+        self.assertEqual(items[1]['workflow_id'], str(self.workform.id))
+
+    def test_put_rejects_unknown_form(self):
+        payload = {
+            'items': [
+                {
+                    'id': 'missing-form',
+                    'type': 'form',
+                    'form_id': '00000000-0000-0000-0000-000000000999',
+                    'label': 'Missing',
+                    'order': 0,
+                }
+            ]
+        }
+
+        resp = self.client.put(
+            '/api/v1/workflows/quick-actions/',
+            data=payload,
+            format='json',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.content)
+        self.assertIn('not found', (resp.json().get('error') or '').lower())

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2951,8 +2951,13 @@ class QuickActionsAPIView(APIView):
         """Update user's quick actions."""
         try:
             logger.info(f"Quick actions update request: {request.data}")
+
+            tenant, error = _require_tenant(request)
+            if error:
+                return error
+
             logger.info(
-                f"Request tenant: {request.tenant}, User: {request.user}, Is superuser: {request.user.is_superuser}"
+                f"Request tenant: {tenant}, User: {request.user}, Is superuser: {request.user.is_superuser}"
             )
 
             serializer = QuickActionsSerializer(data=request.data)
@@ -2969,15 +2974,11 @@ class QuickActionsAPIView(APIView):
 
             for item in items:
                 if item["type"] == "form" and item.get("form_id"):
-                    form = (
-                        TenantForm.objects.filter(
-                            tenant=request.tenant,
-                            id=item["form_id"],
-                            status__in=[FormStatus.DRAFT, FormStatus.ACTIVE],
-                        ).first()
-                        if request.tenant
-                        else None
-                    )
+                    form = TenantForm.objects.filter(
+                        tenant=tenant,
+                        id=item["form_id"],
+                        status__in=[FormStatus.DRAFT, FormStatus.ACTIVE],
+                    ).first()
 
                     if not form:
                         return Response(
@@ -2986,15 +2987,11 @@ class QuickActionsAPIView(APIView):
                         )
 
                 if item["type"] == "workflow" and item.get("workflow_id"):
-                    wf = (
-                        TenantWorkForm.objects.filter(
-                            tenant=request.tenant,
-                            id=item["workflow_id"],
-                            status__in=['draft', 'active'],
-                        ).first()
-                        if request.tenant
-                        else None
-                    )
+                    wf = TenantWorkForm.objects.filter(
+                        tenant=tenant,
+                        id=item["workflow_id"],
+                        status__in=['draft', 'active'],
+                    ).first()
 
                     if not wf:
                         return Response(


### PR DESCRIPTION
## What\n- QuickActions PUT now resolves tenant via _require_tenant (supports X-Tenant-ID force_auth flows) and fails closed with 400 when missing.\n- Adds backend tests for /api/v1/workflows/quick-actions/ PUT (valid targets, missing tenant, missing form).\n\n## Tests\n- python backend/manage.py test tenant_apps.workflows.tests.test_quick_actions_put --verbosity=2\n