### PR TITLE
Mobile: device-safe API base URL

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -116,8 +116,15 @@ npm run web
 
 The app automatically detects development vs production based on the `__DEV__` flag:
 
-- **Development**: Uses `http://localhost:8000/api/v1` (assumes backend running locally)
+- **Development**: Uses a **device-safe** URL derived from Expo's dev host when possible.
+  - Physical devices: `http://<your-dev-machine-lan-ip>:8000/api/v1`
+  - Android emulator fallback: `http://10.0.2.2:8000/api/v1`
+  - iOS simulator fallback: `http://localhost:8000/api/v1`
 - **Production**: Uses your production API URL (configure in `src/services/ApiService.ts`)
+
+To override explicitly (recommended for physical device testing), set:
+
+- `EXPO_PUBLIC_API_BASE_URL=http://<your-ip>:8000/api/v1`
 
 ### Adding New Features
 

--- a/mobile/src/__tests__/ApiService.baseurl.test.ts
+++ b/mobile/src/__tests__/ApiService.baseurl.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable import/first */
+// Base URL resolution tests for ApiService.
+// We keep this isolated so we can reset modules and assert axios.create config.
+
+jest.mock('axios', () => {
+  const axiosMock = {
+    create: jest.fn(() => ({
+      get: jest.fn(),
+      post: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    })),
+  };
+
+  return {
+    __esModule: true,
+    default: axiosMock,
+    ...axiosMock,
+  };
+});
+
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      hostUri: '192.168.0.2:8081',
+      extra: { apiBaseUrl: 'http://localhost:8000/api/v1' },
+    },
+  },
+}));
+
+describe('ApiService – baseURL resolution', () => {
+  it('rewrites localhost to the Expo dev host IP in dev', () => {
+    jest.resetModules();
+
+    // NOTE: use require() (not dynamic import) to keep jest-expo + tsc happy.
+    const axios = require('axios').default;
+    const create = axios.create as jest.Mock;
+    create.mockClear();
+
+    jest.isolateModules(() => {
+      require('../services/ApiService');
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'http://192.168.0.2:8000/api/v1',
+      })
+    );
+  });
+});

--- a/mobile/src/__tests__/ApiService.test.ts
+++ b/mobile/src/__tests__/ApiService.test.ts
@@ -23,6 +23,16 @@ jest.mock('axios', () => {
   };
 });
 
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      hostUri: '192.168.0.2:8081',
+      extra: { apiBaseUrl: 'http://localhost:8000/api/v1' },
+    },
+  },
+}));
+
 import { ApiService } from '../services/ApiService';
 
 // Access the private internal axios instance via type cast

--- a/mobile/src/__tests__/openapi.contract.test.ts
+++ b/mobile/src/__tests__/openapi.contract.test.ts
@@ -28,6 +28,16 @@ jest.mock('axios', () => {
   };
 });
 
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      hostUri: '192.168.0.2:8081',
+      extra: { apiBaseUrl: 'http://localhost:8000/api/v1' },
+    },
+  },
+}));
+
 import { ApiService } from '../services/ApiService';
 
 type OpenApiSpec = {

--- a/mobile/src/services/ApiService.ts
+++ b/mobile/src/services/ApiService.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import Constants from 'expo-constants';
+import { Platform } from 'react-native';
 import {
   LoginRequest,
   LoginResponse,
@@ -18,6 +19,43 @@ import {
   WorkFormExecution,
 } from '../types';
 
+const PROD_DEFAULT_API_BASE_URL = 'https://dev.meatscentral.com/api/v1';
+
+function getExpoDevHost(): string | null {
+  const hostUri =
+    Constants.expoConfig?.hostUri ||
+    (Constants as any).manifest?.debuggerHost ||
+    (Constants as any).manifest2?.extra?.expoClient?.hostUri;
+
+  if (!hostUri || typeof hostUri !== 'string') return null;
+  return hostUri.split(':')[0] || null;
+}
+
+function getDeviceSafeDevApiBaseUrl(): string {
+  const host = getExpoDevHost();
+  if (host) return `http://${host}:8000/api/v1`;
+
+  if (Platform.OS === 'android') return 'http://10.0.2.2:8000/api/v1';
+  return 'http://localhost:8000/api/v1';
+}
+
+function resolveApiBaseUrl(envBaseUrl?: string, extraBaseUrl?: string): string {
+  const env = (envBaseUrl || '').trim();
+  if (env) return env;
+
+  const extra = (extraBaseUrl || '').trim();
+
+  if (extra && /(localhost|127\.0\.0\.1)/.test(extra)) {
+    return getDeviceSafeDevApiBaseUrl();
+  }
+
+  if (__DEV__) {
+    return extra || getDeviceSafeDevApiBaseUrl();
+  }
+
+  return extra || PROD_DEFAULT_API_BASE_URL;
+}
+
 class ApiServiceClass {
   private api: AxiosInstance;
   private baseURL: string;
@@ -26,11 +64,7 @@ class ApiServiceClass {
     const envBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL;
     const extraBaseUrl = (Constants.expoConfig?.extra as any)?.apiBaseUrl as string | undefined;
 
-    // Prefer environment-configured URL (build-time), then app.json extra, then sensible defaults.
-    const configured = (envBaseUrl || extraBaseUrl || '').trim();
-    this.baseURL = (
-      configured || (__DEV__ ? 'http://localhost:8000/api/v1' : 'https://dev.meatscentral.com/api/v1')
-    ).replace(/\/+$/, '');
+    this.baseURL = resolveApiBaseUrl(envBaseUrl, extraBaseUrl).replace(/\/+$/, '');
 
     this.api = axios.create({
       baseURL: this.baseURL,


### PR DESCRIPTION
## Deliverables
- Mobile ApiService resolves a device-safe API base URL:
  - Prefer EXPO_PUBLIC_API_BASE_URL (explicit)
  - Else app.json extra.apiBaseUrl
  - If configured as localhost/127.0.0.1, rewrite using Expo hostUri (LAN IP) when available, or Android emulator 10.0.2.2
- Update mobile README with override instructions
- Stabilize mobile Jest runs by mocking expo-constants, and add a baseURL resolution test

## Expected results
- Physical devices and Android emulators can reach the dev backend without manual code edits
- Mobile CI tests remain deterministic (no native module warnings)

## Testing
- npm -C mobile test
- npm -C mobile run type-check
