### PR TITLE
fix(tenants): always reset RLS session vars

### DIFF
--- a/backend/apps/tenants/middleware.py
+++ b/backend/apps/tenants/middleware.py
@@ -102,11 +102,15 @@ class TenantMiddleware:
 
     def __call__(self, request: HttpRequest):
         """Process the request and set tenant context."""
-        # Skip tenant resolution for health check and readiness endpoints
+        # Skip tenant resolution for health check and readiness endpoints.
+        # Still RESET session vars to prevent pooled-connection tenant leakage.
         if request.path.startswith('/api/v1/health/') or request.path.startswith('/api/v1/ready/'):
             request.tenant = None
             request.tenant_user = None
-            return self.get_response(request)
+            try:
+                return self.get_response(request)
+            finally:
+                self._reset_rls_session_vars()
         
         tenant = None
         resolution_method = None  # Track how tenant was resolved for logging
@@ -401,12 +405,8 @@ class TenantMiddleware:
             raise
         finally:
             # Prevent cross-request tenant leakage on pooled DB connections.
-            if rls_set or getattr(request, '_rls_set', False):
-                try:
-                    with connection.cursor() as cursor:
-                        cursor.execute("RESET app.current_tenant_id")
-                        cursor.execute("RESET app.current_tenant")
-                except Exception:
-                    pass
+            # This is best-effort and intentionally unconditional: if SET fails (or a request
+            # never sets tenant context), we still must not carry a stale tenant into the next request.
+            self._reset_rls_session_vars()
 
         return response

--- a/backend/apps/tenants/test_middleware_rls_reset_unconditional.py
+++ b/backend/apps/tenants/test_middleware_rls_reset_unconditional.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from django.contrib.auth.models import User
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
+
+from apps.tenants.middleware import TenantMiddleware
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
+
+
+class TenantMiddlewareRlsResetUnconditionalTests(TestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.tenant = Tenant.objects.create(
+            name='Acme Tenant',
+            slug='acme',
+            contact_email='acme@example.com',
+            is_active=True,
+        )
+        TenantDomain.objects.create(domain='acme.example.com', tenant=self.tenant, is_primary=True)
+
+        self.user = User.objects.create_user(username='member', password='pass')
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner', is_active=True)
+
+    @override_settings(ALLOWED_HOSTS=['acme.example.com'])
+    def test_resets_rls_session_vars_even_when_set_current_tenant_fails(self):
+        get_response = Mock(return_value=HttpResponse('ok'))
+        middleware = TenantMiddleware(get_response)
+
+        request = self.factory.get('/some/web/page/', HTTP_HOST='acme.example.com')
+        request.user = self.user
+
+        with (
+            patch('apps.tenants.rls.set_current_tenant', return_value=SimpleNamespace(ok=False, error='boom')),
+            patch.object(middleware, '_reset_rls_session_vars') as reset,
+        ):
+            resp = middleware(request)
+
+        self.assertEqual(resp.status_code, 200)
+        reset.assert_called_once()
+
+    @override_settings(ALLOWED_HOSTS=['testserver'])
+    def test_health_route_still_resets_rls_session_vars(self):
+        get_response = Mock(return_value=HttpResponse('ok'))
+        middleware = TenantMiddleware(get_response)
+
+        request = self.factory.get('/api/v1/health/', HTTP_HOST='testserver')
+        request.user = self.user
+
+        with patch.object(middleware, '_reset_rls_session_vars') as reset:
+            resp = middleware(request)
+
+        self.assertEqual(resp.status_code, 200)
+        reset.assert_called_once()


### PR DESCRIPTION
Prevents cross-request tenant leakage on pooled DB connections.

Changes:
- `TenantMiddleware` now RESETs `app.current_tenant_id` and `app.current_tenant` in a best-effort, **unconditional** finally block.
- Health/ready routes also perform a best-effort RESET even though they bypass tenant resolution.
- Adds regression tests asserting RESET happens even when `set_current_tenant()` fails.

Testing:
- `cd backend && python manage.py test apps.tenants.test_middleware_rls_reset_unconditional apps.tenants.test_middleware_debug apps.tenants.test_middleware_host_membership apps.tenants.test_middleware_tenant_header_anonymous --verbosity=2`
