### PR TITLE
Phase 10: Plant Profile metadata-driven form

### DIFF
--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -338,7 +338,7 @@ const augmentSchemaForFrontend = (
   const normalizedEntityKey = String(entityKey || '').trim().toLowerCase();
   const fields = Array.isArray(schema.fields) ? [...schema.fields] : [];
 
-  if (normalizedEntityKey === 'plant' || normalizedEntityKey === 'location') {
+  if (normalizedEntityKey === 'location') {
     const nextFields = fields.map((field) => {
       if (String(field.key).toLowerCase() !== 'booking_contacts') return field;
 
@@ -355,6 +355,196 @@ const augmentSchemaForFrontend = (
 
     return {
       ...schema,
+      fields: nextFields,
+    };
+  }
+
+  if (normalizedEntityKey === 'plant') {
+    const withField = (
+      list: BackendField[],
+      key: string,
+      build: (existing?: BackendField) => BackendField
+    ) => {
+      const index = list.findIndex((field) => String(field.key).toLowerCase() === key.toLowerCase());
+      const existing = index >= 0 ? list[index] : undefined;
+      const nextField = build(existing);
+
+      if (index >= 0) {
+        list[index] = nextField;
+      } else {
+        list.push(nextField);
+      }
+    };
+
+    const locationSection = { title: 'Plant Location' };
+    const exportSection = { title: 'Export' };
+
+    const nextFields = fields.map((field) => {
+      const key = String(field.key || '').toLowerCase();
+
+      if (key === 'booking_contacts') {
+        const ui = field.ui && typeof field.ui === 'object' ? { ...(field.ui as Record<string, unknown>) } : {};
+        ui.add_button_label = 'Add Shipping / Loadout Contact';
+        ui.item_label = 'Shipping / Loadout Contact';
+
+        return {
+          ...field,
+          label: 'Shipping / Loadout',
+          ui,
+        };
+      }
+
+      if (key === 'name') {
+        const ui = field.ui && typeof field.ui === 'object' ? { ...(field.ui as Record<string, unknown>) } : {};
+        ui.max_length = 150;
+        return {
+          ...field,
+          label: 'Plant Name',
+          required: true,
+          placeholder: field.placeholder || 'Enter plant name',
+          ui,
+        };
+      }
+
+      if (key === 'plant_est_num') {
+        const ui = field.ui && typeof field.ui === 'object' ? { ...(field.ui as Record<string, unknown>) } : {};
+        ui.max_length = 50;
+        return {
+          ...field,
+          label: 'Establishment #',
+          required: true,
+          placeholder: field.placeholder || 'Enter establishment number',
+          ui,
+        };
+      }
+
+      if (key === 'plant_type') {
+        return {
+          ...field,
+          label: field.label || 'Plant Type',
+          required: true,
+          placeholder: field.placeholder || 'Select plant type',
+        };
+      }
+
+      if (['address', 'city', 'state', 'zip_code', 'country'].includes(key)) {
+        const ui = field.ui && typeof field.ui === 'object' ? { ...(field.ui as Record<string, unknown>) } : {};
+        ui.section = locationSection;
+        return {
+          ...field,
+          ui,
+        };
+      }
+
+      return field;
+    });
+
+    withField(nextFields, 'proteins_offered', (existing) => ({
+      ...(existing || { key: 'proteins_offered' }),
+      label: 'Protein Types Offered',
+      type: 'select',
+      required: Boolean(existing?.required),
+      placeholder: existing?.placeholder || 'Select protein types offered',
+      help_text: existing?.help_text || '',
+      choices: existing?.choices || [],
+      ui: {
+        ...((existing?.ui as Record<string, unknown> | null) || {}),
+        widget: 'multi_select',
+        data_source: {
+          type: 'choice_list',
+          list: 'protein_types',
+        },
+      },
+    }));
+
+    withField(nextFields, 'proteins_tested', (existing) => ({
+      ...(existing || { key: 'proteins_tested' }),
+      label: 'Protein Tested (COA)',
+      type: 'select',
+      required: Boolean(existing?.required),
+      placeholder: existing?.placeholder || 'Select protein types tested',
+      help_text: existing?.help_text || 'Warning: proteins tested should typically be a subset of proteins offered.',
+      choices: existing?.choices || [],
+      dependencies: ['proteins_offered'],
+      ui: {
+        ...((existing?.ui as Record<string, unknown> | null) || {}),
+        widget: 'multi_select',
+        data_source: {
+          type: 'choice_list',
+          list: 'protein_types',
+        },
+      },
+    }));
+
+    withField(nextFields, 'associated_master_product_ids', (existing) => ({
+      ...(existing || { key: 'associated_master_product_ids' }),
+      label: 'Product List',
+      type: 'select',
+      required: Boolean(existing?.required),
+      placeholder: existing?.placeholder || 'Search and select products',
+      help_text: existing?.help_text || 'Master products commonly sold/produced by this plant.',
+      choices: existing?.choices || [],
+      ui: {
+        ...((existing?.ui as Record<string, unknown> | null) || {}),
+        widget: 'multi_select',
+        data_source: {
+          type: 'master_products',
+        },
+      },
+    }));
+
+    withField(nextFields, 'export_approved', (existing) => ({
+      ...(existing || { key: 'export_approved' }),
+      label: 'Export Approved',
+      type: existing?.type || 'checkbox',
+      required: Boolean(existing?.required),
+      help_text: existing?.help_text || 'Whether this plant is export approved.',
+      ui: {
+        ...((existing?.ui as Record<string, unknown> | null) || {}),
+        section: exportSection,
+      },
+    }));
+
+    withField(nextFields, 'export_documents_handled', (existing) => ({
+      ...(existing || { key: 'export_documents_handled' }),
+      label: 'Export Documents Handled',
+      type: 'select',
+      required: Boolean(existing?.required),
+      placeholder: existing?.placeholder || 'Add export documents handled',
+      help_text: existing?.help_text || 'Shown only when Export Approved is enabled.',
+      choices: existing?.choices || [],
+      dependencies: ['export_approved'],
+      ui: {
+        ...((existing?.ui as Record<string, unknown> | null) || {}),
+        section: exportSection,
+        widget: 'tags',
+        visible_when: {
+          field: 'export_approved',
+          equals: true,
+        },
+      },
+    }));
+
+    const keyFieldsPlant = [
+      'name',
+      'plant_est_num',
+      'plant_type',
+      'address',
+      'city',
+      'state',
+      'zip_code',
+      'country',
+      'proteins_offered',
+      'proteins_tested',
+      'associated_master_product_ids',
+      'export_approved',
+      'export_documents_handled',
+    ];
+
+    return {
+      ...schema,
+      name: schema.name || 'Plant',
+      key_fields: schema.key_fields && schema.key_fields.length ? schema.key_fields : keyFieldsPlant,
       fields: nextFields,
     };
   }
@@ -1096,7 +1286,21 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
             return;
           }
           if (zipKeySet.has(k)) {
-            payload[k] = trimmed.replace(/\D/g, '').slice(0, 5);
+            const country = typeof payload.country === 'string' ? payload.country.trim().toUpperCase() : '';
+            const isUs = country === 'USA' || country === 'UNITED STATES' || country === 'UNITED STATES OF AMERICA';
+
+            if (!isUs) {
+              payload[k] = trimmed;
+              return;
+            }
+
+            const digits = trimmed.replace(/\D/g, '');
+            if (digits.length >= 9) {
+              payload[k] = `${digits.slice(0, 5)}-${digits.slice(5, 9)}`;
+              return;
+            }
+
+            payload[k] = digits.slice(0, 5);
             return;
           }
           if (phoneKeySet.has(k)) {
@@ -1111,6 +1315,13 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           }
         }
       });
+
+      // Normalize integer array inputs (e.g., Plant.associated_master_product_ids).
+      if (Array.isArray(payload.associated_master_product_ids)) {
+        payload.associated_master_product_ids = payload.associated_master_product_ids
+          .map((v) => Number(String(v ?? '').trim()))
+          .filter((n) => Number.isFinite(n));
+      }
 
       // Normalize phone numbers in inline form arrays (digits-only for API payload).
       inlineArrayPhoneKeys.forEach((phoneKeys, arrayKey) => {
@@ -1145,9 +1356,15 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
       // Validate ZIP code(s) before submit.
       for (const k of zipKeySet) {
         const v = payload[k];
-        if (typeof v === 'string' && v.trim() && !/^\d{5}$/.test(v.trim())) {
+        if (typeof v !== 'string' || !v.trim()) continue;
+
+        const country = typeof payload.country === 'string' ? payload.country.trim().toUpperCase() : '';
+        const isUs = country === 'USA' || country === 'UNITED STATES' || country === 'UNITED STATES OF AMERICA';
+        if (!isUs) continue;
+
+        if (!/^\d{5}(-\d{4})?$/.test(v.trim())) {
           const label = zipLabelByKey.get(k) || k;
-          message.error(`${label} must be exactly 5 digits`);
+          message.error(`${label} must be a valid US ZIP code`);
           return;
         }
       }

--- a/frontend/src/features/system/DynamicFormEngine.tsx
+++ b/frontend/src/features/system/DynamicFormEngine.tsx
@@ -34,6 +34,19 @@ type FieldUi = {
     list?: string;
   };
   option_groups?: Record<string, SelectOption[]>;
+
+  /** Max length for string inputs (aligned with backend max_length). */
+  max_length?: number;
+
+  /** Optional section grouping metadata (renders a section header). */
+  section?: string | { title: string; description?: string };
+
+  /** Conditional visibility (additive; ignored if not provided). */
+  visible_when?: {
+    field: string;
+    equals?: unknown;
+    truthy?: boolean;
+  };
 };
 
 interface FieldDefinition {
@@ -241,6 +254,21 @@ const buildValidationSchema = (fields: FieldDefinition[]) => {
   const isArrayField = (field: FieldDefinition) =>
     field.ui?.widget === 'tags' || field.ui?.widget === 'multi_select';
 
+  const isStringLikeField = (field: FieldDefinition) =>
+    field.type === 'text' ||
+    field.type === 'phone' ||
+    field.type === 'select' ||
+    field.type === 'date' ||
+    field.type === 'datetime' ||
+    field.type === 'textarea' ||
+    field.type === 'email' ||
+    field.type === 'url';
+
+  const getMaxLength = (field: FieldDefinition): number | null => {
+    const raw = field.ui?.max_length;
+    return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : null;
+  };
+
   const buildScalar = (field: FieldDefinition) => {
     if (isArrayField(field)) {
       return z.array(z.string());
@@ -267,21 +295,23 @@ const buildValidationSchema = (fields: FieldDefinition[]) => {
 
     let s: any = buildScalar(field);
 
+    const maxLength = getMaxLength(field);
+    if (maxLength && isStringLikeField(field) && typeof s?.max === 'function') {
+      s = s.max(maxLength, `Must be ${maxLength} characters or less`);
+    }
+
     // Inline arrays are primarily for nested child entities (e.g. contacts). For required string fields,
     // enforce a non-empty value client-side so we don't create blank child rows.
-    const isStringField =
-      field.type === 'text' ||
-      field.type === 'phone' ||
-      field.type === 'select' ||
-      field.type === 'date' ||
-      field.type === 'datetime' ||
-      field.type === 'textarea';
-    if (field.required && isStringField) {
+    if (field.required && isStringLikeField(field) && typeof s?.min === 'function') {
+      s = s.min(1, 'Required');
+    }
+
+    if (field.required && isArrayField(field) && typeof s?.min === 'function') {
       s = s.min(1, 'Required');
     }
 
     if (!field.required) {
-      s = s.optional().or(z.literal(''));
+      s = isArrayField(field) ? s.optional() : s.optional().or(z.literal(''));
     }
     return s;
   };
@@ -307,15 +337,63 @@ const buildValidationSchema = (fields: FieldDefinition[]) => {
       return;
     }
 
-    fieldSchema = buildScalar(field);
-    if (!field.required) {
-      fieldSchema = isArrayField(field) ? fieldSchema.optional() : fieldSchema.optional().or(z.literal(''));
-    }
-
+    fieldSchema = buildItemFieldSchema(field);
     schemaShape[field.key] = fieldSchema;
   });
 
-  return z.object(schemaShape);
+  let next = z.object(schemaShape);
+
+  // US ZIP code conditional validation (when country is USA).
+  const hasZip = fields.some((f) => String(f.key).toLowerCase() === 'zip_code');
+  const hasCountry = fields.some((f) => String(f.key).toLowerCase() === 'country');
+
+  if (hasZip && hasCountry) {
+    next = next.superRefine((data, ctx) => {
+      const country = String((data as any)?.country ?? '').trim().toUpperCase();
+      const zip = String((data as any)?.zip_code ?? '').trim();
+
+      if (!zip) return;
+      const isUs = country === 'USA' || country === 'UNITED STATES' || country === 'UNITED STATES OF AMERICA';
+      if (!isUs) return;
+
+      if (!/^\d{5}(-\d{4})?$/.test(zip)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['zip_code'],
+          message: 'Invalid US ZIP code',
+        });
+      }
+    });
+  }
+
+  // Plant profile: warn/error when proteins_tested includes values not listed in proteins_offered.
+  const hasProteinsOffered = fields.some((f) => String(f.key).toLowerCase() === 'proteins_offered');
+  const hasProteinsTested = fields.some((f) => String(f.key).toLowerCase() === 'proteins_tested');
+
+  if (hasProteinsOffered && hasProteinsTested) {
+    next = next.superRefine((data, ctx) => {
+      const offered = Array.isArray((data as any)?.proteins_offered)
+        ? ((data as any).proteins_offered as unknown[]).map((v) => String(v || '').trim()).filter(Boolean)
+        : [];
+      const tested = Array.isArray((data as any)?.proteins_tested)
+        ? ((data as any).proteins_tested as unknown[]).map((v) => String(v || '').trim()).filter(Boolean)
+        : [];
+
+      if (offered.length === 0 || tested.length === 0) return;
+
+      const offeredSet = new Set(offered.map((v) => v.toLowerCase()));
+      const invalid = tested.filter((v) => !offeredSet.has(v.toLowerCase()));
+      if (invalid.length === 0) return;
+
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['proteins_tested'],
+        message: 'This protein type is not listed as offered.',
+      });
+    });
+  }
+
+  return next;
 };
 
 export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
@@ -662,6 +740,8 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
         ? [String(dependencyValue).trim()].filter(Boolean)
         : [];
 
+    const hasDependencies = (field.dependencies || []).length > 0;
+
     const {
       options: cascadingOptions,
       loading: cascadingLoading,
@@ -669,7 +749,7 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     } = useCascadingField({
       fieldId: field.key,
       parentValue: dependencyItems,
-      enabled: cascading && dependencyItems.length > 0,
+      enabled: cascading && (!hasDependencies || dependencyItems.length > 0),
       fetchOptions: async (parentValue) => {
         const proteinTypes = Array.isArray(parentValue)
           ? parentValue.map((item) => String(item || '').trim()).filter(Boolean)
@@ -680,7 +760,7 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     });
 
     const resolvedOptions = cascading ? cascadingOptions : options;
-    const disabled = isSubmitting || (cascading && dependencyItems.length === 0);
+    const disabled = isSubmitting || (cascading && hasDependencies && dependencyItems.length === 0);
 
     useEffect(() => {
       if (field.ui?.widget === 'tags') return;
@@ -730,7 +810,59 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     );
   };
 
+  const seenSections = new Set<string>();
+
+  const isFieldVisible = (field: FieldDefinition): boolean => {
+    const rule = field.ui?.visible_when;
+    if (!rule?.field) return true;
+
+    const raw = (watchedValues as Record<string, unknown> | undefined)?.[rule.field];
+
+    if (typeof rule.equals !== 'undefined') {
+      return raw === rule.equals;
+    }
+
+    if (rule.truthy) {
+      if (Array.isArray(raw)) return raw.length > 0;
+      return Boolean(raw);
+    }
+
+    return Boolean(raw);
+  };
+
+  // When a field becomes hidden, clear its value to avoid submitting stale data.
+  // This is critical for conditional fields like Plant.export_documents_handled.
+  useEffect(() => {
+    for (const field of schema.fields) {
+      if (!field.ui?.visible_when?.field) continue;
+
+      if (isFieldVisible(field)) continue;
+
+      const current = (watchedValues as Record<string, unknown> | undefined)?.[field.key];
+      const hasValue =
+        Array.isArray(current)
+          ? current.length > 0
+          : typeof current === 'string'
+            ? current.trim().length > 0
+            : Boolean(current);
+
+      if (!hasValue) continue;
+
+      const shouldClearToEmptyArray =
+        field.type === 'inline_form_array' ||
+        field.ui?.widget === 'multi_select' ||
+        field.ui?.widget === 'tags';
+
+      setValue(field.key as never, (shouldClearToEmptyArray ? [] : '') as never, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
+  }, [schema.fields, setValue, watchedValues]);
+
   const renderField = (field: FieldDefinition) => {
+    if (!isFieldVisible(field)) return null;
+
     const error = errors[field.key];
     const hasError = !!error;
     // Use config for required indicator (Wave 4 - Task 4.12)
@@ -752,6 +884,12 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
           typeof option === 'string' ? { value: option, label: option } : option
         )
       : getFieldOptions(field);
+
+    const section = field.ui?.section;
+    const sectionTitle = typeof section === 'string' ? section : section?.title;
+    const sectionDescription = typeof section === 'string' ? undefined : section?.description;
+    const shouldRenderSection = Boolean(sectionTitle) && !seenSections.has(String(sectionTitle));
+    if (sectionTitle) seenSections.add(String(sectionTitle));
 
     if (field.type === 'inline_form_array') {
       return <InlineFormArrayField field={field} showRequired={showRequired} />;

--- a/frontend/src/features/system/DynamicFormEngine.visibleWhenClear.test.tsx
+++ b/frontend/src/features/system/DynamicFormEngine.visibleWhenClear.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import DynamicFormEngine from './DynamicFormEngine';
+
+vi.mock('../../services/configService', () => ({
+  resolveConfig: vi.fn(async (_key: string, fallback: unknown) => ({ value: fallback })),
+}));
+
+describe('DynamicFormEngine visible_when', () => {
+  it('clears hidden field values when visible_when becomes false', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <DynamicFormEngine
+        schema={{
+          step_index: 0,
+          name: 'Plant Profile',
+          fields: [
+            {
+              key: 'export_approved',
+              label: 'Export Approved',
+              type: 'checkbox',
+              required: false,
+            },
+            {
+              key: 'export_documents_handled',
+              label: 'Export Documents Handled',
+              type: 'text',
+              required: false,
+              ui: {
+                visible_when: {
+                  field: 'export_approved',
+                  equals: true,
+                },
+              },
+            },
+          ],
+        }}
+        initialValues={{
+          export_approved: true,
+          export_documents_handled: 'LOG (Letter of Guarantee)',
+        }}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Export Approved' }));
+    await user.click(screen.getByRole('button', { name: /submit|save/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      export_approved: false,
+      export_documents_handled: '',
+    });
+  });
+});


### PR DESCRIPTION
Implements the Plant Profile requirements using the metadata-driven UniversalEntityForm (no bespoke UI).\n\nFrontend deliverables:\n- UniversalEntityForm plant schema augmentation: sections (Plant Location/Export), export conditional field, proteins offered/tested, master product list.\n- DynamicFormEngine enhancements: ui.max_length, ui.section headers, ui.visible_when hide+clear, master product options without dependency, and proteins_tested subset validation.\n- Unit test for visible_when clearing behavior.\n\nValidation:\n- frontend type-check\n- frontend unit tests (vitest run --coverage)