### PR TITLE
fix(workforms): deterministic editor load error UI

### DIFF
--- a/frontend/src/pages/WorkForms/Editor.errorState.test.tsx
+++ b/frontend/src/pages/WorkForms/Editor.errorState.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { WorkFormsEditor } from './Editor';
+import { loadWorkflow } from '../../components/FlowEditor/utils/workflowPersistence';
+
+vi.mock('../../components/FlowEditor/utils/workflowPersistence', () => ({
+  loadWorkflow: vi.fn(),
+}));
+
+vi.mock('../../hooks/useWorkFormPermissions', () => ({
+  useWorkFormPermissions: () => ({
+    permissions: {
+      can_create: true,
+      can_edit: true,
+      can_publish: true,
+      can_archive: true,
+      can_delete: true,
+      allowed_modes: ['wizard', 'visual', 'expert'],
+      allowed_node_categories: [],
+      can_access_system_templates: true,
+      can_create_global_templates: false,
+      max_active_flows: null,
+      role: 'owner',
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  canUseEditorMode: () => true,
+  getUpgradeMessage: () => null,
+}));
+
+describe('WorkForms Editor load error state', () => {
+  it('shows a retryable error panel when a workform fails to load', async () => {
+    const err = { response: { status: 500, data: { detail: 'Boom' } }, message: 'Boom' };
+    vi.mocked(loadWorkflow).mockRejectedValueOnce(err);
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/workforms/editor/123']}>
+          <Routes>
+            <Route path="/workforms/editor/:id" element={<WorkFormsEditor />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Couldn't load workform")).toBeInTheDocument();
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+
+    vi.mocked(loadWorkflow).mockRejectedValueOnce(err);
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+    await waitFor(() => {
+      expect(loadWorkflow).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/pages/WorkForms/Editor.tsx
+++ b/frontend/src/pages/WorkForms/Editor.tsx
@@ -236,6 +236,61 @@ const EditorWrapper = styled.div`
   overflow: hidden;
 `;
 
+const CenteredNotice = styled.div`
+  text-align: center;
+  padding: 4rem;
+  color: rgb(var(--color-text-secondary));
+`;
+
+const ErrorPanel = styled.div`
+  border: 1px solid rgb(var(--color-border));
+  border-radius: var(--radius-lg);
+  background: rgb(var(--color-surface));
+  padding: 18px;
+  max-width: 760px;
+  margin: 24px auto;
+`;
+
+const ErrorTitle = styled.h2`
+  margin: 0 0 8px 0;
+  font-size: 18px;
+  font-weight: 800;
+  color: rgb(var(--color-text-primary));
+`;
+
+const ErrorDetail = styled.pre`
+  margin: 0;
+  padding: 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-background));
+  color: rgb(var(--color-text-secondary));
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+const ErrorActions = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+`;
+
+const PrimaryButton = styled.button`
+  padding: 8px 12px;
+  background: rgb(var(--color-primary));
+  border: 1px solid rgb(var(--color-primary));
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  color: rgb(var(--color-primary-foreground));
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.98);
+  }
+`;
+
 // ============================================================================
 // Component
 // ============================================================================
@@ -290,6 +345,36 @@ export const WorkFormsEditor: React.FC = () => {
   });
 
   const isLoading = existingWorkFormQuery.isLoading || cloneWorkFormQuery.isLoading;
+
+  const isLoadError = Boolean(
+    (id && existingWorkFormQuery.isError) ||
+    (cloneId && cloneWorkFormQuery.isError)
+  );
+
+  const activeLoadError = cloneId
+    ? cloneWorkFormQuery.error
+    : existingWorkFormQuery.error;
+
+  const getLoadErrorDetail = useCallback((error: unknown): string => {
+    const e = error as any;
+    return (
+      e?.response?.data?.detail ||
+      e?.response?.data?.error ||
+      e?.message ||
+      'Unknown error'
+    );
+  }, []);
+
+  const handleRetryLoad = useCallback(async () => {
+    setIsInitialized(false);
+    if (cloneId) {
+      await cloneWorkFormQuery.refetch();
+      return;
+    }
+    if (id) {
+      await existingWorkFormQuery.refetch();
+    }
+  }, [cloneId, id, cloneWorkFormQuery, existingWorkFormQuery]);
 
   // Initialize editor with: clone → existing → template → blank
   useEffect(() => {
@@ -405,15 +490,33 @@ export const WorkFormsEditor: React.FC = () => {
   if ((id || cloneId) && isLoading) {
     return (
       <PageContainer>
-        <div style={{ textAlign: 'center', padding: '4rem', color: 'rgb(var(--color-text-secondary))' }}>
-          Loading workform...
-        </div>
+        <CenteredNotice>Loading workform...</CenteredNotice>
       </PageContainer>
     );
   }
 
-  if (existingWorkFormQuery.isError) {
-    logger.error('[WorkFormsEditor] Failed to load workflow', existingWorkFormQuery.error);
+  if (isLoadError) {
+    logger.error('[WorkFormsEditor] Failed to load workflow', activeLoadError);
+
+    return (
+      <PageContainer>
+        <PageHeader>
+          <HeaderLeft>
+            <BackButton onClick={handleBack}>← Back</BackButton>
+            <PageTitle>WorkForms Editor</PageTitle>
+          </HeaderLeft>
+        </PageHeader>
+
+        <ErrorPanel role="alert">
+          <ErrorTitle>Couldn't load workform</ErrorTitle>
+          <ErrorDetail>{getLoadErrorDetail(activeLoadError)}</ErrorDetail>
+          <ErrorActions>
+            <PrimaryButton onClick={() => void handleRetryLoad()}>Try again</PrimaryButton>
+            <BackButton onClick={handleBack}>Back to Catalog</BackButton>
+          </ErrorActions>
+        </ErrorPanel>
+      </PageContainer>
+    );
   }
 
   return (


### PR DESCRIPTION
## What
- Show stable error panel (Try again / Back to Catalog) when WorkForms Editor load fails
- Prevent blank/stuck state when isInitialized never flips due to query error
- Add RTL coverage for the error + retry flow

## Testing
- npm -C frontend run type-check
- npm -C frontend run test -- --run src/pages/WorkForms/Editor.errorState.test.tsx

## Rollback
Revert this PR.