### PR TITLE
feat(frontend): HQ supplier/customer simplification

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -112,6 +112,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-04-27** — Mobile: switch deprecated `expo build:*` scripts to EAS Build (via `npx eas-cli`), add `eas.json` profiles and build metadata (`ios.buildNumber`, `android.versionCode`), and update mobile build docs. (PR: #4659)
 
+- **2026-04-27** — **Phase 10: Supplier/Customer Hierarchical UI Simplification**: flattened Suppliers/Customers sidebar navigation, made Supplier/Customer forms HQ-only (HQ labels + dynamic titles), simplified list views to Company Name + Actions with safe Aggregated Products rollups, and converged Supplier/Customer record view to Cockpit-style tabs (Plants/Locations, Dept. Contacts, Documents, Related, Recent Activity). (PR: pending)
+
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`
 - Stale/Zombie secrets found in GitHub but NOT in `manifests/env.manifest.json` (or legacy `DEV_`/`UAT_`/`PROD_` prefixed):

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -549,6 +549,76 @@ const augmentSchemaForFrontend = (
     };
   }
 
+  if (normalizedEntityKey === 'supplier' || normalizedEntityKey === 'customer') {
+    const fieldsByLowerKey = new Map<string, BackendField>();
+    fields.forEach((field) => {
+      const key = String(field?.key || '').trim().toLowerCase();
+      if (key) fieldsByLowerKey.set(key, field);
+    });
+
+    const pickFieldKey = (candidates: string[]): string | null => {
+      for (const raw of candidates) {
+        const key = String(raw || '').trim().toLowerCase();
+        if (key && fieldsByLowerKey.has(key)) return key;
+      }
+      return null;
+    };
+
+    const selectedKeys = [
+      pickFieldKey(['name', 'company_name']),
+      pickFieldKey(['phone', 'phone_number']),
+      pickFieldKey(['address', 'street_address']),
+      pickFieldKey(['city']),
+      pickFieldKey(['state']),
+      pickFieldKey(['zip_code', 'postal_code']),
+      pickFieldKey(['country']),
+    ].filter((k): k is string => Boolean(k));
+
+    const labelByKey: Record<string, string> = {
+      phone: 'HQ Phone Number',
+      phone_number: 'HQ Phone Number',
+      address: 'HQ Address',
+      street_address: 'HQ Address',
+      city: 'HQ City',
+      state: 'HQ State',
+      zip_code: 'HQ Zip Code',
+      postal_code: 'HQ Zip Code',
+      country: 'HQ Country',
+    };
+
+    const uniqueSelectedKeys = selectedKeys.filter((key, idx, arr) => arr.indexOf(key) === idx);
+
+    const nextFields: BackendField[] = [];
+    uniqueSelectedKeys.forEach((key) => {
+      const field = fieldsByLowerKey.get(key);
+      if (!field) return;
+
+      const label = labelByKey[key] || field.label;
+      const placeholder =
+        field.placeholder ||
+        (key === 'phone' || key === 'phone_number'
+          ? 'Enter HQ phone number'
+          : key === 'address' || key === 'street_address'
+            ? 'Enter HQ address'
+            : null);
+
+      nextFields.push({
+        ...field,
+        label,
+        required: key === 'name' ? true : field.required,
+        placeholder,
+      });
+    });
+
+    const keyFieldsHQ = uniqueSelectedKeys;
+
+    return {
+      ...schema,
+      key_fields: keyFieldsHQ,
+      fields: nextFields,
+    };
+  }
+
   if (normalizedEntityKey !== 'contact') return schema;
 
   const context = inferContactFormContext(values);
@@ -1153,8 +1223,14 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
       ...(recordValues || {}),
       ...(initialValues || {}),
     });
-    const formName =
-      schemaEntityKey === 'contact' && activeMode === 'create'
+
+    const hqEntity = schemaEntityKey === 'supplier' ? 'Supplier' : schemaEntityKey === 'customer' ? 'Customer' : null;
+
+    const formName = hqEntity
+      ? activeMode === 'create'
+        ? `New ${hqEntity} Headquarters`
+        : `${hqEntity} Headquarters Profile`
+      : schemaEntityKey === 'contact' && activeMode === 'create'
         ? getContactCreateTitle(contactContext)
         : schema?.name || `Universal Form: ${entityType}`;
 
@@ -1173,7 +1249,14 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   const modalTitle = useMemo(() => {
     const contactContext = inferContactFormContext(formInitialValues);
 
+    const hqEntity = schemaEntityKey === 'supplier' ? 'Supplier' : schemaEntityKey === 'customer' ? 'Customer' : null;
+
     if (activeMode === 'clone') return `Clone ${entityType}`;
+
+    if (hqEntity) {
+      return activeMode === 'create' ? `New ${hqEntity} Headquarters` : `${hqEntity} Headquarters Profile`;
+    }
+
     if (schemaEntityKey === 'contact' && activeMode === 'create') {
       return getContactCreateTitle(contactContext);
     }

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -83,49 +83,11 @@ export const navigation: NavigationItem[] = [
     label: 'Suppliers',
     icon: '🏭',
     path: '/suppliers',
-    children: [
-      {
-        label: 'New Supplier',
-        icon: '➕',
-        path: '/suppliers/new',
-      },
-      {
-        label: 'Plants',
-        icon: '🏢',
-        path: '/suppliers/plants',
-        children: [
-          {
-            label: 'Contacts',
-            icon: '📞',
-            path: '/suppliers/contacts',
-          },
-        ],
-      },
-    ],
   },
   {
     label: 'Customers',
     icon: '👥',
     path: '/customers',
-    children: [
-      {
-        label: 'New Customer',
-        icon: '➕',
-        path: '/customers/new',
-      },
-      {
-        label: 'Locations',
-        icon: '📍',
-        path: '/customers/locations',
-        children: [
-          {
-            label: 'Contacts',
-            icon: '📞',
-            path: '/customers/contacts',
-          },
-        ],
-      },
-    ],
   },
   {
     label: 'Orders',

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -1,1351 +1,250 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Input, Space, Table, Tag, Typography } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
 import { useQuery } from '@tanstack/react-query';
-import { logger } from '@/utils/logger';
-import { useSearchParams, useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
-import { useTheme } from '../contexts/ThemeContext';
-import { Theme } from '../config/theme';
-import { apiService, Customer, apiClient } from '../services/apiService';
-import { MultiSelect } from '../components/Shared';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
 import EntityFormSurface from '../components/Shared/EntityFormSurface';
+import { apiClient, apiService, type Customer } from '../services/apiService';
 
-interface CustomerLocation {
-  id: number;
-  name: string;
-  code?: string;
-  location_type?: string;
-  address?: string;
-  city?: string;
-  state?: string;
-  zip_code?: string;
-  country?: string;
-  contact_name?: string;
-  email?: string;
-  phone?: string;
-}
+type CustomerProduct = {
+  id: string | number;
+  product_code?: string;
+  name?: string;
+  product_name?: string;
+};
 
-interface CustomerContact {
-  id: number;
-  first_name: string;
-  last_name: string;
-  email?: string;
-  phone?: string;
-  position?: string;
-  company?: string;
-  department?: string;
-}
+type CustomerListRow = Customer & {
+  associated_products?: CustomerProduct[];
+};
 
 const Customers: React.FC = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const customersQuery = useQuery({
     queryKey: ['customers'],
     queryFn: apiService.getCustomers,
   });
 
-  const customers = customersQuery.data ?? [];
-  const loading = customersQuery.isLoading;
+  const customers = (customersQuery.data ?? []) as CustomerListRow[];
 
-  useEffect(() => {
-    if (customersQuery.error) {
-      logger.error('[Customers] Error fetching customers:', customersQuery.error);
-    }
-  }, [customersQuery.error]);
-
-  const [showForm, setShowForm] = useState(false);
-  const [showEditForm, setShowEditForm] = useState(false);
-  const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null);
-  const { theme } = useTheme();
-  const [products, setProducts] = useState<Array<{ id: string; product_code: string; name: string; protein_type: string }>>([]);
   const [searchText, setSearchText] = useState('');
+  const filteredCustomers = useMemo(() => {
+    const q = searchText.trim().toLowerCase();
+    if (!q) return customers;
+    return customers.filter((c) => String(c.name ?? '').toLowerCase().includes(q));
+  }, [customers, searchText]);
 
-  const [selectedCustomerId, setSelectedCustomerId] = useState<number | null>(null);
-  const [customerLocations, setCustomerLocations] = useState<CustomerLocation[]>([]);
-  const [locationsLoading, setLocationsLoading] = useState(false);
-  const [selectedLocationId, setSelectedLocationId] = useState<number | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editingCustomerId, setEditingCustomerId] = useState<string | number | null>(null);
 
-  const [customerContacts, setCustomerContacts] = useState<CustomerContact[]>([]);
-  const [contactsLoading, setContactsLoading] = useState(false);
-  const [locationContacts, setLocationContacts] = useState<CustomerContact[]>([]);
-  const [locationContactsLoading, setLocationContactsLoading] = useState(false);
+  const [productsByCustomerId, setProductsByCustomerId] = useState<Record<string, CustomerProduct[]>>({});
+  const [productsLoadingByCustomerId, setProductsLoadingByCustomerId] = useState<Record<string, boolean>>({});
 
-  const [locationProducts, setLocationProducts] = useState<Array<{ id: string; product_code: string; name?: string; protein_type?: string }>>([]);
-  const [locationProductsLoading, setLocationProductsLoading] = useState(false);
-
-  const [showContactModal, setShowContactModal] = useState(false);
-
-  const [showLocationModal, setShowLocationModal] = useState(false);
-  const [locationProductIds, setLocationProductIds] = useState<string[]>([]);
-
-  const [productPanel, setProductPanel] = useState<'history' | 'preferences'>('history');
-  const [historyProducts, setHistoryProducts] = useState<Array<{ id: string; product_code: string; name: string; protein_type?: string }>>([]);
-  const [preferenceProducts, setPreferenceProducts] = useState<Array<{ id: string; product_code: string; name: string; protein_type?: string }>>([]);
-  const [customerProductsLoading, setCustomerProductsLoading] = useState(false);
-
-
-  // Auto-open form if ?action=create in URL
+  // Back-compat: if anything still links to ?action=create
   useEffect(() => {
     if (searchParams.get('action') === 'create') {
-      setShowForm(true);
+      setCreateOpen(true);
       searchParams.delete('action');
       setSearchParams(searchParams);
     }
   }, [searchParams, setSearchParams]);
 
-  useEffect(() => {
-    fetchProducts();
-  }, []);
+  const loadCustomerProducts = useCallback(
+    async (customerId: string | number) => {
+      const id = String(customerId);
+      if (!id) return;
+      if (productsByCustomerId[id]?.length) return;
 
-  const fetchProducts = async () => {
-    try {
-      const response = await apiClient.get('/system/products/', { params: { limit: 500 } });
-      const productsData = Array.isArray(response.data)
-        ? response.data
-        : (response.data.results || []);
-      setProducts(productsData);
-    } catch (error) {
-      logger.error('[Customers] Error fetching products:', error);
-    }
-  };
-
-  const loadCustomerLocations = async (customerId: number) => {
-    try {
-      setLocationsLoading(true);
-      const response = await apiClient.get('locations/', {
-        params: { customer: customerId },
-      });
-      const raw = response.data as any;
-      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
-      setCustomerLocations(data);
-    } catch (error) {
-      console.error('[Customers] Failed to load locations:', error);
-      setCustomerLocations([]);
-    } finally {
-      setLocationsLoading(false);
-    }
-  };
-
-  const loadCustomerContacts = async (customerId: number) => {
-    try {
-      setContactsLoading(true);
-      const response = await apiClient.get('contacts/', {
-        params: { customer: customerId },
-      });
-      const raw = response.data as any;
-      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
-      setCustomerContacts(data);
-    } catch (error) {
-      console.error('[Customers] Failed to load contacts:', error);
-      setCustomerContacts([]);
-    } finally {
-      setContactsLoading(false);
-    }
-  };
-
-  const loadLocationContacts = async (locationId: number) => {
-    try {
-      setLocationContactsLoading(true);
-      const response = await apiClient.get('contacts/', {
-        params: { location: locationId },
-      });
-      const raw = response.data as any;
-      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
-      setLocationContacts(data);
-    } catch (error) {
-      console.error('[Customers] Failed to load location contacts:', error);
-      setLocationContacts([]);
-    } finally {
-      setLocationContactsLoading(false);
-    }
-  };
-
-  const loadLocationProducts = async (locationId: number) => {
-    try {
-      setLocationProductsLoading(true);
-      const resp = await apiClient.get(`/locations/${locationId}/available-products/`);
-      const raw = resp.data as any;
-      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
-      setLocationProducts(data);
-    } catch (error) {
-      console.error('[Customers] Failed to load location products:', error);
-      setLocationProducts([]);
-    } finally {
-      setLocationProductsLoading(false);
-    }
-  };
-
-  const loadCustomerProductPanels = async (customerId: number) => {
-    try {
-      setCustomerProductsLoading(true);
-
-      const historyResp = await apiClient.get(`/customers/${customerId}/product-history/`);
-      const history = Array.isArray(historyResp.data) ? historyResp.data : (historyResp.data?.results || []);
-      setHistoryProducts(history);
-
-      const prefResp = await apiClient.get(`/customers/${customerId}/products/`);
-      const basePrefs = Array.isArray(prefResp.data) ? prefResp.data : (prefResp.data?.results || []);
-
-      const locResp = await apiClient.get('locations/', { params: { customer: customerId } });
-      const locsRaw = locResp.data as any;
-      const locs = Array.isArray(locsRaw) ? locsRaw : Array.isArray(locsRaw?.results) ? locsRaw.results : [];
-
-      const locProductsLists = await Promise.allSettled(
-        (locs || []).map((loc: any) => apiClient.get(`/locations/${loc.id}/available-products/`))
-      );
-      const locProducts = locProductsLists
-        .filter((r): r is PromiseFulfilledResult<any> => r.status === 'fulfilled')
-        .flatMap((r) => (Array.isArray(r.value.data) ? r.value.data : []));
-
-      const merged = [...basePrefs, ...locProducts];
-      const byId = new Map<string, any>();
-      merged.forEach((p: any) => {
-        if (p?.id && !byId.has(String(p.id))) byId.set(String(p.id), p);
-      });
-      setPreferenceProducts(Array.from(byId.values()));
-    } catch (error) {
-      console.error('[Customers] Failed to load product panels:', error);
-      setHistoryProducts([]);
-      setPreferenceProducts([]);
-    } finally {
-      setCustomerProductsLoading(false);
-    }
-  };
-
-  const toggleCustomerDrilldown = async (customer: Customer) => {
-    if (selectedCustomerId === customer.id) {
-      setSelectedCustomerId(null);
-      setCustomerLocations([]);
-      setCustomerContacts([]);
-      setLocationContacts([]);
-      setSelectedLocationId(null);
-      return;
-    }
-
-    setSelectedCustomerId(customer.id);
-    setSelectedLocationId(null);
-    setLocationContacts([]);
-
-    await Promise.all([loadCustomerLocations(customer.id), loadCustomerContacts(customer.id)]);
-  };
-
-  const openCreateLocation = () => {
-    if (!selectedCustomerId) return;
-    setLocationProductIds([]);
-    setShowLocationModal(true);
-  };
-
-  const assignLocationProducts = async (locationId: number, productIds: string[]) => {
-    if (!productIds.length) return;
-
-    await Promise.allSettled(
-      productIds.map((productId) => apiClient.post(`/locations/${locationId}/available-products/`, { product: productId }))
-    );
-  };
-
-  const openCreateLocationContact = () => {
-    if (!selectedCustomerId || !selectedLocationId) return;
-    setShowContactModal(true);
-  };
-
-  const selectedLocation = selectedLocationId
-    ? customerLocations.find((l) => l.id === selectedLocationId)
-    : null;
-
-  useEffect(() => {
-    if (!selectedLocationId) {
-      setLocationContacts([]);
-      setLocationProducts([]);
-      return;
-    }
-
-    void loadLocationContacts(selectedLocationId);
-    void loadLocationProducts(selectedLocationId);
-  }, [selectedLocationId]);
-
-  useEffect(() => {
-    if (!selectedCustomerId) {
-      setHistoryProducts([]);
-      setPreferenceProducts([]);
-      return;
-    }
-
-    void loadCustomerProductPanels(selectedCustomerId);
-  }, [selectedCustomerId]);
-
-  const handleEdit = (customer: Customer) => {
-    setEditingCustomer(customer);
-    setShowEditForm(true);
-  };
-
-  const handleDelete = async (id: number) => {
-    if (window.confirm('Are you sure you want to delete this customer?')) {
+      setProductsLoadingByCustomerId((prev) => ({ ...prev, [id]: true }));
       try {
-        await apiService.deleteCustomer(id);
-        alert('Customer deleted successfully!');
-        await customersQuery.refetch(); // Re-fetch to update the list
-      } catch (error: unknown) {
-        // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
-        console.error('Error deleting customer:', error);
-        const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
-        const errorMessage = err?.response?.data?.detail 
-          || err?.response?.data?.message 
-          || err?.message 
-          || 'Failed to delete customer';
-        alert(`Error: ${errorMessage}`);
+        const resp = await apiClient.get(`/customers/${encodeURIComponent(id)}/products/`);
+        const raw = resp.data as unknown;
+        const rows = Array.isArray(raw) ? (raw as CustomerProduct[]) : [];
+        setProductsByCustomerId((prev) => ({ ...prev, [id]: rows }));
+      } finally {
+        setProductsLoadingByCustomerId((prev) => ({ ...prev, [id]: false }));
       }
-    }
-  };
+    },
+    [productsByCustomerId]
+  );
 
+  const handleDelete = useCallback(
+    async (customerId: string | number) => {
+      const confirmed = window.confirm('Are you sure you want to delete this customer?');
+      if (!confirmed) return;
 
-  if (loading) {
-    return <LoadingContainer $theme={theme}>Loading customers...</LoadingContainer>;
-  }
+      await apiService.deleteCustomer(Number(customerId));
+      void customersQuery.refetch();
+    },
+    [customersQuery]
+  );
 
-  const visibleCustomers = customers.filter((c) => {
-    if (!searchText.trim()) return true;
-    const haystack = [c.name, c.contact_person, c.email, c.phone, c.city, c.state]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase();
-    return haystack.includes(searchText.trim().toLowerCase());
-  });
+  const columns: ColumnsType<CustomerListRow> = useMemo(
+    () => [
+      {
+        title: 'Company Name',
+        key: 'name',
+        render: (_: unknown, record) => {
+          const displayName = String(record.name ?? '').trim() || 'Unnamed Customer';
+          const associatedProducts = Array.isArray(record.associated_products) ? record.associated_products : [];
+
+          return (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ fontWeight: 600, color: 'rgb(var(--color-text-primary))' }}>{displayName}</span>
+              {associatedProducts.length ? (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                  {associatedProducts.map((p) => (
+                    <Tag key={String(p.id)}>{p.product_name || p.name || p.product_code || 'Product'}</Tag>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          );
+        },
+      },
+      {
+        title: 'Actions',
+        key: 'actions',
+        width: 180,
+        render: (_: unknown, record) => (
+          <Space size="small">
+            <Button
+              type="link"
+              onClick={(e) => {
+                e.stopPropagation();
+                setEditingCustomerId(record.id ?? null);
+                setEditOpen(true);
+              }}
+            >
+              Edit
+            </Button>
+            <Button
+              type="link"
+              danger
+              onClick={(e) => {
+                e.stopPropagation();
+                void handleDelete(record.id ?? '');
+              }}
+            >
+              Delete
+            </Button>
+          </Space>
+        ),
+      },
+    ],
+    [handleDelete]
+  );
 
   return (
-    <PageContainer>
-      <Header>
-        <HeaderText>
-          <Title $theme={theme}>Customers</Title>
-          <Subtitle>Manage customer companies, locations, contacts, and preferred products</Subtitle>
-        </HeaderText>
-        <HeaderActions>
-          <SecondaryButton type="button" onClick={() => navigate('/customers/locations')}>
-            Locations
-          </SecondaryButton>
-          <SecondaryButton type="button" onClick={() => navigate('/customers/contacts')}>
-            Contacts
-          </SecondaryButton>
-          <AddButton onClick={() => { setEditingCustomer(null); setShowForm(true); }}>
-            + New Customer
-          </AddButton>
-        </HeaderActions>
-      </Header>
+    <div style={{ padding: 16 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
+        <div>
+          <Typography.Title level={3} style={{ margin: 0 }}>
+            Customers
+          </Typography.Title>
+          <Typography.Text style={{ color: 'rgb(var(--color-text-tertiary))' }}>
+            Headquarters list
+          </Typography.Text>
+        </div>
 
-      <TableControls>
-        <SearchInput
-          type="text"
-          value={searchText}
-          onChange={(e) => setSearchText(e.target.value)}
-          placeholder="Search customers by name, contact, email, phone, city, or state…"
-          aria-label="Search customers"
-        />
-      </TableControls>
+        <Space>
+          <Input
+            placeholder="Search customers"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            allowClear
+          />
+          <Button type="primary" onClick={() => setCreateOpen(true)}>
+            New Customer Headquarters
+          </Button>
+        </Space>
+      </div>
 
-      {showForm && (
-        <EntityFormSurface
-          entityType="customer"
-          mode="create"
-          isOpen={showForm}
-          onClose={() => setShowForm(false)}
-          onSuccess={() => {
-            setShowForm(false);
-            void customersQuery.refetch();
-          }}
-        />
-      )}
+      <Table<CustomerListRow>
+        rowKey={(row) => String(row.id ?? '')}
+        columns={columns}
+        dataSource={filteredCustomers}
+        loading={customersQuery.isLoading}
+        pagination={{ pageSize: 25 }}
+        onRow={(record) => ({
+          onClick: () => {
+            const id = String(record.id ?? '').trim();
+            if (!id) return;
+            navigate(`/customers/${encodeURIComponent(id)}`);
+          },
+        })}
+        expandable={{
+          onExpand: (expanded, record) => {
+            if (!expanded) return;
+            if (Array.isArray(record.associated_products) && record.associated_products.length) return;
+            void loadCustomerProducts(record.id ?? '');
+          },
+          expandedRowRender: (record) => {
+            const id = String(record.id ?? '').trim();
+            const loading = productsLoadingByCustomerId[id];
+            const products = productsByCustomerId[id] ?? [];
 
-      {showEditForm && editingCustomer && (
-        <EntityFormSurface
-          entityType="customer"
-          mode="edit"
-          entityId={editingCustomer.id}
-          isOpen={showEditForm}
-          onClose={() => {
-            setShowEditForm(false);
-            setEditingCustomer(null);
-          }}
-          onSuccess={() => {
-            setShowEditForm(false);
-            setEditingCustomer(null);
-            void customersQuery.refetch();
-          }}
-        />
-      )}
+            if (Array.isArray(record.associated_products) && record.associated_products.length) {
+              return null;
+            }
 
-      {showLocationModal && selectedCustomerId && (
-        <FormOverlay>
-          <FormContainer $theme={theme} data-testid="location-create-modal">
-            <FormHeader $theme={theme}>
-              <FormTitle $theme={theme}>Add New Location</FormTitle>
-              <CloseButton
-                $theme={theme}
-                onClick={() => setShowLocationModal(false)}
-                aria-label="Close location create modal"
-              >
-                ×
-              </CloseButton>
-            </FormHeader>
-
-            <FormGrid>
-              <FormGroup $fullWidth>
-                <MultiSelect
-                  value={locationProductIds}
-                  onChange={(values) => setLocationProductIds(values.map(String))}
-                  options={products.map((p) => ({
-                    value: String(p.id),
-                    label: `${p.product_code}${p.name ? ' - ' + p.name : ''}`,
-                  }))}
-                  label="Location Products List"
-                  placeholder="(Optional) Select products this location handles"
-                />
-              </FormGroup>
-            </FormGrid>
-
-            <EntityFormSurface
-              entityType="location"
-              mode="create"
-              variant="inline"
-              isOpen={showLocationModal}
-              onClose={() => setShowLocationModal(false)}
-              context={{ customerId: selectedCustomerId }}
-              initialValues={{
-                location_type: 'warehouse',
-                country: 'USA',
-              }}
-              onSuccess={(created) => {
-                const createdId = Number((created as { id?: unknown } | null)?.id);
-                const productIds = [...locationProductIds];
-
-                void (async () => {
-                  if (Number.isFinite(createdId) && createdId > 0) {
-                    try {
-                      await assignLocationProducts(createdId, productIds);
-                    } catch (error) {
-                      console.error('[Customers] Failed to assign location products:', error);
-                      alert('Location created, but failed to assign products.');
-                    }
-                  }
-
-                  setShowLocationModal(false);
-                  setLocationProductIds([]);
-                  await loadCustomerLocations(selectedCustomerId);
-                })();
-              }}
-            />
-          </FormContainer>
-        </FormOverlay>
-      )}
-
-      {showContactModal && selectedCustomerId && selectedLocationId && (
-        <EntityFormSurface
-          entityType="contact"
-          mode="create"
-          isOpen={showContactModal}
-          onClose={() => setShowContactModal(false)}
-          context={{ customerId: selectedCustomerId }}
-          initialValues={{
-            location: String(selectedLocationId),
-            department: 'sales',
-          }}
-          onSuccess={() => {
-            setShowContactModal(false);
-            void loadLocationContacts(selectedLocationId);
-          }}
-        />
-      )}
-
-      <TableContainer $theme={theme} data-testid="customers-table-container">
-        {customers.length === 0 ? (
-          <EmptyState>
-            <EmptyIcon>👥</EmptyIcon>
-            <EmptyText $theme={theme}>No customers found</EmptyText>
-            <EmptySubText $theme={theme}>Add your first customer to get started</EmptySubText>
-          </EmptyState>
-        ) : (
-          <Table>
-            <TableHeader $theme={theme}>
-              <TableRow $theme={theme}>
-                <TableHeaderCell $theme={theme}>Company Name</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Contact Person</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Email</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Phone</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Location</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Actions</TableHeaderCell>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {visibleCustomers.map((customer) => (
-                <React.Fragment key={customer.id}>
-                <TableRow
-                  $theme={theme}
-                  key={customer.id}
-                  onClick={() => void toggleCustomerDrilldown(customer)}
-                  role="button"
-                  tabIndex={0}
-                  aria-expanded={selectedCustomerId === customer.id}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      void toggleCustomerDrilldown(customer);
-                    }
-                  }}
-                >
-                  <TableCell $theme={theme}>
-                    <CompanyButton $theme={theme} $selected={selectedCustomerId === customer.id}>
-                      <div>
-                        <CompanyName $theme={theme}>{customer.name}</CompanyName>
-                        <CompanyMeta>
-                          {[
-                            customer.contact_person,
-                            customer.email,
-                            customer.phone,
-                            [customer.city, customer.state].filter(Boolean).join(', '),
-                          ]
-                            .filter(Boolean)
-                            .slice(0, 2)
-                            .join(' · ') || '—'}
-                        </CompanyMeta>
-                      </div>
-                      <CompanyChevron aria-hidden="true">{selectedCustomerId === customer.id ? '▾' : '▸'}</CompanyChevron>
-                    </CompanyButton>
-                  </TableCell>
-                  <TableCell $theme={theme}>{customer.contact_person || '-'}</TableCell>
-                  <TableCell $theme={theme}>{customer.email || '-'}</TableCell>
-                  <TableCell $theme={theme}>{customer.phone || '-'}</TableCell>
-                  <TableCell $theme={theme}>
-                    {customer.city && customer.state
-                      ? `${customer.city}, ${customer.state}`
-                      : customer.city || customer.state || '-'}
-                  </TableCell>
-                  <TableCell $theme={theme}>
-                    <RowActions>
-                      <ActionButton
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleEdit(customer);
-                        }}
-                      >
-                        Edit
-                      </ActionButton>
-                      <DeleteButton
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          void handleDelete(customer.id);
-                        }}
-                      >
-                        Delete
-                      </DeleteButton>
-                    </RowActions>
-                  </TableCell>
-                </TableRow>
-                {selectedCustomerId === customer.id && (
-                  <ExpandedTableRow $theme={theme}>
-                    <ExpandedTableCell $theme={theme} colSpan={6}>
-                      <ExpandedPanel>
-                        <ExpandedColumn>
-                          <ExpandedHeader>
-                            <ExpandedTitle>Locations</ExpandedTitle>
-                            <ExpandedActions>
-                              <SmallButton type="button" onClick={openCreateLocation} disabled={!selectedCustomerId}>
-                                + New Location
-                              </SmallButton>
-                              <SmallButton
-                                type="button"
-                                onClick={() => navigate(`/customers/${customer.id}/locations`)}
-                              >
-                                Manage
-                              </SmallButton>
-                            </ExpandedActions>
-                          </ExpandedHeader>
-
-                          {locationsLoading ? (
-                            <ExpandedHint>Loading locations…</ExpandedHint>
-                          ) : customerLocations.length === 0 ? (
-                            <ExpandedHint>No locations found for this customer.</ExpandedHint>
-                          ) : (
-                            <ChildList>
-                              {customerLocations.map((loc) => (
-                                <ChildListItem
-                                  key={loc.id}
-                                  type="button"
-                                  $active={selectedLocationId === loc.id}
-                                  onClick={() => {
-                                    setSelectedLocationId(loc.id);
-                                    if (selectedCustomerId) {
-                                      navigate(`/customers/${selectedCustomerId}/locations/${loc.id}`);
-                                    }
-                                  }}
-                                >
-                                  <ChildListName>{loc.name}</ChildListName>
-                                  <ChildListMeta>
-                                    {loc.location_type ? <span>{loc.location_type}</span> : null}
-                                    {loc.city || loc.state ? <span>• {`${loc.city || ''}${loc.city && loc.state ? ', ' : ''}${loc.state || ''}`}</span> : null}
-                                  </ChildListMeta>
-                                </ChildListItem>
-                              ))}
-                            </ChildList>
-                          )}
-                        </ExpandedColumn>
-
-                        <ExpandedColumn>
-                          <ExpandedHeader>
-                            <ExpandedTitle>Location Details & Contacts</ExpandedTitle>
-                            <ExpandedActions>
-                              <SmallButton type="button" onClick={openCreateLocationContact} disabled={!selectedLocationId}>
-                                + New Contact
-                              </SmallButton>
-                            </ExpandedActions>
-                          </ExpandedHeader>
-
-                          {selectedLocation ? (
-                            <MetaCard>
-                              <MetaRow>
-                                <MetaKey>Location Type</MetaKey>
-                                <MetaValue>{selectedLocation.location_type || '—'}</MetaValue>
-                              </MetaRow>
-                              <MetaRow>
-                                <MetaKey>Address</MetaKey>
-                                <MetaValue>{selectedLocation.address || '—'}</MetaValue>
-                              </MetaRow>
-                              <MetaRow>
-                                <MetaKey>City/State/ZIP</MetaKey>
-                                <MetaValue>
-                                  {selectedLocation.city || selectedLocation.state || selectedLocation.zip_code
-                                    ? `${selectedLocation.city || ''}${selectedLocation.city && selectedLocation.state ? ', ' : ''}${selectedLocation.state || ''}${(selectedLocation.city || selectedLocation.state) && selectedLocation.zip_code ? ' ' : ''}${selectedLocation.zip_code || ''}`.trim()
-                                    : '—'}
-                                </MetaValue>
-                              </MetaRow>
-                              <MetaRow>
-                                <MetaKey>Products List</MetaKey>
-                                <MetaValue>
-                                  {locationProductsLoading ? (
-                                    'Loading…'
-                                  ) : locationProducts.length ? (
-                                    <ChildListMeta>
-                                      {locationProducts.slice(0, 20).map((p) => (
-                                        <span key={String(p.id)}>{p.product_code}</span>
-                                      ))}
-                                    </ChildListMeta>
-                                  ) : (
-                                    '—'
-                                  )}
-                                </MetaValue>
-                              </MetaRow>
-                            </MetaCard>
-                          ) : (
-                            <ExpandedHint>Select a location to view details.</ExpandedHint>
-                          )}
-
-                          {selectedLocationId ? (
-                            locationContactsLoading ? (
-                              <ExpandedHint>Loading location contacts…</ExpandedHint>
-                            ) : locationContacts.length === 0 ? (
-                              <ExpandedHint>No contacts found for this location.</ExpandedHint>
-                            ) : (
-                              <ContactsList>
-                                {locationContacts.map((c) => (
-                                  <ContactRow key={c.id}>
-                                    <ContactName>
-                                      {c.first_name} {c.last_name}
-                                    </ContactName>
-                                    <ContactMeta>
-                                      <span>Dept: {String(c.department || '—')}</span>
-                                      {c.position ? <span>{c.position}</span> : null}
-                                      {c.email ? <span>{c.email}</span> : null}
-                                      {c.phone ? <span>{c.phone}</span> : null}
-                                    </ContactMeta>
-                                  </ContactRow>
-                                ))}
-                              </ContactsList>
-                            )
-                          ) : (
-                            <ExpandedHint>Select a location to view its contacts.</ExpandedHint>
-                          )}
-
-                          <MetaCard>
-                            <MetaRow>
-                              <MetaKey>Product History / Preference</MetaKey>
-                              <MetaValue>
-                                <SmallButton type="button" onClick={() => setProductPanel('history')} disabled={productPanel === 'history'}>
-                                  History
-                                </SmallButton>
-                                <SmallButton type="button" onClick={() => setProductPanel('preferences')} disabled={productPanel === 'preferences'}>
-                                  Preferences
-                                </SmallButton>
-                              </MetaValue>
-                            </MetaRow>
-
-                            {customerProductsLoading ? (
-                              <ExpandedHint>Loading products…</ExpandedHint>
-                            ) : productPanel === 'history' ? (
-                              historyProducts.length ? (
-                                <ChildListMeta>
-                                  {historyProducts.slice(0, 40).map((p) => (
-                                    <span key={String(p.id)}>{p.product_code}</span>
-                                  ))}
-                                </ChildListMeta>
-                              ) : (
-                                <ExpandedHint>No product history found.</ExpandedHint>
-                              )
-                            ) : preferenceProducts.length ? (
-                              <ChildListMeta>
-                                {preferenceProducts.slice(0, 40).map((p) => (
-                                  <span key={String(p.id)}>{p.product_code}</span>
-                                ))}
-                              </ChildListMeta>
-                            ) : (
-                              <ExpandedHint>No preferences found.</ExpandedHint>
-                            )}
-                          </MetaCard>
-                        </ExpandedColumn>
-                      </ExpandedPanel>
-                    </ExpandedTableCell>
-                  </ExpandedTableRow>
+            return (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <div style={{ color: 'rgb(var(--color-text-tertiary))' }}>Aggregated Products</div>
+                {loading ? (
+                  <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>Loading…</span>
+                ) : products.length ? (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                    {products.map((p) => (
+                      <Tag key={String(p.id)}>{p.product_name || p.name || p.product_code || 'Product'}</Tag>
+                    ))}
+                  </div>
+                ) : (
+                  <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>No products found.</span>
                 )}
-                </React.Fragment>
-              ))}
-            </TableBody>
-          </Table>
-        )}
-      </TableContainer>
-    </PageContainer>
+              </div>
+            );
+          },
+          rowExpandable: (record) => {
+            const hasInline = Array.isArray(record.associated_products) && record.associated_products.length > 0;
+            return !hasInline;
+          },
+        }}
+      />
+
+      <EntityFormSurface
+        entityType="customer"
+        mode="create"
+        variant="modal"
+        isOpen={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSuccess={() => {
+          setCreateOpen(false);
+          void customersQuery.refetch();
+        }}
+      />
+
+      <EntityFormSurface
+        entityType="customer"
+        mode="edit"
+        variant="modal"
+        isOpen={editOpen}
+        entityId={editingCustomerId ?? undefined}
+        onClose={() => {
+          setEditOpen(false);
+          setEditingCustomerId(null);
+        }}
+        onSuccess={() => {
+          setEditOpen(false);
+          setEditingCustomerId(null);
+          void customersQuery.refetch();
+        }}
+      />
+    </div>
   );
 };
-
-// Styled Components (reusing from Suppliers with customer theme colors)
-const LoadingContainer = styled.div<{ $theme: Theme }>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 200px;
-  font-size: 18px;
-  color: ${(props) => props.$theme.colors.textSecondary};
-`;
-
-const PageContainer = styled.div`
-  padding: 1.5rem;
-  background: rgb(var(--color-background));
-  min-height: 100%;
-  min-width: 0;
-
-  @media (max-width: 420px) {
-    padding: 1rem;
-  }
-`;
-
-const Header = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 12px;
-  margin-bottom: 16px;
-  flex-wrap: wrap;
-`;
-
-const HeaderText = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-const Title = styled.h1<{ $theme: Theme }>`
-  font-size: 32px;
-  font-weight: 700;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  margin: 0;
-
-  @media (max-width: 420px) {
-    font-size: 24px;
-  }
-`;
-
-const Subtitle = styled.p`
-  margin: 0;
-  font-size: 14px;
-  color: rgb(var(--color-text-secondary));
-`;
-
-const HeaderActions = styled.div`
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  flex-wrap: wrap;
-
-  @media (max-width: 420px) {
-    width: 100%;
-    flex-direction: column;
-    align-items: stretch;
-  }
-`;
-
-const SecondaryButton = styled.button`
-  background: transparent;
-  color: rgb(var(--color-text-primary));
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 8px;
-  padding: 10px 14px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  min-height: 44px;
-
-  @media (max-width: 420px) {
-    width: 100%;
-  }
-
-  &:hover {
-    background: rgb(var(--color-surface));
-    border-color: rgb(var(--color-primary) / 0.35);
-  }
-`;
-
-const AddButton = styled.button`
-  background: rgb(var(--color-primary));
-  color: rgb(var(--color-primary-foreground));
-  border: none;
-  border-radius: 8px;
-  padding: 10px 16px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  min-height: 44px;
-
-  @media (max-width: 420px) {
-    width: 100%;
-    justify-content: center;
-  }
-
-  &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 15px rgb(var(--color-primary) / 0.25);
-    filter: brightness(0.98);
-  }
-`;
-
-const TableControls = styled.div`
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  margin-bottom: 12px;
-  flex-wrap: wrap;
-  min-width: 0;
-`;
-
-const SearchInput = styled.input`
-  width: min(520px, 100%);
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid rgb(var(--color-border));
-  background: rgb(var(--color-surface));
-  color: rgb(var(--color-text-primary));
-  min-height: 44px;
-
-  @media (max-width: 520px) {
-    width: 100%;
-    font-size: 16px; /* iOS Safari zoom-on-focus prevention */
-  }
-
-  &::placeholder {
-    color: rgb(var(--color-text-secondary));
-  }
-
-  &:focus {
-    outline: none;
-    border-color: rgb(var(--color-primary));
-    box-shadow: 0 0 0 3px rgb(var(--color-primary) / 0.12);
-  }
-`;
-
-const FormOverlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-`;
-
-const FormContainer = styled.div<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.surface};
-  border-radius: 12px;
-  padding: 0;
-  max-width: 600px;
-  width: 90%;
-  max-height: 80vh;
-  overflow-y: auto;
-`;
-
-const FormHeader = styled.div<{ $theme: Theme }>`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px 30px;
-  border-bottom: 1px solid ${(props) => props.$theme.colors.border};
-
-  @media (max-width: 420px) {
-    padding: 14px 16px;
-  }
-`;
-
-const FormTitle = styled.h2<{ $theme: Theme }>`
-  margin: 0;
-  color: ${(props) => props.$theme.colors.textPrimary};
-`;
-
-const CloseButton = styled.button<{ $theme: Theme }>`
-  background: none;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  color: ${(props) => props.$theme.colors.textSecondary};
-  min-width: 44px;
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  &:hover {
-    color: ${(props) => props.$theme.colors.textPrimary};
-  }
-`;
-
-const Form = styled.form`
-  padding: 30px;
-`;
-
-const FormGrid = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-  margin-bottom: 30px;
-
-  @media (max-width: 520px) {
-    grid-template-columns: 1fr;
-    gap: 12px;
-    margin-bottom: 16px;
-  }
-`;
-
-const FormGroup = styled.div<{ $fullWidth?: boolean }>`
-  grid-column: ${(props) => (props.$fullWidth ? '1 / -1' : 'auto')};
-`;
-
-const Label = styled.label<{ $theme: Theme }>`
-  display: block;
-  margin-bottom: 5px;
-  font-weight: 500;
-  color: ${(props) => props.$theme.colors.textPrimary};
-`;
-
-const Input = styled.input<{ $theme: Theme }>`
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid ${(props) => props.$theme.colors.border};
-  border-radius: 6px;
-  font-size: 14px;
-  transition: border-color 0.2s ease;
-
-  &:focus {
-    outline: none;
-    border-color: rgb(var(--color-primary));
-  }
-`;
-
-const FormActions = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-`;
-
-const CancelButton = styled.button`
-  background: rgb(var(--color-text-secondary));
-  color: rgb(var(--color-primary-foreground));
-  border: none;
-  border-radius: 6px;
-  padding: 10px 20px;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background: rgb(var(--color-text-secondary));
-  }
-`;
-
-const SubmitButton = styled.button`
-  background: rgb(var(--color-primary));
-  color: rgb(var(--color-primary-foreground));
-  border: none;
-  border-radius: 6px;
-  padding: 10px 20px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 15px rgb(var(--color-primary) / 0.3);
-  }
-`;
-
-const TableContainer = styled.div<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.surface};
-  border-radius: 12px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: touch;
-  box-shadow: 0 2px 10px ${(props) => props.$theme.colors.shadow};
-  max-width: 100%;
-  min-width: 0;
-`;
-
-const EmptyState = styled.div`
-  padding: 60px 20px;
-  text-align: center;
-`;
-
-const EmptyIcon = styled.div`
-  font-size: 48px;
-  margin-bottom: 16px;
-`;
-
-const EmptyText = styled.div<{ $theme: Theme }>`
-  font-size: 18px;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  margin-bottom: 8px;
-`;
-
-const EmptySubText = styled.div<{ $theme: Theme }>`
-  color: ${(props) => props.$theme.colors.textSecondary};
-`;
-
-const Table = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-`;
-
-const TableHeader = styled.thead<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.background};
-
-  @media (max-width: 420px) {
-    th:nth-child(2),
-    th:nth-child(3),
-    th:nth-child(4),
-    th:nth-child(5) {
-      display: none;
-    }
-  }
-`;
-
-const TableBody = styled.tbody``;
-
-const TableRow = styled.tr<{ $theme: Theme }>`
-  border-bottom: 1px solid ${(props) => props.$theme.colors.border};
-  cursor: pointer;
-
-  @media (max-width: 420px) {
-    td:nth-child(2),
-    td:nth-child(3),
-    td:nth-child(4),
-    td:nth-child(5) {
-      display: none;
-    }
-  }
-
-  &:hover {
-    background: ${(props) => props.$theme.colors.background};
-  }
-
-  &:focus-visible {
-    outline: 2px solid rgba(var(--color-primary), 0.5);
-    outline-offset: -2px;
-  }
-`;
-
-const TableHeaderCell = styled.th<{ $theme: Theme }>`
-  padding: 15px 20px;
-  text-align: left;
-  font-weight: 600;
-  color: ${(props) => props.$theme.colors.textPrimary};
-
-  @media (max-width: 420px) {
-    padding: 12px 14px;
-  }
-`;
-
-const TableCell = styled.td<{ $theme: Theme }>`
-  padding: 15px 20px;
-
-  @media (max-width: 420px) {
-    padding: 12px 14px;
-  }
-`;
-
-const CompanyButton = styled.div<{ $theme: Theme; $selected: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 8px;
-  border: 1px solid ${(p) => (p.$selected ? 'rgba(var(--color-primary), 0.6)' : 'transparent')};
-  border-radius: 8px;
-  background: ${(p) => (p.$selected ? 'rgba(var(--color-primary), 0.08)' : 'transparent')};
-  pointer-events: none;
-`;
-
-const CompanyName = styled.div<{ $theme: Theme }>`
-  font-weight: 600;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  overflow-wrap: anywhere;
-  word-break: break-word;
-`;
-
-const CompanyMeta = styled.div`
-  display: none;
-  margin-top: 2px;
-  font-size: 12px;
-  color: rgb(var(--color-text-secondary));
-  line-height: 1.2;
-  word-break: break-word;
-
-  @media (max-width: 420px) {
-    display: block;
-  }
-`;
-
-const RowActions = styled.div`
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-
-  @media (max-width: 420px) {
-    justify-content: flex-start;
-  }
-`;
-
-const CompanyChevron = styled.span`
-  color: rgb(var(--color-text-secondary));
-  font-size: 14px;
-`;
-
-const ExpandedTableRow = styled.tr<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.surface};
-`;
-
-const ExpandedTableCell = styled.td<{ $theme: Theme }>`
-  padding: 14px 18px;
-  border-bottom: 1px solid ${(props) => props.$theme.colors.border};
-`;
-
-const ExpandedPanel = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-
-  @media (max-width: 980px) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const ExpandedColumn = styled.div`
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 12px;
-  background: rgb(var(--color-surface));
-  padding: 12px;
-`;
-
-const ExpandedHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 10px;
-
-  @media (max-width: 420px) {
-    flex-wrap: wrap;
-  }
-`;
-
-const ExpandedTitle = styled.div`
-  font-weight: 700;
-  color: rgb(var(--color-text-primary));
-`;
-
-const ExpandedActions = styled.div`
-  display: inline-flex;
-  gap: 8px;
-
-  @media (max-width: 420px) {
-    flex-wrap: wrap;
-    width: 100%;
-  }
-`;
-
-const SmallButton = styled.button`
-  padding: 6px 10px;
-  border-radius: 8px;
-  border: 1px solid rgb(var(--color-border));
-  background: rgb(var(--color-surface));
-  color: rgb(var(--color-text-primary));
-  font-size: 12px;
-  cursor: pointer;
-
-  &:hover:not(:disabled) {
-    border-color: rgba(var(--color-primary), 0.6);
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-`;
-
-const ExpandedHint = styled.div`
-  padding: 12px;
-  color: rgb(var(--color-text-secondary));
-  font-size: 13px;
-`;
-
-const ChildList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;
-
-const ChildListItem = styled.button<{ $active: boolean }>`
-  text-align: left;
-  border-radius: 10px;
-  border: 1px solid ${(p) => (p.$active ? 'rgba(var(--color-primary), 0.7)' : 'transparent')};
-  background: ${(p) => (p.$active ? 'rgba(var(--color-primary), 0.08)' : 'transparent')};
-  padding: 10px 12px;
-  cursor: pointer;
-
-  &:hover {
-    border-color: ${(p) => (p.$active ? 'rgba(var(--color-primary), 0.55)' : 'rgb(var(--color-border))')};
-    background: rgb(var(--color-surface-hover));
-  }
-`;
-
-const ChildListName = styled.div`
-  font-weight: 650;
-  color: rgb(var(--color-text-primary));
-`;
-
-const ChildListMeta = styled.div`
-  margin-top: 2px;
-  font-size: 12px;
-  color: rgb(var(--color-text-secondary));
-  display: inline-flex;
-  gap: 8px;
-  flex-wrap: wrap;
-`;
-
-const MetaCard = styled.div`
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 10px;
-  background: rgba(var(--color-surface), 0.6);
-  padding: 10px 12px;
-  margin-bottom: 10px;
-`;
-
-const MetaRow = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 6px 0;
-`;
-
-const MetaKey = styled.div`
-  font-size: 12px;
-  font-weight: 650;
-  color: rgb(var(--color-text-secondary));
-`;
-
-const MetaValue = styled.div`
-  font-size: 13px;
-  color: rgb(var(--color-text-primary));
-  min-width: 0;
-  text-align: right;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-`;
-
-const ContactsList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;
-
-const ContactRow = styled.div`
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 10px;
-  padding: 10px 12px;
-  background: rgb(var(--color-surface));
-`;
-
-const ContactName = styled.div`
-  font-weight: 650;
-  color: rgb(var(--color-text-primary));
-`;
-
-const ContactMeta = styled.div`
-  margin-top: 2px;
-  font-size: 12px;
-  color: rgb(var(--color-text-secondary));
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-`;
-
-const ActionButton = styled.button`
-  background: rgb(var(--color-primary));
-  color: rgb(var(--color-primary-foreground));
-  border: none;
-  border-radius: 4px;
-  padding: 6px 12px;
-  font-size: 12px;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background: rgba(var(--color-primary), 0.9);
-  }
-
-  @media (max-width: 420px) {
-    min-height: 44px;
-  }
-`;
-
-const DeleteButton = styled.button`
-  background: rgb(var(--color-danger));
-  color: rgb(var(--color-primary-foreground));
-  border: none;
-  border-radius: 4px;
-  padding: 6px 12px;
-  font-size: 12px;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background: rgba(var(--color-danger), 0.9);
-  }
-
-  @media (max-width: 420px) {
-    min-height: 44px;
-  }
-`;
-
-const HelperText = styled.div<{ $theme: Theme }>`
-  margin-top: 8px;
-  font-size: 12px;
-  color: ${(props) => props.$theme.colors.textSecondary};
-  font-style: italic;
-`;
 
 export default Customers;

--- a/frontend/src/pages/Entities/UniversalEntityRecordPage.tsx
+++ b/frontend/src/pages/Entities/UniversalEntityRecordPage.tsx
@@ -67,6 +67,9 @@ export const UniversalEntityRecordPage: React.FC<UniversalEntityRecordPageProps>
   const [childCreateOpen, setChildCreateOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
 
+  const [deptContactsRows, setDeptContactsRows] = useState<Record<string, unknown>[]>([]);
+  const [deptContactsLoading, setDeptContactsLoading] = useState(false);
+
   const [overviewLoading, setOverviewLoading] = useState(false);
   const [relationshipCounts, setRelationshipCounts] = useState<Record<string, number>>({});
   const [relationships, setRelationships] = useState<Record<string, unknown[]>>({});
@@ -96,6 +99,29 @@ export const UniversalEntityRecordPage: React.FC<UniversalEntityRecordPageProps>
     }
   }, [childEndpoint, childFilterKey, entityId, isCustomer, isSupplier, mode]);
 
+  const loadDeptContacts = useCallback(async () => {
+    if (!entityId || !(isSupplier || isCustomer) || mode !== 'view') return;
+    setDeptContactsLoading(true);
+    try {
+      const params: Record<string, unknown> = {
+        page_size: 50,
+        limit: 50,
+      };
+      params[childFilterKey] = entityId;
+
+      const resp = await apiClient.get('contacts/', { params });
+      const payload = resp.data as unknown;
+      const payloadObj = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null;
+      const rows = Array.isArray(payloadObj?.results) ? (payloadObj?.results as unknown[]) : (payload as unknown[]);
+
+      setDeptContactsRows(
+        (Array.isArray(rows) ? rows : []).filter((r) => r && typeof r === 'object') as Record<string, unknown>[]
+      );
+    } finally {
+      setDeptContactsLoading(false);
+    }
+  }, [childFilterKey, entityId, isCustomer, isSupplier, mode]);
+
   const loadOverview = useCallback(async () => {
     if (!entityId || mode !== 'view') return;
 
@@ -124,6 +150,10 @@ export const UniversalEntityRecordPage: React.FC<UniversalEntityRecordPageProps>
   useEffect(() => {
     void loadChildRows();
   }, [loadChildRows]);
+
+  useEffect(() => {
+    void loadDeptContacts();
+  }, [loadDeptContacts]);
 
   useEffect(() => {
     void loadOverview();
@@ -262,6 +292,7 @@ export const UniversalEntityRecordPage: React.FC<UniversalEntityRecordPageProps>
               setEditOpen(false);
               void loadOverview();
               void loadChildRows();
+              void loadDeptContacts();
             }}
           />
 
@@ -277,110 +308,174 @@ export const UniversalEntityRecordPage: React.FC<UniversalEntityRecordPageProps>
 
           <Tabs
             style={{ marginTop: 12 }}
-            items={[
-              {
-                key: 'overview',
-                label: 'Overview',
-                children: overviewLoading ? (
-                  <div style={{ padding: 12 }}>
-                    <Spin />
-                  </div>
-                ) : (
-                  <>
-                    <Card size="small" title="AI Summary" style={{ marginBottom: 12 }}>
-                      <Typography.Paragraph style={{ marginBottom: 0 }}>
-                        {summary || 'Summary unavailable.'}
-                      </Typography.Paragraph>
-                    </Card>
-
-                    <Card size="small" title="Counts">
-                      {Object.keys(relationshipCounts).length ? (
-                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
-                          {Object.entries(relationshipCounts).map(([k, v]) => (
-                            <div key={k} style={{ minWidth: 160 }}>
-                              <div style={{ fontSize: 12, color: 'rgb(var(--color-text-tertiary))' }}>{k}</div>
-                              <div style={{ fontSize: 16, fontWeight: 600, color: 'rgb(var(--color-text-primary))' }}>
-                                {v}
-                              </div>
+            items={
+              isSupplier || isCustomer
+                ? [
+                    {
+                      key: 'children',
+                      label: childLabel,
+                      children: (
+                        <Card
+                          size="small"
+                          title={childLabel}
+                          extra={
+                            <Button type="primary" onClick={() => setChildCreateOpen(true)}>
+                              New {childEntityDisplayName}
+                            </Button>
+                          }
+                        >
+                          {childLoading ? (
+                            <div style={{ padding: 12 }}>
+                              <Spin />
                             </div>
-                          ))}
+                          ) : (
+                            <UnifiedEntityTable
+                              entityType={childEntityType}
+                              data={childRows as any}
+                              loading={childLoading}
+                              onReload={loadChildRows}
+                              recordPathForRow={(_t, row: Record<string, unknown>) => {
+                                const childId = String((row as { id?: unknown }).id ?? '').trim();
+                                if (!childId) return null;
+                                return isSupplier
+                                  ? `/suppliers/${encodeURIComponent(entityId)}/plants/${encodeURIComponent(childId)}`
+                                  : `/customers/${encodeURIComponent(entityId)}/locations/${encodeURIComponent(childId)}`;
+                              }}
+                            />
+                          )}
+                        </Card>
+                      ),
+                    },
+                    {
+                      key: 'dept_contacts',
+                      label: 'Dept. Contacts',
+                      children: (
+                        <Card size="small" title="Dept. Contacts">
+                          {deptContactsLoading ? (
+                            <div style={{ padding: 12 }}>
+                              <Spin />
+                            </div>
+                          ) : deptContactsRows.length ? (
+                            <UnifiedEntityTable entityType="contact" data={deptContactsRows as any} />
+                          ) : (
+                            <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>No contacts found.</span>
+                          )}
+                        </Card>
+                      ),
+                    },
+                    {
+                      key: 'documents',
+                      label: 'Documents',
+                      children: (
+                        <Card size="small" title="Documents">
+                          <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>
+                            Document management is coming soon.
+                          </span>
+                        </Card>
+                      ),
+                    },
+                    {
+                      key: 'related',
+                      label: 'Related',
+                      children: (
+                        <>
+                          {renderRelationshipTable('inquiries', 'Inquiries')}
+                          {renderRelationshipTable('recent_orders', 'Recent Orders')}
+                          {renderRelationshipTable('invoices', 'Invoices')}
+                          {renderRelationshipTable('related_products', 'Related Products')}
+                        </>
+                      ),
+                    },
+                    {
+                      key: 'recent_activity',
+                      label: 'Recent Activity',
+                      children: numericEntityId ? (
+                        <ActivityFeed entityType={normalizedEntityType as any} entityId={numericEntityId} showCreateForm />
+                      ) : (
+                        <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>Recent activity unavailable.</span>
+                      ),
+                    },
+                  ]
+                : [
+                    {
+                      key: 'overview',
+                      label: 'Overview',
+                      children: overviewLoading ? (
+                        <div style={{ padding: 12 }}>
+                          <Spin />
                         </div>
                       ) : (
-                        <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>No related counts available.</span>
-                      )}
-                    </Card>
-                  </>
-                ),
-              },
-              {
-                key: 'details',
-                label: 'Details',
-                children: (
-                  <EntityFormSurface
-                    entityType={entityType}
-                    mode="view"
-                    variant="inline"
-                    isOpen={true}
-                    entityId={entityId}
-                    onClose={() => navigate(basePath)}
-                  />
-                ),
-              },
-              {
-                key: 'related',
-                label: 'Related',
-                children: (
-                  <>
-                    {renderRelationshipTable('contacts', 'Contacts')}
-                    {renderRelationshipTable('inquiries', 'Inquiries')}
-                    {renderRelationshipTable('recent_orders', 'Recent Orders')}
-                    {renderRelationshipTable('invoices', 'Invoices')}
-                    {renderRelationshipTable('related_products', 'Related Products')}
+                        <>
+                          <Card size="small" title="AI Summary" style={{ marginBottom: 12 }}>
+                            <Typography.Paragraph style={{ marginBottom: 0 }}>
+                              {summary || 'Summary unavailable.'}
+                            </Typography.Paragraph>
+                          </Card>
 
-                    {(isSupplier || isCustomer) && (
-                      <Card
-                        size="small"
-                        title={childLabel}
-                        extra={
-                          <Button type="primary" onClick={() => setChildCreateOpen(true)}>
-                            New {childEntityDisplayName}
-                          </Button>
-                        }
-                      >
-                        {childLoading ? (
-                          <div style={{ padding: 12 }}>
-                            <Spin />
-                          </div>
-                        ) : (
-                          <UnifiedEntityTable
-                            entityType={childEntityType}
-                            data={childRows as any}
-                            loading={childLoading}
-                            onReload={loadChildRows}
-                          />
-                        )}
-                      </Card>
-                    )}
-                  </>
-                ),
-              },
-              {
-                key: 'workflows',
-                label: 'Workflows',
-                children: (
-                  <EntityWorkflowStatusPanel entityType={normalizedEntityType} entityId={String(entityId)} />
-                ),
-              },
-              {
-                key: 'timeline',
-                label: 'Timeline',
-                children: numericEntityId ? (
-                  <ActivityFeed entityType={normalizedEntityType as any} entityId={numericEntityId} showCreateForm />
-                ) : (
-                  <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>Timeline unavailable.</span>
-                ),
-              },
-            ]}
+                          <Card size="small" title="Counts">
+                            {Object.keys(relationshipCounts).length ? (
+                              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+                                {Object.entries(relationshipCounts).map(([k, v]) => (
+                                  <div key={k} style={{ minWidth: 160 }}>
+                                    <div style={{ fontSize: 12, color: 'rgb(var(--color-text-tertiary))' }}>{k}</div>
+                                    <div style={{ fontSize: 16, fontWeight: 600, color: 'rgb(var(--color-text-primary))' }}>
+                                      {v}
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>No related counts available.</span>
+                            )}
+                          </Card>
+                        </>
+                      ),
+                    },
+                    {
+                      key: 'details',
+                      label: 'Details',
+                      children: (
+                        <EntityFormSurface
+                          entityType={entityType}
+                          mode="view"
+                          variant="inline"
+                          isOpen={true}
+                          entityId={entityId}
+                          onClose={() => navigate(basePath)}
+                        />
+                      ),
+                    },
+                    {
+                      key: 'related',
+                      label: 'Related',
+                      children: (
+                        <>
+                          {renderRelationshipTable('contacts', 'Contacts')}
+                          {renderRelationshipTable('inquiries', 'Inquiries')}
+                          {renderRelationshipTable('recent_orders', 'Recent Orders')}
+                          {renderRelationshipTable('invoices', 'Invoices')}
+                          {renderRelationshipTable('related_products', 'Related Products')}
+                        </>
+                      ),
+                    },
+                    {
+                      key: 'workflows',
+                      label: 'Workflows',
+                      children: (
+                        <EntityWorkflowStatusPanel entityType={normalizedEntityType} entityId={String(entityId)} />
+                      ),
+                    },
+                    {
+                      key: 'timeline',
+                      label: 'Timeline',
+                      children: numericEntityId ? (
+                        <ActivityFeed entityType={normalizedEntityType as any} entityId={numericEntityId} showCreateForm />
+                      ) : (
+                        <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>Timeline unavailable.</span>
+                      ),
+                    },
+                  ]
+            }
           />
 
           {(isSupplier || isCustomer) && (

--- a/frontend/src/pages/Suppliers.test.tsx
+++ b/frontend/src/pages/Suppliers.test.tsx
@@ -1,52 +1,21 @@
-/**
- * Tests for Suppliers Component
- * 
- * Specifically tests the fix for: f.map is not a function
- * Issue: Products state must always be an array to prevent .map() errors
- */
-
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 import Suppliers from './Suppliers';
 import * as apiService from '../services/apiService';
 
-// Mock the API service
 vi.mock('../services/apiService', () => ({
   apiClient: {
     get: vi.fn(),
-    post: vi.fn(),
-    patch: vi.fn(),
-    delete: vi.fn(),
   },
   apiService: {
     getSuppliers: vi.fn(),
-    createSupplier: vi.fn(),
-    updateSupplier: vi.fn(),
     deleteSupplier: vi.fn(),
   },
 }));
 
-// Mock the theme context
-vi.mock('../contexts/ThemeContext', () => ({
-  useTheme: () => ({
-    theme: {
-      colors: {
-        textSecondary: '#666',
-        textPrimary: '#000',
-        surface: '#fff',
-        background: '#f5f5f5',
-        border: '#ddd',
-        primary: '#007bff',
-        shadow: 'rgba(0,0,0,0.1)',
-        surfaceHover: '#f9f9f9',
-      },
-    },
-  }),
-}));
-
-// Wrapper component for tests
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -61,179 +30,40 @@ const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   );
 };
 
-describe('Suppliers Component', () => {
+describe('Suppliers page (HQ simplified)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default mock implementations
-    (apiService.apiService.getSuppliers as any).mockResolvedValue([]);
+    (apiService.apiService.getSuppliers as any).mockResolvedValue([
+      { id: 1, name: 'Acme Meats' },
+      { id: 2, name: 'Bravo Foods' },
+    ]);
   });
 
-  describe('handling products API responses', () => {
-    it('handles array response correctly', async () => {
-      const mockProducts = [
-        { id: 1, product_code: 'P001', effective_name: 'Product 1' },
-        { id: 2, product_code: 'P002', effective_name: 'Product 2' },
-      ];
+  it('renders Suppliers header and lists suppliers', async () => {
+    render(
+      <TestWrapper>
+        <Suppliers />
+      </TestWrapper>
+    );
 
-      (apiService.apiClient.get as any).mockResolvedValue({
-        data: mockProducts,
-      });
+    expect(await screen.findByText('Suppliers')).toBeInTheDocument();
 
-      render(
-        <TestWrapper>
-          <Suppliers />
-        </TestWrapper>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Suppliers')).toBeInTheDocument();
-      });
-
-      // Should not throw "f.map is not a function" error
-      expect(apiService.apiClient.get).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByText('Acme Meats')).toBeInTheDocument();
+      expect(screen.getByText('Bravo Foods')).toBeInTheDocument();
     });
 
-    it('handles null response gracefully', async () => {
-      (apiService.apiClient.get as any).mockResolvedValue({
-        data: null,
-      });
-
-      render(
-        <TestWrapper>
-          <Suppliers />
-        </TestWrapper>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Suppliers')).toBeInTheDocument();
-      });
-
-      // Should not throw "f.map is not a function" error
-      expect(apiService.apiClient.get).toHaveBeenCalled();
-    });
-
-    it('handles undefined response gracefully', async () => {
-      (apiService.apiClient.get as any).mockResolvedValue({
-        data: undefined,
-      });
-
-      render(
-        <TestWrapper>
-          <Suppliers />
-        </TestWrapper>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Suppliers')).toBeInTheDocument();
-      });
-
-      // Should not throw "f.map is not a function" error
-      expect(apiService.apiClient.get).toHaveBeenCalled();
-    });
-
-    it('handles object response instead of array', async () => {
-      (apiService.apiClient.get as any).mockResolvedValue({
-        data: { results: [], count: 0 }, // Paginated response format
-      });
-
-      render(
-        <TestWrapper>
-          <Suppliers />
-        </TestWrapper>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Suppliers')).toBeInTheDocument();
-      });
-
-      // Should not throw "f.map is not a function" error
-      expect(apiService.apiClient.get).toHaveBeenCalled();
-    });
-
-    it('handles API error gracefully', async () => {
-      (apiService.apiClient.get as any).mockRejectedValue(
-        new Error('Network error')
-      );
-
-      render(
-        <TestWrapper>
-          <Suppliers />
-        </TestWrapper>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Suppliers')).toBeInTheDocument();
-      });
-
-      // Should not throw "f.map is not a function" error
-      expect(apiService.apiClient.get).toHaveBeenCalled();
-    });
-
-    it('handles empty array response', async () => {
-      (apiService.apiClient.get as any).mockResolvedValue({
-        data: [],
-      });
-
-      render(
-        <TestWrapper>
-          <Suppliers />
-        </TestWrapper>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Suppliers')).toBeInTheDocument();
-      });
-
-      // Should not throw "f.map is not a function" error
-      expect(apiService.apiClient.get).toHaveBeenCalled();
-    });
+    expect(apiService.apiService.getSuppliers).toHaveBeenCalled();
   });
 
-  describe('products filtering', () => {
-    it('handles filtered products response gracefully', async () => {
-      const mockProducts = [
-        { id: 1, product_code: 'P001', effective_name: 'Beef Product' },
-      ];
+  it('does not prefetch products on mount (no N+1)', async () => {
+    render(
+      <TestWrapper>
+        <Suppliers />
+      </TestWrapper>
+    );
 
-      // First call returns all products
-      (apiService.apiClient.get as any)
-        .mockResolvedValueOnce({ data: mockProducts })
-        // Second call returns filtered products
-        .mockResolvedValueOnce({ data: mockProducts });
-
-      render(
-        <TestWrapper>
-          <Suppliers />
-        </TestWrapper>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Suppliers')).toBeInTheDocument();
-      });
-
-      // Should handle multiple API calls without errors
-      expect(apiService.apiClient.get).toHaveBeenCalled();
-    });
-
-    it('handles invalid filtered products response', async () => {
-      // First call returns all products
-      (apiService.apiClient.get as any)
-        .mockResolvedValueOnce({ data: [] })
-        // Second call returns invalid data
-        .mockResolvedValueOnce({ data: null });
-
-      render(
-        <TestWrapper>
-          <Suppliers />
-        </TestWrapper>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Suppliers')).toBeInTheDocument();
-      });
-
-      // Should not throw error even with invalid filtered response
-      expect(apiService.apiClient.get).toHaveBeenCalled();
-    });
+    expect(await screen.findByText('Suppliers')).toBeInTheDocument();
+    expect(apiService.apiClient.get).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -1,40 +1,24 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Input, Space, Table, Tag, Typography } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
 import { useQuery } from '@tanstack/react-query';
-import { logger } from '@/utils/logger';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { useSearchParams, useNavigate } from 'react-router-dom';
-import { MultiSelect } from '../components/Shared';
 import EntityFormSurface from '../components/Shared/EntityFormSurface';
-import styled from 'styled-components';
-import { apiService, apiClient, Supplier } from '../services/apiService';
+import { apiClient, apiService, type Supplier } from '../services/apiService';
 
-interface SupplierPlant {
-  id: number;
-  name: string;
-  plant_type?: string;
-  plant_est_num?: string;
-  address?: string;
-  city?: string;
-  state?: string;
-  zip_code?: string;
-  country?: string;
-}
+type SupplierProduct = {
+  id: string | number;
+  product_code?: string;
+  name?: string;
+  product_name?: string;
+};
 
-interface SupplierContact {
-  id: number;
-  first_name: string;
-  last_name: string;
-  email?: string;
-  phone?: string;
-  position?: string;
-  company?: string;
-  department?: string;
-}
-import { useTheme } from '../contexts/ThemeContext';
-import { Theme } from '../config/theme';
+type SupplierListRow = Supplier & {
+  associated_products?: SupplierProduct[];
+};
 
 const Suppliers: React.FC = () => {
-  const { theme } = useTheme();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -43,1116 +27,224 @@ const Suppliers: React.FC = () => {
     queryFn: apiService.getSuppliers,
   });
 
-  const suppliers = suppliersQuery.data ?? [];
-  const loading = suppliersQuery.isLoading;
+  const suppliers = (suppliersQuery.data ?? []) as SupplierListRow[];
 
-  useEffect(() => {
-    if (suppliersQuery.error) {
-      logger.error('[Suppliers] Error fetching suppliers:', suppliersQuery.error);
-    }
-  }, [suppliersQuery.error]);
-
-  const [showForm, setShowForm] = useState(false);
-  const [showEditForm, setShowEditForm] = useState(false);
-  const [editingSupplier, setEditingSupplier] = useState<Supplier | null>(null);
-  const [products, setProducts] = useState<Array<{ id: string; product_code: string; effective_name?: string; name?: string; product_name?: string }>>([]);
-  const [selectedSupplierId, setSelectedSupplierId] = useState<number | null>(null);
   const [searchText, setSearchText] = useState('');
-  const [supplierPlants, setSupplierPlants] = useState<SupplierPlant[]>([]);
-  const [plantsLoading, setPlantsLoading] = useState(false);
-  const [selectedPlantId, setSelectedPlantId] = useState<number | null>(null);
+  const filteredSuppliers = useMemo(() => {
+    const q = searchText.trim().toLowerCase();
+    if (!q) return suppliers;
+    return suppliers.filter((s) => String(s.name ?? '').toLowerCase().includes(q));
+  }, [searchText, suppliers]);
 
-  const [supplierContacts, setSupplierContacts] = useState<SupplierContact[]>([]);
-  const [contactsLoading, setContactsLoading] = useState(false);
-  const [plantContacts, setPlantContacts] = useState<SupplierContact[]>([]);
-  const [plantContactsLoading, setPlantContactsLoading] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editingSupplierId, setEditingSupplierId] = useState<string | number | null>(null);
 
-  const [showContactModal, setShowContactModal] = useState(false);
+  const [productsBySupplierId, setProductsBySupplierId] = useState<Record<string, SupplierProduct[]>>({});
+  const [productsLoadingBySupplierId, setProductsLoadingBySupplierId] = useState<Record<string, boolean>>({});
 
-  const [showPlantModal, setShowPlantModal] = useState(false);
-  const [plantProductIds, setPlantProductIds] = useState<string[]>([]);
-
-
-  const [supplierRollupProducts, setSupplierRollupProducts] = useState<Array<{ id: string; product_code: string; name?: string }>>([]);
-  const [supplierRollupLoading, setSupplierRollupLoading] = useState(false);
-
-  // Auto-open form if ?action=create in URL
+  // Back-compat: if anything still links to ?action=create
   useEffect(() => {
     if (searchParams.get('action') === 'create') {
-      setShowForm(true);
-      // Remove the parameter so it doesn't persist
+      setCreateOpen(true);
       searchParams.delete('action');
       setSearchParams(searchParams);
     }
   }, [searchParams, setSearchParams]);
 
-  useEffect(() => {
-    fetchProducts();
-  }, []);
+  const loadSupplierProducts = useCallback(
+    async (supplierId: string | number) => {
+      const id = String(supplierId);
+      if (!id) return;
+      if (productsBySupplierId[id]?.length) return;
 
-  useEffect(() => {
-    if (!selectedSupplierId) {
-      setSupplierRollupProducts([]);
-      return;
-    }
-
-    void loadSupplierProductsAvailableRollup(selectedSupplierId);
-  }, [selectedSupplierId]);
-
-  // Debug: Log products state changes
-  useEffect(() => {
-    logger.debug('[Suppliers] Products state updated:', {
-      count: Array.isArray(products) ? products.length : 0,
-      products: products,
-      multiSelectOptions: Array.isArray(products) ? products.map(p => ({ 
-        value: String(p.id), 
-        label: `${p.product_code} - ${p.effective_name || p.product_name || p.name || 'Unknown'}` 
-      })) : []
-    });
-  }, [products]);
-
-  const fetchProducts = async () => {
-    try {
-      logger.debug('[Suppliers] Fetching products from system catalog...');
-      const response = await apiClient.get('/system/products/', { params: { limit: 500 } });
-      const productsData = Array.isArray(response.data) ? response.data : (response.data.results || []);
-      setProducts(productsData);
-    } catch (error) {
-      logger.error('[Suppliers] Error fetching products:', error);
-      setProducts([]);
-    }
-  };
-
-  const loadSupplierPlants = async (supplierId: number) => {
-    try {
-      setPlantsLoading(true);
-      const response = await apiClient.get('plants/', {
-        params: { supplier: supplierId },
-      });
-      const raw = response.data as any;
-      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
-      setSupplierPlants(data);
-    } catch (error) {
-      logger.error('[Suppliers] Failed to load supplier plants:', error);
-      setSupplierPlants([]);
-    } finally {
-      setPlantsLoading(false);
-    }
-  };
-
-  const loadSupplierContacts = async (supplierId: number) => {
-    try {
-      setContactsLoading(true);
-      const response = await apiClient.get('contacts/', {
-        params: { supplier: supplierId },
-      });
-      const raw = response.data as any;
-      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
-      setSupplierContacts(data);
-    } catch (error) {
-      logger.error('[Suppliers] Failed to load supplier contacts:', error);
-      setSupplierContacts([]);
-    } finally {
-      setContactsLoading(false);
-    }
-  };
-
-  const loadPlantContacts = async (plantId: number) => {
-    try {
-      setPlantContactsLoading(true);
-      const response = await apiClient.get('contacts/', {
-        params: { plant: plantId },
-      });
-      const raw = response.data as any;
-      const data = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? raw.results : [];
-      setPlantContacts(data);
-    } catch (error) {
-      logger.error('[Suppliers] Failed to load plant contacts:', error);
-      setPlantContacts([]);
-    } finally {
-      setPlantContactsLoading(false);
-    }
-  };
-
-  const loadSupplierProductsAvailableRollup = async (supplierId: number) => {
-    try {
-      setSupplierRollupLoading(true);
-      const plantsResp = await apiClient.get('plants/', { params: { supplier: supplierId, is_active: true } });
-      const rawPlants = plantsResp.data as any;
-      const plants = Array.isArray(rawPlants) ? rawPlants : Array.isArray(rawPlants?.results) ? rawPlants.results : [];
-
-      const lists = await Promise.allSettled(
-        (plants || []).map((p: any) => apiClient.get(`/plants/${p.id}/available-products/`))
-      );
-      const merged = lists
-        .filter((r): r is PromiseFulfilledResult<any> => r.status === 'fulfilled')
-        .flatMap((r) => (Array.isArray(r.value.data) ? r.value.data : []));
-
-      const byId = new Map<string, any>();
-      merged.forEach((p: any) => {
-        if (p?.id && !byId.has(String(p.id))) byId.set(String(p.id), p);
-      });
-      setSupplierRollupProducts(Array.from(byId.values()));
-    } catch (error) {
-      logger.error('[Suppliers] Failed to load supplier products rollup:', error);
-      setSupplierRollupProducts([]);
-    } finally {
-      setSupplierRollupLoading(false);
-    }
-  };
-
-  const toggleSupplierDrilldown = async (supplier: Supplier) => {
-    if (selectedSupplierId === supplier.id) {
-      setSelectedSupplierId(null);
-      setSupplierPlants([]);
-      setSupplierContacts([]);
-      setPlantContacts([]);
-      setSelectedPlantId(null);
-      return;
-    }
-
-    setSelectedSupplierId(supplier.id);
-    setSelectedPlantId(null);
-    setPlantContacts([]);
-
-    await Promise.all([loadSupplierPlants(supplier.id), loadSupplierContacts(supplier.id)]);
-  };
-
-  const openCreatePlant = () => {
-    if (!selectedSupplierId) return;
-    setPlantProductIds([]);
-    setShowPlantModal(true);
-  };
-
-  const assignPlantProducts = async (plantId: number, productIds: string[]) => {
-    if (!productIds.length) return;
-
-    await Promise.allSettled(
-      productIds.map((productId) => apiClient.post(`/plants/${plantId}/available-products/`, { product: productId }))
-    );
-  };
-
-  const openCreatePlantContact = () => {
-    if (!selectedSupplierId || !selectedPlantId) return;
-    setShowContactModal(true);
-  };
-
-  const selectedPlant = selectedPlantId
-    ? supplierPlants.find((p) => p.id === selectedPlantId)
-    : null;
-
-  useEffect(() => {
-    if (!selectedPlantId) {
-      setPlantContacts([]);
-      return;
-    }
-
-    void loadPlantContacts(selectedPlantId);
-  }, [selectedPlantId]);
-
-  const handleEdit = (supplier: Supplier) => {
-    setEditingSupplier(supplier);
-    setShowEditForm(true);
-  };
-
-  const handleDelete = async (id: number) => {
-    if (window.confirm('Are you sure you want to delete this supplier?')) {
+      setProductsLoadingBySupplierId((prev) => ({ ...prev, [id]: true }));
       try {
-        await apiService.deleteSupplier(id);
-        alert('Supplier deleted successfully!');
-        await suppliersQuery.refetch(); // Re-fetch to update the list
-      } catch (error: unknown) {
-        // Type-safe error handling: Use 'unknown' instead of 'any' and assert expected structure
-        // This ensures we handle errors safely while maintaining type checking
-        logger.error('Error deleting supplier:', error);
-        const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string };
-        const errorMessage = err?.response?.data?.detail 
-          || err?.response?.data?.message 
-          || err?.message 
-          || 'Failed to delete supplier';
-        alert(`Error: ${errorMessage}`);
+        const resp = await apiClient.get(`/suppliers/${encodeURIComponent(id)}/products/`);
+        const raw = resp.data as unknown;
+        const rows = Array.isArray(raw) ? (raw as SupplierProduct[]) : [];
+        setProductsBySupplierId((prev) => ({ ...prev, [id]: rows }));
+      } finally {
+        setProductsLoadingBySupplierId((prev) => ({ ...prev, [id]: false }));
       }
-    }
-  };
+    },
+    [productsBySupplierId]
+  );
 
+  const handleDelete = useCallback(
+    async (supplierId: string | number) => {
+      const confirmed = window.confirm('Are you sure you want to delete this supplier?');
+      if (!confirmed) return;
 
-  if (loading) {
-    return <LoadingContainer $theme={theme}>Loading suppliers...</LoadingContainer>;
-  }
+      await apiService.deleteSupplier(Number(supplierId));
+      void suppliersQuery.refetch();
+    },
+    [suppliersQuery]
+  );
 
-  const visibleSuppliers = suppliers.filter((s) => {
-    if (!searchText.trim()) return true;
-    const haystack = [s.name, s.contact_person, s.email, s.phone, s.city, s.state]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase();
-    return haystack.includes(searchText.trim().toLowerCase());
-  });
+  const columns: ColumnsType<SupplierListRow> = useMemo(
+    () => [
+      {
+        title: 'Company Name',
+        key: 'name',
+        render: (_: unknown, record) => {
+          const displayName = String(record.name ?? '').trim() || 'Unnamed Supplier';
+          const associatedProducts = Array.isArray(record.associated_products) ? record.associated_products : [];
+
+          return (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ fontWeight: 600, color: 'rgb(var(--color-text-primary))' }}>{displayName}</span>
+              {associatedProducts.length ? (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                  {associatedProducts.map((p) => (
+                    <Tag key={String(p.id)}>{p.product_name || p.name || p.product_code || 'Product'}</Tag>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          );
+        },
+      },
+      {
+        title: 'Actions',
+        key: 'actions',
+        width: 180,
+        render: (_: unknown, record) => (
+          <Space size="small">
+            <Button
+              type="link"
+              onClick={(e) => {
+                e.stopPropagation();
+                setEditingSupplierId(record.id ?? null);
+                setEditOpen(true);
+              }}
+            >
+              Edit
+            </Button>
+            <Button
+              type="link"
+              danger
+              onClick={(e) => {
+                e.stopPropagation();
+                void handleDelete(record.id ?? '');
+              }}
+            >
+              Delete
+            </Button>
+          </Space>
+        ),
+      },
+    ],
+    [handleDelete]
+  );
 
   return (
-    <PageContainer>
-      <Header>
-        <HeaderText>
-          <Title $theme={theme}>Suppliers</Title>
-          <Subtitle>Manage supplier companies, plants, contacts, and available products</Subtitle>
-        </HeaderText>
-        <HeaderActions>
-          <SecondaryButton type="button" onClick={() => navigate('/suppliers/plants')}>
-            Plants
-          </SecondaryButton>
-          <SecondaryButton type="button" onClick={() => navigate('/suppliers/contacts')}>
-            Contacts
-          </SecondaryButton>
-          <AddButton onClick={() => { setEditingSupplier(null); setShowForm(true); }}>
-            + New Supplier
-          </AddButton>
-        </HeaderActions>
-      </Header>
+    <div style={{ padding: 16 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
+        <div>
+          <Typography.Title level={3} style={{ margin: 0 }}>
+            Suppliers
+          </Typography.Title>
+          <Typography.Text style={{ color: 'rgb(var(--color-text-tertiary))' }}>
+            Headquarters list
+          </Typography.Text>
+        </div>
 
-      <TableControls>
-        <SearchInput
-          type="text"
-          value={searchText}
-          onChange={(e) => setSearchText(e.target.value)}
-          placeholder="Search suppliers by name, contact, email, phone, city, or state…"
-          aria-label="Search suppliers"
-        />
-      </TableControls>
+        <Space>
+          <Input
+            placeholder="Search suppliers"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            allowClear
+          />
+          <Button type="primary" onClick={() => setCreateOpen(true)}>
+            New Supplier Headquarters
+          </Button>
+        </Space>
+      </div>
 
-      {showForm && (
-        <EntityFormSurface
-          entityType="supplier"
-          mode="create"
-          isOpen={showForm}
-          onClose={() => setShowForm(false)}
-          onSuccess={() => {
-            setShowForm(false);
-            void suppliersQuery.refetch();
-          }}
-        />
-      )}
+      <Table<SupplierListRow>
+        rowKey={(row) => String(row.id ?? '')}
+        columns={columns}
+        dataSource={filteredSuppliers}
+        loading={suppliersQuery.isLoading}
+        pagination={{ pageSize: 25 }}
+        onRow={(record) => ({
+          onClick: () => {
+            const id = String(record.id ?? '').trim();
+            if (!id) return;
+            navigate(`/suppliers/${encodeURIComponent(id)}`);
+          },
+        })}
+        expandable={{
+          onExpand: (expanded, record) => {
+            if (!expanded) return;
+            if (Array.isArray(record.associated_products) && record.associated_products.length) return;
+            void loadSupplierProducts(record.id ?? '');
+          },
+          expandedRowRender: (record) => {
+            const id = String(record.id ?? '').trim();
+            const loading = productsLoadingBySupplierId[id];
+            const products = productsBySupplierId[id] ?? [];
 
-      {showEditForm && editingSupplier && (
-        <EntityFormSurface
-          entityType="supplier"
-          mode="edit"
-          entityId={editingSupplier.id}
-          isOpen={showEditForm}
-          onClose={() => {
-            setShowEditForm(false);
-            setEditingSupplier(null);
-          }}
-          onSuccess={() => {
-            setShowEditForm(false);
-            setEditingSupplier(null);
-            void suppliersQuery.refetch();
-          }}
-        />
-      )}
+            if (Array.isArray(record.associated_products) && record.associated_products.length) {
+              return null;
+            }
 
-      {showPlantModal && selectedSupplierId && (
-        <FormOverlay>
-          <FormContainer $theme={theme} data-testid="plant-create-modal">
-            <FormHeader $theme={theme}>
-              <FormTitle $theme={theme}>Add New Plant</FormTitle>
-              <CloseButton $theme={theme} onClick={() => setShowPlantModal(false)}>×</CloseButton>
-            </FormHeader>
-
-            <FormGrid>
-              <FormGroup $fullWidth>
-                <MultiSelect
-                  value={plantProductIds}
-                  onChange={(values) => setPlantProductIds(values.map(String))}
-                  options={Array.isArray(products) ? products.map(p => ({
-                    value: String(p.id),
-                    label: `${p.product_code} - ${p.effective_name || p.product_name || p.name || 'Unknown'}`
-                  })) : []}
-                  label="Plant Products List"
-                  placeholder="(Optional) Select products this plant handles"
-                />
-              </FormGroup>
-            </FormGrid>
-
-            <EntityFormSurface
-              entityType="plant"
-              mode="create"
-              variant="inline"
-              isOpen={showPlantModal}
-              onClose={() => setShowPlantModal(false)}
-              context={{ supplierId: selectedSupplierId }}
-              initialValues={{
-                plant_type: 'processing',
-                country: 'USA',
-              }}
-              onSuccess={(created) => {
-                const createdId = Number((created as { id?: unknown } | null)?.id);
-                const productIds = [...plantProductIds];
-
-                void (async () => {
-                  if (Number.isFinite(createdId) && createdId > 0) {
-                    try {
-                      await assignPlantProducts(createdId, productIds);
-                    } catch (error) {
-                      logger.error('[Suppliers] Failed to assign plant products:', error);
-                      alert('Plant created, but failed to assign products.');
-                    }
-                  }
-
-                  setShowPlantModal(false);
-                  setPlantProductIds([]);
-                  await loadSupplierPlants(selectedSupplierId);
-                })();
-              }}
-            />
-          </FormContainer>
-        </FormOverlay>
-      )}
-
-      {showContactModal && selectedSupplierId && selectedPlantId && (
-        <EntityFormSurface
-          entityType="contact"
-          mode="create"
-          isOpen={showContactModal}
-          onClose={() => setShowContactModal(false)}
-          context={{ supplierId: selectedSupplierId }}
-          initialValues={{
-            plant: String(selectedPlantId),
-            department: 'sales',
-          }}
-          onSuccess={() => {
-            setShowContactModal(false);
-            void loadPlantContacts(selectedPlantId);
-          }}
-        />
-      )}
-
-      <TableContainer $theme={theme}>
-        {suppliers.length === 0 ? (
-          <EmptyState>
-            <EmptyIcon>🏭</EmptyIcon>
-            <EmptyText $theme={theme}>No suppliers found</EmptyText>
-            <EmptySubText $theme={theme}>Add your first supplier to get started</EmptySubText>
-          </EmptyState>
-        ) : (
-          <Table>
-            <TableHeader $theme={theme}>
-              <TableRow $theme={theme}>
-                <TableHeaderCell $theme={theme}>Company Name</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Contact Person</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Email</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Phone</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Location</TableHeaderCell>
-                <TableHeaderCell $theme={theme}>Actions</TableHeaderCell>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {visibleSuppliers.map((supplier) => (
-                <React.Fragment key={supplier.id}>
-                <TableRow
-                  key={supplier.id}
-                  data-testid={`supplier-row-${supplier.id}`}
-                  $theme={theme}
-                  onClick={() => void toggleSupplierDrilldown(supplier)}
-                  role="button"
-                  tabIndex={0}
-                  aria-expanded={selectedSupplierId === supplier.id}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      void toggleSupplierDrilldown(supplier);
-                    }
-                  }}
-                >
-                  <TableCell $theme={theme}>
-                    <CompanyButton $theme={theme} $selected={selectedSupplierId === supplier.id}>
-                      <CompanyName $theme={theme}>{supplier.name}</CompanyName>
-                      <CompanyChevron aria-hidden="true">{selectedSupplierId === supplier.id ? '▾' : '▸'}</CompanyChevron>
-                    </CompanyButton>
-                  </TableCell>
-                  <TableCell $theme={theme}>{supplier.contact_person || '-'}</TableCell>
-                  <TableCell $theme={theme}>{supplier.email || '-'}</TableCell>
-                  <TableCell $theme={theme}>{supplier.phone || '-'}</TableCell>
-                  <TableCell $theme={theme}>
-                    {supplier.city && supplier.state
-                      ? `${supplier.city}, ${supplier.state}`
-                      : supplier.city || supplier.state || '-'}
-                  </TableCell>
-                  <TableCell $theme={theme}>
-                    <ActionButton
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleEdit(supplier);
-                      }}
-                    >
-                      Edit
-                    </ActionButton>
-                    <DeleteButton
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void handleDelete(supplier.id);
-                      }}
-                    >
-                      Delete
-                    </DeleteButton>
-                  </TableCell>
-                </TableRow>
-                {selectedSupplierId === supplier.id && (
-                  <ExpandedTableRow $theme={theme}>
-                    <ExpandedTableCell $theme={theme} colSpan={6}>
-                      <ExpandedPanel>
-                        <ExpandedColumn>
-                          <ExpandedHeader>
-                            <ExpandedTitle>Plants</ExpandedTitle>
-                            <ExpandedActions>
-                              <SmallButton
-                                data-testid="supplier-create-plant"
-                                type="button"
-                                onClick={openCreatePlant}
-                                disabled={!selectedSupplierId}
-                              >
-                                + New Plant
-                              </SmallButton>
-                              <SmallButton
-                                type="button"
-                                onClick={() => navigate(`/suppliers/${supplier.id}/plants`)}
-                              >
-                                Manage
-                              </SmallButton>
-                            </ExpandedActions>
-                          </ExpandedHeader>
-
-                          {plantsLoading ? (
-                            <ExpandedHint>Loading plants…</ExpandedHint>
-                          ) : supplierPlants.length === 0 ? (
-                            <ExpandedHint>No plants found for this supplier.</ExpandedHint>
-                          ) : (
-                            <ChildList>
-                              {supplierPlants.map((plant) => (
-                                <ChildListItem
-                                  key={plant.id}
-                                  data-testid={`plant-row-${plant.id}`}
-                                  type="button"
-                                  $active={selectedPlantId === plant.id}
-                                  onClick={() => {
-                                    setSelectedPlantId(plant.id);
-                                    if (selectedSupplierId) {
-                                      navigate(`/suppliers/${selectedSupplierId}/plants/${plant.id}`);
-                                    }
-                                  }}
-                                >
-                                  <ChildListName>{plant.name}</ChildListName>
-                                  <ChildListMeta>
-                                    <span>{plant.plant_est_num || `Plant #${plant.id}`}</span>
-                                    {plant.plant_type ? <span>• {plant.plant_type}</span> : null}
-                                  </ChildListMeta>
-                                </ChildListItem>
-                              ))}
-                            </ChildList>
-                          )}
-
-                          <MetaCard>
-                            <MetaRow>
-                              <MetaKey>Products Available</MetaKey>
-                              <MetaValue>{supplierRollupLoading ? 'Loading…' : `${supplierRollupProducts.length}`}</MetaValue>
-                            </MetaRow>
-                            {!supplierRollupLoading && supplierRollupProducts.length ? (
-                              <ChildListMeta>
-                                {supplierRollupProducts.slice(0, 40).map((p) => (
-                                  <span key={String(p.id)}>{p.product_code}</span>
-                                ))}
-                              </ChildListMeta>
-                            ) : !supplierRollupLoading ? (
-                              <ExpandedHint>No plant products found.</ExpandedHint>
-                            ) : null}
-                          </MetaCard>
-                        </ExpandedColumn>
-
-                        <ExpandedColumn>
-                          <ExpandedHeader>
-                            <ExpandedTitle>Plant Details & Contacts</ExpandedTitle>
-                            <ExpandedActions>
-                              <SmallButton
-                                data-testid="plant-create-contact"
-                                type="button"
-                                onClick={openCreatePlantContact}
-                                disabled={!selectedPlantId}
-                              >
-                                + New Contact
-                              </SmallButton>
-                            </ExpandedActions>
-                          </ExpandedHeader>
-
-                          {selectedPlant ? (
-                            <MetaCard>
-                              <MetaRow>
-                                <MetaKey>Plant Est. #</MetaKey>
-                                <MetaValue>{selectedPlant.plant_est_num || '—'}</MetaValue>
-                              </MetaRow>
-                              <MetaRow>
-                                <MetaKey>Plant Type</MetaKey>
-                                <MetaValue>{selectedPlant.plant_type || '—'}</MetaValue>
-                              </MetaRow>
-                              <MetaRow>
-                                <MetaKey>Address</MetaKey>
-                                <MetaValue>{selectedPlant.address || '—'}</MetaValue>
-                              </MetaRow>
-                              <MetaRow>
-                                <MetaKey>City/State/ZIP</MetaKey>
-                                <MetaValue>
-                                  {selectedPlant.city || selectedPlant.state || selectedPlant.zip_code
-                                    ? `${selectedPlant.city || ''}${selectedPlant.city && selectedPlant.state ? ', ' : ''}${selectedPlant.state || ''}${(selectedPlant.city || selectedPlant.state) && selectedPlant.zip_code ? ' ' : ''}${selectedPlant.zip_code || ''}`.trim()
-                                    : '—'}
-                                </MetaValue>
-                              </MetaRow>
-                            </MetaCard>
-                          ) : (
-                            <ExpandedHint>Select a plant to view details.</ExpandedHint>
-                          )}
-
-                          {selectedPlantId ? (
-                            plantContactsLoading ? (
-                              <ExpandedHint>Loading plant contacts…</ExpandedHint>
-                            ) : plantContacts.length === 0 ? (
-                              <ExpandedHint>No contacts found for this plant.</ExpandedHint>
-                            ) : (
-                              <ContactsList>
-                                {plantContacts.map((c) => (
-                                  <ContactRow key={c.id}>
-                                    <ContactName>
-                                      {c.first_name} {c.last_name}
-                                    </ContactName>
-                                    <ContactMeta>
-                                      <span>Dept: {String(c.department || '—')}</span>
-                                      {c.position ? <span>{c.position}</span> : null}
-                                      {c.email ? <span>{c.email}</span> : null}
-                                      {c.phone ? <span>{c.phone}</span> : null}
-                                    </ContactMeta>
-                                  </ContactRow>
-                                ))}
-                              </ContactsList>
-                            )
-                          ) : (
-                            <ExpandedHint>Select a plant to view its contacts.</ExpandedHint>
-                          )}
-                        </ExpandedColumn>
-                      </ExpandedPanel>
-                    </ExpandedTableCell>
-                  </ExpandedTableRow>
+            return (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <div style={{ color: 'rgb(var(--color-text-tertiary))' }}>Aggregated Products</div>
+                {loading ? (
+                  <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>Loading…</span>
+                ) : products.length ? (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                    {products.map((p) => (
+                      <Tag key={String(p.id)}>{p.product_name || p.name || p.product_code || 'Product'}</Tag>
+                    ))}
+                  </div>
+                ) : (
+                  <span style={{ color: 'rgb(var(--color-text-tertiary))' }}>No products found.</span>
                 )}
-                </React.Fragment>
-              ))}
-            </TableBody>
-          </Table>
-        )}
-      </TableContainer>
-    </PageContainer>
+              </div>
+            );
+          },
+          rowExpandable: (record) => {
+            const hasInline = Array.isArray(record.associated_products) && record.associated_products.length > 0;
+            return !hasInline;
+          },
+        }}
+      />
+
+      <EntityFormSurface
+        entityType="supplier"
+        mode="create"
+        variant="modal"
+        isOpen={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSuccess={() => {
+          setCreateOpen(false);
+          void suppliersQuery.refetch();
+        }}
+      />
+
+      <EntityFormSurface
+        entityType="supplier"
+        mode="edit"
+        variant="modal"
+        isOpen={editOpen}
+        entityId={editingSupplierId ?? undefined}
+        onClose={() => {
+          setEditOpen(false);
+          setEditingSupplierId(null);
+        }}
+        onSuccess={() => {
+          setEditOpen(false);
+          setEditingSupplierId(null);
+          void suppliersQuery.refetch();
+        }}
+      />
+    </div>
   );
 };
-
-// Styled Components
-const LoadingContainer = styled.div<{ $theme: Theme }>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 200px;
-  font-size: 18px;
-  color: ${(props) => props.$theme.colors.textSecondary};
-`;
-
-const PageContainer = styled.div`
-  padding: 1.5rem;
-  background: rgb(var(--color-background));
-  min-height: 100%;
-`;
-
-const Header = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 12px;
-  margin-bottom: 16px;
-  flex-wrap: wrap;
-`;
-
-const HeaderText = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-const Title = styled.h1<{ $theme: Theme }>`
-  font-size: 32px;
-  font-weight: 700;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  margin: 0;
-`;
-
-const Subtitle = styled.p`
-  margin: 0;
-  font-size: 14px;
-  color: rgb(var(--color-text-secondary));
-`;
-
-const HeaderActions = styled.div`
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  flex-wrap: wrap;
-`;
-
-const SecondaryButton = styled.button`
-  background: transparent;
-  color: rgb(var(--color-text-primary));
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 8px;
-  padding: 10px 14px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-
-  &:hover {
-    background: rgb(var(--color-surface));
-    border-color: rgb(var(--color-primary) / 0.35);
-  }
-`;
-
-const AddButton = styled.button`
-  background: rgb(var(--color-primary));
-  color: white;
-  border: none;
-  border-radius: 8px;
-  padding: 10px 16px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 15px rgb(var(--color-primary) / 0.25);
-    filter: brightness(0.98);
-  }
-`;
-
-const TableControls = styled.div`
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  margin-bottom: 12px;
-`;
-
-const SearchInput = styled.input`
-  width: min(520px, 100%);
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid rgb(var(--color-border));
-  background: rgb(var(--color-surface));
-  color: rgb(var(--color-text-primary));
-
-  &::placeholder {
-    color: rgb(var(--color-text-secondary));
-  }
-
-  &:focus {
-    outline: none;
-    border-color: rgb(var(--color-primary));
-    box-shadow: 0 0 0 3px rgb(var(--color-primary) / 0.12);
-  }
-`;
-
-const FormOverlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-`;
-
-const FormContainer = styled.div<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.surface};
-  border-radius: 12px;
-  padding: 0;
-  max-width: 600px;
-  width: 90%;
-  max-height: 80vh;
-  overflow-y: auto;
-`;
-
-const FormHeader = styled.div<{ $theme: Theme }>`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px 30px;
-  border-bottom: 1px solid ${(props) => props.$theme.colors.border};
-`;
-
-const FormTitle = styled.h2<{ $theme: Theme }>`
-  margin: 0;
-  color: ${(props) => props.$theme.colors.textPrimary};
-`;
-
-const CloseButton = styled.button<{ $theme: Theme }>`
-  background: none;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  color: ${(props) => props.$theme.colors.textSecondary};
-
-  &:hover {
-    color: ${(props) => props.$theme.colors.textPrimary};
-  }
-`;
-
-const Form = styled.form`
-  padding: 30px;
-`;
-
-const FormGrid = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-  margin-bottom: 30px;
-`;
-
-const FormGroup = styled.div<{ $fullWidth?: boolean }>`
-  grid-column: ${(props) => (props.$fullWidth ? '1 / -1' : 'auto')};
-`;
-
-const Label = styled.label<{ $theme: Theme }>`
-  display: block;
-  margin-bottom: 5px;
-  font-weight: 500;
-  color: ${(props) => props.$theme.colors.textPrimary};
-`;
-
-const Input = styled.input<{ $theme: Theme }>`
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid ${(props) => props.$theme.colors.border};
-  border-radius: 6px;
-  font-size: 14px;
-  transition: border-color 0.2s ease;
-  background: ${(props) => props.$theme.colors.surface};
-  color: ${(props) => props.$theme.colors.textPrimary};
-
-  &:focus {
-    outline: none;
-    border-color: ${(props) => props.$theme.colors.primary};
-  }
-`;
-
-const FormActions = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-`;
-
-const CancelButton = styled.button`
-  background: rgb(var(--color-text-secondary));
-  color: white;
-  border: none;
-  border-radius: 6px;
-  padding: 10px 20px;
-  cursor: pointer;
-  transition: filter 0.2s ease;
-
-  &:hover {
-    filter: brightness(0.95);
-  }
-`;
-
-const SubmitButton = styled.button`
-  background: rgb(var(--color-primary));
-  color: white;
-  border: none;
-  border-radius: 6px;
-  padding: 10px 20px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 15px rgba(var(--color-primary), 0.25);
-    filter: brightness(0.98);
-  }
-`;
-
-const TableContainer = styled.div<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.surface};
-  border-radius: 12px;
-  overflow: hidden;
-  box-shadow: 0 2px 10px ${(props) => props.$theme.colors.shadow};
-`;
-
-const EmptyState = styled.div`
-  padding: 60px 20px;
-  text-align: center;
-`;
-
-const EmptyIcon = styled.div`
-  font-size: 48px;
-  margin-bottom: 16px;
-`;
-
-const EmptyText = styled.div<{ $theme: Theme }>`
-  font-size: 18px;
-  color: ${(props) => props.$theme.colors.textPrimary};
-  margin-bottom: 8px;
-`;
-
-const EmptySubText = styled.div<{ $theme: Theme }>`
-  color: ${(props) => props.$theme.colors.textSecondary};
-`;
-
-const Table = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-`;
-
-const TableHeader = styled.thead<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.background};
-`;
-
-const TableBody = styled.tbody``;
-
-const TableRow = styled.tr<{ $theme: Theme }>`
-  border-bottom: 1px solid ${(props) => props.$theme.colors.border};
-  cursor: pointer;
-
-  &:hover {
-    background: ${(props) => props.$theme.colors.surfaceHover};
-  }
-
-  &:focus-visible {
-    outline: 2px solid rgba(var(--color-primary), 0.5);
-    outline-offset: -2px;
-  }
-`;
-
-const TableHeaderCell = styled.th<{ $theme: Theme }>`
-  padding: 15px 20px;
-  text-align: left;
-  font-weight: 600;
-  color: ${(props) => props.$theme.colors.textPrimary};
-`;
-
-const TableCell = styled.td<{ $theme: Theme }>`
-  padding: 15px 20px;
-  color: ${(props) => props.$theme.colors.textPrimary};
-`;
-
-const CompanyButton = styled.div<{ $theme: Theme; $selected: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 8px;
-  border: 1px solid ${(p) => (p.$selected ? 'rgba(var(--color-primary), 0.6)' : 'transparent')};
-  border-radius: 8px;
-  background: ${(p) => (p.$selected ? 'rgba(var(--color-primary), 0.08)' : 'transparent')};
-  pointer-events: none;
-`;
-
-const CompanyName = styled.div<{ $theme: Theme }>`
-  font-weight: 600;
-  color: ${(props) => props.$theme.colors.textPrimary};
-`;
-
-const CompanyChevron = styled.span`
-  color: rgb(var(--color-text-secondary));
-  font-size: 14px;
-`;
-
-const ExpandedTableRow = styled.tr<{ $theme: Theme }>`
-  background: ${(props) => props.$theme.colors.surface};
-`;
-
-const ExpandedTableCell = styled.td<{ $theme: Theme }>`
-  padding: 14px 18px;
-  border-bottom: 1px solid ${(props) => props.$theme.colors.border};
-`;
-
-const ExpandedPanel = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-
-  @media (max-width: 980px) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const ExpandedColumn = styled.div`
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 12px;
-  background: rgb(var(--color-surface));
-  padding: 12px;
-`;
-
-const ExpandedHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 10px;
-`;
-
-const ExpandedTitle = styled.div`
-  font-weight: 700;
-  color: rgb(var(--color-text-primary));
-`;
-
-const ExpandedActions = styled.div`
-  display: inline-flex;
-  gap: 8px;
-`;
-
-const SmallButton = styled.button`
-  padding: 6px 10px;
-  border-radius: 8px;
-  border: 1px solid rgb(var(--color-border));
-  background: rgb(var(--color-surface));
-  color: rgb(var(--color-text-primary));
-  font-size: 12px;
-  cursor: pointer;
-
-  &:hover:not(:disabled) {
-    border-color: rgba(var(--color-primary), 0.6);
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-`;
-
-const ExpandedHint = styled.div`
-  padding: 12px;
-  color: rgb(var(--color-text-secondary));
-  font-size: 13px;
-`;
-
-const ChildList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;
-
-const ChildListItem = styled.button<{ $active: boolean }>`
-  text-align: left;
-  border-radius: 10px;
-  border: 1px solid ${(p) => (p.$active ? 'rgba(var(--color-primary), 0.7)' : 'transparent')};
-  background: ${(p) => (p.$active ? 'rgba(var(--color-primary), 0.08)' : 'transparent')};
-  padding: 10px 12px;
-  cursor: pointer;
-
-  &:hover {
-    border-color: ${(p) => (p.$active ? 'rgba(var(--color-primary), 0.55)' : 'rgb(var(--color-border))')};
-    background: rgb(var(--color-surface-hover));
-  }
-`;
-
-const ChildListName = styled.div`
-  font-weight: 650;
-  color: rgb(var(--color-text-primary));
-`;
-
-const ChildListMeta = styled.div`
-  margin-top: 2px;
-  font-size: 12px;
-  color: rgb(var(--color-text-secondary));
-  display: inline-flex;
-  gap: 8px;
-  flex-wrap: wrap;
-`;
-
-const MetaCard = styled.div`
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 10px;
-  background: rgba(var(--color-surface), 0.6);
-  padding: 10px 12px;
-  margin-bottom: 10px;
-`;
-
-const MetaRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 6px 0;
-`;
-
-const MetaKey = styled.div`
-  font-size: 12px;
-  font-weight: 650;
-  color: rgb(var(--color-text-secondary));
-`;
-
-const MetaValue = styled.div`
-  font-size: 13px;
-  color: rgb(var(--color-text-primary));
-`;
-
-const ContactsList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;
-
-const ContactRow = styled.div`
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 10px;
-  padding: 10px 12px;
-  background: rgb(var(--color-surface));
-`;
-
-const ContactName = styled.div`
-  font-weight: 650;
-  color: rgb(var(--color-text-primary));
-`;
-
-const ContactMeta = styled.div`
-  margin-top: 2px;
-  font-size: 12px;
-  color: rgb(var(--color-text-secondary));
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-`;
-
-const ActionButton = styled.button`
-  background: rgb(var(--color-info));
-  color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 6px 12px;
-  font-size: 12px;
-  cursor: pointer;
-  margin-right: 8px;
-  transition: filter 0.2s ease;
-
-  &:hover {
-    filter: brightness(0.95);
-  }
-`;
-
-const DeleteButton = styled.button`
-  background: rgb(var(--color-danger));
-  color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 6px 12px;
-  font-size: 12px;
-  cursor: pointer;
-  transition: filter 0.2s ease;
-
-  &:hover {
-    filter: brightness(0.95);
-  }
-`;
 
 export default Suppliers;


### PR DESCRIPTION
## Deliverables\n- Flattened Suppliers/Customers sidebar nav (no nested children)\n- HQ-only Supplier/Customer UniversalEntityForm fields + HQ labels + dynamic titles\n- Simplified Suppliers/Customers list pages to **Company Name + Actions (Edit/Delete)**\n- Safe Aggregated Products display (uses serializer if present; otherwise lazy-loads on row expand)\n- Supplier/Customer record view converged to Cockpit-style 5-tab layout:\n  - Suppliers: Plants / Dept. Contacts / Documents / Related / Recent Activity\n  - Customers: Locations / Dept. Contacts / Documents / Related / Recent Activity\n\n## Expected results\n- Enforces HQ -> (Plants/Locations) hierarchy (less orphan creation)\n- Cleaner list views with no horizontal bloat\n- Cockpit-aligned detail UX\n\n## Acceptance criteria\n- Sidebar shows single-click Suppliers and Customers (no children)\n- Supplier/Customer forms show only: Name, HQ Phone, HQ Address, HQ City, HQ State, HQ Zip, HQ Country\n- Create form titles: “New Supplier/Customer Headquarters”; Edit/View: “Supplier/Customer Headquarters Profile”\n- Suppliers/Customers list pages show only Company Name + Actions and navigate to /suppliers/:id or /customers/:id on row click\n- Supplier/Customer record pages render exactly 5 tabs with required labels\n\n## Risks + mitigations\n- Risk: backend list serializer may not provide associated_products → mitigated via lazy expandable rollup fetch (no N+1 on initial render)\n- Risk: test drift from old drilldown UI → mitigated via updated unit test for Suppliers page\n\n## Testing\n- npm --prefix frontend run type-check\n- npm --prefix frontend test -- run\n\n## Rollback\n- Revert this PR to restore prior Suppliers/Customers drilldown pages + tabs\n