### PR TITLE
Backend: fix system config tenant scoping

### DIFF
--- a/backend/apps/system/tests/test_choice_viewsets_tenant_isolation.py
+++ b/backend/apps/system/tests/test_choice_viewsets_tenant_isolation.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.system.models import ConfigAuditLog, SystemChoiceItem, SystemChoiceList, TenantChoiceOverride, TenantConfig
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
+
+
+User = get_user_model()
+
+
+@override_settings(ALLOWED_HOSTS=['*'])
+class SystemConfigChoiceViewSetsTenantIsolationTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+        self.client.force_authenticate(self.user)
+
+        self.tenant_a = Tenant.objects.create(
+            name=f'Tenant A {unique}',
+            slug=f'tenant-a-{unique}',
+            contact_email=f'{unique}-a@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f'Tenant B {unique}',
+            slug=f'tenant-b-{unique}',
+            contact_email=f'{unique}-b@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+
+        self.domain_a = TenantDomain.objects.create(
+            tenant=self.tenant_a,
+            domain=f'{self.tenant_a.slug}.example.com',
+            is_primary=True,
+        )
+        self.domain_b = TenantDomain.objects.create(
+            tenant=self.tenant_b,
+            domain=f'{self.tenant_b.slug}.example.com',
+            is_primary=True,
+        )
+
+        # Mark user as an admin for tenant A (this also promotes is_staff=True via signal).
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role='admin', is_active=True)
+
+        self.choice_list = SystemChoiceList.objects.create(
+            name=f'Protein Type {unique}',
+            slug=f'protein_type_{unique}',
+            description='Test list',
+            is_extensible=True,
+            is_reorderable=True,
+            created_by=self.user,
+        )
+
+        self.system_item = SystemChoiceItem.objects.create(
+            choice_list=self.choice_list,
+            tenant=None,
+            value='BEEF',
+            label='Beef',
+            order=1,
+            is_active=True,
+        )
+        self.tenant_a_item = SystemChoiceItem.objects.create(
+            choice_list=self.choice_list,
+            tenant=self.tenant_a,
+            value='WAGYU',
+            label='Wagyu',
+            order=100,
+            is_active=True,
+        )
+        self.tenant_b_item = SystemChoiceItem.objects.create(
+            choice_list=self.choice_list,
+            tenant=self.tenant_b,
+            value='VENISON',
+            label='Venison',
+            order=200,
+            is_active=True,
+        )
+
+        self.tenant_b_config = TenantConfig.objects.create(
+            tenant=self.tenant_b,
+            key='ui.theme.primary_color',
+            value='not-for-tenant-a',
+            updated_by=self.user,
+        )
+
+        self.tenant_b_override = TenantChoiceOverride.objects.create(
+            tenant=self.tenant_b,
+            choice_list=self.choice_list,
+            disabled_system_items=[self.system_item.id],
+            display_config={},
+            updated_by=self.user,
+        )
+
+        ct = ContentType.objects.get_for_model(TenantConfig)
+        self.tenant_b_log = ConfigAuditLog.objects.create(
+            content_type=ct,
+            object_id=str(self.tenant_b_config.id),
+            entity_type='TenantConfig',
+            entity_name=self.tenant_b_config.key,
+            change_type=ConfigAuditLog.ChangeType.UPDATE,
+            tenant=self.tenant_b,
+            user=self.user,
+            user_email='u@example.com',
+            notes='tenant b only',
+        )
+        self.system_log = ConfigAuditLog.objects.create(
+            content_type=ct,
+            object_id='system',
+            entity_type='System',
+            entity_name='system',
+            change_type=ConfigAuditLog.ChangeType.UPDATE,
+            tenant=None,
+            user=self.user,
+            user_email='u@example.com',
+            notes='system log',
+        )
+
+        self.tenant_headers = {
+            'HTTP_X_TENANT_ID': str(self.tenant_a.id),
+            'HTTP_HOST': self.domain_a.domain,
+        }
+
+    def _get_results(self, resp):
+        data = resp.json()
+        if isinstance(data, dict) and 'results' in data:
+            return data['results']
+        return data
+
+    def test_choice_items_list_is_tenant_scoped_for_tenant_admin(self):
+        resp = self.client.get('/api/v1/system/choice-items/?paginate=false', **self.tenant_headers)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+        results = self._get_results(resp)
+        ids = {row.get('id') for row in results}
+
+        self.assertIn(str(self.system_item.id), ids)
+        self.assertIn(str(self.tenant_a_item.id), ids)
+        self.assertNotIn(str(self.tenant_b_item.id), ids)
+
+    def test_choice_items_retrieve_other_tenant_fails_closed(self):
+        resp = self.client.get(f'/api/v1/system/choice-items/{self.tenant_b_item.id}/', **self.tenant_headers)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_tenant_configs_list_excludes_other_tenant(self):
+        resp = self.client.get('/api/v1/system/tenant-configs/', **self.tenant_headers)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+        results = self._get_results(resp)
+        ids = {row.get('id') for row in results}
+        self.assertNotIn(str(self.tenant_b_config.id), ids)
+
+    def test_tenant_configs_retrieve_other_tenant_fails_closed(self):
+        resp = self.client.get(f'/api/v1/system/tenant-configs/{self.tenant_b_config.id}/', **self.tenant_headers)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_tenant_overrides_list_excludes_other_tenant(self):
+        resp = self.client.get('/api/v1/system/tenant-overrides/', **self.tenant_headers)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+        results = self._get_results(resp)
+        ids = {row.get('id') for row in results}
+        self.assertNotIn(str(self.tenant_b_override.id), ids)
+
+    def test_tenant_overrides_retrieve_other_tenant_fails_closed(self):
+        resp = self.client.get(f'/api/v1/system/tenant-overrides/{self.tenant_b_override.id}/', **self.tenant_headers)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_audit_logs_list_excludes_other_tenant_but_includes_system(self):
+        resp = self.client.get('/api/v1/system/audit-logs/', **self.tenant_headers)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+        results = self._get_results(resp)
+        ids = {row.get('id') for row in results}
+
+        self.assertIn(str(self.system_log.id), ids)
+        self.assertNotIn(str(self.tenant_b_log.id), ids)

--- a/backend/apps/system/views/choice_viewsets.py
+++ b/backend/apps/system/views/choice_viewsets.py
@@ -99,7 +99,7 @@ class IsTenantAdminOrReadOnly(permissions.BasePermission):
         if not request.user.is_authenticated:
             return False
 
-        if request.user.is_superuser or request.user.is_staff:
+        if request.user.is_superuser:
             return True
 
         tenant = getattr(request, 'tenant', None)
@@ -275,6 +275,9 @@ class SystemChoiceListViewSet(viewsets.ReadOnlyModelViewSet):
         
         tenant = getattr(request, 'tenant', None)
 
+        if not request.user.is_superuser and not tenant:
+            return Response({'error': 'Tenant context required.'}, status=status.HTTP_400_BAD_REQUEST)
+
         if tenant:
             # RLS: ensure session vars are set on the active connection for this write.
             from apps.tenants.rls import set_current_tenant
@@ -287,7 +290,7 @@ class SystemChoiceListViewSet(viewsets.ReadOnlyModelViewSet):
 
             # Only allow updating tenant's own items or system items (if admin)
             item_filter = {'id': item_id, 'choice_list': choice_list}
-            if not request.user.is_staff:
+            if not request.user.is_superuser:
                 item_filter['tenant'] = tenant
 
             SystemChoiceItem.objects.filter(**item_filter).update(order=new_order)
@@ -355,7 +358,7 @@ class SystemChoiceItemViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         tenant = getattr(self.request, 'tenant', None)
         
-        if self.request.user.is_staff:
+        if self.request.user.is_superuser:
             return SystemChoiceItem.objects.all()
         
         if tenant:
@@ -413,7 +416,7 @@ class SystemChoiceItemViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         """Only allow updating tenant-owned items (or if admin)."""
         instance = serializer.instance
-        if instance.tenant_id is None and not self.request.user.is_staff:
+        if instance.tenant_id is None and not self.request.user.is_superuser:
             from rest_framework.exceptions import PermissionDenied
 
             raise PermissionDenied("Cannot modify system-defined items.")
@@ -497,7 +500,7 @@ class TenantChoiceOverrideViewSet(viewsets.ModelViewSet):
         tenant = getattr(self.request, 'tenant', None)
         qs = TenantChoiceOverride.objects.all().select_related('tenant', 'choice_list', 'updated_by')
 
-        if self.request.user.is_staff or self.request.user.is_superuser:
+        if self.request.user.is_superuser:
             return qs
 
         if not tenant:
@@ -614,7 +617,7 @@ class TenantConfigViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         tenant = getattr(self.request, 'tenant', None)
         
-        if self.request.user.is_staff:
+        if self.request.user.is_superuser:
             return TenantConfig.objects.all()
         
         if tenant:
@@ -792,8 +795,8 @@ class ConfigAuditLogViewSet(viewsets.ReadOnlyModelViewSet):
         """Filter audit logs by tenant context."""
         tenant = getattr(self.request, 'tenant', None)
         
-        if self.request.user.is_staff:
-            # Staff can see all logs
+        if self.request.user.is_superuser:
+            # Superusers can see all logs
             qs = ConfigAuditLog.objects.all()
         elif tenant:
             # Tenant admins see their tenant's logs + system-level logs


### PR DESCRIPTION
## Deliverables
- Remove `is_staff` global-tenant bypasses in `apps/system/views/choice_viewsets.py` that could expose cross-tenant config/choice data
- Restrict “see all tenants” behavior to `is_superuser`
- Add regression tests proving a tenant admin (who is `is_staff=True` via signals) cannot read other tenants’:
  - /api/v1/system/choice-items/
  - /api/v1/system/tenant-configs/
  - /api/v1/system/tenant-overrides/
  - /api/v1/system/audit-logs/

## Expected results
- Tenant admins no longer gain cross-tenant visibility via `is_staff`
- Tenant isolation is enforced consistently on system config endpoints

## Testing
- python backend/manage.py test apps.system.tests.test_choice_viewsets_tenant_isolation -v 2
