### PR TITLE
fix(workforms): sanitize React Flow payload before persistence

### DIFF
--- a/frontend/src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts
+++ b/frontend/src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts
@@ -10,6 +10,13 @@ describe('prepareWorkflowForSave (sanitization)', () => {
         id: 'n1',
         type: 'actionEmail',
         position: { x: 0, y: 0 },
+        // UI-only runtime fields should never be persisted
+        selected: true,
+        dragging: true,
+        positionAbsolute: { x: 123, y: 456 },
+        measured: { width: 999, height: 888 },
+        width: 999,
+        height: 888,
         data: {
           nodeType: 'actionEmail',
           subject: 'hello',
@@ -44,6 +51,15 @@ describe('prepareWorkflowForSave (sanitization)', () => {
     expect(preparedNodeData.config?.shadowConfig).toBeUndefined();
     expect(preparedNodeData.config?.configStatus).toBeUndefined();
     expect(preparedNodeData.config?._upstreamVariables).toBeUndefined();
+
+    // Top-level UI-only React Flow keys should not persist
+    const preparedNode = prepared.nodes[0] as any;
+    expect(preparedNode.selected).toBeUndefined();
+    expect(preparedNode.dragging).toBeUndefined();
+    expect(preparedNode.positionAbsolute).toBeUndefined();
+    expect(preparedNode.measured).toBeUndefined();
+    expect(preparedNode.width).toBeUndefined();
+    expect(preparedNode.height).toBeUndefined();
   });
 
   it('materializes non-empty schema defaults into persisted node.data', () => {

--- a/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
+++ b/frontend/src/components/FlowEditor/utils/workflowPersistence.ts
@@ -154,6 +154,25 @@ export const prepareWorkflowForSave = (
   const nodesCopy = JSON.parse(JSON.stringify(nodes)) as Node[];
   const edgesCopy = JSON.parse(JSON.stringify(edges)) as Edge[];
 
+  // Strip React Flow UI-only top-level fields before persistence.
+  // (Selected/dragging/measured/etc. are runtime artifacts and can create noisy diffs + bloated payloads.)
+  for (const node of nodesCopy as any[]) {
+    if (!node || typeof node !== 'object') continue;
+    delete node.selected;
+    delete node.dragging;
+    delete node.resizing;
+    delete node.positionAbsolute;
+    delete node.measured;
+    delete node.width;
+    delete node.height;
+    delete node.parentNode; // legacy React Flow key (v10)
+  }
+
+  for (const edge of edgesCopy as any[]) {
+    if (!edge || typeof edge !== 'object') continue;
+    delete edge.selected;
+  }
+
   // Ensure parents appear before children for React Flow subflows.
   // This also prevents "disappearing" nodes when reloading persisted workflows.
   const sortedNodes = sortNodesTopologically(nodesCopy);


### PR DESCRIPTION
## What
- Strip React Flow UI-only top-level node/edge fields (selected/dragging/positionAbsolute/measured/width/height, etc.) before saving workflow_definition
- Extend existing sanitization test to cover top-level keys (prevents regressions)

## Why
Keeps persisted WorkForms JSON stable + minimal, prevents noisy diffs and accidental persistence of runtime/editor artifacts.

## Testing
- npm -C frontend run type-check
- npm -C frontend run test -- --run src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts

## Rollback
Revert this PR.