### PR TITLE
Backend: invitation email task RLS safety

### DIFF
--- a/backend/apps/tenants/invitation_email.py
+++ b/backend/apps/tenants/invitation_email.py
@@ -118,7 +118,7 @@ def schedule_invitation_email(invitation: TenantInvitation) -> None:
         try:
             from .tasks import send_invitation_email_task  # noqa: PLC0415
 
-            send_invitation_email_task.delay(invitation_id)
+            send_invitation_email_task.delay(invitation_id, str(invitation.tenant_id))
             logger.info(
                 "📬 Invitation email queued for %s (invitation=%s)",
                 invitation.email,

--- a/backend/apps/tenants/tasks.py
+++ b/backend/apps/tenants/tasks.py
@@ -12,6 +12,8 @@ from celery import shared_task
 from django.conf import settings
 from django.core.mail import send_mail
 
+from apps.tenants.rls import tenant_rls
+
 from .email_utils import is_sendgrid_quota_exceeded
 
 logger = logging.getLogger(__name__)
@@ -23,7 +25,7 @@ logger = logging.getLogger(__name__)
     max_retries=3,
     default_retry_delay=60,
 )
-def send_invitation_email_task(self, invitation_id: str) -> dict:
+def send_invitation_email_task(self, invitation_id: str, tenant_id: str) -> dict:
     """Send an invitation email in the background.
 
     Retries up to 3 times with exponential back-off for transient failures.
@@ -32,6 +34,7 @@ def send_invitation_email_task(self, invitation_id: str) -> dict:
 
     Args:
         invitation_id: Primary-key string of the ``TenantInvitation`` record.
+        tenant_id: Tenant UUID for RLS scoping.
 
     Returns:
         A dict with ``{"success": True}`` on success.
@@ -41,7 +44,8 @@ def send_invitation_email_task(self, invitation_id: str) -> dict:
     from .models import TenantInvitation  # noqa: PLC0415
 
     try:
-        invitation = TenantInvitation.objects.get(id=invitation_id)
+        with tenant_rls(str(tenant_id), strict=False):
+            invitation = TenantInvitation.objects.get(id=invitation_id, tenant_id=tenant_id)
     except TenantInvitation.DoesNotExist:
         logger.warning("send_invitation_email_task: invitation %s not found", invitation_id)
         return {"success": False, "error": "Invitation not found"}

--- a/backend/apps/tenants/test_invitation_email_task_rls.py
+++ b/backend/apps/tenants/test_invitation_email_task_rls.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from apps.tenants.invitation_email import schedule_invitation_email
+from apps.tenants.models import Tenant, TenantInvitation
+
+
+User = get_user_model()
+
+
+class InvitationEmailTaskRlsTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+
+        self.invitation = TenantInvitation.objects.create(
+            token='',
+            tenant=self.tenant,
+            email=f'invite-{unique}@example.com',
+            role='user',
+            invited_by=self.user,
+        )
+
+    def test_schedule_invitation_email_enqueues_with_tenant_id(self):
+        # Force the on_commit callback to run inline for this unit test.
+        with patch('apps.tenants.tasks.send_invitation_email_task.delay') as delay, patch(
+            'django.db.transaction.on_commit', side_effect=lambda fn: fn()
+        ):
+            schedule_invitation_email(self.invitation)
+
+        delay.assert_called_once_with(str(self.invitation.id), str(self.tenant.id))
+
+    def test_task_scopes_lookup_with_tenant_rls(self):
+        # Import inside test to ensure we patch the task module-level symbol.
+        from apps.tenants.tasks import send_invitation_email_task
+
+        @contextmanager
+        def _fake_tenant_rls(tenant_id: str, *, strict: bool = True):
+            yield None
+
+        with patch('apps.tenants.tasks.tenant_rls', side_effect=_fake_tenant_rls) as rls, patch(
+            'apps.tenants.tasks.send_mail'
+        ) as send_mail:
+            result = send_invitation_email_task.apply(args=[str(self.invitation.id), str(self.tenant.id)])
+
+        self.assertEqual(result.get().get('success'), True)
+        rls.assert_called_once()
+        send_mail.assert_called_once()


### PR DESCRIPTION
## Deliverables
- Make invitation email Celery task tenant/RLS safe by passing `tenant_id` at dispatch time
- Wrap task ORM access in `tenant_rls(..., strict=False)` and query invitation by (id, tenant_id)
- Add unit coverage:
  - schedule_invitation_email enqueues with (invitation_id, tenant_id)
  - task applies tenant_rls and sends mail

## Expected results
- Background workers don’t rely on request middleware for tenant context
- Avoid cross-tenant leakage / zero-row failures under FORCE RLS

## Testing
- python backend/manage.py test apps.tenants.test_invitation_email_task_rls -v 2
