### PR TITLE
test(ai): fix tenant header upload CI

### DIFF
--- a/backend/tenant_apps/ai_assistant/tests_document_upload.py
+++ b/backend/tenant_apps/ai_assistant/tests_document_upload.py
@@ -34,7 +34,10 @@ class AIDocumentUploadTests(APITestCase):
         )
         TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner', is_active=True)
 
-        self.client.force_authenticate(user=self.user)
+        # Use session auth (not DRF force_authenticate) so AuthenticationMiddleware marks
+        # request.user as authenticated before TenantMiddleware runs.
+        # TenantMiddleware intentionally ignores X-Tenant-ID for anonymous requests.
+        self.client.force_login(self.user)
 
     def _upload(self):
         file = SimpleUploadedFile('test.pdf', b'%PDF-1.4\n% test\n', content_type='application/pdf')


### PR DESCRIPTION
### What
Fix backend CI failure for AI document upload tests by using session auth so AuthenticationMiddleware marks request.user authenticated before TenantMiddleware runs.

### Why
TenantMiddleware intentionally ignores X-Tenant-ID for anonymous requests; DRF force_authenticate runs after middleware, so the test looked anonymous at middleware time and raised Tenant context required.

### Testing
cd backend && python manage.py test tenant_apps.ai_assistant.tests_document_upload -v 2