### PR TITLE
CI: sanitize deploy workflow run-name

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -14,15 +14,27 @@ run-name: >-
         github.actor,
         github.run_number
       )
-      || format(
-        '🚀 Deploy: {0} — {1} ({2}) (run#{3})',
-        github.ref_name == 'development' && 'Dev'
-          || github.ref_name == 'uat' && 'UAT'
-          || github.ref_name == 'main' && 'Prod'
-          || github.ref_name,
-        github.ref_name,
-        github.sha,
-        github.run_number
+      || (
+        !contains(github.event.head_commit.message, 'Co-authored-by:')
+          && format(
+            '🚀 Deploy: {0} — {1} (run#{2})',
+            github.ref_name == 'development' && 'Dev'
+              || github.ref_name == 'uat' && 'UAT'
+              || github.ref_name == 'main' && 'Prod'
+              || github.ref_name,
+            github.event.head_commit.message,
+            github.run_number
+          )
+          || format(
+            '🚀 Deploy: {0} — {1} ({2}) (run#{3})',
+            github.ref_name == 'development' && 'Dev'
+              || github.ref_name == 'uat' && 'UAT'
+              || github.ref_name == 'main' && 'Prod'
+              || github.ref_name,
+            github.ref_name,
+            github.sha,
+            github.run_number
+          )
       )
   }}
 


### PR DESCRIPTION
Restores preferred deploy run display titles while preventing commit-message trailers (e.g., `Co-authored-by:`) from leaking into the GitHub Actions run display title.

- If head commit message does **not** contain `Co-authored-by:`, use it in the run name.
- Otherwise fall back to the stable `{branch} ({sha})` run name.

This is the smallest safe change given GitHub Actions expressions do not support string replace/split.