### PR TITLE
Frontend: use logger in WorkForms History/InProgress

### DIFF
--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -28,6 +28,7 @@ import {
 import { businessApi } from '../../services/businessApi';
 import { workformExecutionService, WorkFormExecution } from '@/services/workformExecutionService';
 import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
+import { logger } from '@/utils/logger';
 
 // ============================================================================
 // Types
@@ -544,7 +545,7 @@ const FormsFlowsHistory: React.FC = () => {
       setSubmissions(response.data.results || response.data || []);
       setTotalCount(response.data.count || 0);
     } catch (error) {
-      console.error('Failed to fetch history:', error);
+      logger.error('[WorkFormsHistory] Failed to fetch history', error);
       setSubmissions([]);
       setLoadError(getWorkformsErrorUi(error, 'history.load').message);
     } finally {
@@ -589,7 +590,7 @@ const FormsFlowsHistory: React.FC = () => {
       setWorkflowExecutions(response.results);
       setTotalCount(response.count);
     } catch (error) {
-      console.error('Failed to fetch workflow executions:', error);
+      logger.error('[WorkFormsHistory] Failed to fetch workflow executions', error);
       setWorkflowExecutions([]);
       setRunsLoadError(getWorkformsErrorUi(error, 'history.load').message);
     } finally {

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -27,6 +27,7 @@ import { useQuickActions } from '../../contexts/QuickActionsContext';
 import { workflowExecutionService } from '../../services/workflowExecutionService';
 import { workformExecutionService } from '@/services/workformExecutionService';
 import { getWorkformsErrorUi } from '@/features/workforms/workformsErrors';
+import { logger } from '@/utils/logger';
 
 // ============================================================================
 // Types
@@ -445,7 +446,7 @@ const FormsFlowsInProgress: React.FC = () => {
       setSubmissions(response.data.results || response.data || []);
       setLastUpdated(new Date());
     } catch (error) {
-      console.error('Failed to fetch submissions:', error);
+      logger.error('[WorkFormsInProgress] Failed to fetch submissions', error);
       setSubmissions([]);
       setLoadError(getWorkformsErrorUi(error, 'inProgress.load').message);
     } finally {
@@ -501,7 +502,7 @@ const FormsFlowsInProgress: React.FC = () => {
 
       setSubmissions((prev) => prev.filter((s) => s.id !== submission.id));
     } catch (error) {
-      console.error('Failed to cancel workflow:', error);
+      logger.error('[WorkFormsInProgress] Failed to cancel workflow', error);
       const ui = getWorkformsErrorUi(error, 'inProgress.cancel');
       showAlert({
         type: 'error',


### PR DESCRIPTION
## Deliverables
- Replace remaining `console.error` usage in WorkForms History/InProgress pages with centralized `logger.error`

## Expected results
- Reduced production console noise while preserving debuggability via logger levels

## Testing
- npm -C frontend run type-check
