### PR TITLE
Frontend: tokenized colors for MyTasks surfaces

### DIFF
--- a/frontend/.eslint/scripts/check-colors.cjs
+++ b/frontend/.eslint/scripts/check-colors.cjs
@@ -71,8 +71,9 @@ const HSL_COLOR4_REGEX = /\bhsla?\(\s*\d+\s+\d+%\s+\d+%(?:\s*\/\s*[0-9.]+%?)?\s*
 
 // Named colors we want to forbid in high-churn UI surfaces.
 // We intentionally do NOT include 'transparent' to avoid churn.
-// We match quoted values (JS objects / string-returning templates) to avoid mass legacy churn.
+// We support quoted (JS objects / string-returning templates) AND unquoted CSS values.
 const NAMED_COLOR_REGEX = /(['"`])(?:white|black|red|green|blue|gray|grey)\1/g;
+const UNQUOTED_NAMED_COLOR_REGEX = /:\s*(white|black|red|green|blue|gray|grey)\b/gi;
 
 function isNumericOnlyShortHex(color) {
   // Heuristic: ignore short numeric-only tokens like "#405" in names (not actual colors).
@@ -90,10 +91,23 @@ function getSuggestion(color) {
 function checkFile(filePath) {
   const repoRoot = path.join(__dirname, '../..');
   const relativePath = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+  const extraEnforceRgbFiles = new Set([
+    'src/components/Widgets/QuickActionsWidget.tsx',
+    'src/components/Widgets/MyTasksWidget.tsx',
+    'src/pages/MyTasks/MyTasks.tsx',
+    'src/styles/shared.ts',
+    'src/theme/themeConfig.ts',
+  ]);
+
   const enforceRgb =
     relativePath.includes('src/components/FlowEditor/') ||
     relativePath.includes('src/components/WorkForms/') ||
-    relativePath.includes('src/pages/WorkForms/');
+    relativePath.includes('src/pages/WorkForms/') ||
+    extraEnforceRgbFiles.has(relativePath);
+
+  // Unquoted named colors (e.g. "background: white;") are a common source of drift.
+  // Enforce them only in explicitly targeted high-churn surfaces to avoid mass legacy churn.
+  const enforceUnquotedNamed = extraEnforceRgbFiles.has(relativePath);
 
   const content = fs.readFileSync(filePath, 'utf8');
   const lines = content.split('\n');
@@ -167,6 +181,13 @@ function checkFile(filePath) {
       const namedRegex = new RegExp(NAMED_COLOR_REGEX, 'g');
       while ((match = namedRegex.exec(line)) !== null) {
         pushTokenViolation(match[0], match.index);
+      }
+
+      if (enforceUnquotedNamed) {
+        const unquotedNamedRegex = new RegExp(UNQUOTED_NAMED_COLOR_REGEX, 'g');
+        while ((match = unquotedNamedRegex.exec(line)) !== null) {
+          pushTokenViolation(match[1], match.index);
+        }
       }
     }
   });

--- a/frontend/src/components/Widgets/MyTasksWidget.tsx
+++ b/frontend/src/components/Widgets/MyTasksWidget.tsx
@@ -46,7 +46,7 @@ const TaskItem = styled.div<{ $isOverdue: boolean }>`
   padding: 12px;
   border-radius: var(--radius-md);
   background: rgb(var(--color-background));
-  border: 1px solid ${props => props.$isOverdue ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'};
+  border: 1px solid ${props => props.$isOverdue ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
   cursor: pointer;
   transition: all 0.15s ease;
 
@@ -64,9 +64,9 @@ const TaskPriorityDot = styled.div<{ $priority: string }>`
   flex-shrink: 0;
   background: ${props => {
     switch (props.$priority) {
-      case 'urgent': return 'rgb(239, 68, 68)';
-      case 'high': return 'rgb(234, 179, 8)';
-      case 'normal': return 'rgb(59, 130, 246)';
+      case 'urgent': return 'rgb(var(--color-error))';
+      case 'high': return 'rgb(var(--color-warning))';
+      case 'normal': return 'rgb(var(--color-info))';
       default: return 'rgb(var(--color-text-tertiary))';
     }
   }};
@@ -99,7 +99,7 @@ const TaskDueDate = styled.span<{ $isOverdue: boolean }>`
   display: flex;
   align-items: center;
   gap: 4px;
-  color: ${props => props.$isOverdue ? 'rgb(239, 68, 68)' : 'inherit'};
+  color: ${props => props.$isOverdue ? 'rgb(var(--color-error))' : 'inherit'};
   font-weight: ${props => props.$isOverdue ? '500' : '400'};
 `;
 

--- a/frontend/src/components/Widgets/QuickActionsWidget.tsx
+++ b/frontend/src/components/Widgets/QuickActionsWidget.tsx
@@ -15,9 +15,14 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import { 
-  Zap, Plus, FileText, ShoppingCart, Package, 
-  Users, Truck, Calculator, Search, Settings 
+import {
+  Zap,
+  FileText,
+  ShoppingCart,
+  Package,
+  Users,
+  Truck,
+  Search,
 } from 'lucide-react';
 import { WidgetCard } from './WidgetCard';
 
@@ -32,7 +37,7 @@ interface QuickAction {
   path?: string;
   onClick?: () => void;
   shortcut?: string;
-  color: string;
+  colorVar: string;
 }
 
 export interface QuickActionsWidgetProps {
@@ -50,7 +55,7 @@ const ActionsGrid = styled.div`
   gap: 8px;
 `;
 
-const ActionButton = styled.button<{ $color: string }>`
+const ActionButton = styled.button<{ $colorVar: string }>`
   display: flex;
   align-items: center;
   gap: 10px;
@@ -63,9 +68,9 @@ const ActionButton = styled.button<{ $color: string }>`
   transition: all 0.15s ease;
 
   &:hover {
-    border-color: ${props => props.$color};
-    background: ${props => props.$color}08;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    border-color: rgb(var(${props => props.$colorVar}));
+    background: rgba(var(${props => props.$colorVar}), 0.08);
+    box-shadow: var(--shadow-sm);
   }
 
   &:active {
@@ -73,15 +78,15 @@ const ActionButton = styled.button<{ $color: string }>`
   }
 `;
 
-const ActionIcon = styled.div<{ $color: string }>`
+const ActionIcon = styled.div<{ $colorVar: string }>`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 32px;
   height: 32px;
   border-radius: var(--radius-sm);
-  background: ${props => props.$color}15;
-  color: ${props => props.$color};
+  background: rgba(var(${props => props.$colorVar}), 0.15);
+  color: rgb(var(${props => props.$colorVar}));
   flex-shrink: 0;
 `;
 
@@ -113,7 +118,7 @@ const defaultActions: QuickAction[] = [
     icon: <ShoppingCart size={16} />,
     path: '/purchase-orders',
     shortcut: 'Alt + P',
-    color: 'rgb(59, 130, 246)',
+    colorVar: '--color-info',
   },
   {
     id: 'new_so',
@@ -121,7 +126,7 @@ const defaultActions: QuickAction[] = [
     icon: <Package size={16} />,
     path: '/sales-orders',
     shortcut: 'Alt + S',
-    color: 'rgb(34, 197, 94)',
+    colorVar: '--color-success',
   },
   {
     id: 'new_invoice',
@@ -129,7 +134,7 @@ const defaultActions: QuickAction[] = [
     icon: <FileText size={16} />,
     path: '/accounting/receivables/invoices',
     shortcut: 'Alt + I',
-    color: 'rgb(168, 85, 247)',
+    colorVar: '--color-secondary',
   },
   {
     id: 'new_customer',
@@ -137,21 +142,21 @@ const defaultActions: QuickAction[] = [
     icon: <Users size={16} />,
     path: '/customers',
     shortcut: 'Alt + C',
-    color: 'rgb(236, 72, 153)',
+    colorVar: '--color-primary',
   },
   {
     id: 'search',
     label: 'Universal Search',
     icon: <Search size={16} />,
     shortcut: 'Ctrl + K',
-    color: 'rgb(234, 179, 8)',
+    colorVar: '--color-warning',
   },
   {
     id: 'carriers',
     label: 'Manage Carriers',
     icon: <Truck size={16} />,
     path: '/carriers',
-    color: 'rgb(244, 114, 182)',
+    colorVar: '--color-primary',
   },
 ];
 
@@ -190,10 +195,10 @@ export const QuickActionsWidget: React.FC<QuickActionsWidgetProps> = ({
         {actions.map(action => (
           <ActionButton 
             key={action.id}
-            $color={action.color}
+            $colorVar={action.colorVar}
             onClick={() => handleAction(action)}
           >
-            <ActionIcon $color={action.color}>
+            <ActionIcon $colorVar={action.colorVar}>
               {action.icon}
             </ActionIcon>
             <ActionContent>

--- a/frontend/src/pages/MyTasks/MyTasks.tsx
+++ b/frontend/src/pages/MyTasks/MyTasks.tsx
@@ -37,8 +37,12 @@ const StatsBar = styled.div`
   gap: 16px;
   margin-bottom: 24px;
   padding: 16px;
-  background: linear-gradient(135deg, rgba(239, 68, 68, 0.05) 0%, rgba(234, 179, 8, 0.05) 100%);
-  border: 1px solid rgba(239, 68, 68, 0.2);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--color-error), 0.05) 0%,
+    rgba(var(--color-warning), 0.05) 100%
+  );
+  border: 1px solid rgba(var(--color-error), 0.2);
   border-radius: 8px;
 `;
 
@@ -52,7 +56,7 @@ const Title = styled.h1`
 
 const CountBadge = styled.span`
   background: rgb(var(--color-primary, 102 126 234));
-  color: white;
+  color: rgb(var(--color-primary-foreground, 255 255 255));
   font-size: 14px;
   font-weight: 600;
   padding: 4px 12px;
@@ -68,7 +72,7 @@ const FiltersBar = styled.div`
   padding: 16px;
   background: rgb(var(--color-surface, 255 255 255));
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
 `;
 
 const FilterGroup = styled.div`
@@ -89,7 +93,7 @@ const FilterSelect = styled.select`
   border-radius: 6px;
   font-size: 14px;
   color: rgb(var(--color-text-primary, 44 62 80));
-  background: white;
+  background: rgb(var(--color-surface, 255 255 255));
   cursor: pointer;
 
   &:focus {
@@ -127,12 +131,12 @@ const StatCard = styled.div<{ $variant?: 'danger' | 'warning' | 'info' | 'defaul
   padding: 20px;
   background: rgb(var(--color-surface, 255 255 255));
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
   border-left: 4px solid ${props => {
     switch (props.$variant) {
-      case 'danger': return 'rgb(239, 68, 68)';
-      case 'warning': return 'rgb(234, 179, 8)';
-      case 'info': return 'rgb(59, 130, 246)';
+      case 'danger': return 'rgb(var(--color-error))';
+      case 'warning': return 'rgb(var(--color-warning))';
+      case 'info': return 'rgb(var(--color-info))';
       default: return 'rgb(var(--color-primary, 102 126 234))';
     }
   }};
@@ -161,21 +165,21 @@ const TaskCard = styled.div<{ $priority: string; $isOverdue: boolean; $isAtRisk?
   align-items: flex-start;
   padding: 16px 20px;
   background: ${props => props.$isAtRisk 
-    ? 'linear-gradient(135deg, rgba(239, 68, 68, 0.05) 0%, rgb(var(--color-surface, 255 255 255)) 100%)'
+    ? 'linear-gradient(135deg, rgba(var(--color-error), 0.05) 0%, rgb(var(--color-surface, 255 255 255)) 100%)'
     : 'rgb(var(--color-surface, 255 255 255))'
   };
   border-radius: 8px;
   box-shadow: ${props => props.$isAtRisk 
-    ? '0 2px 8px rgba(239, 68, 68, 0.2)'
-    : '0 1px 3px rgba(0, 0, 0, 0.1)'
+    ? '0 2px 8px rgba(var(--color-error), 0.2)'
+    : 'var(--shadow-sm)'
   };
   border-left: 4px solid ${props => {
-    if (props.$isAtRisk) return 'rgb(239, 68, 68)';
-    if (props.$isOverdue) return 'rgb(239, 68, 68)';
+    if (props.$isAtRisk) return 'rgb(var(--color-error))';
+    if (props.$isOverdue) return 'rgb(var(--color-error))';
     switch (props.$priority) {
-      case 'urgent': return 'rgb(239, 68, 68)';
-      case 'high': return 'rgb(234, 179, 8)';
-      case 'normal': return 'rgb(59, 130, 246)';
+      case 'urgent': return 'rgb(var(--color-error))';
+      case 'high': return 'rgb(var(--color-warning))';
+      case 'normal': return 'rgb(var(--color-info))';
       default: return 'rgb(var(--color-border, 224 224 224))';
     }
   }};
@@ -185,8 +189,8 @@ const TaskCard = styled.div<{ $priority: string; $isOverdue: boolean; $isAtRisk?
   &:hover {
     transform: translateX(4px);
     box-shadow: ${props => props.$isAtRisk
-      ? '0 4px 12px rgba(239, 68, 68, 0.3)'
-      : '0 4px 12px rgba(0, 0, 0, 0.1)'
+      ? '0 4px 12px rgba(var(--color-error), 0.3)'
+      : 'var(--shadow-md)'
     };
   }
 `;
@@ -232,18 +236,18 @@ const PriorityBadge = styled.span<{ $priority: string }>`
   text-transform: uppercase;
   background: ${props => {
     switch (props.$priority) {
-      case 'urgent': return 'rgba(239, 68, 68, 0.1)';
-      case 'high': return 'rgba(234, 179, 8, 0.1)';
-      case 'normal': return 'rgba(59, 130, 246, 0.1)';
-      default: return 'rgba(127, 140, 141, 0.1)';
+      case 'urgent': return 'rgba(var(--color-error), 0.1)';
+      case 'high': return 'rgba(var(--color-warning), 0.1)';
+      case 'normal': return 'rgba(var(--color-info), 0.1)';
+      default: return 'rgba(var(--color-text-secondary), 0.1)';
     }
   }};
   color: ${props => {
     switch (props.$priority) {
-      case 'urgent': return 'rgb(239, 68, 68)';
-      case 'high': return 'rgb(180, 140, 8)';
-      case 'normal': return 'rgb(59, 130, 246)';
-      default: return 'rgb(127, 140, 141)';
+      case 'urgent': return 'rgb(var(--color-error))';
+      case 'high': return 'rgb(var(--color-warning))';
+      case 'normal': return 'rgb(var(--color-info))';
+      default: return 'rgb(var(--color-text-secondary))';
     }
   }};
 `;
@@ -256,8 +260,8 @@ const OverdueBadge = styled.span`
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  background: rgba(239, 68, 68, 0.1);
-  color: rgb(239, 68, 68);
+  background: rgba(var(--color-error), 0.1);
+  color: rgb(var(--color-error));
 `;
 
 const AtRiskBadge = styled.span`
@@ -269,8 +273,8 @@ const AtRiskBadge = styled.span`
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  background: rgba(239, 68, 68, 0.15);
-  color: rgb(239, 68, 68);
+  background: rgba(var(--color-error), 0.15);
+  color: rgb(var(--color-error));
   animation: pulse 2s ease-in-out infinite;
 
   @keyframes pulse {
@@ -288,7 +292,7 @@ const TaskActions = styled.div`
 const ActionButton = styled.button`
   padding: 8px 16px;
   background: rgb(var(--color-primary, 102 126 234));
-  color: white;
+  color: rgb(var(--color-primary-foreground, 255 255 255));
   border: none;
   border-radius: 6px;
   font-size: 13px;
@@ -377,7 +381,7 @@ const WorkflowCard = styled.div`
   
   &:hover {
     border-color: rgb(var(--color-primary, 102 126 234));
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-md);
   }
 `;
 
@@ -440,7 +444,7 @@ const ResumeButton = styled.button`
   gap: 6px;
   padding: 10px 16px;
   background: rgb(var(--color-primary, 102 126 234));
-  color: white;
+  color: rgb(var(--color-primary-foreground, 255 255 255));
   border: none;
   border-radius: 6px;
   font-size: 14px;
@@ -463,7 +467,7 @@ const EmptyState = styled.div`
   padding: 60px 20px;
   background: rgb(var(--color-surface, 255 255 255));
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
 `;
 
 const EmptyIcon = styled.div`
@@ -507,10 +511,10 @@ const LoadingSpinner = styled.div`
 
 const ErrorMessage = styled.div`
   padding: 16px 20px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: rgba(var(--color-error), 0.1);
+  border: 1px solid rgba(var(--color-error), 0.3);
   border-radius: 8px;
-  color: rgb(239, 68, 68);
+  color: rgb(var(--color-error));
   margin-bottom: 24px;
 `;
 

--- a/frontend/src/styles/shared.ts
+++ b/frontend/src/styles/shared.ts
@@ -43,10 +43,10 @@ export const GridContainer = styled.div<{
 `;
 
 export const Card = styled.div<{ $padding?: string; $shadow?: boolean }>`
-  background: white;
+  background: rgb(var(--color-surface));
   border-radius: 8px;
   padding: ${props => props.$padding || '16px'};
-  box-shadow: ${props => props.$shadow ? '0 2px 8px rgba(0, 0, 0, 0.1)' : 'none'};
+  box-shadow: ${props => props.$shadow ? 'var(--shadow-md)' : 'none'};
 `;
 
 export const Panel = styled.div<{ $variant?: 'default' | 'primary' | 'secondary' }>`
@@ -54,7 +54,7 @@ export const Panel = styled.div<{ $variant?: 'default' | 'primary' | 'secondary'
     switch (props.$variant) {
       case 'primary': return 'rgb(var(--color-primary))';
       case 'secondary': return 'rgb(var(--color-secondary))';
-      default: return 'white';
+      default: return 'rgb(var(--color-surface))';
     }
   }};
   border: 1px solid rgb(var(--color-border));
@@ -87,13 +87,13 @@ export const Button = styled.button<{ $variant?: 'primary' | 'secondary' | 'ghos
   ${props => {
     switch (props.$variant) {
       case 'primary':
-        return css`background: rgb(var(--color-primary)); color: white; &:hover { opacity: 0.9; }`;
+        return css`background: rgb(var(--color-primary)); color: rgb(var(--color-primary-foreground, 255 255 255)); &:hover { opacity: 0.9; }`;
       case 'danger':
-        return css`background: rgb(239, 68, 68); color: white; &:hover { opacity: 0.9; }`;
+        return css`background: rgb(var(--color-error)); color: rgb(var(--color-primary-foreground, 255 255 255)); &:hover { opacity: 0.9; }`;
       case 'ghost':
-        return css`background: transparent; color: rgb(var(--color-text-primary)); &:hover { background: rgba(0, 0, 0, 0.05); }`;
+        return css`background: transparent; color: rgb(var(--color-text-primary)); &:hover { background: rgba(var(--color-overlay), 0.05); }`;
       default:
-        return css`background: white; color: rgb(var(--color-text-primary)); border: 1px solid rgb(var(--color-border)); &:hover { background: rgb(var(--color-background-hover)); }`;
+        return css`background: rgb(var(--color-surface)); color: rgb(var(--color-text-primary)); border: 1px solid rgb(var(--color-border)); &:hover { background: rgb(var(--color-background-hover)); }`;
     }
   }}
   
@@ -106,7 +106,7 @@ export const Button = styled.button<{ $variant?: 'primary' | 'secondary' | 'ghos
 export const Input = styled.input<{ $error?: boolean }>`
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid ${props => props.$error ? 'rgb(239, 68, 68)' : 'rgb(var(--color-border))'};
+  border: 1px solid ${props => props.$error ? 'rgb(var(--color-error))' : 'rgb(var(--color-border))'};
   border-radius: 6px;
   font-size: 14px;
   transition: all 0.2s ease;
@@ -134,15 +134,15 @@ export const Badge = styled.span<{ $variant?: 'success' | 'warning' | 'error' | 
   ${props => {
     switch (props.$variant) {
       case 'success':
-        return css`background: rgba(34, 197, 94, 0.1); color: rgb(34, 197, 94);`;
+        return css`background: rgba(var(--color-success), 0.1); color: rgb(var(--color-success));`;
       case 'warning':
-        return css`background: rgba(234, 179, 8, 0.1); color: rgb(234, 179, 8);`;
+        return css`background: rgba(var(--color-warning), 0.1); color: rgb(var(--color-warning));`;
       case 'error':
-        return css`background: rgba(239, 68, 68, 0.1); color: rgb(239, 68, 68);`;
+        return css`background: rgba(var(--color-error), 0.1); color: rgb(var(--color-error));`;
       case 'info':
-        return css`background: rgba(59, 130, 246, 0.1); color: rgb(59, 130, 246);`;
+        return css`background: rgba(var(--color-info), 0.1); color: rgb(var(--color-info));`;
       default:
-        return css`background: rgba(0, 0, 0, 0.05); color: rgb(var(--color-text-secondary));`;
+        return css`background: rgba(var(--color-overlay), 0.05); color: rgb(var(--color-text-secondary));`;
     }
   }}
 `;

--- a/frontend/src/theme/themeConfig.ts
+++ b/frontend/src/theme/themeConfig.ts
@@ -19,10 +19,10 @@ export type ThemeMode = 'light' | 'dark' | 'high-contrast';
 export const lightTheme: ThemeConfig = {
   token: {
     colorPrimary: 'rgb(var(--color-primary))',
-    colorSuccess: 'rgb(34, 197, 94)',
-    colorWarning: 'rgb(234, 179, 8)',
-    colorError: 'rgb(239, 68, 68)',
-    colorInfo: 'rgb(59, 130, 246)',
+    colorSuccess: 'rgb(var(--color-success))',
+    colorWarning: 'rgb(var(--color-warning))',
+    colorError: 'rgb(var(--color-error))',
+    colorInfo: 'rgb(var(--color-info))',
     colorTextBase: 'rgb(var(--color-text-primary))',
     colorBgBase: 'rgb(var(--color-background))',
     fontSize: 14,
@@ -39,7 +39,7 @@ export const lightTheme: ThemeConfig = {
     },
     Card: {
       borderRadius: 8,
-      boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
+      boxShadow: 'var(--shadow-sm)',
     },
   },
 };
@@ -50,10 +50,10 @@ export const lightTheme: ThemeConfig = {
 export const darkTheme: ThemeConfig = {
   token: {
     colorPrimary: 'rgb(var(--color-primary))',
-    colorSuccess: 'rgb(34, 197, 94)',
-    colorWarning: 'rgb(234, 179, 8)',
-    colorError: 'rgb(239, 68, 68)',
-    colorInfo: 'rgb(59, 130, 246)',
+    colorSuccess: 'rgb(var(--color-success))',
+    colorWarning: 'rgb(var(--color-warning))',
+    colorError: 'rgb(var(--color-error))',
+    colorInfo: 'rgb(var(--color-info))',
     colorTextBase: 'rgb(var(--color-text-primary))',
     colorBgBase: 'rgb(var(--color-background))',
     colorBgContainer: 'rgb(var(--color-surface))',
@@ -74,7 +74,7 @@ export const darkTheme: ThemeConfig = {
     Card: {
       borderRadius: 8,
       colorBgContainer: 'rgb(var(--color-surface))',
-      boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.3)',
+      boxShadow: 'var(--shadow-md)',
     },
   },
 };
@@ -86,10 +86,10 @@ export const darkTheme: ThemeConfig = {
 export const highContrastTheme: ThemeConfig = {
   token: {
     colorPrimary: 'rgb(var(--color-primary))',
-    colorSuccess: 'rgb(0, 128, 0)',
-    colorWarning: 'rgb(255, 170, 0)',
-    colorError: 'rgb(204, 0, 0)',
-    colorInfo: 'rgb(0, 102, 204)',
+    colorSuccess: 'rgb(var(--color-success))',
+    colorWarning: 'rgb(var(--color-warning))',
+    colorError: 'rgb(var(--color-error))',
+    colorInfo: 'rgb(var(--color-info))',
     colorTextBase: 'rgb(var(--color-text-primary))',
     colorBgBase: 'rgb(var(--color-background))',
     colorBorder: 'rgb(var(--color-border))',
@@ -138,7 +138,7 @@ export const canvasThemeVars = {
     '--canvas-grid': 'rgb(var(--color-border))',
     '--canvas-node-bg': 'rgb(var(--color-surface))',
     '--canvas-node-border': 'rgb(var(--color-border))',
-    '--canvas-node-shadow': 'rgba(0, 0, 0, 0.1)',
+    '--canvas-node-shadow': 'rgba(var(--color-overlay), 0.1)',
     '--canvas-connection': 'rgb(var(--color-primary))',
     '--canvas-selection': 'rgb(var(--color-primary))',
   },
@@ -147,7 +147,7 @@ export const canvasThemeVars = {
     '--canvas-grid': 'rgb(var(--color-border))',
     '--canvas-node-bg': 'rgb(var(--color-surface))',
     '--canvas-node-border': 'rgb(var(--color-border))',
-    '--canvas-node-shadow': 'rgba(0, 0, 0, 0.5)',
+    '--canvas-node-shadow': 'rgba(var(--color-overlay), 0.5)',
     '--canvas-connection': 'rgb(var(--color-primary))',
     '--canvas-selection': 'rgb(var(--color-primary))',
   },


### PR DESCRIPTION
## Deliverables
- Expand lint:colors allowlist to MyTasks + widgets + shared/theme config
- Replace remaining hardcoded colors with theme/CSS var tokens in those files

## Expected results
- Frontend hardcoded-color guardrail covers key high-churn MyTasks surfaces
- npm -C frontend run lint:colors passes

## Testing
- npm -C frontend run lint:colors
- npm -C frontend run type-check
- npm -C frontend run verify-standards
