### PR TITLE
FE: preserve API error metadata (circuit breaker)

### DIFF
--- a/frontend/src/services/apiErrors.test.ts
+++ b/frontend/src/services/apiErrors.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+
+import { ApiServiceError, createCircuitBreakerError } from './apiErrors';
+
+describe('apiErrors', () => {
+  it('createCircuitBreakerError preserves metadata while keeping a friendly message', () => {
+    const err = createCircuitBreakerError({
+      friendlyMessage: 'Server error. Please try again shortly.',
+      status: 500,
+      request: { method: 'get', url: '/workflows/available-forms/', baseURL: 'https://example.com/api/v1' },
+      responseData: { detail: 'boom' },
+      originalError: new Error('original'),
+    });
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ApiServiceError);
+    expect(err.message).toBe('Server error. Please try again shortly.');
+    expect(err.kind).toBe('circuit_breaker');
+    expect(err.status).toBe(500);
+    expect(err.request?.url).toBe('/workflows/available-forms/');
+    expect(err.responseData).toEqual({ detail: 'boom' });
+    expect(err.originalError).toBeInstanceOf(Error);
+  });
+});

--- a/frontend/src/services/apiErrors.ts
+++ b/frontend/src/services/apiErrors.ts
@@ -1,0 +1,50 @@
+export type ApiServiceErrorKind = 'circuit_breaker' | 'http' | 'network' | 'unknown';
+
+export interface ApiRequestMeta {
+  method?: string;
+  url?: string;
+  baseURL?: string;
+}
+
+export class ApiServiceError extends Error {
+  kind: ApiServiceErrorKind;
+  status?: number;
+  request?: ApiRequestMeta;
+  responseData?: unknown;
+  originalError?: unknown;
+
+  constructor(
+    message: string,
+    opts: {
+      kind: ApiServiceErrorKind;
+      status?: number;
+      request?: ApiRequestMeta;
+      responseData?: unknown;
+      originalError?: unknown;
+    }
+  ) {
+    super(message);
+    this.name = 'ApiServiceError';
+    this.kind = opts.kind;
+    this.status = opts.status;
+    this.request = opts.request;
+    this.responseData = opts.responseData;
+    this.originalError = opts.originalError;
+  }
+}
+
+export function createCircuitBreakerError(args: {
+  friendlyMessage: string;
+  status: number;
+  request?: ApiRequestMeta;
+  responseData?: unknown;
+  originalError?: unknown;
+}): ApiServiceError {
+  return new ApiServiceError(args.friendlyMessage, {
+    kind: 'circuit_breaker',
+    status: args.status,
+    request: args.request,
+    responseData: args.responseData,
+    originalError: args.originalError,
+  });
+}

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -21,6 +21,7 @@ import {
   isUsingJwt,
 } from './jwtService';
 import { triggerGlobalSessionExpired } from '../contexts/SessionManagerContext';
+import { ApiServiceError, createCircuitBreakerError } from './apiErrors';
 
 // API Configuration
 const API_BASE_URL = config.API_BASE_URL;
@@ -231,7 +232,19 @@ apiClient.interceptors.response.use(
         // best-effort
       }
 
-      return Promise.reject(new Error(friendlyMessage));
+      return Promise.reject(
+        createCircuitBreakerError({
+          friendlyMessage,
+          status,
+          request: {
+            method: originalRequest?.method,
+            url: originalRequest?.url,
+            baseURL: (originalRequest as any)?.baseURL,
+          },
+          responseData: (error.response as any)?.data,
+          originalError: error,
+        })
+      );
     }
     
     // Log the error for debugging
@@ -343,7 +356,19 @@ adminClient.interceptors.response.use(
         method: originalRequest?.method,
       });
 
-      return Promise.reject(new Error(friendlyMessage));
+      return Promise.reject(
+        createCircuitBreakerError({
+          friendlyMessage,
+          status,
+          request: {
+            method: originalRequest?.method,
+            url: originalRequest?.url,
+            baseURL: (originalRequest as any)?.baseURL,
+          },
+          responseData: (error.response as any)?.data,
+          originalError: error,
+        })
+      );
     }
     
     // Log the error for debugging
@@ -416,6 +441,16 @@ interface AxiosError {
 
 function getErrorMessage(error: unknown): string {
   if (typeof error === 'string') return error;
+
+  if (error instanceof ApiServiceError) {
+    const data = error.responseData;
+    if (data && typeof data === 'object') {
+      const anyData = data as any;
+      const msg = anyData.message || anyData.error || anyData.detail || anyData.details;
+      if (msg && typeof msg === 'string') return msg;
+    }
+    return error.message;
+  }
   
   if (error && typeof error === 'object') {
     const axiosError = error as AxiosError;


### PR DESCRIPTION
Keeps structured metadata (status/method/url/responseData) on circuit-breaker errors via ApiServiceError instead of throwing a plain Error. Adds vitest coverage.\n\nTesting\n- npx vitest run src/services/apiErrors.test.ts\n- npm run type-check