### PR TITLE
ci: fix Dependabot merge workflow false-failures

### DIFF
--- a/.github/workflows/15-dependabot-merge-when-green.yml
+++ b/.github/workflows/15-dependabot-merge-when-green.yml
@@ -29,12 +29,14 @@ jobs:
           PR_NUMBER="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR associated with this workflow_run; exiting."
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Merge if safe
+        if: steps.pr.outputs.pr_number != ''
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
Our `🤖 Dependabot: Merge when green` workflow sometimes triggers on PR Validation runs where `workflow_run.pull_requests` is empty.

We exited 0 in the PR-number step, but the merge step still ran with an empty `PR_NUMBER`, causing `gh pr view` to fail (no git repo) and marking the run as failed.

## Fix
- Always write `pr_number=` to outputs when missing
- Gate the merge step with `if: steps.pr.outputs.pr_number != `\n\n## Expected result\nNo more noisy red workflow runs when there’s no PR to process.\n\n## Testing\n- `bash scripts/verify_golden_state.sh`