### PR TITLE
fix(workflows): stop available-forms 500 + frontend remount loop

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -114,6 +114,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-04-27** — **Phase 10: Supplier/Customer Hierarchical UI Simplification**: flattened Suppliers/Customers sidebar navigation, made Supplier/Customer forms HQ-only (HQ labels + dynamic titles), simplified list views to Company Name + Actions with safe Aggregated Products rollups, and converged Supplier/Customer record view to Cockpit-style tabs (Plants/Locations, Dept. Contacts, Documents, Related, Recent Activity). (PR: #4705)
 
+- **2026-04-27** — Workflows/QuickActions stability: `/api/v1/workflows/available-forms/` now validates optional entity context and returns 400 (never 500) for bad params/IDs; frontend adds a circuit breaker to prevent remount loops on backend 5xx; Supplier form title rolled back to "New Supplier"/"Supplier" while keeping HQ field labels and phone input typing; Suppliers/Customers table rows now show pointer cursor on hover. (PR: pending)
+
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`
 - Stale/Zombie secrets found in GitHub but NOT in `manifests/env.manifest.json` (or legacy `DEV_`/`UAT_`/`PROD_` prefixed):

--- a/backend/tenant_apps/workflows/tests/test_available_forms_entity_context.py
+++ b/backend/tenant_apps/workflows/tests/test_available_forms_entity_context.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.workflows.models import FormStatus, TenantForm
+
+
+User = get_user_model()
+
+
+class AvailableFormsEntityContextTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+        self.client.force_authenticate(self.user)
+
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        self.form = TenantForm.objects.create(
+            tenant=self.tenant,
+            name='QA Form',
+            status=FormStatus.ACTIVE,
+            created_by=self.user,
+        )
+
+    def test_requires_entity_type_and_id_pair(self):
+        resp = self.client.get(
+            '/api/v1/workflows/available-forms/?entity_type=plant',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_rejects_unknown_entity_type(self):
+        resp = self.client.get(
+            '/api/v1/workflows/available-forms/?entity_type=unknown&entity_id=1',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_rejects_invalid_entity_id_format(self):
+        resp = self.client.get(
+            '/api/v1/workflows/available-forms/?entity_type=plant&entity_id=not-an-int',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_400_for_missing_entity(self):
+        resp = self.client.get(
+            '/api/v1/workflows/available-forms/?entity_type=plant&entity_id=999999',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_valid_entity_context_returns_200(self):
+        from tenant_apps.suppliers.models import Supplier
+        from tenant_apps.plants.models import Plant
+
+        supplier = Supplier.objects.create(tenant=self.tenant, name='Supplier A')
+        plant = Plant.objects.create(tenant=self.tenant, supplier=supplier, name='Plant A', plant_est_num='123')
+
+        resp = self.client.get(
+            f'/api/v1/workflows/available-forms/?entity_type=plant&entity_id={plant.id}',
+            HTTP_X_TENANT_ID=str(self.tenant.id),
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+        rows = resp.json()
+        self.assertIsInstance(rows, list)
+        seen = {(r.get('type'), r.get('id')) for r in rows}
+        self.assertIn(('form', str(self.form.id)), seen)

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2890,10 +2890,90 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
     def list(self, request, *args, **kwargs):
         """Return Quick Action targets (forms + workforms).
 
-        Response rows are normalized to the `AvailableQuickActionTargetSerializer` schema.
+        IMPORTANT: this endpoint is frequently called from globally-mounted UI surfaces.
+        It must never 500 on malformed query parameters or invalid entity context.
+
+        Supported optional query parameters:
+        - entity_type
+        - entity_id
+
+        If provided, we validate the entity exists in the current tenant. This prevents
+        the caller from accidentally passing cross-tenant IDs and triggering server errors.
         """
 
-        forms_qs = self.filter_queryset(self.get_queryset())
+        entity_type = (request.query_params.get('entity_type') or '').strip().lower()
+        entity_id_raw = (request.query_params.get('entity_id') or '').strip()
+
+        if entity_type or entity_id_raw:
+            if not (entity_type and entity_id_raw):
+                return Response(
+                    {'error': 'Both entity_type and entity_id are required when providing entity context.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            allowed = {'supplier', 'customer', 'plant', 'location'}
+            if entity_type not in allowed:
+                return Response(
+                    {'error': f'Unsupported entity_type: {entity_type}.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            tenant = _get_request_tenant(request)
+            if not tenant:
+                return Response(
+                    {'error': 'Tenant context is required (X-Tenant-ID header) when providing entity context.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            try:
+                entity_pk = int(entity_id_raw)
+            except (TypeError, ValueError):
+                return Response(
+                    {'error': f'Invalid entity_id for {entity_type}: {entity_id_raw}.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            try:
+                if entity_type == 'supplier':
+                    from tenant_apps.suppliers.models import Supplier
+
+                    Supplier.objects.get(pk=entity_pk, tenant=tenant)
+                elif entity_type == 'customer':
+                    from tenant_apps.customers.models import Customer
+
+                    Customer.objects.get(pk=entity_pk, tenant=tenant)
+                elif entity_type == 'plant':
+                    from tenant_apps.plants.models import Plant
+
+                    Plant.objects.get(pk=entity_pk, tenant=tenant)
+                elif entity_type == 'location':
+                    from tenant_apps.locations.models import Location
+
+                    Location.objects.get(pk=entity_pk, tenant=tenant)
+            except Exception as exc:
+                logger.warning(
+                    'available-forms: invalid entity context',
+                    extra={
+                        'entity_type': entity_type,
+                        'entity_id': entity_id_raw,
+                        'tenant_id': str(getattr(tenant, 'id', '')),
+                        'error': str(exc),
+                    },
+                )
+                return Response(
+                    {'error': 'Invalid entity context.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        try:
+            forms_qs = self.filter_queryset(self.get_queryset())
+        except Exception as exc:
+            logger.warning('available-forms: invalid filters', extra={'error': str(exc)})
+            return Response(
+                {'error': 'Invalid query parameters.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         forms_data = AvailableFormSerializer(forms_qs, many=True).data
         for row in forms_data:
             row['type'] = 'form'
@@ -2901,6 +2981,15 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
 
         workforms_data = []
         for wf in self._get_workforms(request):
+            try:
+                node_count = wf.get_node_count() if hasattr(wf, 'get_node_count') else None
+            except Exception as exc:
+                logger.warning(
+                    'available-forms: node_count failed; defaulting to 0',
+                    extra={'workform_id': str(getattr(wf, 'id', '')), 'error': str(exc)},
+                )
+                node_count = 0
+
             workforms_data.append(
                 {
                     'id': str(wf.id),
@@ -2912,7 +3001,7 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
                     'is_default': False,
                     'is_quick_action_enabled': True,
                     'step_count': None,
-                    'node_count': wf.get_node_count() if hasattr(wf, 'get_node_count') else None,
+                    'node_count': node_count,
                 }
             )
 

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -602,9 +602,17 @@ const augmentSchemaForFrontend = (
             ? 'Enter HQ address'
             : null);
 
+      const typeOverride =
+        key === 'phone' || key === 'phone_number'
+          ? 'phone'
+          : key === 'address' || key === 'street_address'
+            ? 'text'
+            : field.type;
+
       nextFields.push({
         ...field,
         label,
+        type: typeOverride,
         required: key === 'name' ? true : field.required,
         placeholder,
       });
@@ -1224,15 +1232,18 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
       ...(initialValues || {}),
     });
 
-    const hqEntity = schemaEntityKey === 'supplier' ? 'Supplier' : schemaEntityKey === 'customer' ? 'Customer' : null;
+    const supplierTitle = schemaEntityKey === 'supplier' ? (activeMode === 'create' ? 'New Supplier' : 'Supplier') : null;
+    const hqEntity = schemaEntityKey === 'customer' ? 'Customer' : null;
 
-    const formName = hqEntity
-      ? activeMode === 'create'
-        ? `New ${hqEntity} Headquarters`
-        : `${hqEntity} Headquarters Profile`
-      : schemaEntityKey === 'contact' && activeMode === 'create'
-        ? getContactCreateTitle(contactContext)
-        : schema?.name || `Universal Form: ${entityType}`;
+    const formName = supplierTitle
+      ? supplierTitle
+      : hqEntity
+        ? activeMode === 'create'
+          ? `New ${hqEntity} Headquarters`
+          : `${hqEntity} Headquarters Profile`
+        : schemaEntityKey === 'contact' && activeMode === 'create'
+          ? getContactCreateTitle(contactContext)
+          : schema?.name || `Universal Form: ${entityType}`;
 
     return {
       step_index: 0,
@@ -1249,9 +1260,14 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   const modalTitle = useMemo(() => {
     const contactContext = inferContactFormContext(formInitialValues);
 
-    const hqEntity = schemaEntityKey === 'supplier' ? 'Supplier' : schemaEntityKey === 'customer' ? 'Customer' : null;
+    const supplierTitle = schemaEntityKey === 'supplier' ? (activeMode === 'create' ? 'New Supplier' : 'Supplier') : null;
+    const hqEntity = schemaEntityKey === 'customer' ? 'Customer' : null;
 
     if (activeMode === 'clone') return `Clone ${entityType}`;
+
+    if (supplierTitle) {
+      return supplierTitle;
+    }
 
     if (hqEntity) {
       return activeMode === 'create' ? `New ${hqEntity} Headquarters` : `${hqEntity} Headquarters Profile`;

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -202,8 +202,13 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
     }
   }, []);
 
+  const didInitialFetchRef = React.useRef(false);
+
   useEffect(() => {
     // Always attempt to load: supports cookie-auth sessions (no localStorage token).
+    // Guard against effect re-run (e.g., React dev strict-mode double-invoke) to avoid retry loops.
+    if (didInitialFetchRef.current) return;
+    didInitialFetchRef.current = true;
     refreshQuickActions();
   }, [refreshQuickActions]);
 

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -170,6 +170,7 @@ const Customers: React.FC = () => {
         loading={customersQuery.isLoading}
         pagination={{ pageSize: 25 }}
         onRow={(record) => ({
+          style: { cursor: 'pointer' },
           onClick: () => {
             const id = String(record.id ?? '').trim();
             if (!id) return;

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -170,6 +170,7 @@ const Suppliers: React.FC = () => {
         loading={suppliersQuery.isLoading}
         pagination={{ pageSize: 25 }}
         onRow={(record) => ({
+          style: { cursor: 'pointer' },
           onClick: () => {
             const id = String(record.id ?? '').trim();
             if (!id) return;

--- a/frontend/src/services/quickActionsService.ts
+++ b/frontend/src/services/quickActionsService.ts
@@ -44,6 +44,9 @@ class CancelTokenManager {
 
 export const cancelTokenManager = new CancelTokenManager();
 
+const AVAILABLE_FORMS_CIRCUIT_OPEN_MS = 60_000;
+let availableFormsCircuitOpenUntilMs = 0;
+
 let warnedMissingTenant = false;
 const warnMissingTenantOnce = (endpoint: string) => {
   if (warnedMissingTenant) return;
@@ -177,12 +180,43 @@ export const quickActionsService = {
       return [];
     }
 
+    const now = Date.now();
+    if (availableFormsCircuitOpenUntilMs > now) {
+      logger.warn('[QuickActions] Circuit open; skipping available-forms fetch', {
+        until: new Date(availableFormsCircuitOpenUntilMs).toISOString(),
+      });
+      return [];
+    }
+
     const config = cancelKey ? { cancelToken: cancelTokenManager.create(cancelKey).token } : {};
-    const response = await apiClient.get('/workflows/available-forms/', config);
-    if (cancelKey) cancelTokenManager.remove(cancelKey);
-    // Handle both paginated {results: []} and non-paginated [] responses
-    const data = response.data;
-    return Array.isArray(data) ? data : (data.results || []);
+
+    try {
+      const response = await apiClient.get('/workflows/available-forms/', config);
+      // Handle both paginated {results: []} and non-paginated [] responses
+      const data = response.data;
+      return Array.isArray(data) ? data : (data.results || []);
+    } catch (err: any) {
+      const status = err?.response?.status;
+
+      // Circuit breaker: prevent app-wide remount loops on backend 5xx.
+      if (typeof status === 'number' && status >= 500) {
+        availableFormsCircuitOpenUntilMs = Date.now() + AVAILABLE_FORMS_CIRCUIT_OPEN_MS;
+        logger.error('[QuickActions] available-forms 5xx; opening circuit and degrading gracefully', {
+          status,
+        });
+        return [];
+      }
+
+      // Degrade gracefully for known bad-request and auth cases too.
+      if (status === 400 || status === 401 || status === 403) {
+        logger.warn('[QuickActions] available-forms request rejected; returning empty list', { status });
+        return [];
+      }
+
+      throw err;
+    } finally {
+      if (cancelKey) cancelTokenManager.remove(cancelKey);
+    }
   },
 };
 


### PR DESCRIPTION
## Deliverables
- Backend: /api/v1/workflows/available-forms/ validates optional entity_type + entity_id and returns 400 (never 500) for bad params/IDs
- Backend: defensive guards around filtering + WorkForm node_count extraction
- Frontend: quickActionsService.getAvailableForms() circuit breaker (opens on 5xx, degrades to empty list)
- Frontend: QuickActionsContext initial fetch guard to avoid strict-mode double-effect retry loops
- Frontend: Supplier form title rollback to "New Supplier" (create) / "Supplier" (edit/view), while keeping HQ field labels; HQ phone forced to phone input type; HQ address forced to single-line text
- UX: Suppliers/Customers list rows now show pointer cursor on hover to match clickability

## Expected results
- Editing Plants no longer triggers a 500-driven QuickActions remount loop (React error #185)
- Invalid entity context produces a clear 400 response (or empty list on frontend) instead of crashing

## Acceptance criteria
- GET /api/v1/workflows/available-forms/?entity_type=plant&entity_id=bad returns 400 JSON error
- GET /api/v1/workflows/available-forms/?entity_type=plant&entity_id=<valid> returns 200 list
- QuickActions surfaces do not hard-crash or loop when backend returns 5xx
- Supplier form modal/title reads "New Supplier" on create; "Supplier" on edit/view
- Suppliers/Customers rows show hand cursor on hover

## Testing
- Backend: python backend/manage.py test tenant_apps.workflows.tests.test_available_forms_entity_context tenant_apps.workflows.tests.test_available_forms_includes_workforms
- Frontend: npm --prefix frontend run type-check
- Frontend: npm --prefix frontend test -- run

## Rollback
- Revert this PR to restore previous available-forms behavior and remove circuit breaker.
