### PR TITLE
ci: auto-merge Dependabot PRs when green

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,8 @@ updates:
       day: "monday"
       time: "03:00"
     # Limit concurrent PRs to avoid overwhelming the review queue
-    open-pull-requests-limit: 5
+    # Keep this low so Dependabot PRs don't pile up.
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "backend"
@@ -62,7 +63,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "03:00"
-    open-pull-requests-limit: 10
+    # Keep this low so Dependabot PRs don't pile up.
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "frontend"
@@ -114,7 +116,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "03:00"
-    open-pull-requests-limit: 5
+    # Keep this low so Dependabot PRs don't pile up.
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "ci/cd"
@@ -144,7 +147,8 @@ updates:
     schedule:
       interval: "monthly"
       day: "monday"
-    open-pull-requests-limit: 2
+    # Keep this low so Dependabot PRs don't pile up.
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "docker"
@@ -175,7 +179,8 @@ updates:
     schedule:
       interval: "monthly"
       day: "monday"
-    open-pull-requests-limit: 2
+    # Keep this low so Dependabot PRs don't pile up.
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "docker"

--- a/.github/workflows/15-dependabot-merge-when-green.yml
+++ b/.github/workflows/15-dependabot-merge-when-green.yml
@@ -1,0 +1,91 @@
+name: "🤖 Dependabot: Merge when green"
+
+on:
+  workflow_run:
+    workflows: ["PR Validation"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-dependabot:
+    name: Merge Dependabot PR
+    runs-on: ubuntu-latest
+
+    # Only act on successful PR Validation runs.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Resolve PR number
+        id: pr
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR associated with this workflow_run; exiting."
+            exit 0
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Merge if safe
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          REPO="${GITHUB_REPOSITORY}"
+
+          AUTHOR="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')"
+          STATE="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state')"
+          PR_HEAD_SHA="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
+
+          if [ "$AUTHOR" != "dependabot[bot]" ]; then
+            echo "Not a Dependabot PR ($AUTHOR); skipping."
+            exit 0
+          fi
+
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR is not open ($STATE); skipping."
+            exit 0
+          fi
+
+          if [ "$PR_HEAD_SHA" != "$RUN_HEAD_SHA" ]; then
+            echo "PR head SHA changed since validation run; skipping."
+            echo "validated=$RUN_HEAD_SHA"
+            echo "current=$PR_HEAD_SHA"
+            exit 0
+          fi
+
+          # Guardrail: only auto-merge if the PR only touches dependency/automation files.
+          mapfile -t FILES < <(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
+
+          for f in "${FILES[@]}"; do
+            case "$f" in
+              .github/dependabot.yml|.pre-commit-config.yaml) ;;
+              .github/workflows/*) ;;
+              */package.json|*/package-lock.json|*/yarn.lock|*/pnpm-lock.yaml) ;;
+              backend/requirements*.txt|backend/pyproject.toml|backend/poetry.lock) ;;
+              backend/Dockerfile|frontend/Dockerfile|mobile/Dockerfile|Dockerfile) ;;
+              *)
+                echo "Unexpected file in Dependabot PR: $f"
+                echo "Skipping auto-merge for safety."
+                exit 0
+                ;;
+            esac
+          done
+
+          # If branch protection requires an approval, approve as github-actions[bot].
+          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Auto-approving Dependabot PR after PR Validation passed." || true
+
+          # Merge now that all required checks have passed.
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch


### PR DESCRIPTION
## Deliverables
- Dependabot PR pileup prevention: set `open-pull-requests-limit: 1` for backend/frontend/actions/docker updates
- New workflow: `.github/workflows/15-dependabot-merge-when-green.yml`
  - Triggers on successful **PR Validation** (`workflow_run`)
  - Verifies PR is from `dependabot[bot]`
  - Verifies the PR head SHA matches the validated run
  - Guardrails: only merges if files changed are dependency/automation files
  - Auto-approves (if needed) then squashes + deletes branch

## Why
Repo auto-merge is disabled (GitHub setting), so Dependabot PRs can stack up. This provides CI-gated merging without relying on the repo auto-merge feature.

## Testing
- `bash scripts/verify_golden_state.sh`

## Rollback
- Revert commit `022bbf95` (or delete the workflow file + restore PR limits in `.github/dependabot.yml`).