### PR TITLE
ci: set GIT_COMMIT_SHA in backend env

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -1286,6 +1286,7 @@ jobs:
           	MICROSOFT_TENANT_ID=${{ secrets.MICROSOFT_TENANT_ID }}
           	MICROSOFT_REDIRECT_URI=${{ secrets.MICROSOFT_REDIRECT_URI }}
           	OAUTH_ENCRYPTION_KEY=${{ secrets.OAUTH_ENCRYPTION_KEY }}
+          	GIT_COMMIT_SHA=${{ github.sha }}
           	EOF
 
           chmod 600 backend.env


### PR DESCRIPTION
### What
- reusable-deploy.yml: add GIT_COMMIT_SHA=github.sha to the generated backend/.env file.

### Why
Backend Sentry config tags releases via GIT_COMMIT_SHA; without it, releases show as 'unknown' when Sentry is enabled.

### Verification
- bash .github/scripts/check_infrastructure.sh