### PR TITLE
fix(floweditor): bootstrap schemas on direct import

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -134,6 +134,10 @@ import { AISuggestionsPanel } from './components/AISuggestionsPanel';
 import { validateWorkflow, type ValidationResult } from './utils/validationEngine';
 import { NODE_TYPE_REGISTRY, NodeCategory, CATEGORY_LABELS, CATEGORY_ORDER, getNodeTypeDefinition } from './nodeTypes';
 import type { FormStepData } from './Modals/EntityFormStepModal';
+// Ensure schemaRegistry is populated deterministically even when this component is imported directly.
+// (Some entrypoints bypass FlowEditor/index.ts.) Import is idempotent.
+import './config/nodeConfigSchemas';
+
 import { schemaRegistry } from './config/schemaRegistry';
 import { calculateContainerLayout, autoConnectSequentialSteps, LAYOUT_CONSTANTS } from './utils/containerLayout'; // Phase 3-4
 import { NodeContextMenu, useContextMenu } from './NodeContextMenu'; // Phase E.3

--- a/frontend/src/components/FlowEditor/config/__tests__/flowEditorSchemasLoaded.test.ts
+++ b/frontend/src/components/FlowEditor/config/__tests__/flowEditorSchemasLoaded.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 describe('FlowEditor schema bootstrap', () => {
   it(
-    'registers nodeConfigSchemas when FlowEditor is imported',
+    'registers nodeConfigSchemas when FlowEditor is imported (index.ts)',
     { timeout: 20_000 },
     async () => {
       vi.resetModules();
@@ -14,6 +14,23 @@ describe('FlowEditor schema bootstrap', () => {
       schemaRegistry.clear();
 
       await import('../../index');
+
+      const httpSchema = schemaRegistry.getSchema('actionHTTP');
+      expect(String(httpSchema.version)).not.toContain('fallback');
+      expect(httpSchema.nodeType).toBe('actionHTTP');
+    }
+  );
+
+  it(
+    'registers nodeConfigSchemas when UnifiedFlowEditor is imported directly',
+    { timeout: 20_000 },
+    async () => {
+      vi.resetModules();
+
+      const { schemaRegistry } = await import('../schemaRegistry');
+      schemaRegistry.clear();
+
+      await import('../../UnifiedFlowEditor');
 
       const httpSchema = schemaRegistry.getSchema('actionHTTP');
       expect(String(httpSchema.version)).not.toContain('fallback');


### PR DESCRIPTION
### What
- UnifiedFlowEditor now imports nodeConfigSchemas to ensure deterministic schemaRegistry bootstrap even when imported directly.
- Added a regression test that imports UnifiedFlowEditor directly and asserts non-fallback schemas.

### Verification
- npm -C frontend run test:ci -- src/components/FlowEditor/config/__tests__/flowEditorSchemasLoaded.test.ts