### PR TITLE
CI: scheduled secrets audit

### DIFF
--- a/.github/workflows/secrets-audit.yml
+++ b/.github/workflows/secrets-audit.yml
@@ -1,0 +1,37 @@
+name: "Audit Secrets (Manifest vs GitHub)"
+
+on:
+  schedule:
+    - cron: "17 3 * * *" # daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secrets-audit
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: "Audit secrets"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Run manifest audit (names only)
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          set -euo pipefail
+          python config/manage_env.py audit --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Adds a scheduled + manual workflow that runs config/manage_env.py audit (names only) using PAT for gh secret list.\n\nTesting\n- bash .github/scripts/check_infrastructure.sh