### PR TITLE
Fix dev login: restore nginx→backend connectivity

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -1363,7 +1363,7 @@ jobs:
 
           docker run -d --name pm-backend \
             --restart unless-stopped \
-            -p 127.0.0.1:8000:8000 \
+            -p 8000:8000 \
             --env-file /root/projectmeats/backend/.env \
             -e DB_HOST="${{ secrets.DB_HOST }}" \
             -e DB_NAME="${{ secrets.DB_NAME }}" \
@@ -1770,9 +1770,9 @@ jobs:
             exit 1
           fi
 
-          # Ensure host nginx routes /api/* to the loopback-bound backend.
+          # Ensure host nginx routes /api/* to the backend host (${BACKEND_HOST}:8000).
           # Without this, external API calls can hang (e.g., /api/v1/health/), blocking login.
-          echo "Syncing host nginx reverse-proxy config (backend upstream = 127.0.0.1:8000)..."
+          echo "Syncing host nginx reverse-proxy config (backend upstream = ${BACKEND_HOST}:8000)..."
           NGINX_SITE="/etc/nginx/sites-available/projectmeats-${ENVIRONMENT}"
           sudo tee "$NGINX_SITE" >/dev/null <<NGINX
           server {
@@ -1829,25 +1829,25 @@ jobs:
               proxy_request_buffering off;
 
               location /api/ {
-                  proxy_pass http://127.0.0.1:8000;
+                  proxy_pass http://${BACKEND_HOST}:8000;
                   proxy_http_version 1.1;
                   proxy_set_header Upgrade \$http_upgrade;
                   proxy_set_header Connection "upgrade";
               }
 
               location /admin/ {
-                  proxy_pass http://127.0.0.1:8000;
+                  proxy_pass http://${BACKEND_HOST}:8000;
               }
 
               location /static/ {
-                  proxy_pass http://127.0.0.1:8000;
+                  proxy_pass http://${BACKEND_HOST}:8000;
                   add_header X-Content-Type-Options "nosniff" always;
                   expires 7d;
                   add_header Cache-Control "public, immutable";
               }
 
               location /media/ {
-                  proxy_pass http://127.0.0.1:8000;
+                  proxy_pass http://${BACKEND_HOST}:8000;
                   expires 7d;
                   add_header Cache-Control "public, immutable";
               }


### PR DESCRIPTION
Dev is currently serving /health but /api/v1/* returns 502/timeouts, blocking login (QuickActions, available-forms, WorkForms list). Root cause: backend container was bound to loopback-only (127.0.0.1:8000) on the backend host, while nginx on dev.meatscentral.com proxies to the backend host IP.\n\nChanges:\n- Bind canonical backend container to port 8000 on all interfaces (-p 8000:8000).\n- Generate host nginx config to proxy /api/* to BACKEND_HOST:8000 (not 127.0.0.1).\n\nExpected: https://dev.meatscentral.com/api/v1/health/ returns 200/503 quickly and login works again.