### PR TITLE
fix(floweditor): deterministic schema bootstrap

### DIFF
--- a/frontend/src/components/FlowEditor/config/__tests__/flowEditorSchemasLoaded.test.ts
+++ b/frontend/src/components/FlowEditor/config/__tests__/flowEditorSchemasLoaded.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// This test ensures FlowEditor imports always bootstrap schemaRegistry deterministically.
+// Without this, the config panel can render fallback schemas on first interaction and never recover.
+
+describe('FlowEditor schema bootstrap', () => {
+  it('registers nodeConfigSchemas when FlowEditor is imported', async () => {
+    vi.resetModules();
+
+    const { schemaRegistry } = await import('../schemaRegistry');
+    schemaRegistry.clear();
+
+    await import('../../index');
+
+    const httpSchema = schemaRegistry.getSchema('actionHTTP');
+    expect(String(httpSchema.version)).not.toContain('fallback');
+    expect(httpSchema.nodeType).toBe('actionHTTP');
+  });
+});

--- a/frontend/src/components/FlowEditor/index.ts
+++ b/frontend/src/components/FlowEditor/index.ts
@@ -2,9 +2,15 @@
  * Flow Editor Index
  * 
  * Unified visual editor for forms and workflows.
+ *
+ * Deterministic init:
+ * - Import nodeConfigSchemas here so schemaRegistry is populated before first interaction.
+ *   This prevents "first click" config panel races where fallback schemas are used and never re-render.
  * 
  * Created: 2026-02-04 - Phase 2.1 Visual Editor Foundation
  */
+
+import './config/nodeConfigSchemas';
 
 export { UnifiedFlowEditor } from './UnifiedFlowEditor';
 export type { NODE_TYPE_REGISTRY, NodeTypeDefinition, NodeCategory } from './nodeTypes';


### PR DESCRIPTION
## What
- Import nodeConfigSchemas from FlowEditor index to ensure schemaRegistry is populated before first interaction
- Add regression test proving schemas are available immediately after FlowEditor import (prevents fallback-schema first-click races)

## Testing
- npm -C frontend run type-check
- npm -C frontend run test -- --run src/components/FlowEditor/config/__tests__/flowEditorSchemasLoaded.test.ts

## Rollback
Revert this PR.