### PR TITLE
CI: runner secrets hygiene + DB_PORT default

### DIFF
--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -671,6 +671,7 @@ on:
 ```yaml
 - name: Create Backend .env File Locally
   run: |
+    umask 077
     cat <<- 'EOF' > backend.env
     DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
     DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
@@ -680,9 +681,11 @@ on:
     DB_USER=${{ secrets.DB_USER }}
     DB_PASSWORD=${{ secrets.DB_PASSWORD }}
     DB_HOST=${{ secrets.DB_HOST }}
-    DB_PORT=${{ secrets.DB_PORT }}
+    DB_PORT=${{ secrets.DB_PORT || '5432' }}
     DB_ENGINE=django.db.backends.postgresql
     EOF
+
+    chmod 600 backend.env
 
 - name: Transfer .env to Server
   env:
@@ -690,6 +693,10 @@ on:
   run: |
     sshpass -e ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "mkdir -p /root/projectmeats/backend"
     sshpass -e scp -o StrictHostKeyChecking=no backend.env ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/root/projectmeats/backend/.env
+
+- name: Cleanup generated secret files (runner)
+  if: always()
+  run: rm -f backend.env || true
 ```
 
 ### File Permissions Pattern

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -703,7 +703,7 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
           DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_PORT: ${{ secrets.DB_PORT || '5432' }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_USER: ${{ secrets.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
@@ -727,7 +727,6 @@ jobs:
           check SSH_USER "$SSH_USER"
           check SSH_PASSWORD "$SSH_PASSWORD"
           check DB_HOST "$DB_HOST"
-          check DB_PORT "$DB_PORT"
           check DB_NAME "$DB_NAME"
           check DB_USER "$DB_USER"
           check DB_PASSWORD "$DB_PASSWORD"
@@ -1217,7 +1216,7 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
           DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_PORT: ${{ secrets.DB_PORT || '5432' }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_USER: ${{ secrets.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
@@ -1241,7 +1240,6 @@ jobs:
           check SSH_USER "$SSH_USER"
           check SSH_PASSWORD "$SSH_PASSWORD"
           check DB_HOST "$DB_HOST"
-          check DB_PORT "$DB_PORT"
           check DB_NAME "$DB_NAME"
           check DB_USER "$DB_USER"
           check DB_PASSWORD "$DB_PASSWORD"
@@ -1258,6 +1256,8 @@ jobs:
 
       - name: Create Backend .env File Locally
         run: |
+          # backend.env contains secrets; lock down permissions on the runner and ensure it is cleaned up.
+          umask 077
           cat <<- 'EOF' > backend.env
           	DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
           	DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
@@ -1267,7 +1267,7 @@ jobs:
           	DB_USER=${{ secrets.DB_USER }}
           	DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           	DB_HOST=${{ secrets.DB_HOST }}
-          	DB_PORT=${{ secrets.DB_PORT }}
+          	DB_PORT=${{ secrets.DB_PORT || '5432' }}
           	DB_ENGINE=django.db.backends.postgresql
           	EMAIL_HOST_PASSWORD=${{ secrets.EMAIL_HOST_PASSWORD }}
           	DEFAULT_FROM_EMAIL=no-reply@meatscentral.com
@@ -1285,6 +1285,8 @@ jobs:
           	MICROSOFT_REDIRECT_URI=${{ secrets.MICROSOFT_REDIRECT_URI }}
           	OAUTH_ENCRYPTION_KEY=${{ secrets.OAUTH_ENCRYPTION_KEY }}
           	EOF
+
+          chmod 600 backend.env
           
           # Verify EMAIL_HOST_PASSWORD is set (show length only for security)
           if [ -n "${{ secrets.EMAIL_HOST_PASSWORD }}" ]; then
@@ -1302,6 +1304,12 @@ jobs:
           sshpass -e ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "mkdir -p /root/projectmeats/backend"
           sshpass -e scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null backend.env ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/root/projectmeats/backend/.env
           echo "✓ backend/.env transferred to server"
+
+      - name: Cleanup generated secret files (runner)
+        if: always()
+        run: |
+          # Ensure no secret material is left on disk if a prior step fails.
+          rm -f backend.env || true
       
       - name: Deploy backend container
         env:
@@ -1440,7 +1448,7 @@ jobs:
             -e DB_NAME="${{ secrets.DB_NAME }}" \
             -e DB_USER="${{ secrets.DB_USER }}" \
             -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
-            -e DB_PORT="${{ secrets.DB_PORT }}" \
+            -e DB_PORT="${{ secrets.DB_PORT || '5432' }}" \
             -e DJANGO_SUPERUSER_USERNAME="${{ secrets.DJANGO_SUPERUSER_USERNAME }}" \
             -e DJANGO_SUPERUSER_EMAIL="${{ secrets.DJANGO_SUPERUSER_EMAIL }}" \
             -e DJANGO_SUPERUSER_PASSWORD="${{ secrets.DJANGO_SUPERUSER_PASSWORD }}" \
@@ -1500,7 +1508,7 @@ jobs:
             -e DB_NAME="${{ secrets.DB_NAME }}" \
             -e DB_USER="${{ secrets.DB_USER }}" \
             -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
-            -e DB_PORT="${{ secrets.DB_PORT }}" \
+            -e DB_PORT="${{ secrets.DB_PORT || '5432' }}" \
             -e DJANGO_SUPERUSER_USERNAME="${{ secrets.DJANGO_SUPERUSER_USERNAME }}" \
             -e DJANGO_SUPERUSER_EMAIL="${{ secrets.DJANGO_SUPERUSER_EMAIL }}" \
             -e DJANGO_SUPERUSER_PASSWORD="${{ secrets.DJANGO_SUPERUSER_PASSWORD }}" \

--- a/docs/reference/GOLDEN_PIPELINE.md
+++ b/docs/reference/GOLDEN_PIPELINE.md
@@ -220,23 +220,31 @@ curl -L -s -o /dev/null -w "%{http_code}" https://domain.com/api/health/
 ```yaml
 - name: Create Backend .env File Locally
   run: |
+    umask 077
     cat <<- 'EOF' > backend.env
     	DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
     	DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
     	# ... all secrets from GitHub
+    	DB_PORT=${{ secrets.DB_PORT || '5432' }}
     	EOF
+
+    chmod 600 backend.env
 
 - name: Transfer .env to Server
   env:
     SSHPASS: ${{ secrets.SSH_PASSWORD }}
   run: |
     sshpass -e scp backend.env ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/root/projectmeats/backend/.env
+
+- name: Cleanup generated secret files (runner)
+  if: always()
+  run: rm -f backend.env || true
 ```
 
 ### Required Secrets Per Environment
 **Backend** (dev-backend, uat-backend, production-backend):
 - SSH_HOST, SSH_USER, SSH_PASSWORD
-- DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
+- DB_HOST, DB_NAME, DB_USER, DB_PASSWORD (+ DB_PORT optional; defaults to 5432)
 - DJANGO_SECRET_KEY, DJANGO_SETTINGS_MODULE, ALLOWED_HOSTS, DEBUG
 
 **Frontend** (dev-frontend, uat-frontend, production-frontend):

--- a/scripts/lint-docker-ports.sh
+++ b/scripts/lint-docker-ports.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Lint Docker port bindings to prevent privileged host port usage (<1024)
+# Scans:
+#   - .github/workflows/*.yml|yaml (docker run -p ...)
+#   - docker-compose*.yml|yaml     (ports: "HOST:CONTAINER")
+set -euo pipefail
+
+MIN_PORT=1024
+FAILED=0
+
+log_err() { echo "[lint-docker-ports][ERROR] $*" >&2; }
+log_ok()  { echo "[lint-docker-ports][OK] $*"; }
+
+list_files() {
+  if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git ls-files \
+      '.github/workflows/*.yml' '.github/workflows/*.yaml' \
+      'docker-compose*.yml' 'docker-compose*.yaml' \
+      2>/dev/null || true
+  else
+    find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null || true
+    find . -maxdepth 1 -type f \( -name 'docker-compose*.yml' -o -name 'docker-compose*.yaml' \) 2>/dev/null || true
+  fi
+}
+
+check_host_port() {
+  local file="$1"
+  local line="$2"
+  local host_port="$3"
+
+  if ! [[ "$host_port" =~ ^[0-9]+$ ]]; then
+    return 0
+  fi
+
+  if (( host_port > 0 && host_port < MIN_PORT )); then
+    log_err "${file}: privileged host port binding detected: ${host_port} (<${MIN_PORT})"
+    log_err "  line: ${line}"
+    FAILED=1
+  fi
+}
+
+scan_file() {
+  local file="$1"
+
+  # 1) docker run: -p 8080:80 or -p 127.0.0.1:8080:80
+  while IFS= read -r match; do
+    local line="${match#*:}"
+
+    local host_port
+    host_port="$(printf '%s\n' "$line" | sed -nE 's/.*[[:space:]]-p[[:space:]]+"?([0-9]{1,5}):.*/\1/p')"
+    if [[ -n "${host_port:-}" ]]; then
+      check_host_port "$file" "$line" "$host_port"
+      continue
+    fi
+
+    host_port="$(printf '%s\n' "$line" | sed -nE 's/.*[[:space:]]-p[[:space:]]+"?([0-9]{1,3}(\.[0-9]{1,3}){3}):([0-9]{1,5}):.*/\3/p')"
+    if [[ -n "${host_port:-}" ]]; then
+      check_host_port "$file" "$line" "$host_port"
+    fi
+  done < <(grep -nE -- '[[:space:]]-p[[:space:]]+' "$file" 2>/dev/null || true)
+
+  # 2) docker-compose ports: - "8080:80" or - 127.0.0.1:8080:80
+  while IFS= read -r match; do
+    local line="${match#*:}"
+    local host_port
+    host_port="$(printf '%s\n' "$line" | sed -nE 's/^[[:space:]]*-[[:space:]]*"?([0-9]{1,3}(\.[0-9]{1,3}){3}:)?([0-9]{1,5}):[0-9]{1,5}.*"?$/\3/p')"
+    if [[ -n "${host_port:-}" ]]; then
+      check_host_port "$file" "$line" "$host_port"
+    fi
+  done < <(grep -nE -- '^[[:space:]]*-[[:space:]]*"?([0-9]{1,3}(\.[0-9]{1,3}){3}:)?[0-9]{1,5}:[0-9]{1,5}' "$file" 2>/dev/null || true)
+}
+
+main() {
+  local files
+  files="$(list_files)"
+
+  if [[ -z "${files:-}" ]]; then
+    log_ok "No workflow/compose files found to scan (skipping)."
+    exit 0
+  fi
+
+  while IFS= read -r f; do
+    [[ -z "${f:-}" ]] && continue
+    [[ -f "$f" ]] || continue
+    scan_file "$f"
+  done <<< "$files"
+
+  if (( FAILED == 1 )); then
+    exit 1
+  fi
+
+  log_ok "No privileged host port bindings detected."
+}
+
+main "$@"


### PR DESCRIPTION
## Deliverables\n- Make DB_PORT optional in reusable-deploy (defaults to 5432 per env manifest)\n- Harden generated backend.env permissions (umask/chmod)\n- Ensure backend.env is removed on runner via always() cleanup\n- Add missing scripts/lint-docker-ports.sh to satisfy pre-commit hook\n\n## Verification\n- bash .github/scripts/validate-workflows.sh\n- bash scripts/verify_golden_state.sh\n- scripts/lint-docker-ports.sh\n