### PR TITLE
Fail-close entity lookup without explicit tenant (multi-tenant users)

### DIFF
--- a/backend/apps/core/entity_views.py
+++ b/backend/apps/core/entity_views.py
@@ -314,20 +314,56 @@ def entity_lookup(request, entity_type):
     page_size = min(int(request.query_params.get('page_size', 20)), 100)
     
     # Get tenant from request (set by TenantMiddleware)
-    tenant = getattr(request, 'tenant', None)
+    django_request = getattr(request, '_request', None)
+    tenant = getattr(request, 'tenant', None) or getattr(django_request, 'tenant', None)
 
-    # Fallback: DRF authentication can populate request.user after middleware.
-    # For API endpoints that require tenant filtering, resolve a default tenant
-    # association here if middleware couldn't.
-    if not tenant and getattr(request, 'user', None) and request.user.is_authenticated:
-        tenant_user = (
-            TenantUser.objects.filter(user=request.user, is_active=True)
-            .select_related('tenant')
-            .order_by('-role')
-            .first()
-        )
-        if tenant_user:
-            tenant = tenant_user.tenant
+    def _get_header_tenant_id() -> str | None:
+        if hasattr(request, 'headers'):
+            return request.headers.get('X-Tenant-ID')
+        if django_request is not None and hasattr(django_request, 'headers'):
+            return django_request.headers.get('X-Tenant-ID')
+        return None
+
+    # Fail-closed tenant resolution:
+    # - If tenant is explicitly selected (middleware / header), use it.
+    # - If the user belongs to exactly ONE tenant, we allow a safe default.
+    # - If the user belongs to MULTIPLE tenants, require explicit tenant selection.
+    if entity_type != 'user' and not tenant and getattr(request, 'user', None) and request.user.is_authenticated:
+        header_tenant_id = _get_header_tenant_id()
+        if header_tenant_id:
+            from apps.tenants.models import Tenant
+
+            try:
+                candidate = Tenant.objects.get(id=header_tenant_id, is_active=True)
+            except (Tenant.DoesNotExist, ValueError):
+                return Response({"error": "Invalid tenant selection", "code": "tenant_invalid"}, status=400)
+
+            is_global_admin = request.user.groups.filter(name='Global System Admins').exists()
+            if request.user.is_superuser or is_global_admin:
+                tenant = candidate
+            elif TenantUser.objects.filter(user=request.user, tenant=candidate, is_active=True).exists():
+                tenant = candidate
+            else:
+                return Response({"error": "Tenant access denied", "code": "tenant_forbidden"}, status=403)
+
+        if not tenant:
+            memberships = list(
+                TenantUser.objects.filter(user=request.user, is_active=True)
+                .values_list('tenant_id', flat=True)
+                .distinct()[:2]
+            )
+            if len(memberships) == 1:
+                from apps.tenants.models import Tenant
+
+                tenant = Tenant.objects.filter(id=memberships[0], is_active=True).first()
+            elif len(memberships) > 1:
+                return Response(
+                    {
+                        "error": "Explicit tenant selection required (X-Tenant-ID)",
+                        "code": "tenant_required_multi",
+                    },
+                    status=400,
+                )
 
     # Build base queryset with tenant filter where applicable.
     # Some entities are system-wide (e.g., system.Product) or utility (e.g., User).

--- a/backend/apps/core/tests/test_entity_views.py
+++ b/backend/apps/core/tests/test_entity_views.py
@@ -325,12 +325,29 @@ class EntityLookupTestCase(TestCase):
         """Lookup options should be tenant-filtered"""
         # This test assumes entities have tenant field
         response = self.client.get('/api/v1/entities/supplier/lookup/')
-        
+
         if response.status_code == status.HTTP_200_OK:
             data = response.json()
             # Should only show options for current tenant
             # Implementation depends on whether entity has tenant field
             self.assertIsInstance(data['options'], list)
+
+    def test_lookup_multi_tenant_requires_explicit_tenant(self):
+        """Multi-tenant users must explicitly select tenant (X-Tenant-ID)."""
+        tenant2 = Tenant.objects.create(
+            name='Another Tenant',
+            slug='another-tenant',
+            schema_name='another_tenant_lookup',
+        )
+        TenantUser.objects.create(user=self.user, tenant=tenant2, role='admin', is_active=True)
+
+        # Product lookup requires tenant context. With multiple memberships and no explicit tenant, fail closed.
+        response = self.client.get('/api/v1/entities/product/lookup/')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # With explicit tenant selection it should succeed.
+        response = self.client.get('/api/v1/entities/product/lookup/', HTTP_X_TENANT_ID=str(self.tenant.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class EntityPermissionsTestCase(TestCase):


### PR DESCRIPTION
## What\n- entity_lookup now fails closed for multi-tenant users unless tenant is explicitly selected (middleware or X-Tenant-ID).\n- Single-tenant users still get a safe default tenant for backward compatibility.\n- Adds regression test proving multi-tenant requires X-Tenant-ID for product lookup.\n\n## Tests\n- python backend/manage.py test apps.core.tests.test_entity_views apps.core.tests.test_entity_lookup_product_visibility --verbosity=2\n