### PR TITLE
FE: expand lint:colors guardrail (CSS Color 4 + WorkForms scope)

### DIFF
--- a/frontend/.eslint/scripts/check-colors.cjs
+++ b/frontend/.eslint/scripts/check-colors.cjs
@@ -62,6 +62,18 @@ const HEX_COLOR_REGEX = /#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-
 // NOTE: We scope enforcement to FlowEditor + WorkForms to avoid mass legacy churn.
 const RGB_COLOR_REGEX = /\brgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(?:,\s*[0-9.]+\s*)?\)/g;
 
+// CSS Color 4 space-separated functional notations (e.g. rgb(0 0 0 / 50%)).
+const RGB_COLOR4_REGEX = /\brgba?\(\s*\d+\s+\d+\s+\d+(?:\s*\/\s*[0-9.]+%?)?\s*\)/g;
+
+// hsl()/hsla() comma-based and CSS Color 4 space-separated variants.
+const HSL_COLOR_REGEX = /\bhsla?\(\s*\d+\s*,\s*\d+%\s*,\s*\d+%\s*(?:,\s*[0-9.]+\s*)?\)/g;
+const HSL_COLOR4_REGEX = /\bhsla?\(\s*\d+\s+\d+%\s+\d+%(?:\s*\/\s*[0-9.]+%?)?\s*\)/g;
+
+// Named colors we want to forbid in high-churn UI surfaces.
+// We intentionally do NOT include 'transparent' to avoid churn.
+// We match quoted values (JS objects / string-returning templates) to avoid mass legacy churn.
+const NAMED_COLOR_REGEX = /(['"`])(?:white|black|red|green|blue|gray|grey)\1/g;
+
 function isNumericOnlyShortHex(color) {
   // Heuristic: ignore short numeric-only tokens like "#405" in names (not actual colors).
   // We still catch #000000/#111111 etc.
@@ -80,7 +92,8 @@ function checkFile(filePath) {
   const relativePath = path.relative(repoRoot, filePath).replace(/\\/g, '/');
   const enforceRgb =
     relativePath.includes('src/components/FlowEditor/') ||
-    relativePath.includes('src/components/WorkForms/');
+    relativePath.includes('src/components/WorkForms/') ||
+    relativePath.includes('src/pages/WorkForms/');
 
   const content = fs.readFileSync(filePath, 'utf8');
   const lines = content.split('\n');
@@ -116,11 +129,7 @@ function checkFile(filePath) {
       return;
     }
 
-    const rgbRegex = new RegExp(RGB_COLOR_REGEX, 'g');
-    while ((match = rgbRegex.exec(line)) !== null) {
-      const color = match[0];
-      const columnIndex = match.index;
-
+    const pushTokenViolation = (color, columnIndex) => {
       violations.push({
         line: lineIndex + 1,
         column: columnIndex + 1,
@@ -129,6 +138,36 @@ function checkFile(filePath) {
           'Use theme tokens (e.g. rgb(var(--color-text-primary)) or rgba(var(--color-overlay), 0.5)).',
         lineContent: trimmed,
       });
+    };
+
+    const rgbRegex = new RegExp(RGB_COLOR_REGEX, 'g');
+    while ((match = rgbRegex.exec(line)) !== null) {
+      pushTokenViolation(match[0], match.index);
+    }
+
+    const rgb4Regex = new RegExp(RGB_COLOR4_REGEX, 'g');
+    while ((match = rgb4Regex.exec(line)) !== null) {
+      pushTokenViolation(match[0], match.index);
+    }
+
+    const hslRegex = new RegExp(HSL_COLOR_REGEX, 'g');
+    while ((match = hslRegex.exec(line)) !== null) {
+      pushTokenViolation(match[0], match.index);
+    }
+
+    const hsl4Regex = new RegExp(HSL_COLOR4_REGEX, 'g');
+    while ((match = hsl4Regex.exec(line)) !== null) {
+      pushTokenViolation(match[0], match.index);
+    }
+
+    const cssContext = /(^|[,{]\s*)(color|background(?:Color)?|border(?:Color)?|stroke|fill)\s*:/i.test(line) ||
+      /(\bcolor\b|\bbackground\b|\bborder\b|\bstroke\b|\bfill\b)\s*:/i.test(line);
+
+    if (cssContext) {
+      const namedRegex = new RegExp(NAMED_COLOR_REGEX, 'g');
+      while ((match = namedRegex.exec(line)) !== null) {
+        pushTokenViolation(match[0], match.index);
+      }
     }
   });
 

--- a/frontend/src/components/FlowEditor/AISuggestionBadge.tsx
+++ b/frontend/src/components/FlowEditor/AISuggestionBadge.tsx
@@ -26,7 +26,7 @@ export const AISuggestionBadge: React.FC<AISuggestionBadgeProps> = ({ mode, reas
           gap: '4px',
           padding: '2px 8px',
           backgroundColor: isAI ? 'rgb(var(--color-success))' : 'rgb(var(--color-warning))',
-          color: 'white',
+          color: 'rgb(var(--color-primary-foreground))',
           borderRadius: '12px',
           fontSize: '12px',
           fontWeight: 500

--- a/frontend/src/components/FlowEditor/ConfigPanel/ConditionBuilder.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/ConditionBuilder.tsx
@@ -195,7 +195,7 @@ const LogicButton = styled.button<{ $active: boolean }>`
   padding: 6px 16px;
   border: none;
   background: ${props => props.$active ? 'rgb(var(--color-primary))' : 'rgb(var(--color-background))'};
-  color: ${props => props.$active ? 'white' : 'rgb(var(--color-text-primary))'};
+  color: ${props => props.$active ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-primary))'};
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
@@ -137,7 +137,7 @@ const ToggleButton = styled.button<{ $active: boolean }>`
   padding: 8px 16px;
   border: 1px solid rgb(var(--color-border));
   background: ${props => props.$active ? 'rgb(var(--color-primary))' : 'transparent'};
-  color: ${props => props.$active ? 'white' : 'rgb(var(--color-text-primary))'};
+  color: ${props => props.$active ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-primary))'};
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;

--- a/frontend/src/components/FlowEditor/Modals/WorkflowManagementModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/WorkflowManagementModal.tsx
@@ -239,7 +239,7 @@ const Button = styled.button<{ $variant?: 'primary' | 'secondary' }>`
   padding: 10px 20px;
   font-size: 14px;
   font-weight: 600;
-  color: ${props => props.$variant === 'primary' ? 'white' : 'rgb(var(--color-text-primary))'};
+  color: ${props => props.$variant === 'primary' ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-primary))'};
   background: ${props => props.$variant === 'primary' ? 'rgb(var(--color-primary))' : 'transparent'};
   border: 1px solid ${props => props.$variant === 'primary' ? 'rgb(var(--color-primary))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-md);

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -1394,7 +1394,7 @@ const ConfirmButton = styled.button<{ $variant?: 'danger' | 'secondary' }>`
   padding: 8px 16px;
   font-size: 14px;
   font-weight: 600;
-  color: ${props => props.$variant === 'danger' ? 'white' : 'rgb(var(--color-text-primary))'};
+  color: ${props => props.$variant === 'danger' ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-primary))'};
   background: ${props => props.$variant === 'danger' ? 'rgb(var(--color-error))' : 'transparent'};
   border: 1px solid ${props => props.$variant === 'danger' ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-md);
@@ -1691,7 +1691,7 @@ const PatternButton = styled.button<{ $active: boolean }>`
   flex: 1;
   padding: 6px 10px;
   background: ${props => props.$active ? 'rgb(var(--color-primary))' : 'transparent'};
-  color: ${props => props.$active ? 'white' : 'rgb(var(--color-text-primary))'};
+  color: ${props => props.$active ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-primary))'};
   border: 1px solid ${props => props.$active ? 'rgb(var(--color-primary))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-sm);
   font-size: 11px;
@@ -1941,7 +1941,7 @@ class ConfigPanelErrorBoundary extends React.Component<
             style={{
               padding: '8px 16px',
               background: 'rgb(var(--color-primary))',
-              color: 'white',
+              color: 'rgb(var(--color-primary-foreground))',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer'
@@ -7459,7 +7459,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
             disabled={isSaving}
             style={hasUnsavedChanges ? {
               background: 'rgb(var(--color-primary))',
-              color: 'white',
+              color: 'rgb(var(--color-primary-foreground))',
               borderColor: 'rgb(var(--color-primary))'
             } : {}}
           >
@@ -7571,7 +7571,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
               title={isPaletteVisible ? 'Hide Node Palette (Tab)' : 'Show Node Palette (Tab)'}
               style={isPaletteVisible ? {
                 background: 'rgb(var(--color-primary))',
-                color: 'white',
+                color: 'rgb(var(--color-primary-foreground))',
                 borderColor: 'rgb(var(--color-primary))'
               } : {}}
             >
@@ -7582,7 +7582,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
               title={isAISuggestionsVisible ? 'Hide AI Suggestions' : 'Show AI Suggestions'}
               style={isAISuggestionsVisible ? {
                 background: 'rgb(var(--color-primary))',
-                color: 'white',
+                color: 'rgb(var(--color-primary-foreground))',
                 borderColor: 'rgb(var(--color-primary))'
               } : {}}
             >
@@ -7596,7 +7596,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           title="Canvas Settings (Grid, Background)"
           style={isSettingsPanelOpen ? {
             background: 'rgb(var(--color-primary))',
-            color: 'white',
+            color: 'rgb(var(--color-primary-foreground))',
             borderColor: 'rgb(var(--color-primary))'
           } : {}}
         >
@@ -7618,7 +7618,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           title={isMinimapVisible ? 'Hide Minimap (M)' : 'Show Minimap (M)'}
           style={isMinimapVisible ? {
             background: 'rgb(var(--color-primary))',
-            color: 'white',
+            color: 'rgb(var(--color-primary-foreground))',
             borderColor: 'rgb(var(--color-primary))'
           } : {}}
         >

--- a/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
+++ b/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
@@ -871,7 +871,7 @@ const ToggleButton = styled.button<{ $active: boolean }>`
   gap: 6px;
   padding: 6px 12px;
   background: ${props => props.$active ? 'rgb(var(--color-primary))' : 'transparent'};
-  color: ${props => props.$active ? 'white' : 'rgb(var(--color-text-secondary))'};
+  color: ${props => props.$active ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-secondary))'};
   border: none;
   border-radius: 4px;
   cursor: pointer;

--- a/frontend/src/components/FlowEditor/components/NodeBadge.tsx
+++ b/frontend/src/components/FlowEditor/components/NodeBadge.tsx
@@ -53,11 +53,11 @@ const pulse = keyframes`
 const celebrate = keyframes`
   0%, 100% { 
     transform: scale(1) rotate(0deg); 
-    box-shadow: 0 2px 4px rgb(0 0 0 / 0.2); 
+    box-shadow: 0 2px 4px rgba(var(--color-overlay), 0.2); 
   }
   50% { 
     transform: scale(1.15) rotate(5deg); 
-    box-shadow: 0 4px 12px rgb(34 197 94 / 0.4); 
+    box-shadow: 0 4px 12px rgba(var(--color-success), 0.4); 
   }
 `;
 
@@ -93,17 +93,17 @@ const BadgeContainer = styled.div<{
     }
   }};
   
-  border: 2px solid white;
+  border: 2px solid rgb(var(--color-surface));
   border-radius: 12px;
   padding: 4px 8px;
   min-width: 24px;
   height: 24px;
   
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   font-size: 11px;
   font-weight: 700;
   
-  box-shadow: 0 2px 6px rgb(0 0 0 / 0.2);
+  box-shadow: 0 2px 6px rgba(var(--color-overlay), 0.2);
   pointer-events: all;
   cursor: ${props => props.title ? 'help' : 'default'};
   z-index: 10;
@@ -129,7 +129,7 @@ const BadgeContainer = styled.div<{
   
   &:hover {
     transform: scale(1.1);
-    box-shadow: 0 4px 12px rgb(0 0 0 / 0.3);
+    box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.3);
   }
 `;
 

--- a/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ConditionalEdge.tsx
@@ -38,13 +38,13 @@ const ConditionLabel = styled.div`
   pointer-events: all;
   cursor: pointer;
   transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgb(245 158 11 / 0.2);
+  box-shadow: 0 2px 4px rgba(var(--color-warning), 0.2);
 
   &:hover {
     background: rgb(var(--color-warning));
-    color: white;
+    color: rgb(var(--color-primary-foreground));
     transform: scale(1.05);
-    box-shadow: 0 4px 8px rgb(245 158 11 / 0.3);
+    box-shadow: 0 4px 8px rgba(var(--color-warning), 0.3);
   }
 
   &::before {
@@ -58,14 +58,14 @@ const ConditionLabel = styled.div`
 const TrueFalseIndicator = styled.div<{ isTrue?: boolean }>`
   position: absolute;
   background: ${props => props.isTrue ? 'rgb(var(--color-success))' : 'rgb(var(--color-error))'};
-  border: 2px solid white;
+  border: 2px solid rgb(var(--color-surface));
   border-radius: 50%;
   width: 20px;
   height: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   font-size: 10px;
   font-weight: 700;
   pointer-events: none;

--- a/frontend/src/components/FlowEditor/edges/CustomEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/CustomEdge.tsx
@@ -41,7 +41,7 @@ const EdgeLabel = styled.div`
   pointer-events: all;
   cursor: pointer;
   transition: all 0.2s ease;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+  box-shadow: 0 1px 2px rgba(var(--color-overlay), 0.05);
 
   &:hover {
     background: rgb(var(--color-surface-hover));
@@ -60,7 +60,7 @@ const AddNodeButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   font-size: 16px;
   font-weight: 600;
   cursor: pointer;

--- a/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/EnhancedConnectionEdge.tsx
@@ -186,7 +186,7 @@ const EdgeEditActions = styled.div`
 const EdgeEditActionBtn = styled.button<{ $primary?: boolean }>`
   border: 1px solid rgb(var(--color-border));
   background: ${(p) => (p.$primary ? 'rgb(var(--color-primary))' : 'rgb(var(--color-surface))')};
-  color: ${(p) => (p.$primary ? 'white' : 'rgb(var(--color-text-secondary))')};
+  color: ${(p) => (p.$primary ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-secondary))')};
   font-size: 12px;
   font-weight: 700;
   padding: 6px 10px;
@@ -195,7 +195,7 @@ const EdgeEditActionBtn = styled.button<{ $primary?: boolean }>`
 
   &:hover {
     border-color: rgb(var(--color-primary));
-    color: ${(p) => (p.$primary ? 'white' : 'rgb(var(--color-primary))')};
+    color: ${(p) => (p.$primary ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-primary))')};
     background: ${(p) => (p.$primary ? 'rgb(var(--color-primary))' : 'rgba(var(--color-primary), 0.08)')};
   }
 `;

--- a/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
@@ -47,13 +47,13 @@ const ErrorLabel = styled.div`
   pointer-events: all;
   cursor: pointer;
   transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgb(239 68 68 / 0.2);
+  box-shadow: 0 2px 4px rgba(var(--color-error), 0.2);
 
   &:hover {
     background: rgb(var(--color-error));
-    color: white;
+    color: rgb(var(--color-primary-foreground));
     transform: scale(1.05);
-    box-shadow: 0 4px 8px rgb(239 68 68 / 0.3);
+    box-shadow: 0 4px 8px rgba(var(--color-error), 0.3);
   }
 
   &::before {
@@ -98,7 +98,7 @@ const ToolbarBtn = styled.button`
 const ErrorBadge = styled.div`
   position: absolute;
   background: rgb(var(--color-danger));
-  border: 2px solid white;
+  border: 2px solid rgb(var(--color-surface));
   border-radius: 50%;
   min-width: 20px;
   height: 20px;
@@ -106,11 +106,11 @@ const ErrorBadge = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   font-size: 10px;
   font-weight: 700;
   pointer-events: none;
-  box-shadow: 0 2px 4px rgb(0 0 0 / 0.2);
+  box-shadow: 0 2px 4px rgba(var(--color-overlay), 0.2);
   animation: shake 0.5s ease-in-out infinite;
 
   @keyframes shake {

--- a/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
@@ -38,13 +38,13 @@ const SuccessLabel = styled.div`
   pointer-events: all;
   cursor: pointer;
   transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgb(34 197 94 / 0.2);
+  box-shadow: 0 2px 4px rgba(var(--color-success), 0.2);
 
   &:hover {
     background: rgb(var(--color-success));
-    color: white;
+    color: rgb(var(--color-primary-foreground));
     transform: scale(1.05);
-    box-shadow: 0 4px 8px rgb(34 197 94 / 0.3);
+    box-shadow: 0 4px 8px rgba(var(--color-success), 0.3);
   }
 
   &::before {
@@ -59,7 +59,7 @@ const SuccessLabel = styled.div`
 const SuccessBadge = styled.div`
   position: absolute;
   background: rgb(var(--color-success));
-  border: 2px solid white;
+  border: 2px solid rgb(var(--color-surface));
   border-radius: 50%;
   min-width: 20px;
   height: 20px;
@@ -67,16 +67,16 @@ const SuccessBadge = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   font-size: 10px;
   font-weight: 700;
   pointer-events: none;
-  box-shadow: 0 2px 4px rgb(0 0 0 / 0.2);
+  box-shadow: 0 2px 4px rgba(var(--color-overlay), 0.2);
   animation: celebratePulse 2s ease-in-out infinite;
 
   @keyframes celebratePulse {
-    0%, 100% { transform: scale(1); box-shadow: 0 2px 4px rgb(0 0 0 / 0.2); }
-    50% { transform: scale(1.15); box-shadow: 0 4px 12px rgb(34 197 94 / 0.4); }
+    0%, 100% { transform: scale(1); box-shadow: 0 2px 4px rgba(var(--color-overlay), 0.2); }
+    50% { transform: scale(1.15); box-shadow: 0 4px 12px rgba(var(--color-success), 0.4); }
   }
 `;
 

--- a/frontend/src/components/FlowEditor/nodes/FormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormNode.tsx
@@ -285,7 +285,7 @@ const ToolbarButton = styled.button<{ $primary?: boolean }>`
   border-radius: 10px;
   border: 1px solid rgb(var(--color-border));
   background: ${(p) => (p.$primary ? 'rgb(var(--color-primary))' : 'rgb(var(--color-surface))')};
-  color: ${(p) => (p.$primary ? 'white' : 'rgb(var(--color-text-primary))')};
+  color: ${(p) => (p.$primary ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-primary))')};
   font-size: 12px;
   font-weight: 900;
   cursor: pointer;

--- a/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
@@ -687,7 +687,7 @@ export const FormProcessNode = React.memo<FormProcessNodeProps>(({
                     border: '1px solid rgba(var(--color-header-background), 0.45)',
                     padding: '6px 8px',
                     background: 'rgba(var(--color-header-background), 0.16)',
-                    color: 'white',
+                    color: 'rgb(var(--color-primary-foreground))',
                   }}
                   onClick={(e) => e.stopPropagation()}
                 />

--- a/frontend/src/components/FlowEditor/nodes/SmartWorkFormNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/SmartWorkFormNode.tsx
@@ -222,8 +222,8 @@ const Root = styled.div<{ $selected: boolean }>`
   border: 1px solid rgb(var(--color-border));
   box-shadow: ${(p) =>
     p.$selected
-      ? '0 16px 40px rgb(0 0 0 / 0.16), 0 0 0 6px rgb(var(--color-primary) / 0.10)'
-      : '0 10px 26px rgb(0 0 0 / 0.12)'};
+      ? '0 16px 40px rgba(var(--color-overlay), 0.16), 0 0 0 6px rgba(var(--color-primary), 0.10)'
+      : '0 10px 26px rgba(var(--color-overlay), 0.12)'};
 `;
 
 const TopBar = styled.div`
@@ -286,7 +286,7 @@ const Button = styled.button<{ $primary?: boolean }>`
   border-radius: 10px;
   border: 1px solid rgb(var(--color-border));
   background: ${(p) => (p.$primary ? 'rgb(var(--color-primary))' : 'rgb(var(--color-surface))')};
-  color: ${(p) => (p.$primary ? 'white' : 'rgb(var(--color-text-primary))')};
+  color: ${(p) => (p.$primary ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-primary))')};
   cursor: pointer;
   font-size: 12px;
   font-weight: 900;
@@ -361,7 +361,7 @@ const StepCard = styled.div<{ $active?: boolean; $isDrop?: boolean }>`
   background: ${(p) => (p.$active ? 'rgba(var(--color-primary), 0.06)' : 'rgb(var(--color-background))')};
   padding: 12px;
   margin-bottom: 12px;
-  box-shadow: ${(p) => (p.$active ? '0 10px 22px rgb(0 0 0 / 0.10)' : 'none')};
+  box-shadow: ${(p) => (p.$active ? '0 10px 22px rgba(var(--color-overlay), 0.10)' : 'none')};
 
   ${(p) =>
     p.$isDrop

--- a/frontend/src/components/FlowEditor/nodes/TerminalNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/TerminalNode.tsx
@@ -56,26 +56,26 @@ const InfoRow = styled.div`
 
 const MessageBox = styled.div<{ $type: TerminalType }>`
   padding: 8px;
-  background: ${props =>
-    props.$type === 'success'
-      ? 'rgb(34 197 94 / 0.1)'
-      : props.$type === 'error'
-      ? 'rgb(239 68 68 / 0.1)'
-      : 'rgb(156 163 175 / 0.1)'};
-  border: 1px solid ${props =>
-    props.$type === 'success'
-      ? 'rgb(34 197 94 / 0.2)'
-      : props.$type === 'error'
-      ? 'rgb(239 68 68 / 0.2)'
-      : 'rgb(156 163 175 / 0.2)'};
+  background: ${(p) =>
+    p.$type === 'success'
+      ? 'rgba(var(--color-success), 0.10)'
+      : p.$type === 'error'
+        ? 'rgba(var(--color-error), 0.10)'
+        : 'rgba(var(--color-text-secondary), 0.10)'};
+  border: 1px solid ${(p) =>
+    p.$type === 'success'
+      ? 'rgba(var(--color-success), 0.20)'
+      : p.$type === 'error'
+        ? 'rgba(var(--color-error), 0.20)'
+        : 'rgba(var(--color-text-secondary), 0.20)'};
   border-radius: var(--radius-sm, 4px);
   font-size: 11px;
-  color: ${props =>
-    props.$type === 'success'
-      ? 'rgb(21 128 61)'
-      : props.$type === 'error'
-      ? 'rgb(185 28 28)'
-      : 'rgb(75 85 99)'};
+  color: ${(p) =>
+    p.$type === 'success'
+      ? 'rgb(var(--color-success))'
+      : p.$type === 'error'
+        ? 'rgb(var(--color-error))'
+        : 'rgb(var(--color-text-secondary))'};
   white-space: pre-wrap;
 `;
 
@@ -87,8 +87,8 @@ const Badge = styled.span`
   border-radius: var(--radius-sm, 4px);
   font-size: 10px;
   font-weight: 600;
-  background: rgb(59 130 246 / 0.1);
-  color: rgb(59 130 246);
+  background: rgba(var(--color-info), 0.10);
+  color: rgb(var(--color-info));
 `;
 
 // ============================================================================

--- a/frontend/src/components/FlowEditor/nodes/WaitStateNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/WaitStateNode.tsx
@@ -72,14 +72,11 @@ const Badge = styled.span<{ $variant?: 'warning' | 'info' }>`
   border-radius: var(--radius-sm, 4px);
   font-size: 11px;
   font-weight: 500;
-  background: ${props =>
-    props.$variant === 'warning'
-      ? 'rgb(234 179 8 / 0.1)'
-      : 'rgb(59 130 246 / 0.1)'};
-  color: ${props =>
-    props.$variant === 'warning'
-      ? 'rgb(234 179 8)'
-      : 'rgb(59 130 246)'};
+  background: ${(p) =>
+    p.$variant === 'warning'
+      ? 'rgba(var(--color-warning), 0.10)'
+      : 'rgba(var(--color-info), 0.10)'};
+  color: ${(p) => (p.$variant === 'warning' ? 'rgb(var(--color-warning))' : 'rgb(var(--color-info))')};
 `;
 
 // ============================================================================

--- a/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
@@ -109,7 +109,7 @@ const ViewportButton = styled.button<{ $active: boolean }>`
   background: ${props => props.$active ? 'rgb(var(--color-primary))' : 'transparent'};
   border: 1px solid ${props => props.$active ? 'rgb(var(--color-primary))' : 'rgb(var(--color-border))'};
   border-radius: var(--radius-sm);
-  color: ${props => props.$active ? 'white' : 'rgb(var(--color-text-secondary))'};
+  color: ${props => props.$active ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-secondary))'};
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -117,7 +117,7 @@ const ViewportButton = styled.button<{ $active: boolean }>`
   
   &:hover {
     background: ${props => props.$active ? 'rgb(var(--color-primary))' : 'rgb(var(--color-background))'};
-    color: ${props => props.$active ? 'white' : 'rgb(var(--color-text-primary))'};
+    color: ${props => props.$active ? 'rgb(var(--color-primary-foreground))' : 'rgb(var(--color-text-primary))'};
     border-color: ${props => props.$active ? 'rgb(var(--color-primary))' : 'rgb(var(--color-border))'};
   }
   

--- a/frontend/src/components/FlowEditor/templates/TemplateSelector.tsx
+++ b/frontend/src/components/FlowEditor/templates/TemplateSelector.tsx
@@ -184,18 +184,24 @@ const DifficultyBadge = styled.span<{ $difficulty: TemplateDifficulty }>`
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  background: ${props => {
-    switch (props.$difficulty) {
-      case 'beginner': return 'rgb(34 197 94 / 0.1)';
-      case 'intermediate': return 'rgb(234 179 8 / 0.1)';
-      case 'advanced': return 'rgb(239 68 68 / 0.1)';
+  background: ${(p) => {
+    switch (p.$difficulty) {
+      case 'beginner':
+        return 'rgba(var(--color-success), 0.10)';
+      case 'intermediate':
+        return 'rgba(var(--color-warning), 0.10)';
+      case 'advanced':
+        return 'rgba(var(--color-error), 0.10)';
     }
   }};
-  color: ${props => {
-    switch (props.$difficulty) {
-      case 'beginner': return 'rgb(34 197 94)';
-      case 'intermediate': return 'rgb(234 179 8)';
-      case 'advanced': return 'rgb(239 68 68)';
+  color: ${(p) => {
+    switch (p.$difficulty) {
+      case 'beginner':
+        return 'rgb(var(--color-success))';
+      case 'intermediate':
+        return 'rgb(var(--color-warning))';
+      case 'advanced':
+        return 'rgb(var(--color-error))';
     }
   }};
 `;

--- a/frontend/src/pages/WorkForms/Editor.tsx
+++ b/frontend/src/pages/WorkForms/Editor.tsx
@@ -213,16 +213,16 @@ const StatusBadge = styled.span<{ $status: WorkFormStatus }>`
   border: 1px solid rgb(var(--color-border));
   background: ${p =>
     p.$status === 'active'
-      ? 'rgb(34 197 94 / 0.10)'
+      ? 'rgba(var(--color-success), 0.10)'
       : p.$status === 'draft'
-        ? 'rgb(234 179 8 / 0.10)'
-        : 'rgb(148 163 184 / 0.10)'};
+        ? 'rgba(var(--color-warning), 0.10)'
+        : 'rgba(var(--color-text-secondary), 0.10)'};
   color: ${p =>
     p.$status === 'active'
-      ? 'rgb(34, 197, 94)'
+      ? 'rgb(var(--color-success))'
       : p.$status === 'draft'
-        ? 'rgb(234, 179, 8)'
-        : 'rgb(148, 163, 184)'};
+        ? 'rgb(var(--color-warning))'
+        : 'rgb(var(--color-text-secondary))'};
 `;
 
 const EditorWrapper = styled.div`

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -260,10 +260,12 @@ const StatusBadge = styled.span<{ $status: string }>`
   font-weight: 500;
   border-radius: 12px;
   background: ${({ $status }) =>
-    $status === 'completed' ? 'rgb(34 197 94 / 0.10)' : 'rgb(239 68 68 / 0.10)'
+    $status === 'completed'
+      ? 'rgba(var(--color-success), 0.10)'
+      : 'rgba(var(--color-error), 0.10)'
   };
   color: ${({ $status }) =>
-    $status === 'completed' ? 'rgb(34, 197, 94)' : 'rgb(239, 68, 68)'
+    $status === 'completed' ? 'rgb(var(--color-success))' : 'rgb(var(--color-error))'
   };
 `;
 
@@ -421,10 +423,10 @@ const TimelineDot = styled.div<{ $status: string }>`
   border-radius: 50%;
   border: 2px solid ${({ $status }) => {
     switch ($status) {
-      case 'completed': return 'rgb(34, 197, 94)';
-      case 'failed': return 'rgb(239, 68, 68)';
-      case 'skipped': return 'rgb(127, 140, 141)';
-      default: return 'rgb(59, 130, 246)';
+      case 'completed': return 'rgb(var(--color-success))';
+      case 'failed': return 'rgb(var(--color-error))';
+      case 'skipped': return 'rgb(var(--color-text-secondary))';
+      default: return 'rgb(var(--color-info))';
     }
   }};
   background: rgb(var(--color-surface));

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -236,17 +236,17 @@ const StatusBadge = styled.span<{ $status: string }>`
   border-radius: 12px;
   background: ${({ $status }) =>
     $status === 'in_progress'
-      ? 'rgb(59 130 246 / 0.10)'
+      ? 'rgba(var(--color-info), 0.10)'
       : $status === 'draft'
-        ? 'rgb(var(--color-text-tertiary) / 0.10)'
-        : 'rgb(234 179 8 / 0.10)'
+        ? 'rgba(var(--color-text-tertiary), 0.10)'
+        : 'rgba(var(--color-warning), 0.10)'
   };
   color: ${({ $status }) =>
     $status === 'in_progress'
-      ? 'rgb(59, 130, 246)'
+      ? 'rgb(var(--color-info))'
       : $status === 'draft'
         ? 'rgb(var(--color-text-secondary))'
-        : 'rgb(234, 179, 8)'
+        : 'rgb(var(--color-warning))'
   };
 `;
 
@@ -303,7 +303,7 @@ const ResumeButton = styled.button`
   border: none;
   border-radius: var(--radius-md, 8px);
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-primary-foreground));
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -379,8 +379,8 @@ const FilterSelect = styled.select`
 const CancelButton = styled.button`
   padding: 10px 16px;
   background: transparent;
-  color: rgb(239, 68, 68);
-  border: 1px solid rgb(239, 68, 68);
+  color: rgb(var(--color-error));
+  border: 1px solid rgb(var(--color-error));
   border-radius: var(--radius-md, 8px);
   font-size: 14px;
   font-weight: 500;
@@ -388,7 +388,7 @@ const CancelButton = styled.button`
   transition: all 0.15s ease;
   
   &:hover {
-    background: rgb(239 68 68 / 0.10);
+    background: rgba(var(--color-error), 0.10);
   }
   
   &:disabled {


### PR DESCRIPTION
Expands frontend lint:colors to catch CSS Color 4 functional syntax (space-separated rgb/hsl + / alpha) and named color strings in FlowEditor/WorkForms. Fixes newly detected violations so the guardrail stays green.\n\nTesting\n- npm --prefix frontend run verify-standards