### PR TITLE
openapi: document health and auth endpoints

### DIFF
--- a/backend/apps/core/health_api.py
+++ b/backend/apps/core/health_api.py
@@ -1,0 +1,49 @@
+"""DRF-wrapped health endpoints for OpenAPI visibility.
+
+The canonical routes live under /api/v1/health/* and /api/v1/ready/.
+Historically these were implemented as plain Django views, which drf-spectacular
+won't include in the generated OpenAPI schema.
+
+These APIViews delegate to the existing implementations in projectmeats.health
+to preserve behavior and response shape.
+"""
+
+from __future__ import annotations
+
+from drf_spectacular.utils import OpenApiTypes, extend_schema
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+
+from projectmeats.health import health_check, health_detailed, health_workforms, ready_check
+
+
+class HealthCheckAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(tags=["Health"], responses={200: OpenApiTypes.OBJECT, 503: OpenApiTypes.OBJECT})
+    def get(self, request, *args, **kwargs):
+        return health_check(request._request)
+
+
+class HealthDetailedAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(tags=["Health"], responses={200: OpenApiTypes.OBJECT, 503: OpenApiTypes.OBJECT})
+    def get(self, request, *args, **kwargs):
+        return health_detailed(request._request)
+
+
+class HealthWorkformsAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(tags=["Health"], responses={200: OpenApiTypes.OBJECT, 503: OpenApiTypes.OBJECT})
+    def get(self, request, *args, **kwargs):
+        return health_workforms(request._request)
+
+
+class ReadyCheckAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(tags=["Health"], responses={200: OpenApiTypes.OBJECT, 503: OpenApiTypes.OBJECT})
+    def get(self, request, *args, **kwargs):
+        return ready_check(request._request)

--- a/backend/apps/core/serializers.py
+++ b/backend/apps/core/serializers.py
@@ -36,3 +36,8 @@ class UserFavoriteSerializer(serializers.ModelSerializer):
         model = UserFavorite
         fields = ['id', 'tenant_id', 'entity_type', 'entity_id', 'entity_title', 'created_at']
         read_only_fields = ['id', 'tenant_id', 'created_at']
+
+
+class LoginRequestSerializer(serializers.Serializer):
+    username = serializers.CharField()
+    password = serializers.CharField(write_only=True)

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -2,6 +2,7 @@ import logging
 
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
+from drf_spectacular.utils import OpenApiTypes, extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import api_view, permission_classes, throttle_classes, action
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -11,11 +12,16 @@ from rest_framework.serializers import ValidationError
 from apps.tenants.models import TenantUser
 from apps.core.throttling import AuthRateThrottle
 from apps.core.models import UserFavorite
-from apps.core.serializers import UserFavoriteSerializer
+from apps.core.serializers import LoginRequestSerializer, UserFavoriteSerializer
 
 logger = logging.getLogger(__name__)
 
 
+@extend_schema(
+    tags=["Auth"],
+    request=LoginRequestSerializer,
+    responses={200: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT, 401: OpenApiTypes.OBJECT},
+)
 @api_view(["POST"])
 @permission_classes([AllowAny])
 @throttle_classes([AuthRateThrottle])

--- a/backend/apps/tenants/invitation_views.py
+++ b/backend/apps/tenants/invitation_views.py
@@ -2,6 +2,7 @@
 Views for tenant invitation system.
 """
 from rest_framework import viewsets, status
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
@@ -192,6 +193,11 @@ class TenantInvitationViewSet(viewsets.ModelViewSet):
             )
 
 
+@extend_schema(
+    tags=["Auth"],
+    request=InvitationSignupSerializer,
+    responses={201: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT, 500: OpenApiTypes.OBJECT},
+)
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def signup_with_invitation(request):
@@ -251,6 +257,18 @@ def signup_with_invitation(request):
         )
 
 
+@extend_schema(
+    tags=["Invitations"],
+    parameters=[
+        OpenApiParameter(
+            name='token',
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+            required=True,
+        )
+    ],
+    responses={200: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT, 404: OpenApiTypes.OBJECT},
+)
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def validate_invitation(request):

--- a/backend/projectmeats/urls.py
+++ b/backend/projectmeats/urls.py
@@ -13,7 +13,12 @@ from drf_spectacular.views import (
     SpectacularRedocView,
     SpectacularSwaggerView,
 )
-from .health import health_check, health_detailed, ready_check, health_workforms
+from apps.core.health_api import (
+    HealthCheckAPIView,
+    HealthDetailedAPIView,
+    HealthWorkformsAPIView,
+    ReadyCheckAPIView,
+)
 from apps.core.admin_site import admin_site
 from tenant_apps.workflows.views import SuggestNodesView
 from tenant_apps.workflows.views_triggers import TenantScopedWebhookReceiverAPIView
@@ -29,10 +34,10 @@ admin.site.index_title = 'Admin Dashboard'
 
 urlpatterns = [
     # Health check endpoints
-    path("api/v1/health/", health_check, name="health-check"),
-    path("api/v1/health/detailed/", health_detailed, name="health-detailed"),
-    path("api/v1/health/workforms/", health_workforms, name="health-workforms"),
-    path("api/v1/ready/", ready_check, name="ready-check"),
+    path("api/v1/health/", HealthCheckAPIView.as_view(), name="health-check"),
+    path("api/v1/health/detailed/", HealthDetailedAPIView.as_view(), name="health-detailed"),
+    path("api/v1/health/workforms/", HealthWorkformsAPIView.as_view(), name="health-workforms"),
+    path("api/v1/ready/", ReadyCheckAPIView.as_view(), name="ready-check"),
     # NOTE: System Configuration Studio ARCHIVED 2026-02-14 (superseded by apps.system)
     # Admin interface (using custom three-tier admin site)
     path("admin/", admin_site.urls, name='admin'),  # Custom three-tier admin (primary)


### PR DESCRIPTION
### What
- Add DRF-wrapped health endpoints so drf-spectacular includes /api/v1/health/* and /api/v1/ready/.
- Add explicit OpenAPI request/parameter schemas for auth + invitation endpoints (login, signup-with-invitation, validate-invitation).

### Validation
- cd backend && python manage.py check
- cd backend && python manage.py spectacular --format openapi-json --verbosity 0