### PR TITLE
Backend: fix core views legacy imports

### DIFF
--- a/backend/apps/core/tests/test_core_views_smoke.py
+++ b/backend/apps/core/tests/test_core_views_smoke.py
@@ -1,0 +1,88 @@
+"""Smoke tests for backend/apps/core/views.py APIViews.
+
+These tests protect against regressions where core views reference legacy import paths
+(e.g., apps.sales.* / apps.tenant_apps.*) which can cause runtime 500s.
+
+Scope:
+- GET /api/v1/search/ranked/
+- GET /api/v1/workspace/stats/quick/
+
+These are intentionally shallow (status + minimal shape assertions) to keep them stable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from django.contrib.auth.models import User
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.customers.models import Customer
+from tenant_apps.purchase_orders.models import PurchaseOrder
+from tenant_apps.sales_orders.models import SalesOrder
+from tenant_apps.suppliers.models import Supplier
+
+
+class CoreViewsSmokeTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f"u-{unique}", password="pw")
+        self.tenant = Tenant.objects.create(
+            name=f"Tenant {unique}",
+            slug=f"tenant-{unique}",
+            contact_email=f"t-{unique}@example.com",
+            is_active=True,
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role="admin", is_active=True)
+
+        # Use session auth so TenantMiddleware honors X-Tenant-ID.
+        self.client.force_login(self.user)
+        self.tenant_header = {"HTTP_X_TENANT_ID": str(self.tenant.id)}
+
+    def test_ranked_search_returns_200_with_tenant(self):
+        Customer.objects.create(tenant=self.tenant, name="Smoke Customer")
+        Supplier.objects.create(tenant=self.tenant, name="Smoke Supplier")
+
+        resp = self.client.get(
+            "/api/v1/search/ranked/",
+            {"q": "Smoke", "entity_types": "customer,supplier", "limit": 10},
+            **self.tenant_header,
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("results", resp.data)
+        self.assertIsInstance(resp.data.get("results"), list)
+
+        joined = str(resp.data)
+        self.assertIn("Smoke Customer", joined)
+        self.assertIn("Smoke Supplier", joined)
+
+    def test_workspace_stats_returns_stats_with_tenant(self):
+        supplier = Supplier.objects.create(tenant=self.tenant, name="Stats Supplier")
+        customer = Customer.objects.create(tenant=self.tenant, name="Stats Customer")
+
+        PurchaseOrder.objects.create(
+            tenant=self.tenant,
+            supplier=supplier,
+            order_number="PO-SMOKE",
+            order_date=date.today(),
+        )
+
+        SalesOrder.objects.create(
+            tenant=self.tenant,
+            supplier=supplier,
+            customer=customer,
+            our_sales_order_num="SO-SMOKE",
+        )
+
+        resp = self.client.get("/api/v1/workspace/stats/quick/", **self.tenant_header)
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("stats", resp.data)
+        self.assertIsInstance(resp.data.get("stats"), list)
+        self.assertGreaterEqual(len(resp.data.get("stats")), 1)

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -489,29 +489,29 @@ class RankedSearchView(APIView):
         """
         try:
             if entity_type == 'customer':
-                from apps.sales.models import Customer
+                from tenant_apps.customers.models import Customer
                 return Customer.objects.filter(tenant=tenant, id=entity_id).first()
-            
-            elif entity_type == 'supplier':
-                from apps.procurement.models import Supplier
+
+            if entity_type == 'supplier':
+                from tenant_apps.suppliers.models import Supplier
                 return Supplier.objects.filter(tenant=tenant, id=entity_id).first()
-            
-            elif entity_type == 'product':
-                from apps.inventory.models import Product
-                return Product.objects.filter(tenant=tenant, id=entity_id).first()
-            
-            elif entity_type == 'sales_order':
-                from apps.sales.models import SalesOrder
+
+            if entity_type == 'product':
+                from apps.system.models import Product
+                return Product.objects.filter(id=entity_id).first()
+
+            if entity_type == 'sales_order':
+                from tenant_apps.sales_orders.models import SalesOrder
                 return SalesOrder.objects.filter(tenant=tenant, id=entity_id).first()
-            
-            elif entity_type == 'purchase_order':
-                from apps.procurement.models import PurchaseOrder
+
+            if entity_type == 'purchase_order':
+                from tenant_apps.purchase_orders.models import PurchaseOrder
                 return PurchaseOrder.objects.filter(tenant=tenant, id=entity_id).first()
-            
+
             return None
-            
-        except Exception as e:
-            print(f"[RankedSearchView] Error fetching {entity_type} {entity_id}: {e}")
+
+        except Exception:
+            logger.exception("[RankedSearchView] Error fetching %s %s", entity_type, entity_id)
             return None
 
 
@@ -845,16 +845,14 @@ class WorkspaceStatsView(APIView):
                 status=status.HTTP_403_FORBIDDEN
             )
         
-        from apps.tenant_apps.purchase_orders.models import PurchaseOrder
-        from apps.tenant_apps.sales_orders.models import SalesOrder
-        from apps.tenant_apps.suppliers.models import Supplier
-        from apps.tenant_apps.customers.models import Customer
+        from tenant_apps.purchase_orders.models import PurchaseOrder
+        from tenant_apps.sales_orders.models import SalesOrder
+        from tenant_apps.suppliers.models import Supplier
+        from tenant_apps.customers.models import Customer
         from django.utils import timezone
-        from datetime import timedelta
         
         tenant = request.tenant
         today = timezone.now().date()
-        today - timedelta(days=7)
         
         # Calculate stats
         try:
@@ -875,7 +873,6 @@ class WorkspaceStatsView(APIView):
             
             active_customers = Customer.objects.filter(
                 tenant=tenant,
-                is_active=True
             ).count()
             
             return Response({


### PR DESCRIPTION
## Deliverables
- Fix legacy/broken imports in backend/apps/core/views.py (RankedSearchView + WorkspaceStatsView)
- Remove request-path print() and replace with structured logger.exception
- Add smoke tests for:
  - GET /api/v1/search/ranked/
  - GET /api/v1/workspace/stats/quick/

## Expected results
- Core search/stats endpoints no longer 500 due to missing modules or invalid field filters
- Regression coverage catches future legacy-import reintroductions

## Testing
- python -m compileall backend/apps/core/views.py backend/apps/core/tests/test_core_views_smoke.py
- (CI) Django test suite
