### PR TITLE
WorkForms: trigger preview/debug UX polish

### DIFF
--- a/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
+++ b/frontend/src/components/FlowEditor/ConfigPanel/FormStepConfigPanel.tsx
@@ -417,6 +417,7 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
     generateSuggestions,
     applySuggestion,
     applyAllSuggestions,
+    dismissSuggestion,
     clearSuggestions,
   } = useAutoMapping();
   const [showAutoMapping, setShowAutoMapping] = useState<boolean>(false);
@@ -691,8 +692,7 @@ export const FormStepConfigPanel: React.FC<FormStepConfigPanelProps> = ({
                     // additional logic to convert mapping to form field
                   }}
                   onReject={(suggestionId) => {
-                    // Filter out rejected suggestion
-                    // This would need additional state management
+                    dismissSuggestion(suggestionId);
                   }}
                   onApplyAll={() => {
                     if (nodeId) {

--- a/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
+++ b/frontend/src/components/FlowEditor/components/DryRunDebugger.tsx
@@ -53,13 +53,53 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
     markNodesExecuted,
   } = useFlowEditor();
 
-  // Generate mock input based on node schema
-  useEffect(() => {
-    if (selectedNode) {
-      const mock = generateMockInput(selectedNode);
-      setMockInput(mock);
-    }
+  const mockInputStorageKey = useMemo(() => {
+    if (!selectedNode) return null;
+    if (typeof window === 'undefined') return null;
+    return `dryrun_mock_input:${window.location.pathname}:${selectedNode.id}`;
   }, [selectedNode]);
+
+  // Generate (or restore) mock input when node changes.
+  useEffect(() => {
+    if (!selectedNode) return;
+
+    const fallback = generateMockInput(selectedNode);
+
+    if (!mockInputStorageKey) {
+      setMockInput(fallback);
+      return;
+    }
+
+    try {
+      const raw = localStorage.getItem(mockInputStorageKey);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          setMockInput(parsed as Record<string, any>);
+          return;
+        }
+      }
+    } catch {
+      // best-effort
+    }
+
+    setMockInput(fallback);
+  }, [mockInputStorageKey, selectedNode]);
+
+  // Persist mock input edits for convenience.
+  useEffect(() => {
+    if (!mockInputStorageKey) return;
+
+    const t = window.setTimeout(() => {
+      try {
+        localStorage.setItem(mockInputStorageKey, JSON.stringify(mockInput));
+      } catch {
+        // best-effort
+      }
+    }, 250);
+
+    return () => window.clearTimeout(t);
+  }, [mockInput, mockInputStorageKey]);
 
   // Auto-start a debug session when opened (Phase 9.4)
   useEffect(() => {
@@ -435,7 +475,25 @@ export const DryRunDebugger: React.FC<DryRunDebuggerProps> = ({
       <DebuggerContent>
         {/* Mock Input Section */}
         <Section>
-          <SectionTitle>Mock Input Data</SectionTitle>
+          <SectionTitle>
+            Mock Input Data
+            <ResetMockButton
+              type="button"
+              onClick={() => {
+                const next = generateMockInput(selectedNode);
+                setMockInput(next);
+                if (mockInputStorageKey) {
+                  try {
+                    localStorage.setItem(mockInputStorageKey, JSON.stringify(next));
+                  } catch {
+                    // best-effort
+                  }
+                }
+              }}
+            >
+              Reset Input
+            </ResetMockButton>
+          </SectionTitle>
           <InputEditor>
             {viewMode === 'preview' ? (
               <InputPreview>
@@ -923,6 +981,28 @@ const SectionTitle = styled.h3`
   color: rgb(var(--color-text-primary));
   text-transform: uppercase;
   letter-spacing: 0.5px;
+`;
+
+const ResetMockButton = styled.button`
+  margin-left: auto;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgb(var(--color-border));
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-text-primary));
+  cursor: pointer;
+  font-size: 12px;
+  text-transform: none;
+  letter-spacing: normal;
+
+  &:hover {
+    background: rgb(var(--color-background));
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(var(--color-primary), 0.4);
+    outline-offset: 2px;
+  }
 `;
 
 const DurationBadge = styled.span`

--- a/frontend/src/components/FlowEditor/hooks/useAutoMapping.ts
+++ b/frontend/src/components/FlowEditor/hooks/useAutoMapping.ts
@@ -28,6 +28,7 @@ export interface UseAutoMappingReturn {
   generateSuggestions: (nodeId: string) => void;
   applySuggestion: (nodeId: string, suggestion: FieldMappingSuggestion) => void;
   applyAllSuggestions: (nodeId: string) => void;
+  dismissSuggestion: (suggestionId: string) => void;
   clearSuggestions: () => void;
 }
 
@@ -77,7 +78,7 @@ export function useAutoMapping(): UseAutoMappingReturn {
    */
   const applySuggestion = useCallback((nodeId: string, suggestion: FieldMappingSuggestion) => {
     setNodes((nodes) => {
-      return nodes.map(node => {
+      return nodes.map((node) => {
         if (node.id === nodeId) {
           const updatedNode = AutoMappingService.applySuggestion(node, suggestion);
           logger.debug('Applied suggestion', { component: 'AutoMapping', metadata: { suggestion } });
@@ -85,6 +86,15 @@ export function useAutoMapping(): UseAutoMappingReturn {
         }
         return node;
       });
+    });
+
+    // UX: remove accepted suggestion immediately.
+    setSuggestions((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        suggestions: prev.suggestions.filter((s) => s.id !== suggestion.id),
+      };
     });
   }, [setNodes]);
   
@@ -114,6 +124,16 @@ export function useAutoMapping(): UseAutoMappingReturn {
   /**
    * Clear suggestions
    */
+  const dismissSuggestion = useCallback((suggestionId: string) => {
+    setSuggestions((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        suggestions: prev.suggestions.filter((s) => s.id !== suggestionId),
+      };
+    });
+  }, []);
+
   const clearSuggestions = useCallback(() => {
     setSuggestions(null);
     setError(null);
@@ -126,6 +146,7 @@ export function useAutoMapping(): UseAutoMappingReturn {
     generateSuggestions,
     applySuggestion,
     applyAllSuggestions,
+    dismissSuggestion,
     clearSuggestions,
   };
 }

--- a/frontend/src/components/FlowEditor/utils/__tests__/autoMappingService.applySuggestion.test.ts
+++ b/frontend/src/components/FlowEditor/utils/__tests__/autoMappingService.applySuggestion.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+
+import { AutoMappingService } from '../autoMappingService';
+
+describe('AutoMappingService.applySuggestion', () => {
+  const baseNode: Node = {
+    id: 'n1',
+    type: 'formStep',
+    position: { x: 0, y: 0 },
+    data: {
+      fieldMappings: [],
+    },
+  };
+
+  const suggestion = {
+    id: 's1',
+    targetFieldName: 'name',
+    sourceNodeId: 'up1',
+    sourceFieldName: 'full_name',
+    sourceFieldLabel: 'Full Name',
+    matchScore: 0.95,
+    matchReason: 'exact_name' as const,
+    autoApply: true,
+  };
+
+  it('adds a mapping immutably', () => {
+    const updated = AutoMappingService.applySuggestion(baseNode, suggestion);
+
+    expect(updated).not.toBe(baseNode);
+    expect(updated.data).not.toBe(baseNode.data);
+
+    const mappings = (updated.data as any).fieldMappings;
+    expect(Array.isArray(mappings)).toBe(true);
+    expect(mappings).toHaveLength(1);
+    expect(mappings[0]).toMatchObject({
+      id: 's1',
+      targetFieldName: 'name',
+      sourceNodeId: 'up1',
+      sourceFieldName: 'full_name',
+    });
+  });
+
+  it('does not duplicate existing mappings', () => {
+    const once = AutoMappingService.applySuggestion(baseNode, suggestion);
+    const twice = AutoMappingService.applySuggestion(once, suggestion);
+
+    const mappings = (twice.data as any).fieldMappings;
+    expect(mappings).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/FlowEditor/utils/scheduleCron.test.ts
+++ b/frontend/src/components/FlowEditor/utils/scheduleCron.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  parseTimeOfDay,
+  buildCronExpressionFromFriendlySchedule,
+  buildScheduleSummary,
+} from './scheduleCron';
+
+describe('scheduleCron', () => {
+  describe('parseTimeOfDay', () => {
+    it('parses HH:mm', () => {
+      expect(parseTimeOfDay('13:05')).toEqual({ hour: 13, minute: 5 });
+    });
+
+    it('falls back to 09:00 for invalid input', () => {
+      expect(parseTimeOfDay('not-a-time')).toEqual({ hour: 9, minute: 0 });
+      expect(parseTimeOfDay(null)).toEqual({ hour: 9, minute: 0 });
+    });
+  });
+
+  describe('buildCronExpressionFromFriendlySchedule', () => {
+    it('builds hourly cron (minute only)', () => {
+      expect(buildCronExpressionFromFriendlySchedule({ frequency: 'hourly', atTime: '09:15' })).toBe('15 * * * *');
+    });
+
+    it('builds daily cron', () => {
+      expect(buildCronExpressionFromFriendlySchedule({ frequency: 'daily', atTime: '09:15' })).toBe('15 9 * * *');
+    });
+
+    it('builds weekly cron with DOW mapping', () => {
+      expect(
+        buildCronExpressionFromFriendlySchedule({
+          frequency: 'weekly',
+          atTime: '07:30',
+          daysOfWeek: ['MON', 'WED', 'SUN'],
+        })
+      ).toBe('30 7 * * 0,1,3');
+    });
+
+    it('defaults weekly DOW to Monday when none provided', () => {
+      expect(buildCronExpressionFromFriendlySchedule({ frequency: 'weekly', atTime: '07:30' })).toBe('30 7 * * 1');
+    });
+
+    it('builds monthly cron with clamped dayOfMonth', () => {
+      expect(buildCronExpressionFromFriendlySchedule({ frequency: 'monthly', atTime: '07:30', dayOfMonth: 0 })).toBe(
+        '30 7 1 * *'
+      );
+      expect(buildCronExpressionFromFriendlySchedule({ frequency: 'monthly', atTime: '07:30', dayOfMonth: 99 })).toBe(
+        '30 7 31 * *'
+      );
+    });
+  });
+
+  describe('buildScheduleSummary', () => {
+    it('adds timezone suffix only when not UTC', () => {
+      expect(buildScheduleSummary({ frequency: 'daily', atTime: '09:00', timezone: 'UTC' })).toBe('Daily at 09:00');
+      expect(buildScheduleSummary({ frequency: 'daily', atTime: '09:00', timezone: 'America/Chicago' })).toBe(
+        'Daily at 09:00 (America/Chicago)'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Improvements for WorkForms trigger/preview/test/debug and Smart Auto-Map UX:\n\n- Dry Run Debugger: persist mock inputs per node+route to localStorage and add a Reset Input control\n- Smart Auto-Map: accepted/rejected suggestions are removed immediately (no stale suggestions lingering)\n- Tests: add stable coverage for scheduleCron helpers + AutoMappingService immutability/dedupe\n\nValidation:\n- npm -C frontend run type-check\n- npm -C frontend run test:ci