### PR TITLE
Frontend: replace console logs with logger

### DIFF
--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -2132,7 +2132,7 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
     if (nodeCount > 1000) {
       logger.warn(`[Performance] Large workflow detected: ${nodeCount} nodes, ${edgeCount} edges`);
     } else if (nodeCount > 500) {
-      console.info(`[Performance] Medium workflow: ${nodeCount} nodes, ${edgeCount} edges`);
+      logger.debug(`[Performance] Medium workflow: ${nodeCount} nodes, ${edgeCount} edges`);
     }
     
     // Measure performance of large workflows

--- a/frontend/src/components/FlowEditor/utils/passiveEvents.ts
+++ b/frontend/src/components/FlowEditor/utils/passiveEvents.ts
@@ -20,6 +20,8 @@
  * @module passiveEvents
  */
 
+import { logger } from '@/utils/logger';
+
 // ============================================================================
 // TypeScript Interfaces
 // ============================================================================
@@ -285,7 +287,7 @@ export const enablePassiveByDefault = (eventTypes: string[] = PASSIVE_EVENTS): v
     return originalAddEventListener.call(this, type, listener, options);
   };
 
-  console.info(
+  logger.debug(
     `[passiveEvents] Enabled passive by default for: ${eventTypes.join(', ')}`
   );
 };

--- a/frontend/src/contexts/ActionItemsContext.tsx
+++ b/frontend/src/contexts/ActionItemsContext.tsx
@@ -15,6 +15,7 @@
 import React, { createContext, useContext, ReactNode, useCallback, useRef, useEffect } from 'react';
 import { useActionItemCounts, ActionItemCounts, POLL_INTERVAL_BACKGROUND } from '../hooks/useActionItemCounts';
 import { useAuth } from './AuthContext';
+import { logger } from '@/utils/logger';
 
 // ============================================================================
 // Types
@@ -71,7 +72,7 @@ export const ActionItemsProvider: React.FC<ActionItemsProviderProps> = ({
       if (now >= circuitOpenUntil.current) {
         circuitState.current = 'half-open';
         consecutiveErrorCount.current = 0;
-        console.info('[ActionItems] Circuit breaker transitioning to half-open. Retrying...');
+        logger.info('[ActionItems] Circuit breaker transitioning to half-open. Retrying...');
         return false; // Allow retry
       }
       return true; // Still open, block requests
@@ -85,7 +86,7 @@ export const ActionItemsProvider: React.FC<ActionItemsProviderProps> = ({
       if (errorStatus === 401) {
         circuitState.current = 'open';
         circuitOpenUntil.current = now + CIRCUIT_OPEN_DURATION_MS;
-        console.error('[ActionItems] Circuit breaker OPEN: Authentication failed. Stopping all polling for 5 minutes.');
+        logger.error('[ActionItems] Circuit breaker OPEN: Authentication failed. Stopping all polling for 5 minutes.');
         return true;
       }
       
@@ -96,13 +97,13 @@ export const ActionItemsProvider: React.FC<ActionItemsProviderProps> = ({
         if (consecutiveErrorCount.current >= MAX_CONSECUTIVE_ERRORS) {
           circuitState.current = 'open';
           circuitOpenUntil.current = now + CIRCUIT_OPEN_DURATION_MS;
-          console.error(
+          logger.error(
             `[ActionItems] Circuit breaker OPEN: ${consecutiveErrorCount.current} consecutive 5xx errors. ` +
             `Stopping all polling for 5 minutes.`
           );
           return true;
         } else {
-          console.warn(
+          logger.warn(
             `[ActionItems] Server error (${consecutiveErrorCount.current}/${MAX_CONSECUTIVE_ERRORS}). ` +
             `Will open circuit breaker if this continues.`
           );
@@ -111,7 +112,7 @@ export const ActionItemsProvider: React.FC<ActionItemsProviderProps> = ({
     } else {
       // Success - reset error count
       if (consecutiveErrorCount.current > 0) {
-        console.info('[ActionItems] Backend recovered. Resetting circuit breaker.');
+        logger.info('[ActionItems] Backend recovered. Resetting circuit breaker.');
       }
       consecutiveErrorCount.current = 0;
       circuitState.current = 'closed';

--- a/frontend/src/contexts/FormBuilderContext.tsx
+++ b/frontend/src/contexts/FormBuilderContext.tsx
@@ -9,6 +9,7 @@
  */
 
 import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { logger } from '@/utils/logger';
 
 // ============================================================================
 // Types
@@ -87,7 +88,7 @@ export const FormBuilderProvider: React.FC<FormBuilderProviderProps> = ({
     nodeType: 'form' | 'formProcessGroup' | string;
     formId?: string;
   }) => {
-    console.log('[FormBuilderContext] Opening FormBuilder:', params);
+    logger.debug('[FormBuilderContext] Opening FormBuilder', params);
     
     setState({
       isOpen: true,
@@ -99,7 +100,7 @@ export const FormBuilderProvider: React.FC<FormBuilderProviderProps> = ({
   }, []);
 
   const closeFormBuilder = useCallback(() => {
-    console.log('[FormBuilderContext] Closing FormBuilder');
+    logger.debug('[FormBuilderContext] Closing FormBuilder');
     
     setState({
       isOpen: false,
@@ -111,7 +112,7 @@ export const FormBuilderProvider: React.FC<FormBuilderProviderProps> = ({
   }, []);
 
   const updateNodeData = useCallback((nodeId: string, updates: any) => {
-    console.log('[FormBuilderContext] Updating node data:', { nodeId, updates });
+    logger.debug('[FormBuilderContext] Updating node data', { nodeId, updates });
     
     // Update internal state
     setState(prev => ({

--- a/frontend/src/pages/MyTasks/MyTasks.tsx
+++ b/frontend/src/pages/MyTasks/MyTasks.tsx
@@ -10,6 +10,7 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { showAlert } from '@/utils/uiDialogs';
+import { logger } from '@/utils/logger';
 import { useNotifications, ActionItem } from '../../contexts/NotificationsContext';
 import { DelegateTaskModal, DelegationData, User } from '../../components/Delegation';
 import { DelegationHistory } from '../../components/Delegation';
@@ -596,7 +597,7 @@ export const MyTasks: React.FC = () => {
       });
       setWorkflowExecutions(response.results);
     } catch (err) {
-      console.error('Failed to fetch workflow executions:', err);
+      logger.error('Failed to fetch workflow executions', err);
       const status = (err as any)?.response?.status;
 
       // Degrade gracefully: prefer the normal empty-state UI over a scary error banner.
@@ -625,7 +626,7 @@ export const MyTasks: React.FC = () => {
       // Navigate to the workflow
       window.location.href = `/workflows/run/${execution.id}`;
     } catch (err) {
-      console.error('Failed to resume workflow:', err);
+      logger.error('Failed to resume workflow', err);
       showAlert({
         type: 'error',
         title: 'Error',
@@ -745,7 +746,7 @@ export const MyTasks: React.FC = () => {
     setIsDelegating(true);
     try {
       // In production, this would call the API
-      console.log('Delegating task:', selectedTask.id, 'to:', data.delegateUserId);
+      logger.debug('Delegating task', { taskId: selectedTask.id, delegateUserId: data.delegateUserId });
       
       // Simulate API call
       await new Promise(resolve => setTimeout(resolve, 1000));
@@ -755,7 +756,7 @@ export const MyTasks: React.FC = () => {
       setSelectedTask(null);
       fetchActionItems();
     } catch (err) {
-      console.error('Failed to delegate task:', err);
+      logger.error('Failed to delegate task', err);
     } finally {
       setIsDelegating(false);
     }
@@ -763,7 +764,7 @@ export const MyTasks: React.FC = () => {
   
   // Handle revoke delegation
   const handleRevokeDelegation = useCallback(async (delegationId: string) => {
-    console.log('Revoking delegation:', delegationId);
+    logger.debug('Revoking delegation', { delegationId });
     // In production, this would call the API
   }, []);
 

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -104,11 +104,11 @@ apiClient.interceptors.request.use(
 
       // Check if token needs refresh before making request
       if (isUsingJwt() && needsRefresh() && !isRefreshing) {
-        console.debug('[API] Token needs refresh, refreshing before request...');
+        logger.debug('[API] Token needs refresh, refreshing before request...');
         try {
           await refreshAccessToken();
         } catch (error) {
-          console.error('[API] Token refresh failed in request interceptor:', error);
+          logger.error('[API] Token refresh failed in request interceptor:', error);
           // Don't block the request, let response interceptor handle it
         }
       }
@@ -128,12 +128,12 @@ apiClient.interceptors.request.use(
       
       return config;
     } catch (error) {
-      console.error('[API] Request interceptor error:', error);
+      logger.error('[API] Request interceptor error:', error);
       return config;
     }
   },
   (error) => {
-    console.error('[API] Request interceptor rejected:', error);
+    logger.error('[API] Request interceptor rejected:', error);
     return Promise.reject(error);
   }
 );
@@ -148,11 +148,11 @@ adminClient.interceptors.request.use(
 
       // Check if token needs refresh before making request
       if (isUsingJwt() && needsRefresh() && !isRefreshing) {
-        console.debug('[Admin API] Token needs refresh, refreshing before request...');
+        logger.debug('[Admin API] Token needs refresh, refreshing before request...');
         try {
           await refreshAccessToken();
         } catch (error) {
-          console.error('[Admin API] Token refresh failed in request interceptor:', error);
+          logger.error('[Admin API] Token refresh failed in request interceptor:', error);
         }
       }
       
@@ -160,7 +160,7 @@ adminClient.interceptors.request.use(
       if (authHeader) {
         config.headers.Authorization = authHeader;
       } else {
-        console.warn('[Admin API] No auth header available for request to:', config.url);
+        logger.warn('[Admin API] No auth header available for request to:', config.url);
       }
       
       // Add tenant ID header if available
@@ -171,12 +171,12 @@ adminClient.interceptors.request.use(
       
       return config;
     } catch (error) {
-      console.error('[Admin API] Request interceptor error:', error);
+      logger.error('[Admin API] Request interceptor error:', error);
       return config;
     }
   },
   (error) => {
-    console.error('[Admin API] Request interceptor rejected:', error);
+    logger.error('[Admin API] Request interceptor rejected:', error);
     return Promise.reject(error);
   }
 );
@@ -249,7 +249,7 @@ apiClient.interceptors.response.use(
     
     // Log the error for debugging
     if (status === 401) {
-      console.warn('[API] 401 Unauthorized:', {
+      logger.warn('[API] 401 Unauthorized:', {
         url: originalRequest?.url,
         method: originalRequest?.method,
         hasAuth: !!originalRequest?.headers?.Authorization,
@@ -264,7 +264,7 @@ apiClient.interceptors.response.use(
       // Prevent infinite retry loops
       const retryCount = (originalRequest._retryCount || 0) + 1;
       if (retryCount > 2) {
-        console.error('[API] Max retry attempts reached, showing session expired modal');
+        logger.error('[API] Max retry attempts reached, showing session expired modal');
         clearTokens();
         localStorage.removeItem('user');
         // KEEP tenant context for re-login - user should see same tenant after re-auth
@@ -298,14 +298,14 @@ apiClient.interceptors.response.use(
             // Retry original request with new token
             originalRequest.headers.Authorization = `Bearer ${newToken}`;
             processQueue(null);
-            console.debug('[API] Retrying request with refreshed token');
+            logger.debug('[API] Retrying request with refreshed token');
             return apiClient(originalRequest);
           } else {
             // Refresh returned null - tokens are invalid
             throw new Error('Token refresh returned null');
           }
         } catch (refreshError) {
-          console.error('[API] Token refresh failed:', refreshError);
+          logger.error('[API] Token refresh failed:', refreshError);
           processQueue(refreshError);
           // Refresh failed, show session expired modal
           clearTokens();
@@ -325,7 +325,7 @@ apiClient.interceptors.response.use(
       }
       
       // No JWT or refresh failed, clear auth and show modal
-      console.warn('[API] No JWT auth available, showing session expired modal');
+      logger.warn('[API] No JWT auth available, showing session expired modal');
       clearTokens();
       localStorage.removeItem('user');
       triggerGlobalSessionExpired('Your session has expired. Please log in to continue.');
@@ -373,7 +373,7 @@ adminClient.interceptors.response.use(
     
     // Log the error for debugging
     if (status === 401) {
-      console.warn('[Admin API] 401 Unauthorized:', {
+      logger.warn('[Admin API] 401 Unauthorized:', {
         url: originalRequest?.url,
         method: originalRequest?.method,
         hasAuth: !!originalRequest?.headers?.Authorization,
@@ -387,7 +387,7 @@ adminClient.interceptors.response.use(
       // Prevent infinite retry loops
       const retryCount = (originalRequest._retryCount || 0) + 1;
       if (retryCount > 2) {
-        console.error('[Admin API] Max retry attempts reached, showing session expired modal');
+        logger.error('[Admin API] Max retry attempts reached, showing session expired modal');
         clearTokens();
         localStorage.removeItem('user');
         triggerGlobalSessionExpired('Your session has expired.');
@@ -401,12 +401,12 @@ adminClient.interceptors.response.use(
         
         if (newToken) {
           originalRequest.headers.Authorization = `Bearer ${newToken}`;
-          console.debug('[Admin API] Retrying request with refreshed token');
+          logger.debug('[Admin API] Retrying request with refreshed token');
           return adminClient(originalRequest);
         }
       }
       
-      console.warn('[Admin API] No JWT auth available, showing session expired modal');
+      logger.warn('[Admin API] No JWT auth available, showing session expired modal');
       clearTokens();
       localStorage.removeItem('user');
       triggerGlobalSessionExpired('Your session has expired. Please log in to continue.');
@@ -811,7 +811,7 @@ export class ApiService {
       const response = await apiClient.get('/purchase-orders/');
       return response.data.results || response.data;
     } catch (error) {
-      console.error('Error fetching purchase orders:', error);
+      logger.error('Error fetching purchase orders:', error);
       throw new Error(
         'Purchase orders data unavailable. Please check your connection and try again.'
       );

--- a/frontend/src/services/jwtService.ts
+++ b/frontend/src/services/jwtService.ts
@@ -12,6 +12,7 @@
 
 import axios from 'axios';
 import { config } from '../config/runtime';
+import { logger } from '../utils/logger';
 
 const API_BASE_URL = config.API_BASE_URL;
 
@@ -99,7 +100,7 @@ export function getAccessToken(): string | null {
   if (accessToken) {
     // Check if token is valid
     if (isTokenExpired(accessToken)) {
-      console.debug('[JWT] Access token is expired');
+      logger.debug('[JWT] Access token is expired');
       // Don't return expired token - let refresh handle it
       return null;
     }
@@ -109,7 +110,7 @@ export function getAccessToken(): string | null {
   // Fall back to legacy token for backward compatibility
   const legacyToken = localStorage.getItem(LEGACY_TOKEN_KEY);
   if (legacyToken) {
-    console.debug('[JWT] Using legacy token');
+    logger.debug('[JWT] Using legacy token');
   }
   return legacyToken;
 }
@@ -151,19 +152,19 @@ export async function refreshAccessToken(): Promise<string | null> {
   // Rate limit refresh attempts
   const now = Date.now();
   if (now - lastRefreshAttempt < MIN_REFRESH_INTERVAL_MS) {
-    console.debug('[JWT] Skipping refresh - too soon since last attempt');
+    logger.debug('[JWT] Skipping refresh - too soon since last attempt');
     return getAccessToken();
   }
   
   const refreshToken = getRefreshToken();
   if (!refreshToken) {
-    console.debug('[JWT] No refresh token available');
+    logger.debug('[JWT] No refresh token available');
     return null;
   }
   
   // Check if refresh token itself is expired
   if (isTokenExpired(refreshToken)) {
-    console.debug('[JWT] Refresh token expired');
+    logger.debug('[JWT] Refresh token expired');
     clearTokens();
     return null;
   }
@@ -172,7 +173,7 @@ export async function refreshAccessToken(): Promise<string | null> {
   
   refreshPromise = (async () => {
     try {
-      console.debug('[JWT] Refreshing access token...');
+      logger.debug('[JWT] Refreshing access token...');
       
       // Use axios directly to avoid interceptor loops
       const response = await axios.post(
@@ -189,10 +190,10 @@ export async function refreshAccessToken(): Promise<string | null> {
       // Store new tokens (refresh token rotates)
       storeTokens(access, newRefresh || refreshToken);
       
-      console.debug('[JWT] Token refreshed successfully');
+      logger.debug('[JWT] Token refreshed successfully');
       return access;
     } catch (error) {
-      console.error('[JWT] Token refresh failed:', error);
+      logger.error('[JWT] Token refresh failed:', error);
       
       // If refresh fails with 401, tokens are invalid
       if (axios.isAxiosError(error) && error.response?.status === 401) {
@@ -229,14 +230,14 @@ export function getAuthHeader(): string | null {
     if (!isTokenExpired(accessToken)) {
       return `Bearer ${accessToken}`;
     }
-    console.debug('[JWT] Access token expired, needs refresh');
+    logger.debug('[JWT] Access token expired, needs refresh');
     return null;
   }
   
   // Fall back to legacy token
   const legacyToken = localStorage.getItem(LEGACY_TOKEN_KEY);
   if (legacyToken) {
-    console.debug('[JWT] Using legacy Token auth');
+    logger.debug('[JWT] Using legacy Token auth');
     return `Token ${legacyToken}`;
   }
   

--- a/frontend/src/utils/searchDiagnostic.ts
+++ b/frontend/src/utils/searchDiagnostic.ts
@@ -10,7 +10,7 @@ import { logger } from '@/utils/logger';
 
 
 export const searchDiagnostic = async (query: string = 'test') => {
-  console.group('🔍 Search Diagnostic');
+  logger.debug('[Search Diagnostic] Starting');
   
   try {
     logger.debug('1. Testing search endpoint...');
@@ -58,7 +58,7 @@ export const searchDiagnostic = async (query: string = 'test') => {
     }
   }
   
-  console.groupEnd();
+  logger.debug('[Search Diagnostic] Finished');
 };
 
 // Make available globally in browser console


### PR DESCRIPTION
## Deliverables
- Replace runtime console.* calls with centralized logger in:
  - apiService/jwtService (auth + refresh flows)
  - ActionItemsContext + FormBuilderContext
  - MyTasks delegation/workflow execution handling
  - FlowEditor passiveEvents + performance logging
  - searchDiagnostic utility (remove console.group usage)

## Expected results
- Cleaner production logs; consistent dev-gated debug/info output
- No eslint no-console warnings added for touched files

## Testing
- npm -C frontend run verify-standards
