### PR TITLE
ci: gate migrations on security scans

### DIFF
--- a/.github/scripts/validate-workflows.sh
+++ b/.github/scripts/validate-workflows.sh
@@ -487,7 +487,18 @@ assert_needs_exact('test-frontend', {'build-frontend'})
 assert_needs_exact('check-migrations', {'test-backend'})
 
 # Tests gating is re-enabled: migrations are gated on BOTH backend and frontend test tracks.
-assert_needs_exact('migrate', {'check-migrations', 'test-frontend'})
+# We also allow (and prefer) additionally gating mutations on security scans to avoid
+# "DB advanced but deploy blocked" failure modes.
+allowed_migrate_needs = [
+    {'check-migrations', 'test-frontend'},
+    {'check-migrations', 'test-frontend', 'security-scan-backend', 'security-scan-frontend'},
+]
+if needs_set('migrate') not in allowed_migrate_needs:
+    print(
+        f"ERROR: migrate.needs must be one of {sorted([sorted(s) for s in allowed_migrate_needs])} (found {sorted(needs_set('migrate'))})",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 # Deploy backend is gated on migrations + its own security scan.
 assert_needs_exact('deploy-backend', {'migrate', 'security-scan-backend'})

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -685,8 +685,8 @@ jobs:
   
   migrate:
     name: "Run Database Migrations"
-    # Gate all mutation steps on both backend + frontend tests to avoid partial deploys.
-    needs: [check-migrations, test-frontend]
+    # Gate all mutation steps on tests + security scans to avoid "DB advanced but deploy blocked" failures.
+    needs: [check-migrations, test-frontend, security-scan-backend, security-scan-frontend]
     runs-on: ubuntu-latest
     environment: ${{ inputs.backend_environment }}
     timeout-minutes: 15
@@ -1502,7 +1502,7 @@ jobs:
 
           docker run -d --name pm-backend \
             --restart unless-stopped \
-            -p 8000:8000 \
+            -p 127.0.0.1:8000:8000 \
             --env-file /root/projectmeats/backend/.env \
             -e DB_HOST="${{ secrets.DB_HOST }}" \
             -e DB_NAME="${{ secrets.DB_NAME }}" \


### PR DESCRIPTION
Hardens Golden deploy safety:

- Gate `migrate` on security scan jobs (in addition to backend/frontend tests) to avoid "DB advanced but deploy blocked" scenarios.
- Bind canonical backend container port to localhost (`127.0.0.1:8000:8000`) to reduce exposure and match canary behavior.
- Update `.github/scripts/validate-workflows.sh` golden topology enforcement to allow (and prefer) the safer `migrate.needs` superset.

Testing:
- `bash .github/scripts/validate-workflows.sh`
