### PR TITLE
Secure WorkForms collaboration WebSocket (tenant authz)

### DIFF
--- a/backend/apps/tenants/channels_middleware.py
+++ b/backend/apps/tenants/channels_middleware.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from urllib.parse import parse_qs
+
+from channels.db import database_sync_to_async
+from channels.middleware import BaseMiddleware
+from django.contrib.auth.models import AnonymousUser
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from apps.tenants.models import Tenant, TenantUser
+
+
+def _headers_dict(scope: dict[str, Any]) -> dict[str, str]:
+    headers = {}
+    for k, v in scope.get('headers') or []:
+        try:
+            key = k.decode('latin1').lower()
+            val = v.decode('latin1')
+            headers[key] = val
+        except Exception:
+            continue
+    return headers
+
+
+def _query_params(scope: dict[str, Any]) -> dict[str, str]:
+    raw = (scope.get('query_string') or b'').decode('utf-8', errors='ignore')
+    parsed = parse_qs(raw)
+    return {k: (v[0] if v else '') for k, v in parsed.items()}
+
+
+def _get_bearer_token(scope: dict[str, Any]) -> str | None:
+    params = _query_params(scope)
+    token = params.get('access_token') or params.get('token') or params.get('jwt')
+    if token:
+        return token
+
+    headers = _headers_dict(scope)
+    auth = headers.get('authorization')
+    if not auth:
+        return None
+
+    lowered = auth.lower()
+    if lowered.startswith('bearer '):
+        return auth.split(' ', 1)[1].strip() or None
+
+    return None
+
+
+@database_sync_to_async
+def _get_user_for_token(raw_token: str):
+    auth = JWTAuthentication()
+    try:
+        validated = auth.get_validated_token(raw_token)
+        user = auth.get_user(validated)
+        return user
+    except Exception:
+        return None
+
+
+@database_sync_to_async
+def _resolve_tenant_for_user(user, tenant_id: str | None):
+    if not tenant_id:
+        return None
+
+    try:
+        tenant_uuid = uuid.UUID(str(tenant_id))
+    except Exception:
+        return None
+
+    try:
+        tenant = Tenant.objects.get(id=tenant_uuid, is_active=True)
+    except Tenant.DoesNotExist:
+        return None
+
+    is_global_admin = user.groups.filter(name='Global System Admins').exists()
+    if user.is_superuser or is_global_admin:
+        return tenant
+
+    if TenantUser.objects.filter(user=user, tenant=tenant, is_active=True).exists():
+        return tenant
+
+    return None
+
+
+class JwtAuthMiddleware(BaseMiddleware):
+    """Authenticate WebSocket connections using JWT when no session user exists.
+
+    Browsers cannot set Authorization headers on WebSocket handshakes, so we also
+    accept an access token in the query string: ?access_token=<jwt>.
+
+    This middleware does NOT log token values.
+    """
+
+    async def __call__(self, scope, receive, send):
+        user = scope.get('user')
+        if user is None:
+            scope['user'] = AnonymousUser()
+        elif getattr(user, 'is_authenticated', False):
+            return await super().__call__(scope, receive, send)
+
+        token = _get_bearer_token(scope)
+        if token:
+            resolved = await _get_user_for_token(token)
+            if resolved is not None:
+                scope['user'] = resolved
+
+        return await super().__call__(scope, receive, send)
+
+
+class TenantContextMiddleware(BaseMiddleware):
+    """Resolve and authorize tenant context for WebSocket connections.
+
+    For collaboration we require explicit tenant selection via query string:
+      ?tenant_id=<tenant_uuid>
+
+    The resolved tenant is stored as scope['tenant'].
+    """
+
+    async def __call__(self, scope, receive, send):
+        scope.setdefault('tenant', None)
+
+        user = scope.get('user')
+        if not user or not getattr(user, 'is_authenticated', False):
+            return await super().__call__(scope, receive, send)
+
+        params = _query_params(scope)
+        tenant_id = params.get('tenant_id') or params.get('tenantId')
+
+        tenant = await _resolve_tenant_for_user(user, tenant_id)
+        scope['tenant'] = tenant
+
+        return await super().__call__(scope, receive, send)

--- a/backend/projectmeats/asgi.py
+++ b/backend/projectmeats/asgi.py
@@ -22,12 +22,17 @@ from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 
 import tenant_apps.workflows.routing
+from apps.tenants.channels_middleware import JwtAuthMiddleware, TenantContextMiddleware
 
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
         "websocket": AllowedHostsOriginValidator(
-            AuthMiddlewareStack(URLRouter(tenant_apps.workflows.routing.websocket_urlpatterns))
+            AuthMiddlewareStack(
+                JwtAuthMiddleware(
+                    TenantContextMiddleware(URLRouter(tenant_apps.workflows.routing.websocket_urlpatterns))
+                )
+            )
         ),
     }
 )

--- a/backend/tenant_apps/workflows/consumers.py
+++ b/backend/tenant_apps/workflows/consumers.py
@@ -39,17 +39,50 @@ class WorkflowCollaborationConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         self.workflow_id = str(self.scope.get("url_route", {}).get("kwargs", {}).get("workflow_id", ""))
 
-        query = parse_qs((self.scope.get("query_string") or b"").decode("utf-8"))
-        tenant_id = (query.get("tenant_id") or query.get("tenantId") or [""])[0]
+        user = self.scope.get("user")
+        if not user or not getattr(user, "is_authenticated", False):
+            await self.close(code=4401)
+            return
 
-        # Require tenant id to prevent cross-tenant broadcast leakage.
+        tenant = self.scope.get("tenant")
+        if not tenant:
+            await self.close(code=4403)
+            return
+
+        # Workflow IDs are UUIDs (TenantWorkForm IDs). Fail closed on invalid input.
         try:
-            self.tenant_id = str(uuid.UUID(tenant_id))
+            workflow_uuid = uuid.UUID(str(self.workflow_id))
         except Exception:
             await self.close(code=4400)
             return
 
-        workflow_component = _sanitize_group_component(self.workflow_id)
+        from channels.db import database_sync_to_async
+        from django.db import connection
+
+        @database_sync_to_async
+        def _workflow_exists_for_tenant() -> bool:
+            from apps.system.models import TenantWorkForm
+
+            if connection.vendor == 'postgresql':
+                from apps.tenants.rls import set_current_tenant
+
+                set_current_tenant(str(tenant.id))
+
+            try:
+                return TenantWorkForm.objects.filter(id=workflow_uuid, tenant_id=tenant.id).exists()
+            finally:
+                if connection.vendor == 'postgresql':
+                    with connection.cursor() as cursor:
+                        cursor.execute("RESET app.current_tenant_id")
+                        cursor.execute("RESET app.current_tenant")
+
+        if not await _workflow_exists_for_tenant():
+            await self.close(code=4404)
+            return
+
+        self.tenant_id = str(tenant.id)
+
+        workflow_component = _sanitize_group_component(str(workflow_uuid))
         tenant_component = _sanitize_group_component(self.tenant_id)
         self.group_name = f"workflow-collab__{tenant_component}__{workflow_component}"
 

--- a/backend/tenant_apps/workflows/tests/test_collaboration_websocket_security.py
+++ b/backend/tenant_apps/workflows/tests/test_collaboration_websocket_security.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import uuid
+
+from asgiref.sync import async_to_sync
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth import get_user_model
+from django.test import TransactionTestCase, override_settings
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.system.models import TenantWorkForm
+from apps.tenants.models import Tenant, TenantUser
+from projectmeats.asgi import application
+
+
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+    ALLOWED_HOSTS=["*"],
+)
+class CollaborationWebsocketSecurityTests(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        User = get_user_model()
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        self.workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='WF',
+            description='',
+            status='draft',
+            workflow_definition={'nodes': [], 'edges': []},
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+    def _communicator(self, *, access_token: str | None, tenant_id: str | None, workflow_id: str):
+        params = []
+        if tenant_id is not None:
+            params.append(f'tenant_id={tenant_id}')
+        if access_token is not None:
+            params.append(f'access_token={access_token}')
+        qs = ('?' + '&'.join(params)) if params else ''
+
+        path = f'/ws/workflows/{workflow_id}/collab/{qs}'
+        return WebsocketCommunicator(
+            application,
+            path,
+            headers=[(b'host', b'testserver'), (b'origin', b'http://testserver')],
+        )
+
+    def test_rejects_anonymous(self):
+        async def run():
+            comm = self._communicator(
+                access_token=None, tenant_id=str(self.tenant.id), workflow_id=str(self.workform.id)
+            )
+            connected, _ = await comm.connect(timeout=1)
+            self.assertFalse(connected)
+            await comm.disconnect()
+
+        async_to_sync(run)()
+
+    def test_rejects_authenticated_missing_tenant(self):
+        async def run():
+            token = str(AccessToken.for_user(self.user))
+            comm = self._communicator(access_token=token, tenant_id=None, workflow_id=str(self.workform.id))
+            connected, _ = await comm.connect(timeout=1)
+            self.assertFalse(connected)
+            await comm.disconnect()
+
+        async_to_sync(run)()
+
+    def test_rejects_authenticated_non_member_tenant(self):
+        other = Tenant.objects.create(
+            name='Other',
+            slug=f'other-{uuid.uuid4().hex[:6]}',
+            contact_email='other@example.com',
+            is_active=True,
+        )
+
+        async def run():
+            token = str(AccessToken.for_user(self.user))
+            comm = self._communicator(access_token=token, tenant_id=str(other.id), workflow_id=str(self.workform.id))
+            connected, _ = await comm.connect(timeout=1)
+            self.assertFalse(connected)
+            await comm.disconnect()
+
+        async_to_sync(run)()
+
+    def test_rejects_workflow_not_in_tenant(self):
+        other = Tenant.objects.create(
+            name='Other',
+            slug=f'other-{uuid.uuid4().hex[:6]}',
+            contact_email='other@example.com',
+            is_active=True,
+        )
+        TenantUser.objects.create(tenant=other, user=self.user, role='admin', is_active=True)
+
+        other_workform = TenantWorkForm.objects.create(
+            tenant=other,
+            name='Other WF',
+            description='',
+            status='draft',
+            workflow_definition={'nodes': [], 'edges': []},
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        async def run():
+            token = str(AccessToken.for_user(self.user))
+            comm = self._communicator(
+                access_token=token, tenant_id=str(self.tenant.id), workflow_id=str(other_workform.id)
+            )
+            connected, _ = await comm.connect(timeout=1)
+            self.assertFalse(connected)
+            await comm.disconnect()
+
+        async_to_sync(run)()
+
+    def test_allows_valid_member_and_workflow(self):
+        async def run():
+            token = str(AccessToken.for_user(self.user))
+            comm = self._communicator(
+                access_token=token, tenant_id=str(self.tenant.id), workflow_id=str(self.workform.id)
+            )
+            connected, _ = await comm.connect(timeout=1)
+            self.assertTrue(connected)
+
+            joined = await comm.receive_json_from(timeout=1)
+            self.assertEqual(joined.get('type'), 'presence.joined')
+            self.assertEqual(joined.get('tenant_id'), str(self.tenant.id))
+            self.assertEqual(joined.get('workflow_id'), str(self.workform.id))
+
+            await comm.disconnect()
+
+        async_to_sync(run)()

--- a/frontend/src/components/FlowEditor/hooks/useCollaboration.ts
+++ b/frontend/src/components/FlowEditor/hooks/useCollaboration.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { config, getRuntimeConfig } from '../../../config/runtime';
+import { getAccessToken } from '../../../services/jwtService';
 
 export type CollaborationStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
 
@@ -83,10 +84,14 @@ export function useCollaboration({ workflowId, tenantId }: UseCollaborationArgs)
   const wsUrl = useMemo(() => {
     if (!workflowId || !tenantId) return null;
 
+    const accessToken = getAccessToken();
+    if (!accessToken) return null;
+
     const base = deriveWsBaseUrl();
     const url = new URL(`${base}/ws/workflows/${workflowId}/collab/`);
     url.searchParams.set('tenant_id', tenantId);
     url.searchParams.set('client_id', localClientIdRef.current);
+    url.searchParams.set('access_token', accessToken);
     return url.toString();
   }, [workflowId, tenantId]);
 


### PR DESCRIPTION
## What\n- Add Channels middleware to authenticate WebSocket connections via JWT (query param) + resolve tenant context with membership checks.\n- Harden WorkflowCollaborationConsumer to fail-closed unless user is authenticated and workflow belongs to the resolved tenant.\n- Frontend collaboration socket now includes access token and only connects when authenticated.\n- Add backend regression tests using WebsocketCommunicator + InMemory channel layer.\n\n## Tests\n- python backend/manage.py test tenant_apps.workflows.tests.test_collaboration_websocket_security --verbosity=2\n- npm -C frontend run type-check\n