### PR TITLE
ci: add timeouts to critical workflows

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -59,6 +59,7 @@ jobs:
   check_infrastructure:
     name: "Check Infrastructure (Golden Drift Gate)"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -96,6 +97,7 @@ jobs:
   # 3. All commits are eventually deployed (git history is cumulative)
   check-latest:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [check_infrastructure]
     outputs:
       should_deploy: ${{ steps.check.outputs.should_deploy }}
@@ -134,6 +136,7 @@ jobs:
   # Route to Development
   # ==========================================
   deploy-dev:
+    timeout-minutes: 90
     if: |
       needs.check-latest.outputs.should_deploy == 'true' &&
       ((github.event_name == 'push' && github.ref == 'refs/heads/development') ||
@@ -154,6 +157,7 @@ jobs:
   # Route to UAT
   # ==========================================
   deploy-uat:
+    timeout-minutes: 90
     if: |
       needs.check-latest.outputs.should_deploy == 'true' &&
       ((github.event_name == 'push' && github.ref == 'refs/heads/uat') ||
@@ -174,6 +178,7 @@ jobs:
   # Route to Production
   # ==========================================
   deploy-prod:
+    timeout-minutes: 90
     if: |
       needs.check-latest.outputs.should_deploy == 'true' &&
       ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -25,6 +25,7 @@ jobs:
   infrastructure-check:
     name: Infrastructure Drift Gate
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -43,6 +44,7 @@ jobs:
   validate-migrations:
     name: Validate Migrations
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     services:
       postgres:
@@ -102,6 +104,7 @@ jobs:
   backend-tests:
     name: Backend Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     needs: [validate-migrations]
 
     services:
@@ -147,6 +150,7 @@ jobs:
   frontend-typecheck:
     name: Frontend Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -202,6 +206,7 @@ jobs:
   frontend-tests:
     name: Frontend Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -225,6 +230,7 @@ jobs:
   mobile-checks:
     name: Mobile Lint/Test/Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: [validate-migrations]
 
     steps:


### PR DESCRIPTION
### What
Add timeout-minutes to main-pipeline.yml and pr-validation.yml jobs.

### Why
Prevents hung CI jobs from blocking deploys and wasting runner minutes.

### Validation
- bash .github/scripts/validate-workflows.sh