### PR TITLE
Docs: refresh master plan + roadmap (2026-04-27)

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1643,7 +1643,7 @@ Deliverables:
 
 - 2026-04-01 — Docs: clarify historical checklists + fix roadmap duplication — PR: #4337.
 
-- 2026-04-01 — Docs: align README with canonical master plan (remove 100 laims) — PR: #4338.
+- 2026-04-01 — Docs: align README with canonical master plan (remove 100laims) — PR: #4338.
 
 - 2026-04-01 — CI/CD: fix Master Pipeline workflow file issue (run-name + md paths-ignore) — PR: #4339.
 
@@ -1730,3 +1730,5 @@ Deliverables:
 - **2026-04-27** — Frontend: expand `lint:colors` guardrail to MyTasks surfaces and tokenized remaining hardcoded colors in MyTasks/QuickActions widgets, shared styles, and theme config. (PR: #4650)
 - **2026-04-27** — Docs: record backend audit P0s in canonical master plan + PR log. (PR: #4651)
 - **2026-04-27** — Backend: fix `apps/core/views.py` legacy imports/print() and add smoke tests for Ranked Search + Workspace Stats core endpoints. (PR: #4652)
+
+- **2026-04-27** — Ops note: .github/MASTER_PLAN.md had one or more NUL (\0) bytes; repaired by re-serializing as plain UTF-8 text while preserving content.

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -1,7 +1,7 @@
 # MASTER_PLAN.md (Canonical)
 
 **Status**: 🔄 Living document (canonical source of truth)  
-**Last Updated**: 2026-04-21  
+**Last Updated**: 2026-04-27  
 **Primary Focus**: Phase 10 (DRY/Canonical Architecture Standardization) - Industry-leader compliance  
 
 This file is the **canonical plan + current truth snapshot**.
@@ -10,28 +10,34 @@ This file is the **canonical plan + current truth snapshot**.
 
 ---
 
-## Current Execution Snapshot (as of 2026-04-20)
+## Current Execution Snapshot (as of 2026-04-27)
 
 ### What is true right now
 - **WorkForms E2E** is shipped end-to-end (execute + monitoring + notifications + Quick Actions + Gmail connector MVP).
-- **Primary execution focus (P0):** close remaining correctness + UX gaps surfaced by squad audits.
-- Recently shipped hardening includes FlowEditor a11y tabs + HelpModal stability, back-compat theme token aliases, WorkForms RBAC regression coverage, and debug logging cleanup (see PR refs in `.github/MASTER_PLAN.md`).
+- **Primary execution focus (P0):** close remaining correctness + tenant isolation gaps surfaced by squad audits.
+- **Newly shipped since last snapshot (evidence; see `.github/MASTER_PLAN.md`)**:
+  - Core API reliability: fix `apps/core/views.py` legacy imports/`print()` landmines + add smoke tests (PR #4652).
+  - Frontend standards: expand `lint:colors` + remove remaining hardcoded colors in MyTasks surfaces (PR #4650); replace high-churn `console.*` with `logger.*` (PR #4654).
+  - Backend tenant safety: fail-closed `current/current_theme/admin_permissions` when tenant context is missing/ambiguous (PR #4656); wrap tenant-scoped Celery ORM in `tenant_rls(..., strict=False)` (PR #4657).
+  - Mobile: device-safe API base URL + tests (PR #4658); switch builds to EAS (PR #4659).
 
 ### P0 priorities (next)
-- **Core API reliability**: fix `apps/core/views.py` legacy imports/`print()` that can cause runtime 500s in Ranked Search + Workspace Stats; add smoke tests.
-- **WorkForms Editor stability**: deterministic schema init (no timer races), resolve form "fields" model mismatch, sanitize UI-only shadow state on save; continue hardening remaining a11y + theme-token usage as needed.
+- **Core API reliability**: ✅ shipped (PR #4652). Next: expand smoke coverage for always-on endpoints (health, tenant resolution, auth bootstrap) and keep them in PR gates.
 - **Security / tenant isolation** (RLS correctness):
+  - **P0 data isolation**: remove `is_staff` global bypasses in `apps/system/views/choice_viewsets.py` (tenant admins are promoted to `is_staff=True` via signals; must not yield cross-tenant reads/writes).
+  - Make invitation email Celery task tenant/RLS safe (pass `tenant_id`; wrap task ORM in `tenant_rls` before querying invitation).
   - Workflow webhook receiver must set `request.tenant` + `set_current_tenant()` **before** ORM lookup (FORCE RLS correctness).
   - Legacy workflow webhook endpoint must fail closed unless tenant context is resolvable (migrate callers to tenant-path URL).
   - Integrations OAuth callback must set tenant + RLS session vars before writing tenant-scoped rows.
   - WorkForms create must not bypass activation validation when `status=active`.
+- **WorkForms Editor stability**: deterministic schema init (no timer races), resolve form "fields" model mismatch, sanitize UI-only shadow state on save; continue hardening remaining a11y + theme-token usage as needed.
 - **CI guardrails (never-miss-again)**:
-  - Fix backend runtime `SECRET_KEY` injection (ensure `backend/.env` includes `SECRET_KEY` mapped from `DJANGO_SECRET_KEY`).
-  - Enforce job-level timeouts + add Golden-compliant post-deploy smoke gates (direct-to-container).
-  - Keep Golden Drift Gate green; follow-ups include re-enabling backend/frontend test gates in `reusable-deploy.yml`.
-- **Mobile parity**: align WorkForms mobile models with backend (`workflow_definition`), extend OpenAPI contract coverage for `/tenant-workforms/*`, and add a real WorkForm detail view.
+  - Deploy-by-digest default for UAT/Prod and digest-align the migration artifact.
+  - Manifest-driven required-secret enforcement per lane (remove hardcoded lists).
+  - Docs drift prevention: "CURRENT" docs must not recommend forbidden Golden patterns (runner-driven migrations only).
+- **Mobile parity**: ✅ shipped foundations (PRs #4658/#4659). Next: switch-tenant persistence, consistent error normalization, and auth expiry/401 behavior parity.
 
-### Squad deep dive plan (as of 2026-04-21)
+### Squad deep dive plan (as of 2026-04-27)
 
 This is a prioritized, PR-sized execution plan synthesized from squad deep dives (frontend/backend/devops/testing + lead synthesis). It is intentionally biased toward **guardrails first**, then **tenant/RLS correctness**, then **editor stability + standards**, then **mobile parity**.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,13 +8,22 @@ For current priorities, status, and evidence, see **`MASTER_PLAN.md` (canonical)
 
 ---
 
-## 🔎 Discovery Backlog (2026-04-21)
+## 🔎 Discovery Backlog (last refreshed 2026-04-27)
 
 This is a lightweight pointer list from squad discovery. **Execute via `MASTER_PLAN.md` (canonical) + `.github/MASTER_PLAN.md` (PR log)**.
 
-- P0 Security/RLS correctness: workflow webhooks RLS ordering + legacy endpoint fail-closed; integrations OAuth callback RLS ordering; prevent WorkForms activation bypass on create.
-- P0 Mobile: align WorkForms contract (types + OpenAPI coverage) and add a real WorkForm detail view.
-- P0 CI follow-up: re-enable backend/frontend tests in `reusable-deploy.yml`; update workflow validator to cover current canonical topology.
+- P0 Security/RLS correctness:
+  - Fix cross-tenant exposure risk in `apps/system` config/choice endpoints (remove `is_staff` global bypass; tenant admins are `is_staff=True`).
+  - Make invitation email Celery task tenant/RLS safe (pass tenant_id; wrap task ORM in tenant_rls).
+  - Workflow webhooks RLS ordering + legacy endpoint fail-closed; integrations OAuth callback RLS ordering; prevent WorkForms activation bypass on create.
+- P0 CI hardening:
+  - Default deploy-by-digest for UAT/Prod and digest-align migrations.
+  - Manifest-driven required secrets gate per lane; docs drift lint for Golden migration rules.
+- P0 Frontend standards/a11y:
+  - Remove remaining FlowEditor/WorkForms named colors (white/black) and replace console.* with logger.*.
+  - Make WorkForms cards/modals keyboard accessible (semantic controls + dialog semantics/focus).
+- P1 Mobile parity:
+  - Fix switch-tenant persistence; normalize errors; define auth expiry/401 behavior.
 
 ---
 


### PR DESCRIPTION
## Deliverables
- Refresh canonical MASTER_PLAN.md snapshot to 2026-04-27 and reflect recently shipped work (PRs #4650–#4659)
- Refresh ROADMAP discovery pointers to avoid pointing at already-shipped work
- Repair .github/MASTER_PLAN.md file integrity by removing NUL (\0) byte(s) and appending an ops note

## Expected results
- Canonical plan reflects current reality and new P0 audit findings
- PR execution log is searchable/indexable again (not treated as binary)

## Testing
- N/A (docs)
