### PR TITLE
CI: run frontend unit tests in PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -164,6 +164,29 @@ jobs:
         working-directory: ./frontend
         run: npm run verify-standards
 
+  frontend-tests:
+    name: Frontend Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Run frontend unit tests
+        working-directory: ./frontend
+        run: npm run test:ci
+
   mobile-checks:
     name: Mobile Lint/Test/Type Check
     runs-on: ubuntu-latest

--- a/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.a11yTabs.test.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/TabbedConfigPanel.a11yTabs.test.tsx
@@ -64,24 +64,24 @@ describe('TabbedConfigPanel a11y tabs', () => {
   it('renders ARIA tablist/tabs and a tabpanel with stable data-testids', async () => {
     await renderPanel('form');
 
-    const tablist = screen.getByRole('tablist', { name: 'Config tabs' });
-    expect(tablist).toHaveAttribute('data-testid', 'config-tabs');
+    const tablist = screen.getByRole('tablist', { name: 'Node configuration' });
+    expect(tablist).toHaveAttribute('data-testid', 'flow-config-tablist');
 
     const general = screen.getByRole('tab', { name: 'General' });
     const fields = screen.getByRole('tab', { name: 'Fields' });
     const advanced = screen.getByRole('tab', { name: 'Advanced' });
     const preview = screen.getByRole('tab', { name: 'Preview' });
 
-    expect(general).toHaveAttribute('data-testid', 'config-tab-general');
-    expect(fields).toHaveAttribute('data-testid', 'config-tab-fields');
-    expect(advanced).toHaveAttribute('data-testid', 'config-tab-advanced');
-    expect(preview).toHaveAttribute('data-testid', 'config-tab-preview');
+    expect(general).toHaveAttribute('data-testid', 'flow-config-tab-general');
+    expect(fields).toHaveAttribute('data-testid', 'flow-config-tab-fields');
+    expect(advanced).toHaveAttribute('data-testid', 'flow-config-tab-advanced');
+    expect(preview).toHaveAttribute('data-testid', 'flow-config-tab-preview');
 
     expect(general).toHaveAttribute('aria-selected', 'true');
     expect(fields).toHaveAttribute('aria-selected', 'false');
 
     const panel = screen.getByRole('tabpanel');
-    expect(panel).toHaveAttribute('data-testid', 'config-tabpanel-general');
+    expect(panel).toHaveAttribute('data-testid', 'flow-config-tabpanel-general');
 
     const panelId = panel.getAttribute('id');
     expect(panelId).toBeTruthy();
@@ -112,7 +112,7 @@ describe('TabbedConfigPanel a11y tabs', () => {
     fireEvent.keyDown(fields, { key: 'Enter' });
     expect(fields).toHaveAttribute('aria-selected', 'true');
 
-    expect(await screen.findByTestId('config-tabpanel-fields')).toBeInTheDocument();
+    expect(await screen.findByTestId('flow-config-tabpanel-fields')).toBeInTheDocument();
   });
 
   it('hides Fields/Preview for non-form nodes', async () => {

--- a/frontend/src/components/FlowEditor/Modals/EntityMapperModal.test.tsx
+++ b/frontend/src/components/FlowEditor/Modals/EntityMapperModal.test.tsx
@@ -255,28 +255,32 @@ describe('EntityMapperModal', () => {
   });
 
   describe('Mapping Deletion', () => {
-    it('allows removing mapping', async () => {
-      render(
-        <EntityMapperModal
-          open={true}
-          onClose={mockOnClose}
-          formId="form123"
-          existingMappings={[{ formFieldId: 'field1', entityAttribute: 'name' }]}
-          onSave={mockOnSave}
-        />
-      );
+    it(
+      'allows removing mapping',
+      { timeout: 20_000 },
+      async () => {
+        render(
+          <EntityMapperModal
+            open={true}
+            onClose={mockOnClose}
+            formId="form123"
+            existingMappings={[{ formFieldId: 'field1', entityAttribute: 'name' }]}
+            onSave={mockOnSave}
+          />
+        );
 
-      // Find delete button (rendered as icon)
-      const deleteButtons = screen.getAllByRole('button');
-      const deleteButton = deleteButtons.find(btn => btn.className?.includes('danger'));
-      
-      if (deleteButton) {
-        fireEvent.click(deleteButton);
+        // Find delete button (rendered as icon)
+        const deleteButtons = screen.getAllByRole('button');
+        const deleteButton = deleteButtons.find((btn) => btn.className?.includes('danger'));
+
+        if (deleteButton) {
+          fireEvent.click(deleteButton);
+        }
+
+        // Verify mapping removed (implementation-specific)
+        expect(true).toBe(true);
       }
-
-      // Verify mapping removed (implementation-specific)
-      expect(true).toBe(true);
-    });
+    );
   });
 
   describe('Validation', () => {

--- a/frontend/src/components/FlowEditor/config/__tests__/flowEditorSchemasLoaded.test.ts
+++ b/frontend/src/components/FlowEditor/config/__tests__/flowEditorSchemasLoaded.test.ts
@@ -4,16 +4,20 @@ import { describe, expect, it, vi } from 'vitest';
 // Without this, the config panel can render fallback schemas on first interaction and never recover.
 
 describe('FlowEditor schema bootstrap', () => {
-  it('registers nodeConfigSchemas when FlowEditor is imported', async () => {
-    vi.resetModules();
+  it(
+    'registers nodeConfigSchemas when FlowEditor is imported',
+    { timeout: 20_000 },
+    async () => {
+      vi.resetModules();
 
-    const { schemaRegistry } = await import('../schemaRegistry');
-    schemaRegistry.clear();
+      const { schemaRegistry } = await import('../schemaRegistry');
+      schemaRegistry.clear();
 
-    await import('../../index');
+      await import('../../index');
 
-    const httpSchema = schemaRegistry.getSchema('actionHTTP');
-    expect(String(httpSchema.version)).not.toContain('fallback');
-    expect(httpSchema.nodeType).toBe('actionHTTP');
-  });
+      const httpSchema = schemaRegistry.getSchema('actionHTTP');
+      expect(String(httpSchema.version)).not.toContain('fallback');
+      expect(httpSchema.nodeType).toBe('actionHTTP');
+    }
+  );
 });


### PR DESCRIPTION
## Deliverables
- Add frontend-tests job to PR Validation to run: npm run test:ci
- Fix FlowEditor tests for Vitest v4 (options signature) + longer timeouts where needed
- Update TabbedConfigPanel a11y test expectations to match current ARIA labels/testids

## Verification
- bash .github/scripts/validate-workflows.sh
- npm -C frontend run test:ci
