### PR TITLE
Mobile: run WorkForms (execute endpoint)

### DIFF
--- a/mobile/src/__tests__/ApiService.test.ts
+++ b/mobile/src/__tests__/ApiService.test.ts
@@ -208,4 +208,23 @@ describe('ApiService – workforms', () => {
     expect(result.workflow_definition?.nodes?.length).toBe(1);
     expect(internalApi.get).toHaveBeenCalledWith('/tenant-workforms/wf-1/');
   });
+
+  it('executeWorkForm POSTs to /tenant-workforms/{id}/execute/ with initial_data', async () => {
+    const mockExecution = {
+      id: 'exec-1',
+      workform_id: 'wf-1',
+      workform_name: 'Intake',
+      status: 'in_progress',
+      started_at: '2026-04-21T00:00:00Z',
+      completed_at: null,
+      error_message: '',
+    };
+    internalApi.post.mockResolvedValueOnce({ data: mockExecution });
+
+    const result = await ApiService.executeWorkForm('wf-1', { foo: 'bar' });
+    expect(result.id).toBe('exec-1');
+    expect(internalApi.post).toHaveBeenCalledWith('/tenant-workforms/wf-1/execute/', {
+      initial_data: { foo: 'bar' },
+    });
+  });
 });

--- a/mobile/src/screens/WorkFormDetailScreen.tsx
+++ b/mobile/src/screens/WorkFormDetailScreen.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   ScrollView,
   RefreshControl,
+  Alert,
 } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RouteProp } from '@react-navigation/native';
@@ -77,12 +78,13 @@ function getDefinitionPreview(definition?: WorkflowDefinition): { preview: strin
 }
 
 export default function WorkFormDetailScreen({ navigation, route }: Props) {
-  const { id } = route.params;
+  const { id, isGuest = false } = route.params;
 
   const [form, setForm] = useState<WorkForm | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [executing, setExecuting] = useState(false);
 
   const load = useCallback(
     async (isRefresh = false) => {
@@ -111,7 +113,30 @@ export default function WorkFormDetailScreen({ navigation, route }: Props) {
     load();
   }, [load]);
 
+  const handleExecute = useCallback(async () => {
+    if (isGuest) {
+      Alert.alert('Guest mode', 'WorkForm execution is disabled in guest mode.');
+      return;
+    }
+
+    if (executing) {
+      return;
+    }
+
+    setExecuting(true);
+    try {
+      const execution = await ApiService.executeWorkForm(id, {});
+      Alert.alert('Execution started', `Execution ID: ${execution.id}`);
+      await load(true);
+    } catch {
+      Alert.alert('Error', 'Unable to start WorkForm execution. Please try again.');
+    } finally {
+      setExecuting(false);
+    }
+  }, [executing, id, isGuest, load]);
+
   const statusLabel = form ? (form.is_active ? 'Active' : 'Inactive') : '—';
+  const headerSubtitle = isGuest ? 'Guest · View only' : 'Run and view details';
 
   const definitionCounts = useMemo(() => getDefinitionCounts(form?.workflow_definition), [form?.workflow_definition]);
   const definitionPreview = useMemo(() => getDefinitionPreview(form?.workflow_definition), [form?.workflow_definition]);
@@ -141,7 +166,7 @@ export default function WorkFormDetailScreen({ navigation, route }: Props) {
             {form?.name ?? 'WorkForm'}
           </Text>
           <Text style={styles.headerSubtitle} numberOfLines={1}>
-            Read-only summary
+            {headerSubtitle}
           </Text>
         </View>
         <View
@@ -211,6 +236,23 @@ export default function WorkFormDetailScreen({ navigation, route }: Props) {
               <Text style={styles.metaLabel}>Last executed</Text>
               <Text style={styles.metaValue}>{formatDate(form.last_executed_at)}</Text>
             </View>
+
+            <TouchableOpacity
+              style={[styles.executeBtn, (isGuest || executing) && styles.executeBtnDisabled]}
+              onPress={handleExecute}
+              disabled={isGuest || executing}
+              accessibilityLabel={isGuest ? 'Run WorkForm disabled' : 'Run WorkForm'}
+              accessibilityHint={
+                isGuest
+                  ? 'WorkForm execution is disabled in guest mode'
+                  : 'Starts a server-side WorkForm execution'
+              }
+              testID="workform-execute"
+            >
+              <Text style={styles.executeBtnText}>{executing ? 'Starting…' : 'Run WorkForm'}</Text>
+            </TouchableOpacity>
+
+            {isGuest ? <Text style={styles.executeHint}>Execution is disabled in guest mode.</Text> : null}
           </View>
         ) : null}
 
@@ -401,5 +443,24 @@ const styles = StyleSheet.create({
   retryBtnText: {
     color: '#fff',
     fontWeight: 'bold',
+  },
+  executeBtn: {
+    marginTop: 12,
+    backgroundColor: '#3498db',
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  executeBtnDisabled: {
+    opacity: 0.5,
+  },
+  executeBtnText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  executeHint: {
+    marginTop: 8,
+    color: '#7f8c8d',
+    fontSize: 12,
   },
 });

--- a/mobile/src/screens/WorkFormsScreen.tsx
+++ b/mobile/src/screens/WorkFormsScreen.tsx
@@ -97,7 +97,7 @@ export default function WorkFormsScreen({ navigation, tenant, user, isGuest = fa
   const handleFormPress = (form: WorkForm) => {
     // Full editing is handled on the web Workform Editor.
     // On mobile, show a read-only summary (works for both guest + authed).
-    navigation.navigate('WorkFormDetail', { id: form.id });
+    navigation.navigate('WorkFormDetail', { id: form.id, isGuest });
   };
 
   if (loading) {

--- a/mobile/src/services/ApiService.ts
+++ b/mobile/src/services/ApiService.ts
@@ -15,6 +15,7 @@ import {
   TenantInvite,
   InviteAcceptRequest,
   WorkForm,
+  WorkFormExecution,
 } from '../types';
 
 class ApiServiceClass {
@@ -332,6 +333,13 @@ class ApiServiceClass {
       workflow_definition: definition && typeof definition === 'object' ? definition : undefined,
       form_references: Array.isArray(row.form_references) ? row.form_references : undefined,
     };
+  }
+
+  async executeWorkForm(id: string, initialData: Record<string, unknown> = {}): Promise<WorkFormExecution> {
+    const response = await this.api.post(`/tenant-workforms/${id}/execute/`, {
+      initial_data: initialData,
+    });
+    return response.data;
   }
 }
 

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -80,7 +80,7 @@ export type RootStackParamList = {
   Home: undefined;
   GuestHome: undefined;
   WorkForms: undefined;
-  WorkFormDetail: { id: string };
+  WorkFormDetail: { id: string; isGuest?: boolean };
 };
 
 // Authentication types
@@ -182,6 +182,18 @@ export interface WorkForm {
   // Detail-only fields
   workflow_definition?: WorkflowDefinition;
   form_references?: string[];
+}
+
+export type WorkFormExecutionStatus = 'in_progress' | 'completed' | 'failed' | 'cancelled';
+
+export interface WorkFormExecution {
+  id: string;
+  workform_id: string;
+  workform_name: string;
+  status: WorkFormExecutionStatus | string;
+  started_at: string;
+  completed_at: string | null;
+  error_message: string;
 }
 
 // Common entity types (shared with backend)


### PR DESCRIPTION
## Deliverables\n- Mobile: add "Run WorkForm" button on WorkForm detail (disabled for guest)\n- ApiService: add executeWorkForm() calling POST /api/v1/tenant-workforms/{id}/execute/\n- Types: add WorkFormExecution + pass isGuest through navigation\n\n## Expected result\nMobile users can start server-side WorkForm execution from the detail screen; guest sessions remain view-only.\n\n## Testing\n- npm -C mobile run type-check\n- npm -C mobile test\n- npm -C mobile run lint\n