### PR TITLE
Fail-closed: require tenant context on create (no default tenant fallback)

### DIFF
--- a/backend/apps/tenants/test_create_requires_tenant_context.py
+++ b/backend/apps/tenants/test_create_requires_tenant_context.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
+from apps.tenants.models import Tenant
+from tenant_apps.customers.views import CustomerViewSet
+from tenant_apps.plants.views import PlantViewSet
+from tenant_apps.purchase_orders.views import PurchaseOrderViewSet
+from tenant_apps.sales_orders.views import SalesOrderViewSet
+
+
+User = get_user_model()
+
+
+class CreateRequiresTenantContextTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='u', password='pw')
+        self.tenant = Tenant.objects.create(name='T', slug='t', contact_email='t@example.com', is_active=True)
+
+    def _mock_serializer(self):
+        serializer = Mock()
+        serializer.save = Mock()
+        serializer.data = {}
+        return serializer
+
+    def test_purchase_orders_create_requires_tenant(self):
+        view = PurchaseOrderViewSet()
+        view.request = SimpleNamespace(user=self.user, tenant=None)
+        with self.assertRaises(DRFValidationError):
+            view.perform_create(self._mock_serializer())
+
+    def test_sales_orders_create_requires_tenant(self):
+        view = SalesOrderViewSet()
+        view.request = SimpleNamespace(user=self.user, tenant=None)
+        with self.assertRaises(DRFValidationError):
+            view.perform_create(self._mock_serializer())
+
+    def test_customers_create_requires_tenant(self):
+        view = CustomerViewSet()
+        view.request = SimpleNamespace(user=self.user, tenant=None)
+        with self.assertRaises(DRFValidationError):
+            view.perform_create(self._mock_serializer())
+
+    def test_plants_create_requires_tenant(self):
+        view = PlantViewSet()
+        view.request = SimpleNamespace(user=self.user, tenant=None)
+        with self.assertRaises(DRFValidationError):
+            view.perform_create(self._mock_serializer())

--- a/backend/tenant_apps/customers/views.py
+++ b/backend/tenant_apps/customers/views.py
@@ -29,7 +29,6 @@ from apps.system.serializers import SystemProductSerializer
 
 from tenant_apps.customers.models import Customer
 from tenant_apps.customers.serializers import CustomerSerializer
-from apps.tenants.models import TenantUser
 import logging
 from django.utils import timezone
 
@@ -134,55 +133,24 @@ class CustomerViewSet(viewsets.ModelViewSet):
         return Customer.objects.none()
 
     def perform_create(self, serializer):
+        """Set the tenant when creating a new customer.
+
+        Tenant context must be explicitly resolved by middleware/auth.
+        We do not silently default to the user's first tenant on writes.
         """
-        Set the tenant when creating a new customer.
-        
-        Tenant Resolution:
-        1. Use request.tenant from TenantMiddleware
-        2. Fallback to user's TenantUser association if middleware didn't set tenant
-        3. Raise ValidationError if no tenant found
-        
-        Args:
-            serializer: Validated serializer instance
-            
-        Raises:
-            ValidationError: If no tenant context is available
-        """
-        tenant = None
-        
-        # Get tenant from middleware (request.tenant)
-        if hasattr(self.request, 'tenant') and self.request.tenant:
-            tenant = self.request.tenant
-        
-        # Fallback: Query user's TenantUser association if middleware didn't set tenant
-        elif self.request.user and self.request.user.is_authenticated:
-            tenant_user = (
-                TenantUser.objects.filter(user=self.request.user, is_active=True)
-                .select_related('tenant')
-                .order_by('-role')  # Prioritize owner/admin roles
-                .first()
-            )
-            if tenant_user:
-                tenant = tenant_user.tenant
-                logger.debug(
-                    f'Tenant resolved from user association: {tenant.slug} '
-                    f'for user {self.request.user.username}'
-                )
-        
-        # Require tenant - raise error if still not found
+
+        tenant = getattr(self.request, 'tenant', None)
         if not tenant:
-            error_message = 'Tenant context is required to create a customer. Please ensure you are associated with a tenant.'
             logger.error(
                 'Customer creation attempted without tenant context',
                 extra={
                     'user': self.request.user.username if self.request.user.is_authenticated else 'Anonymous',
                     'has_request_tenant': hasattr(self.request, 'tenant'),
                     'timestamp': timezone.now().isoformat(),
-                }
+                },
             )
-            raise ValidationError(error_message)
-        
-        # Save with tenant association
+            raise DRFValidationError('Tenant context is required to create a customer.')
+
         serializer.save(tenant=tenant)
         logger.info(f'Created customer: {serializer.data.get("name")} for tenant: {tenant.name}')
 

--- a/backend/tenant_apps/plants/views.py
+++ b/backend/tenant_apps/plants/views.py
@@ -38,37 +38,24 @@ class PlantViewSet(viewsets.ModelViewSet):
         return Plant.objects.none()
 
     def perform_create(self, serializer):
-        """Set the tenant when creating a new plant."""
-        tenant = None
-        
-        # First, try to get tenant from middleware (request.tenant)
-        if hasattr(self.request, 'tenant') and self.request.tenant:
-            tenant = self.request.tenant
-        
-        # If middleware didn't set tenant, try to get user's default tenant
-        elif self.request.user and self.request.user.is_authenticated:
-            from apps.tenants.models import TenantUser
-            tenant_user = (
-                TenantUser.objects.filter(user=self.request.user, is_active=True)
-                .select_related('tenant')
-                .order_by('-role')  # Prioritize owner/admin roles
-                .first()
-            )
-            if tenant_user:
-                tenant = tenant_user.tenant
-        
-        # If still no tenant, raise error
+        """Set the tenant when creating a new plant.
+
+        Tenant context must be explicitly resolved by middleware/auth.
+        We do not silently default to the user's first tenant on writes.
+        """
+
+        tenant = getattr(self.request, 'tenant', None)
         if not tenant:
             logger.error(
                 'Plant creation attempted without tenant context',
                 extra={
                     'user': self.request.user.username if self.request.user and self.request.user.is_authenticated else 'Anonymous',
                     'has_request_tenant': hasattr(self.request, 'tenant'),
-                    'timestamp': timezone.now().isoformat()
-                }
+                    'timestamp': timezone.now().isoformat(),
+                },
             )
-            raise ValidationError('Tenant context is required to create a plant.')
-        
+            raise DRFValidationError('Tenant context is required to create a plant.')
+
         serializer.save(tenant=tenant)
 
     def create(self, request, *args, **kwargs):

--- a/backend/tenant_apps/purchase_orders/views.py
+++ b/backend/tenant_apps/purchase_orders/views.py
@@ -85,27 +85,13 @@ class PurchaseOrderViewSet(CsvExportMixin, viewsets.ModelViewSet):
         return Response(PurchaseOrderSerializer(po).data)
 
     def perform_create(self, serializer):
-        """Set the tenant and auto-generate order_number when creating a new purchase order."""
-        tenant = None
+        """Set the tenant when creating a new purchase order.
 
-        # First, try to get tenant from middleware (request.tenant)
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            tenant = self.request.tenant
+        Tenant context must be explicitly resolved by middleware/auth.
+        We do not silently default to the user's first tenant on writes.
+        """
 
-        # If middleware didn't set tenant, try to get user's default tenant
-        elif self.request.user and self.request.user.is_authenticated:
-            from apps.tenants.models import TenantUser
-
-            tenant_user = (
-                TenantUser.objects.filter(user=self.request.user, is_active=True)
-                .select_related("tenant")
-                .order_by("-role")  # Prioritize owner/admin roles
-                .first()
-            )
-            if tenant_user:
-                tenant = tenant_user.tenant
-
-        # If still no tenant, raise error
+        tenant = getattr(self.request, "tenant", None)
         if not tenant:
             logger.error(
                 "Purchase order creation attempted without tenant context",
@@ -117,12 +103,9 @@ class PurchaseOrderViewSet(CsvExportMixin, viewsets.ModelViewSet):
                     "timestamp": timezone.now().isoformat(),
                 },
             )
-            raise ValidationError(
-                "Tenant context is required to create a purchase order."
-            )
-        
+            raise DRFValidationError("Tenant context is required to create a purchase order.")
+
         # Delegate order_number generation to the model layer (2YYNNN format).
-        # This keeps admin/scripts consistent with API creation behavior.
         serializer.save(tenant=tenant)
 
     def create(self, request, *args, **kwargs):

--- a/backend/tenant_apps/sales_orders/views.py
+++ b/backend/tenant_apps/sales_orders/views.py
@@ -87,27 +87,13 @@ class SalesOrderViewSet(CsvExportMixin, viewsets.ModelViewSet):
         return Response(SalesOrderSerializer(so).data)
 
     def perform_create(self, serializer):
-        """Set the tenant and auto-generate our_sales_order_num when creating a new sales order."""
-        tenant = None
+        """Set the tenant and auto-generate our_sales_order_num when creating a new sales order.
 
-        # First, try to get tenant from middleware (request.tenant)
-        if hasattr(self.request, "tenant") and self.request.tenant:
-            tenant = self.request.tenant
+        Tenant context must be explicitly resolved by middleware/auth.
+        We do not silently default to the user's first tenant on writes.
+        """
 
-        # If middleware didn't set tenant, try to get user's default tenant
-        elif self.request.user and self.request.user.is_authenticated:
-            from apps.tenants.models import TenantUser
-
-            tenant_user = (
-                TenantUser.objects.filter(user=self.request.user, is_active=True)
-                .select_related("tenant")
-                .order_by("-role")  # Prioritize owner/admin roles
-                .first()
-            )
-            if tenant_user:
-                tenant = tenant_user.tenant
-
-        # If still no tenant, raise error
+        tenant = getattr(self.request, "tenant", None)
         if not tenant:
             logger.error(
                 "Sales order creation attempted without tenant context",
@@ -119,10 +105,8 @@ class SalesOrderViewSet(CsvExportMixin, viewsets.ModelViewSet):
                     "timestamp": timezone.now().isoformat(),
                 },
             )
-            raise ValidationError(
-                "Tenant context is required to create a sales order."
-            )
-        
+            raise DRFValidationError("Tenant context is required to create a sales order.")
+
         # Auto-generate our_sales_order_num if not provided (atomic to prevent duplicates)
         with transaction.atomic():
             if not serializer.validated_data.get('our_sales_order_num'):


### PR DESCRIPTION
## What\n- Remove per-view default-tenant fallback (TenantUser.first()) from high-traffic create endpoints:\n  - purchase_orders, sales_orders, customers, plants\n- These now require request.tenant (middleware/auth) and fail closed with 400 if missing.\n- Add guardrail test asserting perform_create raises DRF ValidationError when tenant is absent.\n\n## Tests\n- python backend/manage.py test apps.tenants.test_create_requires_tenant_context --verbosity=2\n