### PR TITLE
Mobile: clear persisted tenant on Switch Org

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -4,6 +4,8 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+import { clearPersistedTenantSelection } from './src/utils/tenantStorage';
+
 // Screens
 import LoginScreen from './src/screens/LoginScreen';
 import HomeScreen from './src/screens/HomeScreen';
@@ -218,10 +220,19 @@ export default function App() {
                       if (isGuest) {
                         // Guest: fully sign out and return to login
                         handleLogout();
-                      } else {
-                        setCurrentTenant(null);
-                        ApiService.clearTenantId();
+                        return;
                       }
+
+                      const run = async () => {
+                        try {
+                          await clearPersistedTenantSelection();
+                        } finally {
+                          setCurrentTenant(null);
+                          ApiService.clearTenantId();
+                        }
+                      };
+
+                      void run();
                     }}
                   />
                 )}

--- a/mobile/src/__tests__/tenantStorage.test.ts
+++ b/mobile/src/__tests__/tenantStorage.test.ts
@@ -1,0 +1,18 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { clearPersistedTenantSelection } from '../utils/tenantStorage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    removeItem: jest.fn(),
+  },
+}));
+
+describe('tenantStorage', () => {
+  it('clears persisted currentTenant selection', async () => {
+    await clearPersistedTenantSelection();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('currentTenant');
+  });
+});

--- a/mobile/src/utils/tenantStorage.ts
+++ b/mobile/src/utils/tenantStorage.ts
@@ -1,0 +1,5 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export async function clearPersistedTenantSelection(): Promise<void> {
+  await AsyncStorage.removeItem('currentTenant');
+}


### PR DESCRIPTION
## Deliverables
- Fix mobile “Switch Organization” so it clears persisted `currentTenant` in AsyncStorage
- Add a small storage helper (`mobile/src/utils/tenantStorage.ts`) and Jest coverage

## Expected results
- After switching org (non-guest), app returns to tenant picker and does not restore the previous tenant on restart

## Testing
- npm -C mobile test
- npm -C mobile run lint
- npm -C mobile run type-check
