### PR TITLE
ci: robust Dependabot merge PR resolution

### DIFF
--- a/.github/workflows/15-dependabot-merge-when-green.yml
+++ b/.github/workflows/15-dependabot-merge-when-green.yml
@@ -23,10 +23,21 @@ jobs:
       - name: Resolve PR number
         id: pr
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
+          # GitHub doesn't always populate workflow_run.pull_requests.
+          # Prefer it when present, but fall back to resolving PRs associated with the validated commit SHA.
           PR_NUMBER="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
+
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER="$(gh api -H "Accept: application/vnd.github+json" "repos/${REPO}/commits/${RUN_HEAD_SHA}/pulls" --jq '[.[] | select(.state=="open") | select(.base.ref=="development") | .number][0] // empty' || true)"
+          fi
+
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR associated with this workflow_run; exiting."
             echo "pr_number=" >> "$GITHUB_OUTPUT"
@@ -49,6 +60,7 @@ jobs:
 
           AUTHOR="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')"
           STATE="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state')"
+          BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq '.baseRefName')"
           PR_HEAD_SHA="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
 
           if [ "$AUTHOR" != "dependabot[bot]" ]; then
@@ -58,6 +70,11 @@ jobs:
 
           if [ "$STATE" != "OPEN" ]; then
             echo "PR is not open ($STATE); skipping."
+            exit 0
+          fi
+
+          if [ "$BASE_REF" != "development" ]; then
+            echo "PR base is not development ($BASE_REF); skipping."
             exit 0
           fi
 


### PR DESCRIPTION
## Problem
`workflow_run.pull_requests` is sometimes empty even for PR-triggered workflows. Our Dependabot merge workflow then cannot determine PR number and skips merging.

## Fix
- Resolve PR number from the validated commit SHA via `repos/{repo}/commits/{sha}/pulls`
- Only select **open** PRs targeting **development**
- Keep existing safety guardrails + SHA match check

## Testing
- `bash scripts/verify_golden_state.sh`