### PR TITLE
fix(health): return 503 when DB unhealthy

### DIFF
--- a/backend/apps/core/tests/test_health.py
+++ b/backend/apps/core/tests/test_health.py
@@ -45,3 +45,13 @@ class HealthCheckTests(TestCase):
         self.assertIn('services', data)
         self.assertIn('error', data['services'])
         self.assertEqual(data['services']['error']['code'], 'service_checks_failed')
+
+    @patch('projectmeats.health.connection.cursor', side_effect=Exception('db down'))
+    def test_health_returns_503_when_db_unhealthy(self, _mock_cursor):
+        resp = self.client.get('/api/v1/health/')
+        self.assertEqual(resp.status_code, 503)
+
+        data = json.loads(resp.content.decode('utf-8'))
+        self.assertEqual(data['database_status']['status'], 'unhealthy')
+        self.assertEqual(data['database_status']['error']['code'], 'db_connection_failed')
+        self.assertIn('services', data)

--- a/backend/projectmeats/health.py
+++ b/backend/projectmeats/health.py
@@ -137,9 +137,11 @@ def health_check(request):
 
     service_summary = services.get("summary", {}) if isinstance(services, dict) else {}
 
+    http_status = status.HTTP_200_OK if db_status == "healthy" else status.HTTP_503_SERVICE_UNAVAILABLE
+
     return JsonResponse(
         {
-            "status": "healthy" if db_status == "healthy" else "degraded",
+            "status": "healthy" if db_status == "healthy" else "unhealthy",
             "timestamp": timezone.now().isoformat(),
             "version": "1.0.0",
             # Backward-compatible field
@@ -152,7 +154,8 @@ def health_check(request):
             "integration_summary": integration_summary,
             "integration_warnings": integration_warnings,
             "services": services,
-        }
+        },
+        status=http_status,
     )
 
 


### PR DESCRIPTION
Fixes deploy health-gate correctness by making `/api/v1/health/` return HTTP 503 when the database is unreachable.

Why:
- Previously health returned 200 with `status=degraded` even when DB was down, allowing "green" deploy gates with a broken backend.

Changes:
- `backend/projectmeats/health.py`: set response status code to 503 when DB check fails.
- `backend/apps/core/tests/test_health.py`: add regression test asserting 503 + stable error payload.

Testing:
- `cd backend && python manage.py test apps.core.tests.test_health --verbosity=2`
