### PR TITLE
Backend: fail-closed tenant actions for multi-tenant users

### DIFF
--- a/backend/apps/tenants/test_current_tenant_failclosed.py
+++ b/backend/apps/tenants/test_current_tenant_failclosed.py
@@ -1,0 +1,113 @@
+"""Fail-closed tenant resolution regression tests.
+
+These tests enforce the "no assumptions" rule for tenant-specific endpoints:
+- If a user belongs to multiple tenants, tenant selection must be explicit.
+
+Endpoints under test (apps.tenants.views.TenantViewSet actions):
+- GET /api/v1/tenants/current/
+- GET /api/v1/tenants/current_theme/
+- GET /api/v1/tenants/admin_permissions/
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.tenants.models import Tenant, TenantUser
+
+
+User = get_user_model()
+
+
+class TenantAmbiguityFailClosedTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f"u-{unique}", password="pw")
+
+        self.tenant_a = Tenant.objects.create(
+            name=f"Tenant A {unique}",
+            slug=f"tenant-a-{unique}",
+            contact_email=f"a-{unique}@example.com",
+            is_active=True,
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f"Tenant B {unique}",
+            slug=f"tenant-b-{unique}",
+            contact_email=f"b-{unique}@example.com",
+            is_active=True,
+            created_by=self.user,
+        )
+
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role="admin", is_active=True)
+        TenantUser.objects.create(tenant=self.tenant_b, user=self.user, role="admin", is_active=True)
+
+        # Session auth so TenantMiddleware can safely honor X-Tenant-ID.
+        self.client.force_login(self.user)
+
+    def test_current_requires_explicit_tenant_when_multi_membership(self):
+        resp = self.client.get("/api/v1/tenants/current/")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.data.get("code"), "tenant_required_multi")
+
+        resp = self.client.get("/api/v1/tenants/current/", HTTP_X_TENANT_ID=str(self.tenant_a.id))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data.get("slug"), self.tenant_a.slug)
+
+    def test_current_theme_requires_explicit_tenant_when_multi_membership(self):
+        resp = self.client.get("/api/v1/tenants/current_theme/")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.data.get("code"), "tenant_required_multi")
+
+        resp = self.client.get(
+            "/api/v1/tenants/current_theme/",
+            HTTP_X_TENANT_ID=str(self.tenant_b.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_admin_permissions_requires_explicit_tenant_when_multi_membership(self):
+        resp = self.client.get("/api/v1/tenants/admin_permissions/")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.data.get("code"), "tenant_required_multi")
+
+        resp = self.client.get(
+            "/api/v1/tenants/admin_permissions/",
+            HTTP_X_TENANT_ID=str(self.tenant_a.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data.get("role"), "admin")
+
+
+class TenantSingleMembershipDefaultsTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f"u1-{unique}", password="pw")
+        self.tenant = Tenant.objects.create(
+            name=f"Tenant {unique}",
+            slug=f"tenant-{unique}",
+            contact_email=f"t-{unique}@example.com",
+            is_active=True,
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role="admin", is_active=True)
+        self.client.force_login(self.user)
+
+    def test_current_allows_safe_default_when_single_membership(self):
+        resp = self.client.get("/api/v1/tenants/current/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data.get("slug"), self.tenant.slug)
+
+    def test_current_theme_allows_safe_default_when_single_membership(self):
+        resp = self.client.get("/api/v1/tenants/current_theme/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_admin_permissions_allows_safe_default_when_single_membership(self):
+        resp = self.client.get("/api/v1/tenants/admin_permissions/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data.get("role"), "admin")

--- a/backend/apps/tenants/views.py
+++ b/backend/apps/tenants/views.py
@@ -215,16 +215,29 @@ class TenantViewSet(viewsets.ModelViewSet):
     def current(self, request):
         """Return the current active tenant.
 
-        Prefers `request.tenant` (TenantMiddleware) and falls back to the first
-        active tenant membership for the user.
+        Fail-closed tenant resolution:
+        - If tenant is explicitly selected (middleware/header/domain), use it.
+        - If the user belongs to exactly ONE tenant, we allow a safe default.
+        - If the user belongs to MULTIPLE tenants, require explicit selection.
         """
         tenant = getattr(request, 'tenant', None)
 
         if not tenant:
-            tenant_user = TenantUser.objects.filter(
-                user=request.user, is_active=True
-            ).select_related('tenant').first()
-            tenant = tenant_user.tenant if tenant_user else None
+            memberships = list(
+                TenantUser.objects.filter(user=request.user, is_active=True)
+                .select_related('tenant')[:2]
+            )
+
+            if len(memberships) == 1:
+                tenant = memberships[0].tenant
+            elif len(memberships) > 1:
+                return Response(
+                    {
+                        "error": "Explicit tenant selection required (X-Tenant-ID)",
+                        "code": "tenant_required_multi",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         if not tenant:
             return Response(
@@ -238,27 +251,39 @@ class TenantViewSet(viewsets.ModelViewSet):
     def current_theme(self, request):
         """Get theme settings for the current tenant.
 
-        Prefers `request.tenant` (TenantMiddleware) and falls back to the first
-        active tenant membership for the user.
+        Fail-closed tenant resolution:
+        - If tenant is explicitly selected (middleware/header/domain), use it.
+        - If the user belongs to exactly ONE tenant, we allow a safe default.
+        - If the user belongs to MULTIPLE tenants, require explicit selection.
 
         Returns tenant logo, name, and theme colors.
-        Used by frontend to apply tenant-specific branding.
         """
         tenant = getattr(request, 'tenant', None)
 
-        if request.user.is_superuser and tenant:
-            return Response(tenant.get_theme_settings())
+        if not tenant:
+            memberships = list(
+                TenantUser.objects.filter(user=request.user, is_active=True)
+                .select_related('tenant')[:2]
+            )
 
-        tenant_user_qs = TenantUser.objects.filter(user=request.user, is_active=True).select_related('tenant')
-        tenant_user = tenant_user_qs.filter(tenant=tenant).first() if tenant else tenant_user_qs.first()
+            if len(memberships) == 1:
+                tenant = memberships[0].tenant
+            elif len(memberships) > 1:
+                return Response(
+                    {
+                        "error": "Explicit tenant selection required (X-Tenant-ID)",
+                        "code": "tenant_required_multi",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
-        if not tenant_user:
+        if not tenant:
             return Response(
                 {"error": "User not associated with any tenant"},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        return Response(tenant_user.tenant.get_theme_settings())
+        return Response(tenant.get_theme_settings())
 
     @action(detail=False, methods=["get"])
     def admin_permissions(self, request):
@@ -271,11 +296,6 @@ class TenantViewSet(viewsets.ModelViewSet):
         """
         if request.user.is_superuser:
             tenant = getattr(request, 'tenant', None)
-            tenant_user = None
-
-            if not tenant:
-                tenant_user = TenantUser.objects.filter(user=request.user, is_active=True).select_related('tenant').first()
-                tenant = tenant_user.tenant if tenant_user else None
 
             return Response({
                 'can_manage_users': True,
@@ -295,8 +315,26 @@ class TenantViewSet(viewsets.ModelViewSet):
             })
 
         tenant = getattr(request, 'tenant', None)
+
+        if not tenant:
+            memberships = list(
+                TenantUser.objects.filter(user=request.user, is_active=True)
+                .select_related('tenant')[:2]
+            )
+
+            if len(memberships) == 1:
+                tenant = memberships[0].tenant
+            elif len(memberships) > 1:
+                return Response(
+                    {
+                        "error": "Explicit tenant selection required (X-Tenant-ID)",
+                        "code": "tenant_required_multi",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
         tenant_user_qs = TenantUser.objects.filter(user=request.user, is_active=True)
-        tenant_user = tenant_user_qs.filter(tenant=tenant).select_related('tenant').first() if tenant else tenant_user_qs.select_related('tenant').first()
+        tenant_user = tenant_user_qs.filter(tenant=tenant).select_related('tenant').first() if tenant else None
 
         if not tenant_user:
             return Response(


### PR DESCRIPTION
## Deliverables
- Make tenant-specific TenantViewSet actions fail-closed when user has multiple tenant memberships and no explicit tenant context:
  - GET /api/v1/tenants/current/
  - GET /api/v1/tenants/current_theme/
  - GET /api/v1/tenants/admin_permissions/
- Add regression tests enforcing:
  - multi-tenant + no X-Tenant-ID => 400 (code: tenant_required_multi)
  - single-tenant + no X-Tenant-ID => safe default (200)

## Expected results
- No silent "first tenant" fallback for multi-tenant users
- Stable, explicit error contract for missing tenant context

## Testing
- python -m compileall backend/apps/tenants/views.py backend/apps/tenants/test_current_tenant_failclosed.py
- (CI) Django test suite
