### PR TITLE
fix(ci): postdeploy reusable secret contract

### DIFF
--- a/.github/workflows/reusable-postdeploy-smoke.yml
+++ b/.github/workflows/reusable-postdeploy-smoke.yml
@@ -9,13 +9,6 @@ on:
       frontend_environment:
         required: true
         type: string
-    secrets:
-      SSH_HOST:
-        required: true
-      SSH_USER:
-        required: true
-      SSH_PASSWORD:
-        required: true
 
 jobs:
   smoke-backend-container:


### PR DESCRIPTION
Fixes main-pipeline failure in Post-Deploy Validation: the nested reusable workflow call was requiring SSH_* as workflow_call secrets, but env-scoped secrets cannot be forwarded reliably through a reusable-workflow-call job.\n\nChange: remove workflow_call secret requirements from reusable-postdeploy-smoke.yml and rely on the jobs' environment scoping (dev-backend/dev-frontend) to provide SSH_* via the normal secrets context.\n\nValidation: bash .github/scripts/validate-workflows.sh