### PR TITLE
docs: align API routing to /api/v1

### DIFF
--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -715,7 +715,7 @@ chmod -R 775 /root/projectmeats/staticfiles
 ```bash
 MAX_ATTEMPTS=15
 ATTEMPT=1
-HEALTH_URL="https://$DOMAIN/api/health/"
+HEALTH_URL="https://$DOMAIN/api/v1/health/"
 
 while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
   HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" "$HEALTH_URL")

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cd frontend && npm start
 
 **Access Points:**
 - Frontend: http://localhost:3000
-- Backend API: http://localhost:8000/api/
+- Backend API: http://localhost:8000/api/v1/
 - Django Admin: http://localhost:8000/admin/
 
 ---

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,7 +1,8 @@
 # ProjectMeats API Reference
 
 **Version**: 2.0.0  
-**Base URL**: `https://api.meatscentral.com/api/v1/`  
+**Base URL**: `https://meatscentral.com/api/v1/` (Production)  
+**Environments**: `https://dev.meatscentral.com/api/v1/` | `https://uat.meatscentral.com/api/v1/`  
 **Documentation**: `/api/docs/` (Swagger UI) | `/api/redoc/` (ReDoc)
 
 ---
@@ -13,7 +14,7 @@ All API requests require authentication via Token header:
 ```bash
 curl -H "Authorization: Token YOUR_AUTH_TOKEN" \
      -H "X-Tenant-ID: YOUR_TENANT_UUID" \
-     https://api.meatscentral.com/api/v1/customers/
+     https://meatscentral.com/api/v1/customers/
 ```
 
 ### Obtain Token
@@ -23,7 +24,7 @@ POST /api/v1/auth/login/
 Content-Type: application/json
 
 {
-  "email": "user@example.com",
+  "username": "user@example.com",
   "password": "your-password"
 }
 ```
@@ -230,7 +231,7 @@ List endpoints return paginated results:
 ```json
 {
   "count": 150,
-  "next": "https://api.meatscentral.com/api/v1/customers/?page=2",
+  "next": "https://meatscentral.com/api/v1/customers/?page=2",
   "previous": null,
   "results": [...]
 }
@@ -359,7 +360,7 @@ Webhook payload:
 
 Download the OpenAPI spec:
 ```bash
-curl https://api.meatscentral.com/api/schema/ > openapi.yaml
+curl https://meatscentral.com/api/schema/ > openapi.yaml
 ```
 
 ---

--- a/docs/LOAD_TESTING.md
+++ b/docs/LOAD_TESTING.md
@@ -66,21 +66,21 @@ locust -f locustfile.py \
   --users 50 \
   --spawn-rate 2 \
   --run-time 1m \
-  --host=https://api.meatscentral.com
+  --host=https://meatscentral.com
 
 # Gradually increase
 locust -f locustfile.py \
   --users 500 \
   --spawn-rate 10 \
   --run-time 5m \
-  --host=https://api.meatscentral.com
+  --host=https://meatscentral.com
 
 # Stress test (1000+ users)
 locust -f locustfile.py \
   --users 1000 \
   --spawn-rate 20 \
   --run-time 10m \
-  --host=https://api.meatscentral.com \
+  --host=https://meatscentral.com \
   --html=stress_test_report.html
 ```
 
@@ -303,8 +303,8 @@ docker logs pm-backend | grep "500"
 # Increase backend instances
 docker-compose up --scale backend=3
 
-# Verify load balancing
-curl http://localhost:8000/api/health/
+# Verify backend is reachable
+curl http://localhost:8000/api/v1/health/
 ```
 
 #### Connection Pooling
@@ -426,7 +426,7 @@ Max retries exceeded with url: /api/auth/login/
 ```
 
 **Solutions**:
-- Verify backend is running: `curl http://localhost:8000/api/health/`
+- Verify backend is running: `curl http://localhost:8000/api/v1/health/`
 - Check firewall rules
 - Ensure correct host/port in `--host` parameter
 

--- a/docs/TESTING_AND_DOCUMENTATION_GUIDE.md
+++ b/docs/TESTING_AND_DOCUMENTATION_GUIDE.md
@@ -323,7 +323,7 @@ Response 200:
 
 **Frontend** (`.env`):
 ```bash
-VITE_API_BASE_URL=https://api.meatscentral.com/api/v1
+VITE_API_BASE_URL=https://meatscentral.com/api/v1
 VITE_ENVIRONMENT=production
 VITE_ENABLE_ANALYTICS=true
 ```
@@ -358,7 +358,7 @@ python manage.py migrate
 - [ ] Run `python manage.py check --deploy` (backend)
 - [ ] Run migrations: `python manage.py migrate`
 - [ ] Collect static files: `python manage.py collectstatic`
-- [ ] Test health endpoint: `curl https://api.meatscentral.com/health/`
+- [ ] Test health endpoint: `curl https://meatscentral.com/api/v1/health/`
 - [ ] Verify Cockpit search works
 - [ ] Test WorkForms editor loads
 - [ ] Check error logs for 24 hours

--- a/docs/TROUBLESHOOTING_MULTI_STEP_CONTAINERS.md
+++ b/docs/TROUBLESHOOTING_MULTI_STEP_CONTAINERS.md
@@ -341,7 +341,7 @@ rf.getViewport();
 
 ```bash
 # Check backend health
-curl http://localhost:8000/api/health/
+curl http://localhost:8000/api/v1/health/
 
 # List workflows
 curl -H "Authorization: Bearer TOKEN" \

--- a/docs/architecture/AUTHENTICATION_EXPLANATION.md
+++ b/docs/architecture/AUTHENTICATION_EXPLANATION.md
@@ -294,7 +294,7 @@ export DEBUG=False  # CRITICAL (though hardcoded as backup)
 export DJANGO_SETTINGS_MODULE=projectmeats.settings.production
 export DATABASE_URL=postgresql://...
 export SECRET_KEY=<production-secret-key>
-export ALLOWED_HOSTS=api.meatscentral.com,meatscentral.com
+export ALLOWED_HOSTS=meatscentral.com,www.meatscentral.com
 ```
 
 ---

--- a/docs/guides/ALLOWED_HOSTS_CONFIGURATION.md
+++ b/docs/guides/ALLOWED_HOSTS_CONFIGURATION.md
@@ -144,7 +144,7 @@ ALLOWED_HOSTS = list(set(_ext_hosts + _int_hosts + _COMMON_INTERNAL_HOSTS))
 **GitHub Secret Setup**:
 ```yaml
 Environment: prod-backend
-ALLOWED_HOSTS=meatscentral.com,www.meatscentral.com,api.meatscentral.com
+ALLOWED_HOSTS=meatscentral.com,www.meatscentral.com
 INTERNAL_ALLOWED_HOSTS=10.244.45.4,172.17.0.1
 ```
 
@@ -183,7 +183,7 @@ STAGING_SSH_PASSWORD=<password>
 
 #### Production Backend (`prod-backend`)
 ```yaml
-ALLOWED_HOSTS=meatscentral.com,www.meatscentral.com,api.meatscentral.com
+ALLOWED_HOSTS=meatscentral.com,www.meatscentral.com
 INTERNAL_ALLOWED_HOSTS=10.244.45.4,172.17.0.1
 PRODUCTION_HOST=<prod-backend-ip>
 PRODUCTION_USER=django
@@ -310,7 +310,7 @@ ALLOWED_HOSTS=dev.meatscentral.com,157.245.114.182
 
 ### 2. Use Wildcards for Subdomains
 ```bash
-# Allows dev.meatscentral.com, api.meatscentral.com, etc.
+# Allows dev.meatscentral.com, uat.meatscentral.com, etc.
 ALLOWED_HOSTS=.meatscentral.com
 ```
 
@@ -320,7 +320,7 @@ ALLOWED_HOSTS=.meatscentral.com
 ALLOWED_HOSTS=localhost,127.0.0.1,.meatscentral.com
 
 # Production - restrictive
-ALLOWED_HOSTS=meatscentral.com,www.meatscentral.com,api.meatscentral.com
+ALLOWED_HOSTS=meatscentral.com,www.meatscentral.com
 ```
 
 ### 4. Document Changes

--- a/docs/reference/GOLDEN_PIPELINE.md
+++ b/docs/reference/GOLDEN_PIPELINE.md
@@ -197,7 +197,7 @@ docker run -d --name pm-backend \
   registry.digitalocean.com/meatscentral/projectmeats-backend:dev-abc123
 
 # 4. Health check (15 retries, 5s intervals)
-curl -L -s -o /dev/null -w "%{http_code}" https://domain.com/api/health/
+curl -L -s -o /dev/null -w "%{http_code}" https://domain.com/api/v1/health/
 ```
 
 ### Frontend (Unchanged from V1.0)
@@ -287,12 +287,12 @@ Feature Branch → Development (auto-deploy to dev)
 
 ```bash
 # V1.0 Pattern (still works)
-HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" https://example.com/api/health/)
+HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" https://example.com/api/v1/health/)
 
 # V2.0 Pattern (with retries and logging)
 MAX_ATTEMPTS=15
 ATTEMPT=1
-HEALTH_URL="https://example.com/api/health/"
+HEALTH_URL="https://example.com/api/v1/health/"
 
 while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
   HTTP_CODE=$(curl -L -s -o /dev/null -w "%{http_code}" "$HEALTH_URL")

--- a/docs/workforms/WORKFORMS_SESSION_STATE.md
+++ b/docs/workforms/WORKFORMS_SESSION_STATE.md
@@ -248,7 +248,7 @@ python manage.py check
 python manage.py test apps/workflows
 
 # Check deployed version
-curl https://dev.meatscentral.com/api/health/
+curl https://dev.meatscentral.com/api/v1/health/
 ```
 
 ### Workforms-Specific Testing

--- a/scripts/verify-phase5-api.sh
+++ b/scripts/verify-phase5-api.sh
@@ -10,7 +10,7 @@ set -e
 
 # Configuration
 BASE_URL="${BASE_URL:-http://localhost:8000}"
-API_URL="${BASE_URL}/api/workflows"
+API_URL="${BASE_URL}/api/v1/workflows"
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -25,7 +25,7 @@ echo ""
 
 # Check if server is running
 echo -n "Checking if server is running... "
-if curl -s "${BASE_URL}/api/health/" > /dev/null 2>&1; then
+if curl -s "${BASE_URL}/api/v1/health/" > /dev/null 2>&1; then
     echo -e "${GREEN}✓${NC} Server is up"
 else
     echo -e "${RED}✗${NC} Server is not running at ${BASE_URL}"


### PR DESCRIPTION
### What
- Remove api.meatscentral.com subdomain references (use same-origin host + /api/v1).
- Standardize health check paths to /api/v1/health/ in docs and scripts.
- Fix local dev README backend API path to /api/v1/.

### Notes
Docs-only behavioral change; no runtime code changes.