### PR TITLE
ci: inject SECRET_KEY into backend env

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -1259,6 +1259,8 @@ jobs:
           # backend.env contains secrets; lock down permissions on the runner and ensure it is cleaned up.
           umask 077
           cat <<- 'EOF' > backend.env
+          	# Django reads SECRET_KEY at runtime; keep DJANGO_SECRET_KEY for backward compatibility.
+          	SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
           	DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
           	DJANGO_SETTINGS_MODULE=${{ secrets.DJANGO_SETTINGS_MODULE }}
           	ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -24,7 +24,10 @@ This file is the **canonical plan + current truth snapshot**.
   - Legacy workflow webhook endpoint must fail closed unless tenant context is resolvable (migrate callers to tenant-path URL).
   - Integrations OAuth callback must set tenant + RLS session vars before writing tenant-scoped rows.
   - WorkForms create must not bypass activation validation when `status=active`.
-- **CI guardrails (never-miss-again)**: keep Golden Drift Gate green; follow-ups include re-enabling backend/frontend test gates in `reusable-deploy.yml`.
+- **CI guardrails (never-miss-again)**:
+  - Fix backend runtime `SECRET_KEY` injection (ensure `backend/.env` includes `SECRET_KEY` mapped from `DJANGO_SECRET_KEY`).
+  - Enforce job-level timeouts + add Golden-compliant post-deploy smoke gates (direct-to-container).
+  - Keep Golden Drift Gate green; follow-ups include re-enabling backend/frontend test gates in `reusable-deploy.yml`.
 - **Mobile parity**: align WorkForms mobile models with backend (`workflow_definition`), extend OpenAPI contract coverage for `/tenant-workforms/*`, and add a real WorkForm detail view.
 
 ### Squad deep dive plan (as of 2026-04-21)


### PR DESCRIPTION
### Why
Django settings read SECRET_KEY, but the deploy pipeline only wrote DJANGO_SECRET_KEY into backend/.env. The runtime container uses --env-file /root/projectmeats/backend/.env, so SECRET_KEY could be missing.

### What
- reusable-deploy.yml: write SECRET_KEY from the DJANGO_SECRET_KEY secret into backend.env (keep DJANGO_SECRET_KEY for backward compatibility).
- MASTER_PLAN.md: record as a P0 CI guardrail follow-up.

### Verification
- bash .github/scripts/check_infrastructure.sh