### PR TITLE
WorkForms: surface circuit breaker errors

### DIFF
--- a/frontend/src/components/errors/ApiErrorContent.tsx
+++ b/frontend/src/components/errors/ApiErrorContent.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import {
+  formatApiErrorMeta,
+  getApiErrorPresentation,
+  type ApiErrorPresentation,
+} from '@/services/apiErrorPresentation';
+
+const BlockWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const Message = styled.div`
+  color: rgb(var(--color-text-primary));
+`;
+
+const Meta = styled.div`
+  color: rgb(var(--color-text-secondary));
+  font-size: 12px;
+  line-height: 1.35;
+`;
+
+const InlineMeta = styled.span`
+  color: rgb(var(--color-text-secondary));
+  font-size: 12px;
+`;
+
+export interface ApiErrorContentProps {
+  error: unknown;
+  fallbackMessage?: string;
+  includeMeta?: boolean;
+  variant?: 'inline' | 'block';
+}
+
+export const ApiErrorContent: React.FC<ApiErrorContentProps> = ({
+  error,
+  fallbackMessage,
+  includeMeta = true,
+  variant = 'block',
+}) => {
+  const presentation: ApiErrorPresentation = getApiErrorPresentation(error, { fallbackMessage });
+  const meta = includeMeta ? formatApiErrorMeta(presentation) : undefined;
+
+  if (variant === 'inline') {
+    return (
+      <>
+        {presentation.friendlyMessage}
+        {meta ? <InlineMeta>{` (${meta})`}</InlineMeta> : null}
+      </>
+    );
+  }
+
+  return (
+    <BlockWrap>
+      <Message>{presentation.friendlyMessage}</Message>
+      {meta ? <Meta>{meta}</Meta> : null}
+    </BlockWrap>
+  );
+};

--- a/frontend/src/contexts/QuickActionsContext.test.tsx
+++ b/frontend/src/contexts/QuickActionsContext.test.tsx
@@ -10,7 +10,7 @@
  * - Error handling
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QuickActionsProvider, useQuickActions } from './QuickActionsContext';
 import { getAvailableWorkForms } from '@/services/workformsApi';
@@ -611,11 +611,13 @@ describe('QuickActionsContext', () => {
         expect(screen.getByTestId('error')).toHaveTextContent('Form not found');
       });
       
-      expect(vi.mocked(showAlert)).toHaveBeenCalledWith({
-        type: 'error',
-        title: 'Error',
-        content: 'Form not found',
-      });
+      expect(vi.mocked(showAlert)).toHaveBeenCalledTimes(1);
+      const alertArgs = vi.mocked(showAlert).mock.calls[0][0];
+      expect(alertArgs.type).toBe('error');
+      expect(alertArgs.title).toBe('Error');
+
+      const renderedAlert = render(<>{alertArgs.content}</>);
+      expect(within(renderedAlert.container).getByText('Form not found')).toBeInTheDocument();
       
       consoleSpy.mockRestore();
     });

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -8,6 +8,8 @@ import React, { createContext, useContext, useState, useEffect, useCallback, Rea
 import { getAvailableWorkForms } from '@/services/workformsApi';
 import { showAlert } from '@/utils/uiDialogs';
 import { logger } from '@/utils/logger';
+import { ApiErrorContent } from '@/components/errors/ApiErrorContent';
+import { getApiErrorPresentation } from '@/services/apiErrorPresentation';
 import {
   quickActionsService,
   formSubmissionService,
@@ -261,13 +263,14 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
       logger.debug('[QuickActions] Form submission created:', submission?.id);
     } catch (err: any) {
       logger.error('[QuickActions] Failed to start form submission:', err);
-      const errorMsg = err?.response?.data?.error || err?.message || 'Failed to start form';
-      setError(errorMsg);
+      const presentation = getApiErrorPresentation(err, { fallbackMessage: 'Failed to start form' });
+      setError(presentation.friendlyMessage);
+
       // Alert the user since the modal won't open
       showAlert({
         type: 'error',
         title: 'Error',
-        content: errorMsg,
+        content: <ApiErrorContent error={err} fallbackMessage={presentation.friendlyMessage} />,
       });
     }
   }, [startFormSubmission]);

--- a/frontend/src/features/workforms/workformsErrors.test.ts
+++ b/frontend/src/features/workforms/workformsErrors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { ApiServiceError } from '@/services/apiErrors';
 import { getWorkformsErrorMessage, getWorkformsErrorUi } from './workformsErrors';
 
 describe('workformsErrors', () => {
@@ -36,5 +37,16 @@ describe('workformsErrors', () => {
     const ui = getWorkformsErrorUi(err, 'catalog.load');
     expect(ui.title).toBe("Couldn't load catalog");
     expect(ui.message).toBe('Boom');
+  });
+
+  it('reads status/message from ApiServiceError (circuit breaker)', () => {
+    const err = new ApiServiceError('Server error. Please try again shortly.', {
+      kind: 'circuit_breaker',
+      status: 503,
+    });
+
+    const ui = getWorkformsErrorUi(err, 'catalog.load');
+    expect(ui.title).toBe("Couldn't load catalog");
+    expect(ui.message).toMatch(/server error/i);
   });
 });

--- a/frontend/src/features/workforms/workformsErrors.ts
+++ b/frontend/src/features/workforms/workformsErrors.ts
@@ -1,3 +1,5 @@
+import { ApiServiceError } from '@/services/apiErrors';
+
 export type WorkformsErrorContext =
   | 'catalog.load'
   | 'catalog.start'
@@ -17,12 +19,29 @@ type ErrorWithResponse = {
 };
 
 function getHttpStatus(error: unknown): number | undefined {
+  if (error instanceof ApiServiceError) {
+    return typeof error.status === 'number' ? error.status : undefined;
+  }
+
   const e = error as ErrorWithResponse | null;
   const status = e?.response?.status;
   return typeof status === 'number' ? status : undefined;
 }
 
 function getBackendMessage(error: unknown): string | undefined {
+  if (error instanceof ApiServiceError) {
+    const data = error.responseData as any;
+    const candidates = [
+      typeof data?.detail === 'string' ? data.detail : undefined,
+      typeof data?.error === 'string' ? data.error : undefined,
+      typeof data?.message === 'string' ? data.message : undefined,
+      typeof error.friendlyMessage === 'string' ? error.friendlyMessage : undefined,
+      typeof error.message === 'string' ? error.message : undefined,
+    ].filter(Boolean) as string[];
+
+    return candidates[0];
+  }
+
   const e = error as ErrorWithResponse | null;
   const data = e?.response?.data;
 

--- a/frontend/src/pages/WorkForms/Catalog.errorState.test.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.errorState.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import Catalog from './Catalog';
 import { getAvailableWorkForms } from '../../services/workformsApi';
+import { ApiServiceError } from '../../services/apiErrors';
 import { quickActionsService } from '@/services/quickActionsService';
 
 vi.mock('../../services/workformsApi', () => ({
@@ -72,6 +73,38 @@ describe('WorkForms Catalog error state', () => {
 
     expect(await screen.findByText("Couldn't load catalog")).toBeInTheDocument();
     expect(screen.getByText('Boom')).toBeInTheDocument();
+    expect(screen.getByText(/status 500/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('surfaces circuit-breaker friendly errors with status', async () => {
+    const err = new ApiServiceError('Server error. Please try again shortly.', {
+      kind: 'circuit_breaker',
+      status: 503,
+      code: 'CIRCUIT_BREAKER',
+    });
+
+    vi.mocked(getAvailableWorkForms).mockRejectedValueOnce(err);
+    vi.mocked(quickActionsService.getAvailableForms).mockRejectedValueOnce(err);
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/workforms/catalog']}>
+          <Routes>
+            <Route path="/workforms/catalog" element={<Catalog />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Couldn't load catalog")).toBeInTheDocument();
+    expect(screen.getByText('Server error. Please try again shortly.')).toBeInTheDocument();
+    expect(screen.getByText(/status 503/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -20,6 +20,7 @@ import React, { useState } from 'react';
 import { logger } from '@/utils/logger';
 import { showAlert } from '@/utils/uiDialogs';
 import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
+import { ApiErrorContent } from '@/components/errors/ApiErrorContent';
 
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -571,7 +572,11 @@ const FormsFlowsCatalog: React.FC = () => {
     },
     onError: (error: any) => {
       const ui = getWorkformsErrorUi(error, 'catalog.delete');
-      showAlert({ type: 'error', title: ui.title, content: ui.message });
+      showAlert({
+        type: 'error',
+        title: ui.title,
+        content: <ApiErrorContent error={error} fallbackMessage={ui.message} />,
+      });
     },
   });
 
@@ -836,7 +841,7 @@ const FormsFlowsCatalog: React.FC = () => {
       showAlert({
         type: 'error',
         title: ui.title,
-        content: ui.message,
+        content: <ApiErrorContent error={error} fallbackMessage={ui.message} />,
       });
     } finally {
       setIsQuickRunning(null);
@@ -870,7 +875,7 @@ const FormsFlowsCatalog: React.FC = () => {
       showAlert({
         type: 'error',
         title: ui.title,
-        content: ui.message,
+        content: <ApiErrorContent error={error} fallbackMessage={ui.message} />,
       });
     }
   };
@@ -967,7 +972,9 @@ const FormsFlowsCatalog: React.FC = () => {
         <EmptyState role="status" aria-live="polite">
           <EmptyStateIcon aria-hidden="true">⚠️</EmptyStateIcon>
           <EmptyStateTitle>{catalogErrorUi.title}</EmptyStateTitle>
-          <EmptyStateDescription>{catalogErrorUi.message}</EmptyStateDescription>
+          <EmptyStateDescription>
+            <ApiErrorContent error={error} fallbackMessage={catalogErrorUi.message} variant="inline" />
+          </EmptyStateDescription>
           <Button variant="primary" onClick={() => void refetch()}>
             Try again
           </Button>

--- a/frontend/src/pages/WorkForms/Editor.errorState.test.tsx
+++ b/frontend/src/pages/WorkForms/Editor.errorState.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { WorkFormsEditor } from './Editor';
 import { loadWorkflow } from '../../components/FlowEditor/utils/workflowPersistence';
+import { ApiServiceError } from '../../services/apiErrors';
 
 vi.mock('../../components/FlowEditor/utils/workflowPersistence', () => ({
   loadWorkflow: vi.fn(),
@@ -56,7 +57,8 @@ describe('WorkForms Editor load error state', () => {
     );
 
     expect(await screen.findByText("Couldn't load workform")).toBeInTheDocument();
-    expect(screen.getByText('Boom')).toBeInTheDocument();
+    expect(screen.getByText(/Boom/)).toBeInTheDocument();
+    expect(screen.getByText(/status 500/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
 
     vi.mocked(loadWorkflow).mockRejectedValueOnce(err);
@@ -66,5 +68,35 @@ describe('WorkForms Editor load error state', () => {
     await waitFor(() => {
       expect(loadWorkflow).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('surfaces circuit-breaker friendly errors with status', async () => {
+    const err = new ApiServiceError('Server temporarily unreachable. Please try again shortly.', {
+      kind: 'circuit_breaker',
+      status: 502,
+      code: 'CIRCUIT_BREAKER',
+    });
+
+    vi.mocked(loadWorkflow).mockRejectedValueOnce(err);
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/workforms/editor/123']}>
+          <Routes>
+            <Route path="/workforms/editor/:id" element={<WorkFormsEditor />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Couldn't load workform")).toBeInTheDocument();
+    expect(screen.getByText(/Server temporarily unreachable\. Please try again shortly\./)).toBeInTheDocument();
+    expect(screen.getByText(/status 502/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/WorkForms/Editor.tsx
+++ b/frontend/src/pages/WorkForms/Editor.tsx
@@ -14,6 +14,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Wand2, Eye, Code2, Lock } from 'lucide-react';
 
 import { logger } from '@/utils/logger';
+import { toApiErrorText } from '@/services/apiErrorPresentation';
 import { UnifiedFlowEditor } from '../../components/FlowEditor';
 import { FLOW_TEMPLATES } from '../../components/FlowEditor/templates/flowTemplates';
 import {
@@ -355,15 +356,10 @@ export const WorkFormsEditor: React.FC = () => {
     ? cloneWorkFormQuery.error
     : existingWorkFormQuery.error;
 
-  const getLoadErrorDetail = useCallback((error: unknown): string => {
-    const e = error as any;
-    return (
-      e?.response?.data?.detail ||
-      e?.response?.data?.error ||
-      e?.message ||
-      'Unknown error'
-    );
-  }, []);
+  const getLoadErrorDetail = useCallback(
+    (error: unknown): string => toApiErrorText(error, { fallbackMessage: 'Unknown error' }),
+    []
+  );
 
   const handleRetryLoad = useCallback(async () => {
     setIsInitialized(false);

--- a/frontend/src/pages/WorkForms/Execute.tsx
+++ b/frontend/src/pages/WorkForms/Execute.tsx
@@ -10,6 +10,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Skeleton } from 'antd';
 import { showAlert } from '@/utils/uiDialogs';
+import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
+import { ApiErrorContent } from '@/components/errors/ApiErrorContent';
 import {
   createFormSubmission,
   executeTenantWorkForm,
@@ -82,8 +84,12 @@ export const ExecuteWorkForm: React.FC = () => {
       navigate(`/workforms/executions/${data.id}`, { replace: true });
     },
     onError: (err: any) => {
-      const msg = err?.response?.data?.error || err?.message || 'Failed to start WorkForm.';
-      showAlert({ type: 'error', title: 'Error', content: msg });
+      const ui = getWorkformsErrorUi(err, 'execute.start');
+      showAlert({
+        type: 'error',
+        title: ui.title,
+        content: <ApiErrorContent error={err} fallbackMessage={ui.message} />,
+      });
       navigate('/workforms/catalog', { replace: true });
     },
   });

--- a/frontend/src/services/apiErrorPresentation.ts
+++ b/frontend/src/services/apiErrorPresentation.ts
@@ -1,0 +1,96 @@
+import { ApiServiceError } from './apiErrors';
+
+export interface ApiErrorPresentation {
+  /** A message intended to be safe and helpful for end users */
+  friendlyMessage: string;
+  /** HTTP status code when known */
+  status?: number;
+  /** Transport/error code when known (e.g. axios ERR_NETWORK) */
+  code?: string;
+  /** Normalized classification */
+  kind?: string;
+}
+
+type ErrorWithResponse = {
+  response?: {
+    status?: number;
+    data?: any;
+  };
+  code?: string;
+  message?: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function extractBackendMessage(data: unknown): string | undefined {
+  if (!isObject(data)) return undefined;
+
+  const anyData = data as any;
+  const msg = anyData.message ?? anyData.error ?? anyData.detail ?? anyData.details;
+  return typeof msg === 'string' ? msg : undefined;
+}
+
+function looksLikeAxiosStatusMessage(msg: string): boolean {
+  return /request failed with status code \d+/i.test(msg);
+}
+
+export function getApiErrorPresentation(
+  error: unknown,
+  opts?: {
+    fallbackMessage?: string;
+  }
+): ApiErrorPresentation {
+  const fallbackMessage = opts?.fallbackMessage ?? 'Something went wrong. Please try again.';
+
+  if (error instanceof ApiServiceError) {
+    return {
+      friendlyMessage: error.friendlyMessage ?? error.message ?? fallbackMessage,
+      status: error.status,
+      code: error.code,
+      kind: error.kind,
+    };
+  }
+
+  const e = (error ?? null) as ErrorWithResponse | null;
+  const status = typeof e?.response?.status === 'number' ? e.response.status : undefined;
+  const code = typeof e?.code === 'string' ? e.code : undefined;
+
+  const backendMessage = extractBackendMessage(e?.response?.data);
+  const rawMessage = typeof e?.message === 'string' ? e.message : undefined;
+
+  const friendlyMessage =
+    backendMessage ??
+    (rawMessage && !looksLikeAxiosStatusMessage(rawMessage) ? rawMessage : undefined) ??
+    fallbackMessage;
+
+  return {
+    friendlyMessage,
+    status,
+    code,
+    kind: undefined,
+  };
+}
+
+export function formatApiErrorMeta(presentation: ApiErrorPresentation): string | undefined {
+  const parts = [
+    typeof presentation.status === 'number' ? `Status ${presentation.status}` : undefined,
+    presentation.code ? `Code ${presentation.code}` : undefined,
+    presentation.kind ? presentation.kind : undefined,
+  ].filter(Boolean) as string[];
+
+  return parts.length ? parts.join(' • ') : undefined;
+}
+
+export function toApiErrorText(
+  error: unknown,
+  opts?: {
+    fallbackMessage?: string;
+    includeMeta?: boolean;
+  }
+): string {
+  const presentation = getApiErrorPresentation(error, { fallbackMessage: opts?.fallbackMessage });
+  const meta = opts?.includeMeta === false ? undefined : formatApiErrorMeta(presentation);
+  return meta ? `${presentation.friendlyMessage}\n\n${meta}` : presentation.friendlyMessage;
+}

--- a/frontend/src/services/apiErrors.test.ts
+++ b/frontend/src/services/apiErrors.test.ts
@@ -15,7 +15,9 @@ describe('apiErrors', () => {
     expect(err).toBeInstanceOf(Error);
     expect(err).toBeInstanceOf(ApiServiceError);
     expect(err.message).toBe('Server error. Please try again shortly.');
+    expect(err.friendlyMessage).toBe('Server error. Please try again shortly.');
     expect(err.kind).toBe('circuit_breaker');
+    expect(err.code).toBe('CIRCUIT_BREAKER');
     expect(err.status).toBe(500);
     expect(err.request?.url).toBe('/workflows/available-forms/');
     expect(err.responseData).toEqual({ detail: 'boom' });

--- a/frontend/src/services/apiErrors.ts
+++ b/frontend/src/services/apiErrors.ts
@@ -8,7 +8,15 @@ export interface ApiRequestMeta {
 
 export class ApiServiceError extends Error {
   kind: ApiServiceErrorKind;
+
+  /** A message intended to be safe and helpful for end users. */
+  friendlyMessage: string;
+
   status?: number;
+
+  /** Transport/error code when known. */
+  code?: string;
+
   request?: ApiRequestMeta;
   responseData?: unknown;
   originalError?: unknown;
@@ -18,6 +26,7 @@ export class ApiServiceError extends Error {
     opts: {
       kind: ApiServiceErrorKind;
       status?: number;
+      code?: string;
       request?: ApiRequestMeta;
       responseData?: unknown;
       originalError?: unknown;
@@ -26,7 +35,9 @@ export class ApiServiceError extends Error {
     super(message);
     this.name = 'ApiServiceError';
     this.kind = opts.kind;
+    this.friendlyMessage = message;
     this.status = opts.status;
+    this.code = opts.code;
     this.request = opts.request;
     this.responseData = opts.responseData;
     this.originalError = opts.originalError;
@@ -43,6 +54,7 @@ export function createCircuitBreakerError(args: {
   return new ApiServiceError(args.friendlyMessage, {
     kind: 'circuit_breaker',
     status: args.status,
+    code: 'CIRCUIT_BREAKER',
     request: args.request,
     responseData: args.responseData,
     originalError: args.originalError,


### PR DESCRIPTION
## Deliverables\n- Add shared ApiService error presentation utilities + UI content\n- Surface friendly messages + status/code in WorkForms Catalog/Editor/Execute and QuickActions\n- Add/adjust unit tests for error-state rendering\n\n## Verification\n- npm -C frontend run type-check\n- npm -C frontend run verify-standards\n- npm -C frontend run test:ci\n