### PR TITLE
Mobile: switch build scripts to EAS

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -30,10 +30,10 @@ This mobile app provides core functionality for managing meat sales operations o
 ## Tech Stack
 
 - **React Native**: 0.74.5
-- **Expo**: ~51.0.0
+- **Expo**: ~55.0.15
 - **React Navigation**: ^6.1.0
 - **TypeScript**: ~5.3.3
-- **Axios**: ^1.6.0 (API communication)
+- **Axios**: ^1.15.0 (API communication)
 - **Styled Components**: ^6.1.0
 - **AsyncStorage**: For local data persistence
 
@@ -72,7 +72,7 @@ mobile/
 
 - Node.js (v18 or later)
 - npm or yarn
-- Expo CLI: `npm install -g expo-cli`
+- Expo CLI is provided via the local `expo` dependency (use `npx expo` if needed)
 - For iOS: Xcode and iOS Simulator
 - For Android: Android Studio and Android Emulator
 - Expo Go app on your physical device (for testing)
@@ -147,26 +147,32 @@ All shared utilities are centralized in the `/shared` directory at the repositor
 
 ## Building for Production
 
-### Android
+ProjectMeats Mobile uses **EAS Build** (Expo's modern build system). The legacy `expo build:*` commands are deprecated.
 
-1. Configure `app.json` with your app details
-2. Build APK:
+### One-time setup
+
 ```bash
-expo build:android
+# Creates/updates eas.json and links the project
+npm run eas:configure
 ```
 
-3. Build AAB (for Google Play):
+### Android / iOS builds
+
 ```bash
-expo build:android -t app-bundle
+# Android (production profile)
+npm run build:android
+
+# iOS (production profile)
+npm run build:ios
 ```
 
-### iOS
+### Environment variables for builds
 
-1. Configure `app.json` with your app details
-2. Build IPA:
-```bash
-expo build:ios
-```
+For production/preview builds, prefer configuring the API base URL via EAS environment variables:
+
+- `EXPO_PUBLIC_API_BASE_URL=https://<your-api-host>/api/v1`
+
+This keeps `app.json` safe for local dev (it may use localhost, which the app rewrites to device-safe values in development).
 
 ## Deployment
 

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -17,14 +17,16 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.projectmeats.mobile"
+      "bundleIdentifier": "com.projectmeats.mobile",
+      "buildNumber": "1"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.projectmeats.mobile"
+      "package": "com.projectmeats.mobile",
+      "versionCode": 1
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,0 +1,15 @@
+{
+  "cli": {
+    "version": ">= 10.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,8 +9,9 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "build:android": "expo build:android",
-    "build:ios": "expo build:ios",
+    "eas:configure": "npx eas-cli@latest configure",
+    "build:android": "npx eas-cli@latest build --platform android --profile production",
+    "build:ios": "npx eas-cli@latest build --platform ios --profile production",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "type-check": "tsc --noEmit"

--- a/mobile/src/__tests__/ApiService.baseurl.test.ts
+++ b/mobile/src/__tests__/ApiService.baseurl.test.ts
@@ -39,11 +39,13 @@ describe('ApiService – baseURL resolution', () => {
     jest.resetModules();
 
     // NOTE: use require() (not dynamic import) to keep jest-expo + tsc happy.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const axios = require('axios').default;
     const create = axios.create as jest.Mock;
     create.mockClear();
 
     jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       require('../services/ApiService');
     });
 


### PR DESCRIPTION
## Deliverables
- Replace deprecated `expo build:*` scripts with EAS Build scripts (no new deps; uses `npx eas-cli@latest`)
- Add `mobile/eas.json` with standard build profiles (development/preview/production)
- Add build metadata to `app.json` (`ios.buildNumber`, `android.versionCode`)
- Update mobile README to reflect current Expo/Axios versions and EAS-based build instructions

## Expected results
- Mobile build workflow matches modern Expo guidance (EAS Build)
- App metadata is present for store submissions

## Testing
- npm -C mobile test
- npm -C mobile run lint
- npm -C mobile run type-check
