### PR TITLE
test: tenant execute isolation + WorkForms permissions hook

### DIFF
--- a/backend/apps/system/tests/test_tenant_workform_execute_permissions.py
+++ b/backend/apps/system/tests/test_tenant_workform_execute_permissions.py
@@ -37,9 +37,43 @@ class TenantWorkFormExecutePermissionsTests(APITestCase):
             is_active=True,
         )
 
+        other_unique = uuid.uuid4().hex[:8]
+        self.other_tenant = Tenant.objects.create(
+            name=f'Tenant Other {other_unique}',
+            slug=f'tenant-other-{other_unique}',
+            contact_email=f'{other_unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+
+        TenantUser.objects.create(
+            tenant=self.other_tenant,
+            user=self.user,
+            role='user',
+            is_active=True,
+        )
+
         self.workform = TenantWorkForm.objects.create(
             tenant=self.tenant,
             name='WF',
+            description='',
+            status='active',
+            workflow_definition={
+                'nodes': [
+                    {'id': 't1', 'type': 'triggerManual', 'data': {}},
+                    {'id': 'end', 'type': 'end', 'data': {}},
+                ],
+                'edges': [
+                    {'id': 'e1', 'source': 't1', 'target': 'end', 'type': 'default'},
+                ],
+            },
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        self.other_workform = TenantWorkForm.objects.create(
+            tenant=self.other_tenant,
+            name='Other WF',
             description='',
             status='active',
             workflow_definition={
@@ -86,5 +120,18 @@ class TenantWorkFormExecutePermissionsTests(APITestCase):
             )
 
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, resp.content)
+        self.assertEqual(TenantWorkFormExecution.objects.count(), 0)
+        mock_delay.assert_not_called()
+
+    def test_cannot_execute_workform_from_other_tenant(self):
+        with patch('apps.system.tasks.execute_workform_execution.delay') as mock_delay:
+            resp = self.client.post(
+                f'/api/v1/tenant-workforms/{self.other_workform.id}/execute/',
+                data={'initial_data': {}},
+                format='json',
+                HTTP_X_TENANT_ID=str(self.tenant.id),
+            )
+
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND, resp.content)
         self.assertEqual(TenantWorkFormExecution.objects.count(), 0)
         mock_delay.assert_not_called()

--- a/frontend/src/hooks/useWorkFormPermissions.test.tsx
+++ b/frontend/src/hooks/useWorkFormPermissions.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { apiClient } from '../services/apiService';
+import { canUseEditorMode, canUseNodeCategory, useWorkFormPermissions } from './useWorkFormPermissions';
+
+vi.mock('../services/apiService', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+describe('useWorkFormPermissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns default permissions when API fails (non-401)', async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce({
+      response: { status: 500, data: { detail: 'Boom' } },
+      message: 'Boom',
+    });
+
+    const { result } = renderHook(() => useWorkFormPermissions(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith('/workflows/permissions/');
+    expect(result.current.error).toBeNull();
+    expect(result.current.permissions.role).toBe('anonymous');
+    expect(result.current.permissions.can_create).toBe(false);
+  });
+
+  it('propagates 401 errors so auth handling can run', async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce({
+      response: { status: 401, data: { detail: 'Unauthorized' } },
+      message: 'Unauthorized',
+    });
+
+    const { result } = renderHook(() => useWorkFormPermissions(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith('/workflows/permissions/');
+    expect(result.current.permissions.role).toBe('anonymous');
+  });
+});
+
+describe('WorkForms permission helpers', () => {
+  it('canUseEditorMode fails closed when permissions are missing', () => {
+    expect(canUseEditorMode(undefined, 'visual')).toBe(false);
+  });
+
+  it('canUseNodeCategory allows all categories when allowed_node_categories is empty', () => {
+    expect(
+      canUseNodeCategory(
+        {
+          can_create: false,
+          can_edit: false,
+          can_publish: false,
+          can_archive: false,
+          can_delete: false,
+          allowed_modes: [],
+          allowed_node_categories: [],
+          can_access_system_templates: false,
+          can_create_global_templates: false,
+          max_active_flows: 0,
+          role: 'anonymous',
+        },
+        'anything'
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What
- Backend: regression test ensures /tenant-workforms/{id}/execute/ cannot execute a WorkForm from a different tenant (404 + no execution enqueued)
- Frontend: vitest coverage for useWorkFormPermissions fail-closed behavior and 401 propagation

## Why
Locks down tenant isolation and permission gating behavior to prevent future regressions.

## Testing
- python manage.py test apps.system.tests.test_tenant_workform_execute_permissions
- npm -C frontend run test -- --run src/hooks/useWorkFormPermissions.test.tsx

## Risk / Rollback
Low risk (tests only). Rollback by reverting this PR.