### PR TITLE
chore(frontend): replace FlowEditor named colors

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/DataMappingPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DataMappingPanel.tsx
@@ -64,7 +64,7 @@ const Title = styled.h3`
 const AddButton = styled.button`
   padding: 8px 12px;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border: none;
   border-radius: 6px;
   font-size: 14px;
@@ -178,7 +178,7 @@ const DeleteButton = styled.button`
 
   &:hover {
     background: rgb(var(--color-error));
-    color: white;
+    color: rgb(var(--color-text-inverse));
   }
 `;
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/DocumentConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DocumentConfigPanel.tsx
@@ -240,7 +240,7 @@ const ToggleSlider = styled.span`
     width: 18px;
     left: 3px;
     bottom: 3px;
-    background-color: white;
+    background-color: rgb(var(--color-text-inverse));
     transition: 0.3s;
     border-radius: 50%;
   }

--- a/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/DynamicConfigPanel.tsx
@@ -1473,7 +1473,7 @@ const Button = styled.button<{ variant?: 'primary' | 'secondary' | 'danger'; ful
     if (variant === 'primary') {
       return `
         background: rgb(var(--color-primary));
-        color: white;
+        color: rgb(var(--color-text-inverse));
         &:hover:not(:disabled) {
           background: rgb(var(--color-primary-hover));
         }
@@ -1481,7 +1481,7 @@ const Button = styled.button<{ variant?: 'primary' | 'secondary' | 'danger'; ful
     } else if (variant === 'danger') {
       return `
         background: rgb(var(--color-error));
-        color: white;
+        color: rgb(var(--color-text-inverse));
         &:hover:not(:disabled) {
           background: rgb(var(--color-error));
         }

--- a/frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPicker.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/EntityFieldPicker.tsx
@@ -202,7 +202,7 @@ const ActionButton = styled.button`
   cursor: pointer;
   transition: all 0.2s ease;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
 
   &:hover {
     background: rgba(var(--color-primary), 0.9);

--- a/frontend/src/components/FlowEditor/ConfigPanel/FieldConfigurationPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FieldConfigurationPanel.tsx
@@ -212,7 +212,7 @@ const PreviewField = styled.div`
   padding: 10px 12px;
   border: 1px solid rgb(var(--color-border));
   border-radius: 6px;
-  background: white;
+  background: rgb(var(--color-surface));
   color: rgb(var(--color-text-tertiary));
   font-size: 14px;
 `;

--- a/frontend/src/components/FlowEditor/ConfigPanel/FieldWithContext.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FieldWithContext.tsx
@@ -123,7 +123,7 @@ const ContextButton = styled.button<{ $active: boolean }>`
     width: 16px;
     height: 16px;
     color: ${props => props.$active 
-      ? 'white' 
+      ? 'rgb(var(--color-text-inverse))' 
       : 'rgb(var(--color-text-tertiary))'
     };
   }

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormProcessConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormProcessConfigPanel.tsx
@@ -108,7 +108,7 @@ const Toggle = styled.label`
       width: 18px;
       left: 3px;
       bottom: 3px;
-      background: white;
+      background: rgb(var(--color-surface));
       transition: 0.2s;
       border-radius: 50%;
     }

--- a/frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormSelectionPanel.tsx
@@ -167,7 +167,7 @@ const Button = styled.button<{ variant?: 'primary' | 'secondary' }>`
 
   ${props => props.variant === 'primary' ? `
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
 
     &:hover:not(:disabled) {
       background: rgba(var(--color-primary), 0.9);

--- a/frontend/src/components/FlowEditor/ConfigPanel/InsertVariableButton.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/InsertVariableButton.tsx
@@ -110,7 +110,7 @@ const Button = styled.button<{
       return `
         background: rgb(var(--color-primary));
         border-color: rgb(var(--color-primary));
-        color: white;
+        color: rgb(var(--color-text-inverse));
         
         &:hover:not(:disabled) {
           background: rgb(var(--color-primary-hover));

--- a/frontend/src/components/FlowEditor/ConfigPanel/LiveFormPreview.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/LiveFormPreview.tsx
@@ -65,7 +65,7 @@ const PreviewTitle = styled.h3`
 `;
 
 const PreviewCard = styled.div`
-  background: white;
+  background: rgb(var(--color-surface));
   border-radius: 12px;
   padding: 24px;
   box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
@@ -126,7 +126,7 @@ const HelpText = styled.span`
 
 const Input = styled.input`
   padding: 10px 12px;
-  background: white;
+  background: rgb(var(--color-surface));
   border: 2px solid rgb(var(--color-border));
   border-radius: 8px;
   font-size: 14px;
@@ -146,7 +146,7 @@ const Input = styled.input`
 
 const Textarea = styled.textarea`
   padding: 10px 12px;
-  background: white;
+  background: rgb(var(--color-surface));
   border: 2px solid rgb(var(--color-border));
   border-radius: 8px;
   font-size: 14px;
@@ -169,7 +169,7 @@ const Textarea = styled.textarea`
 
 const Select = styled.select`
   padding: 10px 12px;
-  background: white;
+  background: rgb(var(--color-surface));
   border: 2px solid rgb(var(--color-border));
   border-radius: 8px;
   font-size: 14px;

--- a/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/NodeConfigPanel.tsx
@@ -253,7 +253,7 @@ const Button = styled.button<{ $variant?: 'primary' | 'secondary' | 'ghost' }>`
     if (props.$variant === 'primary') {
       return `
         background: rgb(var(--color-primary));
-        color: white;
+        color: rgb(var(--color-text-inverse));
         border: none;
         
         &:hover {
@@ -345,7 +345,7 @@ const IconButton = styled.button`
   
   &:hover.delete {
     background: rgb(var(--color-error));
-    color: white;
+    color: rgb(var(--color-text-inverse));
   }
 `;
 

--- a/frontend/src/components/FlowEditor/ConfigPanel/OutlookEmailConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/OutlookEmailConfigPanel.tsx
@@ -51,7 +51,7 @@ const AddButton = styled.button`
   gap: 6px;
   padding: 6px 12px;
   border: 1px solid rgb(var(--color-border));
-  background: white;
+  background: rgb(var(--color-surface));
   color: rgb(var(--color-text-primary));
   border-radius: 6px;
   font-size: 13px;

--- a/frontend/src/components/FlowEditor/ConfigPanel/SectionConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/SectionConfigPanel.tsx
@@ -209,7 +209,7 @@ const ToggleSlider = styled.span`
     width: 18px;
     left: 3px;
     bottom: 3px;
-    background-color: white;
+    background-color: rgb(var(--color-text-inverse));
     transition: 0.3s;
     border-radius: 50%;
   }
@@ -278,7 +278,7 @@ const Button = styled.button<{ variant?: 'primary' | 'secondary' }>`
 
   ${props => props.variant === 'primary' ? `
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
 
     &:hover:not(:disabled) {
       opacity: 0.9;

--- a/frontend/src/components/FlowEditor/ConfigPanel/SkeletonLoaders.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/SkeletonLoaders.tsx
@@ -161,7 +161,7 @@ export const RetryButton = styled.button`
   gap: 8px;
   padding: 8px 16px;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border: none;
   border-radius: 6px;
   font-size: 14px;

--- a/frontend/src/components/FlowEditor/ConfigPanel/StepManagerPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/StepManagerPanel.tsx
@@ -176,7 +176,7 @@ const StepNumber = styled.div`
   width: 28px;
   height: 28px;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border-radius: 50%;
   font-size: 14px;
   font-weight: 600;

--- a/frontend/src/components/FlowEditor/ConfigPanel/ValidationRuleBuilder.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/ValidationRuleBuilder.tsx
@@ -380,7 +380,7 @@ const Button = styled.button<{ $variant?: 'primary' | 'secondary' }>`
   
   ${props => props.$variant === 'primary' ? `
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
     
     &:hover {
       opacity: 0.9;

--- a/frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VariablePickerWithUpstream.tsx
@@ -138,7 +138,7 @@ const PickerContainer = styled.div<{ $position?: { top: number; left: number } }
   left: ${props => props.$position?.left ?? 200}px;
   width: 420px;
   max-height: 500px;
-  background: white;
+  background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: 8px;
   box-shadow: 0 10px 30px rgba(var(--color-overlay), 0.15);
@@ -175,7 +175,7 @@ const SearchContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  background: white;
+  background: rgb(var(--color-surface));
   
   svg {
     color: rgb(var(--color-text-secondary));

--- a/frontend/src/components/FlowEditor/ConfigPanel/VisualFormBuilderPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/VisualFormBuilderPanel.tsx
@@ -101,7 +101,7 @@ const Title = styled.h3`
 const AddFieldButton = styled.button`
   padding: 8px 16px;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border: none;
   border-radius: 6px;
   font-size: 14px;
@@ -202,7 +202,7 @@ const FieldLabel = styled.div`
 const RequiredBadge = styled.span`
   font-size: 10px;
   background: rgb(var(--color-error));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   padding: 2px 6px;
   border-radius: 4px;
   font-weight: 600;

--- a/frontend/src/components/FlowEditor/ConfigPanel/shared/StyledComponents.ts
+++ b/frontend/src/components/FlowEditor/ConfigPanel/shared/StyledComponents.ts
@@ -464,14 +464,14 @@ export const Button = styled.button<{
       case 'primary':
         return `
           background: rgb(var(--color-primary));
-          color: white;
+          color: rgb(var(--color-text-inverse));
           &:hover { background: rgb(var(--color-primary-dark)); }
           &:active { transform: translateY(1px); }
         `;
       case 'danger':
         return `
           background: rgb(var(--color-error));
-          color: white;
+          color: rgb(var(--color-text-inverse));
           &:hover { background: rgb(var(--color-danger)); }
           &:active { transform: translateY(1px); }
         `;
@@ -547,7 +547,7 @@ export const AddButton = styled.button`
   gap: 6px;
   padding: 6px 12px;
   border: 1px solid rgb(var(--color-border));
-  background: white;
+  background: rgb(var(--color-surface));
   color: rgb(var(--color-text-primary));
   border-radius: var(--radius-md);
   font-size: 13px;

--- a/frontend/src/components/FlowEditor/ErrorBoundary.tsx
+++ b/frontend/src/components/FlowEditor/ErrorBoundary.tsx
@@ -231,7 +231,7 @@ const ResetButton = styled.button`
   gap: 8px;
   padding: 10px 20px;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border: none;
   border-radius: 6px;
   font-size: 14px;

--- a/frontend/src/components/FlowEditor/Modals/EntityFormStepModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/EntityFormStepModal.tsx
@@ -171,7 +171,7 @@ const StepNumber = styled.span<{ $active: boolean; $completed: boolean }>`
       : 'rgb(var(--color-border))'};
   color: ${props =>
     props.$active || props.$completed
-      ? 'white'
+      ? 'rgb(var(--color-text-inverse))'
       : 'rgb(var(--color-text-tertiary))'};
   font-size: 12px;
   font-weight: 600;
@@ -303,7 +303,7 @@ const Button = styled.button<{ $variant?: 'primary' | 'secondary' | 'ghost' }>`
         return `
           background: rgb(var(--color-primary));
           border-color: rgb(var(--color-primary));
-          color: white;
+          color: rgb(var(--color-text-inverse));
           &:hover:not(:disabled) {
             background: rgb(var(--color-primary-hover));
             border-color: rgb(var(--color-primary-hover));

--- a/frontend/src/components/FlowEditor/Modals/FlowPreviewModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FlowPreviewModal.tsx
@@ -136,13 +136,13 @@ const Button = styled.button<{ variant?: 'primary' | 'ghost' | 'danger' }>`
     if (props.variant === 'primary') {
       return `
         background: rgb(var(--color-primary));
-        color: white;
+        color: rgb(var(--color-text-inverse));
         &:hover { opacity: 0.9; }
       `;
     } else if (props.variant === 'danger') {
       return `
         background: rgb(var(--color-error));
-        color: white;
+        color: rgb(var(--color-text-inverse));
         &:hover { opacity: 0.9; }
       `;
     } else {
@@ -303,7 +303,7 @@ const StatusBadge = styled.div<{ status: NodeExecutionState['status'] }>`
       default: return 'rgb(var(--color-border))';
     }
   }};
-  color: white;
+  color: rgb(var(--color-text-inverse));
 `;
 
 const NodeData = styled.pre`

--- a/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/FormProcessModal.tsx
@@ -373,7 +373,7 @@ const Button = styled.button<{ $variant?: 'primary' | 'secondary' | 'ghost' }>`
     if (props.$variant === 'primary') {
       return `
         background: linear-gradient(135deg, rgb(var(--color-primary)), rgb(var(--color-primary-active)));
-        color: white;
+        color: rgb(var(--color-text-inverse));
         
         &:hover:not(:disabled) {
           transform: translateY(-1px);

--- a/frontend/src/components/FlowEditor/Modals/SharedTemplateDeleteModal.tsx
+++ b/frontend/src/components/FlowEditor/Modals/SharedTemplateDeleteModal.tsx
@@ -297,7 +297,7 @@ const Button = styled.button<{ $variant?: 'primary' | 'danger' | 'ghost' }>`
 
   ${props => props.$variant === 'primary' && `
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
 
     &:hover:not(:disabled) {
       background: rgb(var(--color-primary-hover));
@@ -306,7 +306,7 @@ const Button = styled.button<{ $variant?: 'primary' | 'danger' | 'ghost' }>`
 
   ${props => props.$variant === 'danger' && `
     background: rgb(var(--color-error));
-    color: white;
+    color: rgb(var(--color-text-inverse));
 
     &:hover:not(:disabled) {
       background: rgb(var(--color-error-hover));

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.accessibility.css
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.accessibility.css
@@ -53,7 +53,7 @@
   top: 10px;
   right: 10px;
   background: rgba(var(--color-overlay), 0.75);
-  color: white;
+  color: rgb(var(--color-text-inverse));
   padding: 8px 12px;
   border-radius: 6px;
   font-size: 12px;
@@ -86,7 +86,7 @@
   top: -40px;
   left: 0;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   padding: 8px 16px;
   text-decoration: none;
   z-index: 10000;
@@ -97,7 +97,7 @@
 
 .skip-link:focus {
   top: 0;
-  outline: 3px solid white;
+  outline: 3px solid rgb(var(--color-text-inverse));
   outline-offset: 2px;
 }
 
@@ -369,11 +369,11 @@
 
   /* High contrast for printed diagrams */
   .react-flow__node {
-    border: 2px solid black !important;
+    border: 2px solid rgb(var(--color-text-primary)) !important;
   }
 
   .react-flow__edge path {
-    stroke: black !important;
+    stroke: rgb(var(--color-text-primary)) !important;
     stroke-width: 2px !important;
   }
 }

--- a/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
+++ b/frontend/src/components/FlowEditor/UnifiedFlowEditor.tsx
@@ -394,7 +394,7 @@ const BannerActions = styled.div`
 const MigrateButton = styled.button`
   padding: 6px 12px;
   background: rgb(var(--color-warning));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border: none;
   border-radius: var(--radius-sm);
   font-size: 13px;
@@ -744,7 +744,7 @@ const WizardButton = styled.button<{ $variant?: 'primary' | 'secondary' | 'ghost
     if (props.$variant === 'primary') {
       return `
         background: rgb(var(--color-primary));
-        color: white;
+        color: rgb(var(--color-text-inverse));
         border: none;
         
         &:hover {
@@ -1105,7 +1105,7 @@ const EmptyPrimaryButton = styled.button`
   border-radius: var(--radius-md);
   font-size: 12px;
   font-weight: 700;
-  color: white;
+  color: rgb(var(--color-text-inverse));
   cursor: pointer;
   transition: all 0.15s ease;
 
@@ -1172,7 +1172,7 @@ const ToolbarButton = styled.button`
   
   &:hover {
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
     border-color: rgb(var(--color-primary));
   }
   
@@ -1602,7 +1602,7 @@ const AlignmentButton = styled.button`
   
   &:active {
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
   }
   
   svg {
@@ -1618,7 +1618,7 @@ const DragGhost = styled.div<{ $color?: string }>`
   opacity: 0.6;
   padding: 12px 16px;
   background: ${props => props.$color || 'rgb(var(--color-primary))'};
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border-radius: var(--radius-md);
   font-size: 14px;
   font-weight: 500;
@@ -1741,7 +1741,7 @@ const ToggleSwitch = styled.button<{ $active: boolean }>`
     left: ${props => props.$active ? '22px' : '2px'};
     width: 16px;
     height: 16px;
-    background: white;
+    background: rgb(var(--color-surface));
     border-radius: 50%;
     transition: left 0.15s ease;
   }
@@ -8335,19 +8335,19 @@ const UnifiedFlowEditorInner: React.FC<UnifiedFlowEditorProps> = ({
           success: {
             iconTheme: {
               primary: 'rgb(var(--color-success))', // green-500
-              secondary: 'white',
+              secondary: 'rgb(var(--color-text-inverse))',
             },
           },
           error: {
             iconTheme: {
               primary: 'rgb(var(--color-error))', // red-500
-              secondary: 'white',
+              secondary: 'rgb(var(--color-text-inverse))',
             },
           },
           loading: {
             iconTheme: {
               primary: 'rgb(var(--color-primary))',
-              secondary: 'white',
+              secondary: 'rgb(var(--color-text-inverse))',
             },
           },
         }}

--- a/frontend/src/components/FlowEditor/components/AISuggestionsPanel.tsx
+++ b/frontend/src/components/FlowEditor/components/AISuggestionsPanel.tsx
@@ -255,7 +255,7 @@ const AddIcon = styled.div`
   
   ${SuggestionItem}:hover & {
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
   }
 `;
 

--- a/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
+++ b/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
@@ -1010,7 +1010,7 @@ const RunButton = styled.button`
   gap: 8px;
   padding: 12px 24px;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border: none;
   border-radius: 8px;
   font-size: 14px;

--- a/frontend/src/components/FlowEditor/components/ExpressionInput.tsx
+++ b/frontend/src/components/FlowEditor/components/ExpressionInput.tsx
@@ -76,7 +76,7 @@ const ChipElement = styled.div<{ selected?: boolean }>`
     ? 'rgb(var(--color-primary))' 
     : 'rgba(var(--color-primary), 0.15)'};
   color: ${props => props.selected 
-    ? 'white' 
+    ? 'rgb(var(--color-text-inverse))' 
     : 'rgb(var(--color-primary))'};
   border-radius: 4px;
   font-size: 13px;
@@ -88,7 +88,7 @@ const ChipElement = styled.div<{ selected?: boolean }>`
   
   &:hover {
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
   }
 `;
 

--- a/frontend/src/components/FlowEditor/components/SnapPreviewOverlay.tsx
+++ b/frontend/src/components/FlowEditor/components/SnapPreviewOverlay.tsx
@@ -71,7 +71,7 @@ const SnapLabel = styled.div<{ left: number; top: number }>`
   
   padding: 4px 12px;
   background: rgba(var(--color-primary), 0.95);
-  color: white;
+  color: rgb(var(--color-text-inverse));
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;

--- a/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
+++ b/frontend/src/components/FlowEditor/config/fieldRenderers/basicRenderers.tsx
@@ -290,7 +290,7 @@ const ToggleSwitch = styled.input.attrs({ type: 'checkbox' })`
     border-radius: 50%;
     top: 3px;
     left: 3px;
-    background: white;
+    background: rgb(var(--color-surface));
     transition: transform 0.2s;
   }
 

--- a/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/ErrorEdge.tsx
@@ -208,14 +208,14 @@ export const ErrorEdge = React.memo<EdgeProps<Edge<ErrorEdgeData>>>(({
           <path
             d="M 8,2 L 14,14 L 2,14 Z"
             fill="rgb(var(--color-error))"
-            stroke="white"
+            stroke="rgb(var(--color-text-inverse))"
             strokeWidth="1"
           />
           <text
             x="8"
             y="12"
             textAnchor="middle"
-            fill="white"
+            fill="rgb(var(--color-text-inverse))"
             fontSize="8"
             fontWeight="700"
           >

--- a/frontend/src/components/FlowEditor/edges/InsertNodeEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/InsertNodeEdge.tsx
@@ -24,7 +24,7 @@ const AddButton = styled.button`
 
   &:hover {
     background: rgb(var(--color-primary));
-    color: white;
+    color: rgb(var(--color-text-inverse));
     border-color: rgb(var(--color-primary));
     transform: scale(1.1);
   }

--- a/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
+++ b/frontend/src/components/FlowEditor/edges/SuccessEdge.tsx
@@ -136,11 +136,11 @@ export const SuccessEdge = React.memo<EdgeProps<Edge<SuccessEdgeData>>>(({
           orient="auto"
           markerUnits="userSpaceOnUse"
         >
-          <circle cx="8" cy="8" r="7" fill="rgb(var(--color-success))" stroke="white" strokeWidth="1" />
+          <circle cx="8" cy="8" r="7" fill="rgb(var(--color-success))" stroke="rgb(var(--color-text-inverse))" strokeWidth="1" />
           <path
             d="M 5,8 L 7,10 L 11,6"
             fill="none"
-            stroke="white"
+            stroke="rgb(var(--color-text-inverse))"
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"

--- a/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/BaseNode.tsx
@@ -140,7 +140,7 @@ const NodeHeader = styled.div<{ $color: string }>`
   padding: 8px 12px;
   background: ${props => props.$color};
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  color: white;
+  color: rgb(var(--color-text-inverse));
   font-weight: 600;
   font-size: 13px;
 `;
@@ -176,14 +176,14 @@ const NodeTitleInput = styled.input`
   border: 1px solid rgba(var(--color-header-background), 0.5);
   border-radius: 4px;
   padding: 2px 6px;
-  color: white;
+  color: rgb(var(--color-text-inverse));
   font-size: 13px;
   font-weight: 600;
   outline: none;
   
   &:focus {
     background: rgba(var(--color-header-background), 0.3);
-    border-color: white;
+    border-color: rgb(var(--color-text-inverse));
   }
 `;
 
@@ -334,7 +334,7 @@ const ButtonHandle = styled(Handle)`
     background: rgb(var(--color-primary));
 
     &::after {
-      color: white;
+      color: rgb(var(--color-text-inverse));
     }
   }
 `;
@@ -345,7 +345,7 @@ const HeaderToggleButton = styled.button`
   border-radius: 8px;
   border: 1px solid rgba(var(--color-header-background), 0.45);
   background: rgba(var(--color-header-background), 0.16);
-  color: white;
+  color: rgb(var(--color-text-inverse));
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -581,7 +581,7 @@ export const BaseNode: React.FC<BaseNodeProps & { children?: React.ReactNode }> 
       <NodeHeader className={headerDragHandleClass} $color={nodeType.color}>
         <NodeIconWrapper>
           {iconType ? (
-            <NodeIcon type={iconType} size={16} color="white" />
+            <NodeIcon type={iconType} size={16} color="rgb(var(--color-text-inverse))" />
           ) : (
             nodeType.icon
           )}

--- a/frontend/src/components/FlowEditor/nodes/FormProcessAddButtonNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessAddButtonNode.tsx
@@ -23,7 +23,7 @@ const CircleButton = styled.button`
   border-radius: 999px;
   border: 2px solid rgb(var(--color-surface));
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   box-shadow:
     0 12px 24px rgba(var(--color-primary), 0.25),
     0 2px 8px rgba(var(--color-overlay), 0.10);

--- a/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessChildWrapper.tsx
@@ -110,7 +110,7 @@ const StepBadge = styled.div`
   top: -12px;
   left: 12px;
   background: rgba(var(--color-primary), 0.9);
-  color: white;
+  color: rgb(var(--color-text-inverse));
   font-size: 11px;
   font-weight: 600;
   padding: 4px 10px;

--- a/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/FormProcessNode.tsx
@@ -143,7 +143,7 @@ const ContainerHeader = styled.div`
   border-radius: 10px 10px 0 0;
   cursor: grab;
   user-select: none;
-  color: white;
+  color: rgb(var(--color-text-inverse));
   overflow: hidden; /* Contain header styling within rounded corners */
   
   &:hover {
@@ -159,7 +159,7 @@ const ExpandIcon = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white; /* White icon for solid header */
+  color: rgb(var(--color-text-inverse)); /* White icon for solid header */
   transition: transform 0.2s ease;
   border: none;
   background: transparent;
@@ -206,7 +206,7 @@ const StatusBadge = styled.div<{ type: 'configured' | 'draft' }>`
   background: ${props => props.type === 'configured' 
     ? 'rgba(var(--color-header-background), 0.3)' 
     : 'rgba(var(--color-header-background), 0.2)'};
-  color: white;
+  color: rgb(var(--color-text-inverse));
 `;
 
 const ContainerBody = styled.div<{ isExpanded: boolean }>`
@@ -326,7 +326,7 @@ const ConfigButton = styled.button`
   padding: 10px;
   margin-top: 12px;
   background: linear-gradient(135deg, rgb(var(--color-primary)), rgb(var(--color-primary-active)));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border: none;
   border-radius: 6px;
   font-size: 13px;

--- a/frontend/src/components/FlowEditor/nodes/OutlookEmailNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/OutlookEmailNode.tsx
@@ -8,7 +8,7 @@ import { Mail } from 'lucide-react';
 import styled from 'styled-components';
 
 const NodeContainer = styled.div`
-  background: white;
+  background: rgb(var(--color-surface));
   border: 2px solid rgb(var(--color-primary));
   border-radius: 8px;
   padding: 12px;
@@ -35,7 +35,7 @@ const NodeIcon = styled.div`
   width: 32px;
   height: 32px;
   background: rgb(var(--color-primary));
-  color: white;
+  color: rgb(var(--color-text-inverse));
   border-radius: 6px;
 `;
 

--- a/frontend/src/components/FlowEditor/nodes/SubWorkflowNode.tsx
+++ b/frontend/src/components/FlowEditor/nodes/SubWorkflowNode.tsx
@@ -104,7 +104,7 @@ const WorkflowIcon = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: rgb(var(--color-text-inverse));
   font-size: 14px;
   font-weight: 700;
 `;

--- a/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
+++ b/frontend/src/components/FlowEditor/panels/PreviewPanel.tsx
@@ -147,7 +147,7 @@ const PreviewViewport = styled.div<{ $size: ViewportSize }>`
     }
   }};
   max-width: 100%;
-  background: white;
+  background: rgb(var(--color-surface));
   border-radius: var(--radius-lg);
   box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
   padding: 24px;

--- a/frontend/src/pages/WorkForms/History.tsx
+++ b/frontend/src/pages/WorkForms/History.tsx
@@ -360,7 +360,7 @@ const PageButton = styled.button<{ $active?: boolean }>`
     $active ? 'rgb(var(--color-primary))' : 'transparent'
   };
   color: ${({ $active }) => 
-    $active ? 'white' : 'rgb(var(--color-text-secondary))'
+    $active ? 'rgb(var(--color-text-inverse))' : 'rgb(var(--color-text-secondary))'
   };
   font-size: 14px;
   cursor: pointer;


### PR DESCRIPTION
## Deliverables\n- Replaced named colors (e.g. white/black) in FlowEditor + WorkForms History with theme tokens\n\n## Expected results\n- Full design-system compliance (no named colors)\n- Better dark-mode and theming consistency\n\n## Testing\n- npm -C frontend run type-check\n- npm -C frontend run verify-standards\n