### PR TITLE
chore(frontend): canonicalize logging via logger

### DIFF
--- a/frontend/src/components/Cockpit/PinnedToolsBar.tsx
+++ b/frontend/src/components/Cockpit/PinnedToolsBar.tsx
@@ -7,6 +7,7 @@ import { useCockpitNavigation } from '../../contexts/CockpitNavigationContext';
 import { useCockpitPinnedTools } from '../../contexts/CockpitPinnedToolsContext';
 import { useQuickActions } from '../../contexts/QuickActionsContext';
 import { notify } from '../../utils/notify';
+import { logger } from '@/utils/logger';
 import { businessApi } from '../../services/businessApi';
 import {
   ActionItemsWidget,
@@ -161,7 +162,7 @@ export const PinnedToolsBar: React.FC = () => {
       setRecordDetail(resp.data);
       return resp.data;
     } catch (e) {
-      console.warn('[PinnedToolsBar] Failed to load active record context:', e);
+      logger.warn('[PinnedToolsBar] Failed to load active record context:', e);
       setRecordDetail(null);
       return null;
     } finally {
@@ -191,7 +192,7 @@ export const PinnedToolsBar: React.FC = () => {
           })
         );
       } catch (e) {
-        console.warn('[PinnedToolsBar] Failed to persist active record context:', e);
+        logger.warn('[PinnedToolsBar] Failed to persist active record context:', e);
       }
 
       const desiredLabel = tool === 'email' ? 'Email Drafter' : 'Smart Quote';

--- a/frontend/src/components/FlowEditor/config/schemaRegistry.ts
+++ b/frontend/src/components/FlowEditor/config/schemaRegistry.ts
@@ -82,7 +82,7 @@ class ConfigSchemaRegistry {
    */
   initialize(schemas: NodeConfigSchema[]): void {
     if (this.initialized) {
-      console.warn('ConfigSchemaRegistry already initialized, skipping');
+      logger.warn('ConfigSchemaRegistry already initialized, skipping');
       return;
     }
 
@@ -92,24 +92,24 @@ class ConfigSchemaRegistry {
         const normalizedSchema = this.normalizeRequiredValidators(schema);
         const validation = this.validateSchema(normalizedSchema);
         if (!validation.valid) {
-          console.error(`Invalid schema for ${schema.nodeType}:`, validation.errors);
+          logger.error(`Invalid schema for ${schema.nodeType}:`, validation.errors);
           continue;
         }
 
         if (validation.warnings && validation.warnings.length > 0) {
-          console.warn(`Warnings for schema ${schema.nodeType}:`, validation.warnings);
+          logger.warn(`Warnings for schema ${schema.nodeType}:`, validation.warnings);
         }
 
         this.schemas.set(normalizedSchema.nodeType, normalizedSchema);
       } catch (error) {
-        console.error(`[Schema Registry] Failed to register schema for ${schema?.nodeType || 'unknown'}:`, error);
+        logger.error(`[Schema Registry] Failed to register schema for ${schema?.nodeType || 'unknown'}:`, error);
         continue;
       }
     }
 
     this.initialized = true;
     if (this.shouldDebugLog()) {
-      console.debug(`ConfigSchemaRegistry initialized with ${this.schemas.size} schemas`);
+      logger.debug(`ConfigSchemaRegistry initialized with ${this.schemas.size} schemas`);
     }
   }
 
@@ -132,7 +132,7 @@ class ConfigSchemaRegistry {
 
     // Check for existing schema
     if (this.schemas.has(normalizedSchema.nodeType) && !overwrite) {
-      console.warn(
+      logger.warn(
         `Schema for ${normalizedSchema.nodeType} already registered. ` +
         `Use overwrite=true to replace existing schema.`
       );
@@ -141,7 +141,7 @@ class ConfigSchemaRegistry {
 
     this.schemas.set(normalizedSchema.nodeType, normalizedSchema);
     if (this.shouldDebugLog()) {
-      console.debug(`Registered schema for node type: ${normalizedSchema.nodeType}`);
+      logger.debug(`Registered schema for node type: ${normalizedSchema.nodeType}`);
     }
   }
 
@@ -154,7 +154,7 @@ class ConfigSchemaRegistry {
   getSchema(nodeType: string): NodeConfigSchema {
     const schema = this.schemas.get(nodeType);
     if (!schema) {
-      console.warn(`[Schema Registry] No schema found for node type: ${nodeType}, using fallback`);
+      logger.warn(`[Schema Registry] No schema found for node type: ${nodeType}, using fallback`);
       return this.createFallbackSchema(nodeType);
     }
     return schema;

--- a/frontend/src/components/FlowEditor/utils/nodeSorting.ts
+++ b/frontend/src/components/FlowEditor/utils/nodeSorting.ts
@@ -52,12 +52,12 @@ export function sortNodesTopologically(nodes: Node[]): Node[] {
   const validNodes = nodes.filter(node => node != null && typeof node === 'object' && node.id);
   
   if (validNodes.length === 0) {
-    console.warn('[Node Sort] No valid nodes found after filtering null/undefined entries');
+    logger.warn('[Node Sort] No valid nodes found after filtering null/undefined entries');
     return [];
   }
   
   if (validNodes.length !== nodes.length) {
-    console.warn(`[Node Sort] Filtered out ${nodes.length - validNodes.length} null/undefined nodes`);
+    logger.warn(`[Node Sort] Filtered out ${nodes.length - validNodes.length} null/undefined nodes`);
   }
 
   // Build a map of node IDs for quick lookup
@@ -80,7 +80,7 @@ export function sortNodesTopologically(nodes: Node[]): Node[] {
 
     const node = nodeMap.get(nodeId);
     if (!node) {
-      console.warn(`[Node Sort] Node ${nodeId} not found in map (orphaned reference)`);
+      logger.warn(`[Node Sort] Node ${nodeId} not found in map (orphaned reference)`);
       return;
     }
 
@@ -133,12 +133,12 @@ function verifyNodeOrdering(nodes: Node[]): boolean {
       const parentIndex = nodeIndices.get(node.parentId);
       
       if (parentIndex === undefined) {
-        console.error(
+        logger.error(
           `[Node Sort] ❌ Parent ${node.parentId} of node ${node.id} not found in sorted array`
         );
         hasOrderingError = true;
       } else if (parentIndex >= index) {
-        console.error(
+        logger.error(
           `[Node Sort] ❌ Parent ${node.parentId} at index ${parentIndex} must come before child ${node.id} at index ${index}`
         );
         hasOrderingError = true;
@@ -147,7 +147,7 @@ function verifyNodeOrdering(nodes: Node[]): boolean {
   });
 
   if (hasOrderingError) {
-    console.error('[Node Sort] ❌ Sorting failed - parent-child ordering violated');
+    logger.error('[Node Sort] ❌ Sorting failed - parent-child ordering violated');
   } else {
     logger.debug(`✅ Successfully sorted ${nodes.length} nodes`, { component: 'NodeSorting' });
   }
@@ -232,7 +232,7 @@ export function getNodeDepth(nodes: Node[], nodeId: string): number {
   while (current.parentId) {
     const parent = nodeMap.get(current.parentId);
     if (!parent) {
-      console.warn(`[Node Depth] Orphaned node ${current.id} has parent ${current.parentId} that doesn't exist`);
+      logger.warn(`[Node Depth] Orphaned node ${current.id} has parent ${current.parentId} that doesn't exist`);
       break;
     }
     depth++;
@@ -240,7 +240,7 @@ export function getNodeDepth(nodes: Node[], nodeId: string): number {
     
     // Prevent infinite loop from cycles
     if (depth > nodes.length) {
-      console.error(`[Node Depth] Cycle detected in hierarchy for node ${nodeId}`);
+      logger.error(`[Node Depth] Cycle detected in hierarchy for node ${nodeId}`);
       return -1;
     }
   }

--- a/frontend/src/contexts/CockpitPinnedToolsContext.tsx
+++ b/frontend/src/contexts/CockpitPinnedToolsContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { WidgetConfig } from '../components/Widgets/WidgetGrid';
+import { logger } from '@/utils/logger';
 
 export type PinnedToolKind = 'widget' | 'tool';
 
@@ -46,7 +47,7 @@ export const CockpitPinnedToolsProvider: React.FC<{ children: React.ReactNode }>
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) setPinned(parsed);
     } catch (e) {
-      console.warn('[CockpitPinnedTools] Failed to load pinned tools:', e);
+      logger.warn('[CockpitPinnedTools] Failed to load pinned tools:', e);
     }
   }, []);
 
@@ -54,7 +55,7 @@ export const CockpitPinnedToolsProvider: React.FC<{ children: React.ReactNode }>
     try {
       localStorage.setItem(getStorageKey(), JSON.stringify(pinned));
     } catch (e) {
-      console.warn('[CockpitPinnedTools] Failed to persist pinned tools:', e);
+      logger.warn('[CockpitPinnedTools] Failed to persist pinned tools:', e);
     }
   }, [pinned]);
 


### PR DESCRIPTION
## What
- Replace console.* usage with canonical logger in key FlowEditor + Cockpit pinned-tools codepaths

## Why
Keeps logging consistent (levels/formatting), avoids noisy console output, and supports centralized filtering in production.

## Testing
- npm -C frontend run type-check
- npm -C frontend run test -- --run src/components/FlowEditor/utils/__tests__/workflowPersistence.sanitize.test.ts

## Rollback
Revert this PR.