### PR TITLE
Workflows: harden available-forms response contract tests

### DIFF
--- a/backend/tenant_apps/workflows/tests/test_available_forms_includes_workforms.py
+++ b/backend/tenant_apps/workflows/tests/test_available_forms_includes_workforms.py
@@ -90,5 +90,18 @@ class AvailableFormsIncludesWorkformsTests(APITestCase):
         self.assertIn(('workflow', str(self.malformed_workform.id)), seen)
         self.assertNotIn(('workflow', str(self.other_workform.id)), seen)
 
+        # Contract: rows must include stable keys needed by the WorkForms catalog.
+        for row in rows:
+            self.assertIn('id', row)
+            self.assertIn('type', row)
+            self.assertIn('name', row)
+            self.assertIn('status', row)
+
+            if row.get('type') == 'form':
+                # Forms do not have a node_count.
+                self.assertIsNone(row.get('node_count'))
+            elif row.get('type') == 'workflow':
+                self.assertIsInstance(row.get('node_count'), int)
+
         malformed_row = next(r for r in rows if r.get('id') == str(self.malformed_workform.id))
         self.assertEqual(malformed_row.get('node_count'), 0)


### PR DESCRIPTION
## What
- Tighten backend contract test for /api/v1/workflows/available-forms/ (stable keys + node_count shape).

## Tests
- python backend/manage.py test tenant_apps.workflows.tests.test_available_forms_includes_workforms --verbosity=2
