### PR TITLE
Fix dev login: host nginx /api upstream

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -1770,6 +1770,112 @@ jobs:
             exit 1
           fi
 
+          # Ensure host nginx routes /api/* to the loopback-bound backend.
+          # Without this, external API calls can hang (e.g., /api/v1/health/), blocking login.
+          echo "Syncing host nginx reverse-proxy config (backend upstream = 127.0.0.1:8000)..."
+          NGINX_SITE="/etc/nginx/sites-available/projectmeats-${ENVIRONMENT}"
+          sudo tee "$NGINX_SITE" >/dev/null <<NGINX
+          server {
+              listen 80;
+              listen [::]:80;
+              server_name ${DOMAIN_NAME};
+
+              location /.well-known/acme-challenge/ {
+                  root /var/www/certbot;
+                  allow all;
+              }
+
+              location / {
+                  return 301 https://\$server_name\$request_uri;
+              }
+          }
+
+          server {
+              listen 443 ssl http2;
+              listen [::]:443 ssl http2;
+              server_name ${DOMAIN_NAME};
+              client_max_body_size 50M;
+
+              include /etc/nginx/mime.types;
+              default_type application/octet-stream;
+
+              ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
+              ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
+
+              ssl_protocols TLSv1.2 TLSv1.3;
+              ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+              ssl_prefer_server_ciphers off;
+              ssl_session_cache shared:SSL:10m;
+              ssl_session_timeout 10m;
+              ssl_stapling on;
+              ssl_stapling_verify on;
+
+              add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+              add_header X-Frame-Options "SAMEORIGIN" always;
+              add_header X-Content-Type-Options "nosniff" always;
+              add_header X-XSS-Protection "1; mode=block" always;
+              add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+              proxy_set_header Host \$host;
+              proxy_set_header X-Real-IP \$remote_addr;
+              proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto \$scheme;
+              proxy_set_header X-Forwarded-Host \$host;
+
+              proxy_connect_timeout 5s;
+              proxy_send_timeout 60s;
+              proxy_read_timeout 60s;
+              proxy_buffering off;
+              proxy_request_buffering off;
+
+              location /api/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade \$http_upgrade;
+                  proxy_set_header Connection "upgrade";
+              }
+
+              location /admin/ {
+                  proxy_pass http://127.0.0.1:8000;
+              }
+
+              location /static/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  add_header X-Content-Type-Options "nosniff" always;
+                  expires 7d;
+                  add_header Cache-Control "public, immutable";
+              }
+
+              location /media/ {
+                  proxy_pass http://127.0.0.1:8000;
+                  expires 7d;
+                  add_header Cache-Control "public, immutable";
+              }
+
+              location /health {
+                  access_log off;
+                  return 200 "healthy\n";
+                  add_header Content-Type text/plain;
+              }
+
+              location / {
+                  proxy_pass http://127.0.0.1:8080;
+                  proxy_intercept_errors on;
+                  error_page 404 = @frontend_fallback;
+              }
+
+              location @frontend_fallback {
+                  proxy_pass http://127.0.0.1:8080;
+              }
+          }
+          NGINX
+
+          sudo ln -sf "$NGINX_SITE" /etc/nginx/sites-enabled/projectmeats-${ENVIRONMENT}
+          sudo rm -f /etc/nginx/sites-enabled/default 2>/dev/null || true
+          sudo nginx -t
+          sudo systemctl reload nginx
+          echo "✓ Host nginx config synced and reloaded"
+
           echo "Cleaning up frontend canary container..."
           docker rm -f "$CAND_NAME" 2>/dev/null || true
           


### PR DESCRIPTION
Problem: On dev.meatscentral.com, /api/v1/* requests hang/time out, blocking login.\n\nFix: During frontend deploy, sync host nginx config so /api proxies to http://127.0.0.1:8000 (backend) and / proxies to http://127.0.0.1:8080 (frontend).