### PR TITLE
fix(email): harden RLS UUID casting

### DIFF
--- a/backend/apps/core/management/commands/audit_rls_compliance.py
+++ b/backend/apps/core/management/commands/audit_rls_compliance.py
@@ -206,7 +206,7 @@ class Command(BaseCommand):
                     cursor.execute(f"""
                         CREATE POLICY {policy_name} ON {table_name}
                         FOR ALL
-                        USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+                        USING (tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid)
                     """)
                     self.stdout.write(
                         self.style.SUCCESS(f"  ✓ Created policy {policy_name}")

--- a/backend/apps/email_integration/migrations/0005_fix_email_rls_uuid_cast_safety.py
+++ b/backend/apps/email_integration/migrations/0005_fix_email_rls_uuid_cast_safety.py
@@ -1,0 +1,88 @@
+from django.db import migrations
+
+
+SAFE_EXPR = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid"
+UNSAFE_EXPR = "tenant_id = current_setting('app.current_tenant', true)::uuid"
+
+
+def _alter_policy_sql(*, table: str, policy: str, expr: str) -> str:
+    # Postgres supports ALTER POLICY ... USING (...)
+    # We wrap in a DO block to be idempotent (policy may already exist).
+    return f"""
+    DO $$
+    BEGIN
+        -- Ensure RLS is enabled/forced even if the policy already exists.
+        ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE {table} FORCE ROW LEVEL SECURITY;
+
+        IF EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE tablename = '{table}'
+              AND policyname = '{policy}'
+        ) THEN
+            ALTER POLICY {policy} ON {table}
+                USING ({expr});
+        ELSE
+            CREATE POLICY {policy} ON {table}
+                FOR ALL
+                USING ({expr});
+        END IF;
+    END $$;
+    """
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('email_integration', '0004_enable_rls_email_integration'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+            -- Email Integration: harden UUID casting in RLS policies.
+            """
+            + _alter_policy_sql(
+                table='email_accounts',
+                policy='email_accounts_tenant_isolation',
+                expr=SAFE_EXPR,
+            )
+            + _alter_policy_sql(
+                table='email_actions',
+                policy='email_actions_tenant_isolation',
+                expr=SAFE_EXPR,
+            )
+            + _alter_policy_sql(
+                table='email_triggers',
+                policy='email_triggers_tenant_isolation',
+                expr=SAFE_EXPR,
+            )
+            + _alter_policy_sql(
+                table='email_logs',
+                policy='email_logs_tenant_isolation',
+                expr=SAFE_EXPR,
+            ),
+            reverse_sql="""
+            -- Revert to legacy UUID casts (kept for rollback safety).
+            """
+            + _alter_policy_sql(
+                table='email_accounts',
+                policy='email_accounts_tenant_isolation',
+                expr=UNSAFE_EXPR,
+            )
+            + _alter_policy_sql(
+                table='email_actions',
+                policy='email_actions_tenant_isolation',
+                expr=UNSAFE_EXPR,
+            )
+            + _alter_policy_sql(
+                table='email_triggers',
+                policy='email_triggers_tenant_isolation',
+                expr=UNSAFE_EXPR,
+            )
+            + _alter_policy_sql(
+                table='email_logs',
+                policy='email_logs_tenant_isolation',
+                expr=UNSAFE_EXPR,
+            ),
+        ),
+    ]

--- a/backend/apps/email_integration/tests/test_rls_uuid_cast_safety.py
+++ b/backend/apps/email_integration/tests/test_rls_uuid_cast_safety.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from django.db import connection
+from django.test import TransactionTestCase
+
+
+class EmailIntegrationRlsUuidCastSafetyTestCase(TransactionTestCase):
+    """Regression test for invalid UUID casts when app.current_tenant = ''."""
+
+    def test_email_integration_policies_use_nullif_current_setting(self):
+        if connection.vendor != 'postgresql':
+            self.skipTest('RLS policy introspection requires PostgreSQL')
+
+        expected_policy_fields = {
+            ('email_accounts', 'email_accounts_tenant_isolation'): 'qual',
+            ('email_actions', 'email_actions_tenant_isolation'): 'qual',
+            ('email_triggers', 'email_triggers_tenant_isolation'): 'qual',
+            ('email_logs', 'email_logs_tenant_isolation'): 'qual',
+        }
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT tablename, policyname, qual
+                FROM pg_policies
+                WHERE schemaname = current_schema()
+                  AND tablename IN ('email_accounts', 'email_actions', 'email_triggers', 'email_logs')
+                """
+            )
+            rows = cursor.fetchall()
+
+        by_key = {(t, p): q for (t, p, q) in rows}
+
+        for key, field in expected_policy_fields.items():
+            self.assertIn(key, by_key, msg=f"Missing policy in pg_policies: {key}")
+            expr = by_key[key]
+            self.assertTrue(expr, msg=f"Empty policy expression for {key} ({field})")
+
+            s = str(expr).lower()
+            self.assertIn('current_setting', s)
+            self.assertIn('app.current_tenant', s)
+            self.assertIn('nullif', s)
+            self.assertIn('uuid', s)

--- a/manifests/RLS_POLICIES.md
+++ b/manifests/RLS_POLICIES.md
@@ -96,6 +96,21 @@ All workflow-related tables have Row-Level Security **ENABLED** and **FORCED**:
 
 ---
 
+## Email Integration Module (4 tables) - ✅ 100% COMPLIANT
+
+| Table Name | RLS Enabled | Policy Name | Session Variable |
+|------------|-------------|-------------|------------------|
+| `email_accounts` | ✅ | `email_accounts_tenant_isolation` | `app.current_tenant` |
+| `email_actions` | ✅ | `email_actions_tenant_isolation` | `app.current_tenant` |
+| `email_triggers` | ✅ | `email_triggers_tenant_isolation` | `app.current_tenant` |
+| `email_logs` | ✅ | `email_logs_tenant_isolation` | `app.current_tenant` |
+
+**Migrations**:
+- `email_integration/0004_enable_rls_email_integration`
+- `email_integration/0005_fix_email_rls_uuid_cast_safety`
+
+---
+
 ## Tenant Integrations Module (2 tables) - ✅ 100% COMPLIANT
 
 | Table Name | RLS Enabled | Policy Name | Session Variable |


### PR DESCRIPTION
Hardens Email Integration RLS policies to use NULLIF(current_setting(...), '')::uuid to avoid invalid UUID-cast failures and align with repo RLS standards.

Includes:
- Additive migration email_integration/0005 to ALTER/CREATE email_* tenant isolation policies with safe UUID casting
- Update audit_rls_compliance --fix to create safe policies
- Postgres-only regression test asserting policies contain NULLIF
- Update manifests/RLS_POLICIES.md to document Email Integration tables

Testing:
- bash .github/scripts/validate-migrations.sh
- python manage.py test apps.email_integration.tests.test_rls_uuid_cast_safety --verbosity=2