### PR TITLE
WorkForms: a11y hardening for cards and modals

### DIFF
--- a/frontend/src/components/FlowEditor/templates/TemplateSelector.a11y.test.tsx
+++ b/frontend/src/components/FlowEditor/templates/TemplateSelector.a11y.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { TemplateSelector } from './TemplateSelector';
+
+describe('TemplateSelector a11y', () => {
+  it('renders a dialog with an accessible name and focuses search input on open', async () => {
+    const onClose = vi.fn();
+
+    const opener = document.createElement('button');
+    opener.textContent = 'Open Template Selector';
+    document.body.appendChild(opener);
+    opener.focus();
+
+    render(
+      <TemplateSelector
+        isOpen
+        onClose={onClose}
+        onSelectTemplate={vi.fn()}
+        onStartBlank={vi.fn()}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: /choose a template/i });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /search templates/i })).toHaveFocus();
+    });
+
+    // Cleanup
+    opener.remove();
+  });
+
+  it('closes on Escape and restores focus to opener', async () => {
+    const onClose = vi.fn();
+
+    const opener = document.createElement('button');
+    opener.textContent = 'Open Template Selector';
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const { unmount } = render(
+      <TemplateSelector
+        isOpen
+        onClose={onClose}
+        onSelectTemplate={vi.fn()}
+        onStartBlank={vi.fn()}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: /choose a template/i });
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await waitFor(() => {
+      expect(opener).toHaveFocus();
+    });
+
+    opener.remove();
+  });
+});

--- a/frontend/src/components/FlowEditor/templates/TemplateSelector.tsx
+++ b/frontend/src/components/FlowEditor/templates/TemplateSelector.tsx
@@ -6,7 +6,7 @@
  * Created: 2026-02-04
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { X, Search, Star, Clock, Zap } from 'lucide-react';
 import { 
@@ -164,6 +164,11 @@ const TemplateCard = styled.div`
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(var(--color-overlay), 0.1);
   }
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: 2px;
+  }
 `;
 
 const TemplateHeader = styled.div`
@@ -312,6 +317,23 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
 
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+
+    const t = window.setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(t);
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, []);
+
   // Get templates
   const featuredTemplate = useMemo(() => getFeaturedTemplate(), []);
   const popularTemplates = useMemo(() => getPopularTemplates(5), []);
@@ -345,12 +367,66 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
     onClose();
   };
 
+  const handleCardKeyDown = (e: React.KeyboardEvent, onActivate: () => void) => {
+    if (e.target !== e.currentTarget) return;
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onActivate();
+    }
+  };
+
+  const handleModalKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      onClose();
+      return;
+    }
+
+    if (e.key !== 'Tab') return;
+
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const focusable = Array.from(
+      modal.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((el) => el.offsetParent !== null);
+
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (e.shiftKey) {
+      if (!active || active === first || !modal.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
   return (
     <Overlay onClick={onClose}>
-      <Modal onClick={(e) => e.stopPropagation()}>
+      <Modal
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="template-selector-title"
+        tabIndex={-1}
+        onKeyDown={handleModalKeyDown}
+        onClick={(e) => e.stopPropagation()}
+      >
         <Header>
-          <Title>Choose a Template</Title>
-          <CloseButton onClick={onClose}>
+          <Title id="template-selector-title">Choose a Template</Title>
+          <CloseButton onClick={onClose} aria-label="Close template selector">
             <X size={24} />
           </CloseButton>
         </Header>
@@ -359,8 +435,10 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
           <SearchBar>
             <SearchIcon size={18} />
             <SearchInput
+              ref={searchInputRef}
               type="text"
               placeholder="Search templates..."
+              aria-label="Search templates"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
@@ -388,7 +466,14 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
               {filteredTemplates.length > 0 ? (
                 <TemplateGrid>
                   {filteredTemplates.map((template) => (
-                    <TemplateCard key={template.id} onClick={() => handleTemplateClick(template)}>
+                    <TemplateCard
+                      key={template.id}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Select template: ${template.name}`}
+                      onClick={() => handleTemplateClick(template)}
+                      onKeyDown={(e) => handleCardKeyDown(e, () => handleTemplateClick(template))}
+                    >
                       <TemplateHeader>
                         <TemplateThumbnail>{template.thumbnail}</TemplateThumbnail>
                         <DifficultyBadge $difficulty={template.difficulty}>
@@ -430,7 +515,13 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                   </SectionTitle>
                 </SectionHeader>
                 <TemplateGrid>
-                  <TemplateCard onClick={() => handleTemplateClick(featuredTemplate)}>
+                  <TemplateCard
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Select template: ${featuredTemplate.name}`}
+                    onClick={() => handleTemplateClick(featuredTemplate)}
+                    onKeyDown={(e) => handleCardKeyDown(e, () => handleTemplateClick(featuredTemplate))}
+                  >
                     <TemplateHeader>
                       <TemplateThumbnail>{featuredTemplate.thumbnail}</TemplateThumbnail>
                       <DifficultyBadge $difficulty={featuredTemplate.difficulty}>
@@ -465,7 +556,14 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                 </SectionHeader>
                 <TemplateGrid>
                   {popularTemplates.map((template) => (
-                    <TemplateCard key={template.id} onClick={() => handleTemplateClick(template)}>
+                    <TemplateCard
+                      key={template.id}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Select template: ${template.name}`}
+                      onClick={() => handleTemplateClick(template)}
+                      onKeyDown={(e) => handleCardKeyDown(e, () => handleTemplateClick(template))}
+                    >
                       <TemplateHeader>
                         <TemplateThumbnail>{template.thumbnail}</TemplateThumbnail>
                         <DifficultyBadge $difficulty={template.difficulty}>
@@ -501,7 +599,14 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                   </SectionHeader>
                   <TemplateGrid>
                     {templates.map((template) => (
-                      <TemplateCard key={template.id} onClick={() => handleTemplateClick(template)}>
+                      <TemplateCard
+                        key={template.id}
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`Select template: ${template.name}`}
+                        onClick={() => handleTemplateClick(template)}
+                        onKeyDown={(e) => handleCardKeyDown(e, () => handleTemplateClick(template))}
+                      >
                         <TemplateHeader>
                           <TemplateThumbnail>{template.thumbnail}</TemplateThumbnail>
                           <DifficultyBadge $difficulty={template.difficulty}>

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -65,23 +65,12 @@ export const CardHeader: React.FC<CardHeaderProps> = ({ title, description, acti
   </div>
 );
 
-export const CardContent: React.FC<{
+export type CardContentProps = React.HTMLAttributes<HTMLDivElement> & {
   children: React.ReactNode;
-  className?: string;
-  style?: React.CSSProperties;
-  onClick?: (e: React.MouseEvent) => void;
-  onMouseDown?: (e: React.MouseEvent) => void;
-  onMouseEnter?: (e: React.MouseEvent) => void;
-  onMouseMove?: (e: React.MouseEvent) => void;
-}> = ({ children, className, style, onClick, onMouseDown, onMouseEnter, onMouseMove }) => (
-  <div
-    className={className}
-    style={style}
-    onClick={onClick}
-    onMouseDown={onMouseDown}
-    onMouseEnter={onMouseEnter}
-    onMouseMove={onMouseMove}
-  >
+};
+
+export const CardContent: React.FC<CardContentProps> = ({ children, ...props }) => (
+  <div {...props}>
     {children}
   </div>
 );

--- a/frontend/src/pages/WorkForms/Catalog.a11yKeyboard.test.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.a11yKeyboard.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import Catalog from './Catalog';
+import { getAvailableWorkForms } from '../../services/workformsApi';
+import { quickActionsService } from '@/services/quickActionsService';
+
+vi.mock('../../services/workformsApi', () => ({
+  getAvailableWorkForms: vi.fn(),
+  createFormSubmission: vi.fn(),
+}));
+
+vi.mock('@/services/quickActionsService', () => ({
+  quickActionsService: {
+    getAvailableForms: vi.fn(),
+  },
+}));
+
+vi.mock('../../hooks/useWorkFormPermissions', () => ({
+  useWorkFormPermissions: () => ({
+    permissions: {
+      can_create: true,
+      can_edit: true,
+      can_publish: true,
+      can_archive: true,
+      can_delete: true,
+      allowed_modes: ['wizard', 'visual', 'expert'],
+      allowed_node_categories: [],
+      can_access_system_templates: true,
+      can_create_global_templates: false,
+      max_active_flows: null,
+      role: 'owner',
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  getUpgradeMessage: () => null,
+}));
+
+vi.mock('../../contexts/QuickActionsContext', () => ({
+  useQuickActions: () => ({
+    refreshQuickActions: vi.fn(),
+  }),
+}));
+
+describe('WorkForms Catalog keyboard a11y', () => {
+  it('opens a catalog card via Enter key', async () => {
+    vi.mocked(getAvailableWorkForms).mockResolvedValueOnce([
+      {
+        id: 'wf-1',
+        name: 'Beta WorkForm',
+        description: 'desc',
+        status: 'draft',
+        node_count: 1,
+        edge_count: 0,
+        updated_at: '2026-02-01T00:00:00Z',
+      } as any,
+    ]);
+
+    vi.mocked(quickActionsService.getAvailableForms).mockResolvedValueOnce([] as any);
+
+    const user = userEvent.setup();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/workforms/catalog']}>
+          <Routes>
+            <Route path="/workforms/catalog" element={<Catalog />} />
+            <Route path="/workforms/editor/:id" element={<div data-testid="editor-page" />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Wait for item to render
+    const cardButton = await screen.findByRole('button', { name: /open beta workform/i });
+
+    cardButton.focus();
+    expect(cardButton).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByTestId('editor-page')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WorkForms/Catalog.tsx
+++ b/frontend/src/pages/WorkForms/Catalog.tsx
@@ -1076,7 +1076,20 @@ const FormsFlowsCatalog: React.FC = () => {
             <GridContainer>
               {filteredTemplates.map((template) => (
                 <FormCard key={template.id}>
-                  <CardContent onClick={() => handleTemplateSelect(template)} style={{ cursor: 'pointer' }}>
+                  <CardContent
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => handleTemplateSelect(template)}
+                    onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleTemplateSelect(template);
+                      }
+                    }}
+                    aria-label={`Use template: ${template.name}`}
+                    style={{ cursor: 'pointer' }}
+                  >
                     <FormCardHeader>
                       <FormIcon>{template.thumbnail || '📋'}</FormIcon>
                       <FormInfo>
@@ -1132,7 +1145,20 @@ const FormsFlowsCatalog: React.FC = () => {
                 data-item-id={form.id}
                 data-kind={form.kind ?? (isWorkform ? 'workform' : 'form')}
               >
-                <CardContent onClick={() => void handleEditForm(form)} style={{ cursor: 'pointer' }}>
+                <CardContent
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => void handleEditForm(form)}
+                  onKeyDown={(e) => {
+                    if (e.target !== e.currentTarget) return;
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      void handleEditForm(form);
+                    }
+                  }}
+                  aria-label={`Open ${form.name}`}
+                  style={{ cursor: 'pointer' }}
+                >
                   <FormCardHeader>
                     <FormIcon>{form.icon || '📋'}</FormIcon>
                     <FormInfo>
@@ -1225,9 +1251,19 @@ const FormsFlowsCatalog: React.FC = () => {
                 data-kind={form.kind ?? (isWorkform ? 'workform' : 'form')}
               >
                 <CardContent
+                  role="button"
+                  tabIndex={0}
                   onClick={() => {
                     void handleEditForm(form);
                   }}
+                  onKeyDown={(e) => {
+                    if (e.target !== e.currentTarget) return;
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      void handleEditForm(form);
+                    }
+                  }}
+                  aria-label={`Open ${form.name}`}
                   style={{ cursor: 'pointer' }}
                 >
                   <FormCardHeader>

--- a/frontend/src/pages/WorkForms/InProgress.tsx
+++ b/frontend/src/pages/WorkForms/InProgress.tsx
@@ -196,16 +196,22 @@ const CardGrid = styled.div`
   }
 `;
 
-const Card = styled.div`
+const Card = styled.div<{ $clickable?: boolean }>`
   background: rgb(var(--color-surface));
   border: 1px solid rgb(var(--color-border));
   border-radius: var(--radius-lg, 12px);
   padding: 20px;
   transition: all 0.15s ease;
+  cursor: ${(p) => (p.$clickable ? 'pointer' : 'default')};
   
   &:hover {
     border-color: rgb(var(--color-primary));
     box-shadow: 0 4px 12px rgb(var(--color-text-primary) / 0.10);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: 2px;
   }
 `;
 
@@ -684,9 +690,18 @@ const FormsFlowsInProgress: React.FC = () => {
                 {filtered.map((ex) => (
                   <Card
                     key={ex.id}
+                    $clickable
                     role="listitem"
-                    aria-label={`${ex.workform_name}, status ${ex.status}`}
+                    tabIndex={0}
+                    aria-label={`${ex.workform_name}, status ${ex.status}. Press Enter to view details.`}
                     onClick={() => navigate(`/workforms/executions/${ex.id}`)}
+                    onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        navigate(`/workforms/executions/${ex.id}`);
+                      }
+                    }}
                   >
                     <CardHeader>
                       <CardIcon aria-hidden="true">


### PR DESCRIPTION
Keyboard/a11y improvements for WorkForms surfaces:\n\n- Catalog + Templates cards: make cards focusable and operable via Enter/Space (role=button, tabIndex=0)\n- Ensure nested controls (Run/Delete) don"t trigger card navigation\n- In Progress cards: keyboard open via Enter/Space + visible focus ring\n- TemplateSelector modal: proper dialog semantics (role/aria-*), Escape closes, focus trap + restore focus to opener\n- Tests: Catalog keyboard open + TemplateSelector dialog semantics/focus\n\nValidation:\n- npm -C frontend run type-check\n- npm -C frontend run test:ci