### PR TITLE
fix(integrations): scope email sync tasks to tenant RLS

### DIFF
--- a/backend/apps/integrations/tasks.py
+++ b/backend/apps/integrations/tasks.py
@@ -9,6 +9,8 @@ import random
 from celery import group, shared_task
 
 from apps.integrations.models import ExternalAuthProvider
+from apps.tenants.models import Tenant
+from apps.tenants.rls import tenant_rls
 from tenant_apps.integrations.services.email_ingestion import EmailIngestionService
 
 logger = logging.getLogger(__name__)
@@ -26,22 +28,31 @@ def sync_tenant_emails(self):
 
     This task runs every 5 minutes via Celery Beat.
 
-    Previous behavior: sequential polling across all providers.
-    New behavior: enqueue one task per active provider so work can run in parallel
-    across Celery workers.
+    IMPORTANT: ExternalAuthProvider is RLS-protected. Celery workers must set
+    tenant context explicitly or queries will return 0 rows under FORCE RLS.
 
     Returns:
         dict: dispatch metadata (provider count + group id)
     """
     try:
-        provider_ids = list(
-            ExternalAuthProvider.objects.filter(
-                provider_type='microsoft',
-                is_active=True,
-            ).values_list('id', flat=True)
-        )
+        tenant_ids = list(Tenant.objects.filter(is_active=True).values_list('id', flat=True))
+        tasks = []
 
-        if not provider_ids:
+        for tenant_id in tenant_ids:
+            with tenant_rls(str(tenant_id)):
+                provider_ids = list(
+                    ExternalAuthProvider.objects.filter(
+                        tenant_id=tenant_id,
+                        provider_type='microsoft',
+                        is_active=True,
+                    ).values_list('id', flat=True)
+                )
+
+            for pid in provider_ids:
+                # Jitter dispatch slightly to avoid stampedes against Graph API.
+                tasks.append(sync_email_provider_inbox.s(pid, str(tenant_id)).set(countdown=random.randint(0, 15)))
+
+        if not tasks:
             logger.info('No active Microsoft providers found; skipping email sync dispatch')
             return {
                 'success': True,
@@ -49,23 +60,14 @@ def sync_tenant_emails(self):
                 'group_id': None,
             }
 
-        # Jitter dispatch slightly to avoid stampedes against Graph API.
-        tasks = [
-            sync_email_provider_inbox.s(pid).set(countdown=random.randint(0, 15))
-            for pid in provider_ids
-        ]
         job = group(tasks)
         async_result = job.apply_async(expires=240)  # if beat lags, drop stale work
 
-        logger.info(
-            'Dispatched email sync fan-out: %s providers (group=%s)',
-            len(provider_ids),
-            async_result.id,
-        )
+        logger.info('Dispatched email sync fan-out: %s providers (group=%s)', len(tasks), async_result.id)
 
         return {
             'success': True,
-            'providers_dispatched': len(provider_ids),
+            'providers_dispatched': len(tasks),
             'group_id': async_result.id,
         }
 
@@ -81,11 +83,12 @@ def sync_tenant_emails(self):
     soft_time_limit=300,  # 5 minutes
     time_limit=360,  # 6 minutes hard limit
 )
-def sync_email_provider_inbox(self, provider_id: int):
+def sync_email_provider_inbox(self, provider_id: int, tenant_id: str):
     """Poll inbox for a single ExternalAuthProvider (tenant-scoped)."""
     try:
-        service = EmailIngestionService()
-        stats = service.poll_provider_by_id(provider_id)
+        with tenant_rls(str(tenant_id)):
+            service = EmailIngestionService()
+            stats = service.poll_provider_by_id(provider_id, tenant_id=str(tenant_id))
 
         logger.info(
             'Email sync provider complete: provider_id=%s tenant=%s saved=%s fetched=%s errors=%s',
@@ -123,8 +126,9 @@ def sync_single_tenant(self, tenant_id: str):
     try:
         logger.info('Manual sync triggered for tenant %s', tenant_id)
 
-        service = EmailIngestionService()
-        stats = service.poll_tenant_by_id(tenant_id)
+        with tenant_rls(str(tenant_id)):
+            service = EmailIngestionService()
+            stats = service.poll_tenant_by_id(tenant_id)
 
         logger.info(
             'Manual sync completed for tenant %s: saved=%s fetched=%s errors=%s',

--- a/backend/apps/integrations/test_tasks_rls_scope.py
+++ b/backend/apps/integrations/test_tasks_rls_scope.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from django.test import TestCase
+
+
+class IntegrationsEmailTasksRlsScopeTests(TestCase):
+    def test_sync_email_provider_inbox_scopes_rls_and_passes_tenant_id(self):
+        from apps.integrations import tasks
+
+        calls: list[str] = []
+
+        @contextmanager
+        def fake_tenant_rls(tenant_id: str, *, strict: bool = True):
+            calls.append(f"enter:{tenant_id}")
+            try:
+                yield None
+            finally:
+                calls.append(f"exit:{tenant_id}")
+
+        with patch.object(tasks, 'tenant_rls', fake_tenant_rls), patch(
+            'tenant_apps.integrations.services.email_ingestion.EmailIngestionService.poll_provider_by_id',
+            return_value={'tenant_id': 't1', 'emails_saved': 0, 'emails_fetched': 0, 'errors': 0},
+        ) as poll_provider:
+            result = tasks.sync_email_provider_inbox.run(123, 't1')
+
+        self.assertEqual(result['success'], True)
+        poll_provider.assert_called_once_with(123, tenant_id='t1')
+        self.assertEqual(calls, ['enter:t1', 'exit:t1'])
+
+    def test_sync_single_tenant_scopes_rls(self):
+        from apps.integrations import tasks
+
+        calls: list[str] = []
+
+        @contextmanager
+        def fake_tenant_rls(tenant_id: str, *, strict: bool = True):
+            calls.append(f"enter:{tenant_id}")
+            try:
+                yield None
+            finally:
+                calls.append(f"exit:{tenant_id}")
+
+        with patch.object(tasks, 'tenant_rls', fake_tenant_rls), patch(
+            'tenant_apps.integrations.services.email_ingestion.EmailIngestionService.poll_tenant_by_id',
+            return_value={'emails_saved': 0, 'emails_fetched': 0, 'errors': 0},
+        ) as poll_tenant:
+            result = tasks.sync_single_tenant.run('t1')
+
+        self.assertEqual(result['success'], True)
+        poll_tenant.assert_called_once_with('t1')
+        self.assertEqual(calls, ['enter:t1', 'exit:t1'])

--- a/backend/apps/tenants/rls.py
+++ b/backend/apps/tenants/rls.py
@@ -13,6 +13,7 @@ connection right before a write.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 from django.db import connection
@@ -61,3 +62,27 @@ def reset_current_tenant() -> None:
     except Exception:  # pragma: no cover
         # Never break application logic due to cleanup failure.
         return
+
+
+@contextmanager
+def tenant_rls(tenant_id: str, *, strict: bool = True):
+    """Context manager to scope a block of ORM work to a tenant RLS context.
+
+    Celery workers / management commands do not run TenantMiddleware, so any ORM
+    access to RLS-protected tenant tables must explicitly set/reset the session
+    variables.
+
+    Args:
+        tenant_id: Tenant UUID.
+        strict: When True, raise if tenant context cannot be set.
+    """
+
+    result = set_current_tenant(str(tenant_id))
+    if strict and not result.ok:
+        reset_current_tenant()
+        raise RuntimeError(f"Failed to set tenant RLS context: {result.error}")
+
+    try:
+        yield result
+    finally:
+        reset_current_tenant()

--- a/backend/apps/tenants/test_rls_contextmanager.py
+++ b/backend/apps/tenants/test_rls_contextmanager.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.tenants.rls import RlsSetResult, tenant_rls
+
+
+class TenantRlsContextManagerTests(TestCase):
+    def test_tenant_rls_resets_on_exit(self):
+        with patch('apps.tenants.rls.set_current_tenant', return_value=RlsSetResult(ok=True)) as set_tenant, patch(
+            'apps.tenants.rls.reset_current_tenant'
+        ) as reset_tenant:
+            with tenant_rls('t1'):
+                pass
+
+        set_tenant.assert_called_once_with('t1')
+        reset_tenant.assert_called_once()
+
+    def test_tenant_rls_strict_raises_when_set_fails(self):
+        with patch(
+            'apps.tenants.rls.set_current_tenant',
+            return_value=RlsSetResult(ok=False, error='db down'),
+        ), patch('apps.tenants.rls.reset_current_tenant') as reset_tenant:
+            with self.assertRaises(RuntimeError):
+                with tenant_rls('t1', strict=True):
+                    pass
+
+        reset_tenant.assert_called_once()

--- a/backend/tenant_apps/integrations/services/email_ingestion.py
+++ b/backend/tenant_apps/integrations/services/email_ingestion.py
@@ -388,16 +388,19 @@ class EmailIngestionService:
         )
         self.stats['emails_saved'] += 1
     
-    def poll_provider_by_id(self, provider_id: int) -> Dict[str, int]:
+    def poll_provider_by_id(self, provider_id: int, *, tenant_id: str | None = None) -> Dict[str, int]:
         """Poll inbox for a specific ExternalAuthProvider.
 
         This is the unit of work used by the Phase 8.3 Celery fan-out.
+
+        Note: Callers in Celery worker contexts must set tenant RLS session vars.
+        Passing tenant_id provides additional defense-in-depth filtering.
         """
-        provider = (
-            ExternalAuthProvider.objects.select_related('tenant')
-            .filter(id=provider_id, is_active=True)
-            .first()
-        )
+        qs = ExternalAuthProvider.objects.select_related('tenant').filter(id=provider_id, is_active=True)
+        if tenant_id:
+            qs = qs.filter(tenant_id=tenant_id)
+
+        provider = qs.first()
         if not provider:
             logger.error('No active provider found for id=%s', provider_id)
             return {'error': 'Provider not found or inactive'}


### PR DESCRIPTION
### What
- Add apps.tenants.rls.tenant_rls() context manager (set/reset RLS vars).
- Use it in Celery email sync tasks: sync_tenant_emails, sync_email_provider_inbox, sync_single_tenant.
- Pass tenant_id into the provider fan-out task and filter provider lookup for defense-in-depth.

### Why
Celery workers do not run TenantMiddleware; without explicit RLS scoping, tenant-protected ORM queries can return 0 rows or behave incorrectly under FORCE RLS.

### Testing
cd backend && python manage.py test apps.integrations.test_tasks_rls_scope apps.tenants.test_rls_contextmanager -v 2