### PR TITLE
Shared: make isNetworkError React Native-safe

### DIFF
--- a/frontend/src/shared-utils.test.ts
+++ b/frontend/src/shared-utils.test.ts
@@ -418,6 +418,16 @@ describe('shared/utils', () => {
       expect(isNetworkError({ message: 'Network Error' })).toBe(true);
     });
 
+    it('does not throw when navigator is undefined (React Native safety)', () => {
+      const originalNavigator = (globalThis as any).navigator;
+
+      vi.stubGlobal('navigator', undefined as any);
+      expect(() => isNetworkError({ code: 'OTHER_ERROR' })).not.toThrow();
+      expect(isNetworkError({ code: 'OTHER_ERROR' })).toBe(false);
+
+      vi.stubGlobal('navigator', originalNavigator);
+    });
+
     it('returns false for other errors', () => {
       expect(isNetworkError({ code: 'OTHER_ERROR' })).toBe(false);
       expect(isNetworkError({ message: 'Other error' })).toBe(false);

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -228,11 +228,15 @@ export const getErrorMessage = (error: unknown): string => {
 };
 
 export const isNetworkError = (error: unknown): boolean => {
+  const isOnline =
+    typeof navigator !== 'undefined' && typeof (navigator as any).onLine === 'boolean'
+      ? Boolean((navigator as any).onLine)
+      : true;
+
   if (typeof error === 'object' && error !== null) {
     const err = error as { code?: string; message?: string };
-    return err.code === 'NETWORK_ERROR' || 
-           err.message === 'Network Error' ||
-           !navigator?.onLine;
+    return err.code === 'NETWORK_ERROR' || err.message === 'Network Error' || !isOnline;
   }
-  return !navigator?.onLine;
+
+  return !isOnline;
 };


### PR DESCRIPTION
## Deliverables
- Make `shared/utils.ts:isNetworkError()` React Native-safe (avoid ReferenceError when `navigator` is undefined)
- Add unit coverage in `frontend/src/shared-utils.test.ts` to assert RN-safe behavior

## Expected results
- Mobile code can safely call `isNetworkError()` without crashing when `navigator` is absent

## Testing
- npm -C frontend run test:ci -- src/shared-utils.test.ts
