### PR TITLE
Fix: prevent WorkForms/QuickActions 400s when tenant missing

### DIFF
--- a/frontend/src/contexts/QuickActionsContext.test.tsx
+++ b/frontend/src/contexts/QuickActionsContext.test.tsx
@@ -104,7 +104,10 @@ describe('QuickActionsContext', () => {
     vi.clearAllMocks();
     
     // Mock localStorage
-    localStorageMock = { authToken: 'test-token' };
+    localStorageMock = {
+      authToken: 'test-token',
+      tenantId: '11111111-1111-4111-8111-111111111111',
+    };
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => localStorageMock[key] || null);
     
     // Default mock responses
@@ -158,10 +161,35 @@ describe('QuickActionsContext', () => {
       expect(screen.getByTestId('forms-count')).toHaveTextContent('2');
     });
 
+    it('should not make requests when tenantId is missing', async () => {
+      localStorageMock = { authToken: 'test-token' };
+
+      render(
+        <QuickActionsProvider>
+          <TestConsumer />
+        </QuickActionsProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('ready');
+      });
+
+      expect(quickActionsService.getQuickActions).not.toHaveBeenCalled();
+      expect(quickActionsService.getAvailableForms).not.toHaveBeenCalled();
+      expect(getAvailableWorkForms).not.toHaveBeenCalled();
+
+      expect(screen.getByTestId('actions-count')).toHaveTextContent('0');
+      expect(screen.getByTestId('forms-count')).toHaveTextContent('0');
+      expect(screen.getByTestId('error')).toHaveTextContent('none');
+    });
+
     it('should load quick actions on mount when authenticated via JWT accessToken', async () => {
       // Token must look like a non-expired JWT for jwtService.getAccessToken() to return it
       const exp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
-      localStorageMock = { accessToken: `header.${btoa(JSON.stringify({ exp }))}.sig` };
+      localStorageMock = {
+        accessToken: `header.${btoa(JSON.stringify({ exp }))}.sig`,
+        tenantId: '11111111-1111-4111-8111-111111111111',
+      };
 
       render(
         <QuickActionsProvider>
@@ -178,7 +206,10 @@ describe('QuickActionsContext', () => {
     });
 
     it('should treat 401/403 as logged-out state (no error)', async () => {
-      localStorageMock = {}; // No JWT or legacy token (cookie-auth may still exist in real app)
+      localStorageMock = {
+        // No JWT or legacy token (cookie-auth may still exist in real app)
+        tenantId: '11111111-1111-4111-8111-111111111111',
+      };
 
       vi.mocked(quickActionsService.getQuickActions).mockRejectedValue({ response: { status: 401 } } as any);
       vi.mocked(quickActionsService.getAvailableForms).mockRejectedValue({ response: { status: 401 } } as any);

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -8,6 +8,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback, Rea
 import { getAvailableWorkForms } from '@/services/workformsApi';
 import { showAlert } from '@/utils/uiDialogs';
 import { logger } from '@/utils/logger';
+import { getValidTenantId } from '@/utils/tenantId';
 import { ApiErrorContent } from '@/components/errors/ApiErrorContent';
 import { getApiErrorPresentation } from '@/services/apiErrorPresentation';
 import {
@@ -67,10 +68,12 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
   const [availableForms, setAvailableForms] = useState<AvailableForm[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  
+
   const [activeSubmission, setActiveSubmission] = useState<FormSubmission | null>(null);
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [isFormModalOpen, setIsFormModalOpen] = useState(false);
+
+  const warnedMissingTenantRef = React.useRef(false);
 
   // Load quick actions on mount
   const refreshQuickActions = useCallback(async () => {
@@ -82,6 +85,20 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
     try {
       setIsLoading(true);
       setError(null);
+
+      // Tenant-scoped endpoints will 400 if tenant context is missing/invalid.
+      // Avoid noisy console errors and defer loading until tenant is selected.
+      const tenantId = getValidTenantId();
+      if (!tenantId) {
+        if (!warnedMissingTenantRef.current) {
+          warnedMissingTenantRef.current = true;
+          logger.warn('[QuickActions] Skipping initial load; missing/invalid tenantId');
+        }
+        setQuickActions([]);
+        setAvailableForms([]);
+        setError(null);
+        return;
+      }
 
       const [actionsResult, formsResult, workformsResult] = await Promise.allSettled([
         quickActionsService.getQuickActions(),

--- a/frontend/src/services/apiService.refreshQueue.test.ts
+++ b/frontend/src/services/apiService.refreshQueue.test.ts
@@ -54,6 +54,15 @@ vi.mock('../utils/logger', () => ({
   },
 }));
 
+// tenantId utilities import logger via the @ alias; mock it too to avoid noisy output.
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 vi.mock('../contexts/SessionManagerContext', () => ({
   triggerGlobalSessionExpired: (...args: any[]) => mockTriggerGlobalSessionExpired(...args),
 }));

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -13,6 +13,7 @@ import axios, { AxiosError as AxiosErrorType, InternalAxiosRequestConfig } from 
 import * as Sentry from '@sentry/react';
 import { config } from '../config/runtime';
 import { logger } from '../utils/logger';
+import { getValidTenantId } from '../utils/tenantId';
 import {
   getAuthHeader,
   needsRefresh,
@@ -120,10 +121,21 @@ apiClient.interceptors.request.use(
       }
       // Note: Missing auth header is expected during login/public endpoints
       
-      // Add tenant ID header if available
-      const tenantId = localStorage.getItem('tenantId');
+      // Add tenant ID header if available (and valid).
+      // Backend expects a UUID; never send literal "undefined"/"null".
+      const tenantId = getValidTenantId();
+      const headersAny = config.headers as any;
       if (tenantId) {
-        config.headers['X-Tenant-ID'] = tenantId;
+        headersAny['X-Tenant-ID'] = tenantId;
+      } else if (headersAny) {
+        // Ensure we don't leak a stale/invalid header from previous config reuse.
+        if (typeof headersAny.delete === 'function') {
+          headersAny.delete('X-Tenant-ID');
+          headersAny.delete('x-tenant-id');
+        } else {
+          delete headersAny['X-Tenant-ID'];
+          delete headersAny['x-tenant-id'];
+        }
       }
       
       return config;
@@ -162,10 +174,20 @@ adminClient.interceptors.request.use(
         logger.warn('[Admin API] No auth header available for request to:', config.url);
       }
       
-      // Add tenant ID header if available
-      const tenantId = localStorage.getItem('tenantId');
+      // Add tenant ID header if available (and valid).
+      // Backend expects a UUID; never send literal "undefined"/"null".
+      const tenantId = getValidTenantId();
+      const headersAny = config.headers as any;
       if (tenantId) {
-        config.headers['X-Tenant-ID'] = tenantId;
+        headersAny['X-Tenant-ID'] = tenantId;
+      } else if (headersAny) {
+        if (typeof headersAny.delete === 'function') {
+          headersAny.delete('X-Tenant-ID');
+          headersAny.delete('x-tenant-id');
+        } else {
+          delete headersAny['X-Tenant-ID'];
+          delete headersAny['x-tenant-id'];
+        }
       }
       
       return config;

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -230,7 +230,7 @@ apiClient.interceptors.response.use(
           scope.setTag('http.status_code', status);
           scope.setTag('http.method', originalRequest?.method || 'unknown');
           scope.setTag('http.url', originalRequest?.url || 'unknown');
-          scope.setTag('tenant.id', localStorage.getItem('tenantId') || 'unknown');
+          scope.setTag('tenant.id', getValidTenantId() || 'unknown');
           scope.setContext('http', {
             status,
             method: originalRequest?.method,
@@ -724,7 +724,7 @@ export class ApiService {
         metadata: {
           endpoint: '/suppliers/',
           hasAuth: !!localStorage.getItem('authToken'),
-          hasTenant: !!localStorage.getItem('tenantId'),
+          hasTenant: Boolean(getValidTenantId()),
           baseURL: API_BASE_URL,
         },
       });

--- a/frontend/src/services/quickActionsService.test.ts
+++ b/frontend/src/services/quickActionsService.test.ts
@@ -46,14 +46,21 @@ import {
 } from './quickActionsService';
 
 describe('QuickActionsService', () => {
+  const TENANT_ID = '11111111-1111-4111-8111-111111111111';
+
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+
+    // Most QuickActions endpoints are tenant-scoped.
+    localStorage.setItem('tenantId', '11111111-1111-4111-8111-111111111111');
   });
 
   describe('quickActionsService', () => {
     describe('getQuickActions', () => {
       it('should fetch quick actions', async () => {
+        localStorage.setItem('tenantId', TENANT_ID);
+
         const mockResponse = {
           data: {
             items: [
@@ -70,7 +77,18 @@ describe('QuickActionsService', () => {
         expect(result.items[0].label).toBe('New Supplier');
       });
 
+      it('should skip request when tenant is missing/invalid', async () => {
+        localStorage.removeItem('tenantId');
+
+        const result = await quickActionsService.getQuickActions();
+
+        expect(mockApiClient.get).not.toHaveBeenCalled();
+        expect(result).toEqual({ items: [] });
+      });
+
       it('should support cancel key for request cancellation', async () => {
+        localStorage.setItem('tenantId', TENANT_ID);
+
         const mockResponse = { data: { items: [] } };
         mockApiClient.get.mockResolvedValue(mockResponse);
 
@@ -85,6 +103,8 @@ describe('QuickActionsService', () => {
 
     describe('updateQuickActions', () => {
       it('should update quick actions', async () => {
+        localStorage.setItem('tenantId', TENANT_ID);
+
         const items = [
           { id: 'qa_1', type: 'form' as const, form_id: 'f1', label: 'Updated', icon: 'truck', order: 0 },
         ];
@@ -96,10 +116,18 @@ describe('QuickActionsService', () => {
         expect(mockApiClient.put).toHaveBeenCalledWith('/workflows/quick-actions/', { items });
         expect(result.success).toBe(true);
       });
+
+      it('should throw when updating quick actions without tenant', async () => {
+        localStorage.removeItem('tenantId');
+
+        await expect(quickActionsService.updateQuickActions([] as any)).rejects.toThrow('Tenant not selected');
+      });
     });
 
     describe('getAvailableForms', () => {
       it('should fetch available forms as array', async () => {
+        localStorage.setItem('tenantId', TENANT_ID);
+
         const mockForms = [
           { id: 'f1', name: 'Supplier Form', description: 'Add supplier', icon: 'truck', status: 'active' },
         ];
@@ -111,7 +139,18 @@ describe('QuickActionsService', () => {
         expect(result).toEqual(mockForms);
       });
 
+      it('should skip available-forms request when tenant is missing/invalid', async () => {
+        localStorage.removeItem('tenantId');
+
+        const result = await quickActionsService.getAvailableForms();
+
+        expect(mockApiClient.get).not.toHaveBeenCalled();
+        expect(result).toEqual([]);
+      });
+
       it('should handle paginated response', async () => {
+        localStorage.setItem('tenantId', TENANT_ID);
+
         const mockForms = [{ id: 'f1', name: 'Form 1' }];
         mockApiClient.get.mockResolvedValue({ data: { results: mockForms } });
 

--- a/frontend/src/services/quickActionsService.ts
+++ b/frontend/src/services/quickActionsService.ts
@@ -7,6 +7,7 @@
 import axios, { CancelTokenSource } from 'axios';
 import { apiClient } from './apiService';
 import { logger } from '@/utils/logger';
+import { getValidTenantId } from '@/utils/tenantId';
 
 // Cancel token manager for request cancellation
 class CancelTokenManager {
@@ -42,6 +43,13 @@ class CancelTokenManager {
 }
 
 export const cancelTokenManager = new CancelTokenManager();
+
+let warnedMissingTenant = false;
+const warnMissingTenantOnce = (endpoint: string) => {
+  if (warnedMissingTenant) return;
+  warnedMissingTenant = true;
+  logger.warn('[QuickActions] Skipping tenant-scoped request; missing/invalid tenantId', { endpoint });
+};
 
 // Types
 export interface QuickActionItem {
@@ -132,9 +140,13 @@ export const quickActionsService = {
    * @param cancelKey - Optional key for cancellation tracking
    */
   async getQuickActions(cancelKey?: string): Promise<{ items: QuickActionItem[] }> {
-    const config = cancelKey 
-      ? { cancelToken: cancelTokenManager.create(cancelKey).token }
-      : {};
+    const tenantId = getValidTenantId();
+    if (!tenantId) {
+      warnMissingTenantOnce('/workflows/quick-actions/');
+      return { items: [] };
+    }
+
+    const config = cancelKey ? { cancelToken: cancelTokenManager.create(cancelKey).token } : {};
     const response = await apiClient.get('/workflows/quick-actions/', config);
     if (cancelKey) cancelTokenManager.remove(cancelKey);
     return response.data;
@@ -144,6 +156,12 @@ export const quickActionsService = {
    * Update user's quick actions
    */
   async updateQuickActions(items: QuickActionItem[]): Promise<{ success: boolean; items: QuickActionItem[] }> {
+    const tenantId = getValidTenantId();
+    if (!tenantId) {
+      // Updating quick actions without a tenant will always fail server-side; surface a clear error.
+      throw new Error('Tenant not selected');
+    }
+
     const response = await apiClient.put('/workflows/quick-actions/', { items });
     return response.data;
   },
@@ -153,9 +171,13 @@ export const quickActionsService = {
    * @param cancelKey - Optional key for cancellation tracking
    */
   async getAvailableForms(cancelKey?: string): Promise<AvailableForm[]> {
-    const config = cancelKey 
-      ? { cancelToken: cancelTokenManager.create(cancelKey).token }
-      : {};
+    const tenantId = getValidTenantId();
+    if (!tenantId) {
+      warnMissingTenantOnce('/workflows/available-forms/');
+      return [];
+    }
+
+    const config = cancelKey ? { cancelToken: cancelTokenManager.create(cancelKey).token } : {};
     const response = await apiClient.get('/workflows/available-forms/', config);
     if (cancelKey) cancelTokenManager.remove(cancelKey);
     // Handle both paginated {results: []} and non-paginated [] responses

--- a/frontend/src/services/workformsApi.test.ts
+++ b/frontend/src/services/workformsApi.test.ts
@@ -1,0 +1,102 @@
+/**
+ * WorkForms API (tenant guard) tests
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApiClient = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('./apiService', () => ({
+  apiClient: mockApiClient,
+}));
+
+import { getAvailableWorkForms, listTenantWorkForms } from './workformsApi';
+
+describe('workformsApi tenant guards', () => {
+  const TENANT_ID = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('getAvailableWorkForms: does not request when tenantId is missing', async () => {
+    const result = await getAvailableWorkForms();
+
+    expect(mockApiClient.get).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('getAvailableWorkForms: includes params when tenantId is present', async () => {
+    localStorage.setItem('tenantId', TENANT_ID);
+
+    mockApiClient.get.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 'wf-1',
+            name: 'WorkForm 1',
+            description: '',
+            status: 'active',
+            node_count: 0,
+            edge_count: 0,
+            updated_at: '2026-02-01T00:00:00Z',
+          },
+        ],
+      },
+    });
+
+    const result = await getAvailableWorkForms({ status: 'active' });
+
+    expect(mockApiClient.get).toHaveBeenCalledWith('/tenant-workforms/', { params: { status: 'active' } });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('wf-1');
+  });
+
+  it('listTenantWorkForms: does not request when tenantId is missing', async () => {
+    const result = await listTenantWorkForms();
+
+    expect(mockApiClient.get).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('listTenantWorkForms: requests when tenantId is present', async () => {
+    localStorage.setItem('tenantId', TENANT_ID);
+
+    mockApiClient.get.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 'wf-1',
+            tenant: TENANT_ID,
+            name: 'WorkForm 1',
+            description: '',
+            status: 'active',
+            workflow_definition: {},
+            form_references: [],
+            version: 1,
+            execution_count: 0,
+            clone_count: 0,
+            node_count: 0,
+            edge_count: 0,
+            node_types_summary: {},
+            validation_status: { valid: true, missing_forms: [], total_references: 0 },
+            created_at: '2026-02-01T00:00:00Z',
+            updated_at: '2026-02-01T00:00:00Z',
+          },
+        ],
+      },
+    });
+
+    const result = await listTenantWorkForms({ search: 'abc' });
+
+    expect(mockApiClient.get).toHaveBeenCalledWith('/tenant-workforms/', { params: { search: 'abc' } });
+    expect(result).toHaveLength(1);
+  });
+});

--- a/frontend/src/services/workformsApi.ts
+++ b/frontend/src/services/workformsApi.ts
@@ -13,6 +13,24 @@
  */
 
 import { apiClient } from './apiService';
+import { logger } from '@/utils/logger';
+import { getValidTenantId } from '@/utils/tenantId';
+
+let warnedMissingTenant = false;
+const warnMissingTenantOnce = (endpoint: string) => {
+  if (warnedMissingTenant) return;
+  warnedMissingTenant = true;
+  logger.warn('[WorkForms] Skipping tenant-scoped request; missing/invalid tenantId', { endpoint });
+};
+
+const requireTenantId = (endpoint: string): string => {
+  const tenantId = getValidTenantId();
+  if (!tenantId) {
+    warnMissingTenantOnce(endpoint);
+    throw new Error('Tenant not selected');
+  }
+  return tenantId;
+};
 
 // ============================================================================
 // Types
@@ -153,6 +171,12 @@ export const getAvailableWorkForms = async (params?: {
   status?: 'draft' | 'active' | 'archived';
   search?: string;
 }): Promise<AvailableWorkForm[]> => {
+  const tenantId = getValidTenantId();
+  if (!tenantId) {
+    warnMissingTenantOnce('/tenant-workforms/');
+    return [];
+  }
+
   const response = await apiClient.get('/tenant-workforms/', { params });
   const data = response.data?.results || response.data || [];
   return Array.isArray(data) ? data : [];
@@ -181,6 +205,8 @@ export const executeTenantWorkForm = async (
   workformId: string,
   initialData?: Record<string, unknown>
 ): Promise<WorkFormExecuteResponse> => {
+  requireTenantId('/tenant-workforms/{id}/execute/');
+
   const response = await apiClient.post(`/tenant-workforms/${workformId}/execute/`, {
     initial_data: initialData ?? {},
   });
@@ -380,6 +406,12 @@ export const listTenantWorkForms = async (params?: {
   status?: 'draft' | 'active' | 'archived';
   search?: string;
 }): Promise<TenantWorkForm[]> => {
+  const tenantId = getValidTenantId();
+  if (!tenantId) {
+    warnMissingTenantOnce('/tenant-workforms/');
+    return [];
+  }
+
   const response = await apiClient.get('/tenant-workforms/', { params });
   return response.data.results || response.data || [];
 };
@@ -388,6 +420,8 @@ export const listTenantWorkForms = async (params?: {
  * Get a specific tenant workflow by ID
  */
 export const getTenantWorkForm = async (workformId: string): Promise<TenantWorkForm> => {
+  requireTenantId('/tenant-workforms/{id}/');
+
   const response = await apiClient.get(`/tenant-workforms/${workformId}/`);
   return response.data;
 };
@@ -401,6 +435,8 @@ export const createTenantWorkForm = async (data: {
   status?: 'draft' | 'active' | 'archived';
   workflow_definition: any;
 }): Promise<TenantWorkForm> => {
+  requireTenantId('/tenant-workforms/');
+
   const response = await apiClient.post('/tenant-workforms/', data);
   return response.data;
 };
@@ -412,6 +448,8 @@ export const updateTenantWorkForm = async (
   workformId: string,
   data: Partial<TenantWorkForm>
 ): Promise<TenantWorkForm> => {
+  requireTenantId('/tenant-workforms/{id}/');
+
   const response = await apiClient.put(`/tenant-workforms/${workformId}/`, data);
   return response.data;
 };
@@ -420,6 +458,8 @@ export const updateTenantWorkForm = async (
  * Delete a tenant workflow
  */
 export const deleteTenantWorkForm = async (workformId: string): Promise<void> => {
+  requireTenantId('/tenant-workforms/{id}/');
+
   await apiClient.delete(`/tenant-workforms/${workformId}/`);
 };
 
@@ -438,6 +478,8 @@ export const cloneWorkForm = async (
     include_form_references?: boolean;
   }
 ): Promise<TenantWorkForm> => {
+  requireTenantId('/tenant-workforms/{id}/clone/');
+
   const response = await apiClient.post(`/tenant-workforms/${workformId}/clone/`, data);
   return response.data;
 };
@@ -459,6 +501,8 @@ export const getWorkFormUsage = async (
   created_at: string;
   updated_at: string;
 }> => {
+  requireTenantId('/tenant-workforms/{id}/usage/');
+
   const response = await apiClient.get(`/tenant-workforms/${workformId}/usage/`);
   return response.data;
 };
@@ -473,6 +517,8 @@ export const validateWorkForm = async (
   missing_forms: string[];
   total_references: number;
 }> => {
+  requireTenantId('/tenant-workforms/{id}/validate/');
+
   const response = await apiClient.post(`/tenant-workforms/${workformId}/validate/`);
   return response.data;
 };
@@ -516,6 +562,8 @@ export interface ContainerDetail {
 export const listWorkFormContainers = async (
   workformId: string
 ): Promise<{ containers: ContainerSummary[] }> => {
+  requireTenantId('/tenant-workforms/{id}/containers/');
+
   const response = await apiClient.get(`/tenant-workforms/${workformId}/containers/`);
   return response.data;
 };
@@ -527,6 +575,8 @@ export const getContainerDetail = async (
   workformId: string,
   containerId: string
 ): Promise<ContainerDetail> => {
+  requireTenantId('/tenant-workforms/{id}/containers/{containerId}/');
+
   const response = await apiClient.get(`/tenant-workforms/${workformId}/containers/${containerId}/`);
   return response.data;
 };
@@ -539,6 +589,8 @@ export const addNodeToContainer = async (
   nodeId: string,
   containerId: string
 ): Promise<{ message: string; node_id: string; container_id: string }> => {
+  requireTenantId('/tenant-workforms/{id}/containers/add-node/');
+
   const response = await apiClient.post(`/tenant-workforms/${workformId}/containers/add-node/`, {
     node_id: nodeId,
     container_id: containerId
@@ -553,6 +605,8 @@ export const removeNodeFromContainer = async (
   workformId: string,
   nodeId: string
 ): Promise<{ message: string; node_id: string }> => {
+  requireTenantId('/tenant-workforms/{id}/containers/remove-node/');
+
   const response = await apiClient.post(`/tenant-workforms/${workformId}/containers/remove-node/`, {
     node_id: nodeId
   });

--- a/frontend/src/utils/tenantId.test.ts
+++ b/frontend/src/utils/tenantId.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}));
+
+import { getValidTenantId, isUuid } from './tenantId';
+
+const VALID_UUID = '11111111-1111-4111-8111-111111111111';
+
+describe('tenantId utilities', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('isUuid', () => {
+    it('accepts valid UUIDs', () => {
+      expect(isUuid(VALID_UUID)).toBe(true);
+    });
+
+    it('rejects non-UUID values', () => {
+      expect(isUuid('tenant-123')).toBe(false);
+      expect(isUuid('')).toBe(false);
+      expect(isUuid(null)).toBe(false);
+    });
+  });
+
+  describe('getValidTenantId', () => {
+    it('returns null when tenantId is missing', () => {
+      expect(getValidTenantId()).toBeNull();
+    });
+
+    it('returns tenantId when it is a valid UUID', () => {
+      localStorage.setItem('tenantId', VALID_UUID);
+      expect(getValidTenantId()).toBe(VALID_UUID);
+    });
+
+    it('treats literal "undefined" as invalid and clears storage', () => {
+      localStorage.setItem('tenantId', 'undefined');
+      expect(getValidTenantId()).toBeNull();
+      expect(localStorage.getItem('tenantId')).toBeNull();
+    });
+
+    it('treats literal "null" as invalid and clears storage', () => {
+      localStorage.setItem('tenantId', 'null');
+      expect(getValidTenantId()).toBeNull();
+      expect(localStorage.getItem('tenantId')).toBeNull();
+    });
+
+    it('treats non-UUID tenantId as invalid', () => {
+      localStorage.setItem('tenantId', 'tenant-123');
+      expect(getValidTenantId()).toBeNull();
+    });
+
+    it('falls back to currentTenantId key', () => {
+      localStorage.setItem('currentTenantId', VALID_UUID);
+      expect(getValidTenantId()).toBe(VALID_UUID);
+    });
+  });
+});

--- a/frontend/src/utils/tenantId.ts
+++ b/frontend/src/utils/tenantId.ts
@@ -1,0 +1,56 @@
+/**
+ * Tenant ID utilities
+ *
+ * Prevents accidental propagation of malformed tenant context (e.g. the literal
+ * strings "undefined"/"null") into request headers.
+ */
+
+import { logger } from '@/utils/logger';
+
+// UUID v1-v5 w/ RFC4122 variant check.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const isUuid = (value: unknown): value is string => {
+  return typeof value === 'string' && UUID_REGEX.test(value.trim());
+};
+
+/**
+ * Reads tenantId from localStorage and returns a valid UUID or null.
+ *
+ * NOTE: We intentionally treat non-UUID values as invalid, because the backend
+ * expects a UUID in X-Tenant-ID.
+ */
+export const getValidTenantId = (): string | null => {
+  if (typeof window === 'undefined') return null;
+
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem('tenantId') || localStorage.getItem('currentTenantId');
+  } catch {
+    return null;
+  }
+
+  if (!raw) return null;
+
+  const trimmed = raw.trim();
+
+  // Common failure mode: someone did localStorage.setItem('tenantId', String(undefined))
+  // or the value got persisted incorrectly.
+  if (trimmed === 'undefined' || trimmed === 'null') {
+    try {
+      localStorage.removeItem('tenantId');
+    } catch {
+      // best-effort
+    }
+
+    logger.warn('[Tenant] Ignoring malformed tenantId in storage', { tenantId: trimmed });
+    return null;
+  }
+
+  if (!isUuid(trimmed)) {
+    logger.warn('[Tenant] Ignoring non-UUID tenantId in storage', { tenantId: trimmed });
+    return null;
+  }
+
+  return trimmed;
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -143,6 +143,9 @@ export default defineConfig({
       'src/components/FlowEditor/__tests__/UnifiedFlowEditor.integration.test.tsx',
     ],
     pool: 'forks', // Use forks instead of threads for stability
+    // Coverage + parallel file execution can intermittently miss V8 coverage shard files.
+    // Disable file-level parallelism for deterministic CI runs.
+    fileParallelism: false,
     passWithNoTests: true,
     bail: 1, // Stop on first failure for faster feedback
     coverage: {


### PR DESCRIPTION
Fixes dev console 400 spam for tenant-scoped boot calls (Quick Actions + /tenant-workforms/) by validating tenant context and gating requests until tenant is a valid UUID.\n\nChanges:\n- Add getValidTenantId() UUID validator (guards against literal 'undefined'/'null')\n- apiService: only set X-Tenant-ID when valid; otherwise delete stale header\n- QuickActionsContext: skip initial load when tenant missing/invalid (avoid noisy 400s)\n- QuickActions/workforms services: return empty for reads without tenant; throw for writes\n- Tests: cover tenant guards + tenantId validation\n- Vitest stability: disable file-level parallelism to avoid intermittent V8 coverage shard ENOENT\n\nValidation:\n- npm -C frontend run type-check\n- npm -C frontend run test:ci