### PR TITLE
fix(workflows): harden available-forms endpoint

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -116,6 +116,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-04-27** — Workflows/QuickActions stability: `/api/v1/workflows/available-forms/` now validates optional entity context and returns 400 (never 500) for bad params/IDs; frontend adds a circuit breaker to prevent remount loops on backend 5xx; Supplier form title rolled back to "New Supplier"/"Supplier" while keeping HQ field labels and phone input typing; Suppliers/Customers table rows now show pointer cursor on hover. (PR: #4707)
 
+- **2026-04-27** — Workflows/QuickActions hardening: `/api/v1/workflows/available-forms/` now degrades safely even if form/workform serialization or node_count fails (skips bad rows; never 500) with regression coverage; frontend stops probing legacy `/api/v1/products/master/` and calls canonical `/api/v1/master-products/` only (avoids noisy 404 spam). (PR: #4709)
+
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`
 - Stale/Zombie secrets found in GitHub but NOT in `manifests/env.manifest.json` (or legacy `DEV_`/`UAT_`/`PROD_` prefixed):

--- a/backend/tenant_apps/workflows/tests/test_available_forms_never_500.py
+++ b/backend/tenant_apps/workflows/tests/test_available_forms_never_500.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.system.models import TenantWorkForm
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.workflows.models import FormStatus, TenantForm
+
+
+User = get_user_model()
+
+
+class AvailableFormsNever500Tests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+        self.client.force_authenticate(self.user)
+
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        self.form = TenantForm.objects.create(
+            tenant=self.tenant,
+            name='QA Form',
+            status=FormStatus.ACTIVE,
+            created_by=self.user,
+        )
+
+        self.workform = TenantWorkForm.objects.create(
+            tenant=self.tenant,
+            name='QA WorkForm',
+            status='active',
+            workflow_definition={'nodes': [{'id': 't1', 'type': 'triggerManual'}], 'edges': []},
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+    def test_never_500_when_form_serializer_raises(self):
+        # Force the serializer to error in a way we might see from malformed data.
+        # We patch the serializer class so that instantiation raises, which should be
+        # handled per-row and never bubble up as a 500.
+        with patch('tenant_apps.workflows.views.AvailableFormSerializer') as mocked:
+            mocked.side_effect = RuntimeError('boom')
+
+            resp = self.client.get(
+                '/api/v1/workflows/available-forms/',
+                HTTP_X_TENANT_ID=str(self.tenant.id),
+            )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+        rows = resp.json()
+        self.assertIsInstance(rows, list)
+
+        # WorkForms should still return even if forms serialization fails.
+        seen = {(r.get('type'), r.get('id')) for r in rows}
+        self.assertIn(('workflow', str(self.workform.id)), seen)

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2966,48 +2966,67 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
                 )
 
         try:
-            forms_qs = self.filter_queryset(self.get_queryset())
-        except Exception as exc:
-            logger.warning('available-forms: invalid filters', extra={'error': str(exc)})
-            return Response(
-                {'error': 'Invalid query parameters.'},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        forms_data = AvailableFormSerializer(forms_qs, many=True).data
-        for row in forms_data:
-            row['type'] = 'form'
-            row['node_count'] = None
-
-        workforms_data = []
-        for wf in self._get_workforms(request):
             try:
-                node_count = wf.get_node_count() if hasattr(wf, 'get_node_count') else None
+                forms_qs = self.filter_queryset(self.get_queryset())
             except Exception as exc:
-                logger.warning(
-                    'available-forms: node_count failed; defaulting to 0',
-                    extra={'workform_id': str(getattr(wf, 'id', '')), 'error': str(exc)},
+                logger.warning('available-forms: invalid filters', extra={'error': str(exc)})
+                return Response(
+                    {'error': 'Invalid query parameters.'},
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
-                node_count = 0
 
-            workforms_data.append(
-                {
-                    'id': str(wf.id),
-                    'type': 'workflow',
-                    'name': wf.name,
-                    'description': wf.description or '',
-                    'icon': 'workflow',
-                    'status': wf.status,
-                    'is_default': False,
-                    'is_quick_action_enabled': True,
-                    'step_count': None,
-                    'node_count': node_count,
-                }
-            )
+            forms_data = []
+            for form in forms_qs:
+                try:
+                    row = AvailableFormSerializer(form).data
+                    row['type'] = 'form'
+                    row['node_count'] = None
+                    forms_data.append(row)
+                except Exception as exc:
+                    logger.exception(
+                        'available-forms: form serialization failed; skipping',
+                        extra={'form_id': str(getattr(form, 'id', '')), 'error': str(exc)},
+                    )
 
-        data = forms_data + workforms_data
-        data.sort(key=lambda r: str(r.get('name') or '').lower())
-        return Response(data)
+            workforms_data = []
+            for wf in self._get_workforms(request):
+                try:
+                    try:
+                        node_count = wf.get_node_count() if hasattr(wf, 'get_node_count') else None
+                    except Exception as exc:
+                        logger.warning(
+                            'available-forms: node_count failed; defaulting to 0',
+                            extra={'workform_id': str(getattr(wf, 'id', '')), 'error': str(exc)},
+                        )
+                        node_count = 0
+
+                    workforms_data.append(
+                        {
+                            'id': str(wf.id),
+                            'type': 'workflow',
+                            'name': wf.name,
+                            'description': wf.description or '',
+                            'icon': 'workflow',
+                            'status': wf.status,
+                            'is_default': False,
+                            'is_quick_action_enabled': True,
+                            'step_count': None,
+                            'node_count': node_count,
+                        }
+                    )
+                except Exception as exc:
+                    logger.exception(
+                        'available-forms: workform serialization failed; skipping',
+                        extra={'workform_id': str(getattr(wf, 'id', '')), 'error': str(exc)},
+                    )
+
+            data = forms_data + workforms_data
+            data.sort(key=lambda r: str(r.get('name') or '').lower())
+            return Response(data)
+        except Exception as exc:
+            # Absolute safety net: UI surfaces expect this endpoint to be resilient.
+            logger.exception('available-forms: internal error; returning empty list', extra={'error': str(exc)})
+            return Response([])
 
 
 @extend_schema(tags=["Workflows", "Quick Actions"])

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2901,71 +2901,72 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
         the caller from accidentally passing cross-tenant IDs and triggering server errors.
         """
 
-        entity_type = (request.query_params.get('entity_type') or '').strip().lower()
-        entity_id_raw = (request.query_params.get('entity_id') or '').strip()
-
-        if entity_type or entity_id_raw:
-            if not (entity_type and entity_id_raw):
-                return Response(
-                    {'error': 'Both entity_type and entity_id are required when providing entity context.'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            allowed = {'supplier', 'customer', 'plant', 'location'}
-            if entity_type not in allowed:
-                return Response(
-                    {'error': f'Unsupported entity_type: {entity_type}.'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            tenant = _get_request_tenant(request)
-            if not tenant:
-                return Response(
-                    {'error': 'Tenant context is required (X-Tenant-ID header) when providing entity context.'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            try:
-                entity_pk = int(entity_id_raw)
-            except (TypeError, ValueError):
-                return Response(
-                    {'error': f'Invalid entity_id for {entity_type}: {entity_id_raw}.'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            try:
-                if entity_type == 'supplier':
-                    from tenant_apps.suppliers.models import Supplier
-
-                    Supplier.objects.get(pk=entity_pk, tenant=tenant)
-                elif entity_type == 'customer':
-                    from tenant_apps.customers.models import Customer
-
-                    Customer.objects.get(pk=entity_pk, tenant=tenant)
-                elif entity_type == 'plant':
-                    from tenant_apps.plants.models import Plant
-
-                    Plant.objects.get(pk=entity_pk, tenant=tenant)
-                elif entity_type == 'location':
-                    from tenant_apps.locations.models import Location
-
-                    Location.objects.get(pk=entity_pk, tenant=tenant)
-            except Exception as exc:
-                logger.warning(
-                    'available-forms: invalid entity context',
-                    extra={
-                        'entity_type': entity_type,
-                        'entity_id': entity_id_raw,
-                        'tenant_id': str(getattr(tenant, 'id', '')),
-                        'error': str(exc),
-                    },
-                )
-                return Response(
-                    {'error': 'Invalid entity context.'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
+        # Absolute safety net: UI surfaces expect this endpoint to be resilient.
         try:
+            entity_type = (request.query_params.get('entity_type') or '').strip().lower()
+            entity_id_raw = (request.query_params.get('entity_id') or '').strip()
+
+            if entity_type or entity_id_raw:
+                if not (entity_type and entity_id_raw):
+                    return Response(
+                        {'error': 'Both entity_type and entity_id are required when providing entity context.'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+                allowed = {'supplier', 'customer', 'plant', 'location'}
+                if entity_type not in allowed:
+                    return Response(
+                        {'error': f'Unsupported entity_type: {entity_type}.'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+                tenant = _get_request_tenant(request)
+                if not tenant:
+                    return Response(
+                        {'error': 'Tenant context is required (X-Tenant-ID header) when providing entity context.'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+                try:
+                    entity_pk = int(entity_id_raw)
+                except (TypeError, ValueError):
+                    return Response(
+                        {'error': f'Invalid entity_id for {entity_type}: {entity_id_raw}.'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+                try:
+                    if entity_type == 'supplier':
+                        from tenant_apps.suppliers.models import Supplier
+
+                        Supplier.objects.get(pk=entity_pk, tenant=tenant)
+                    elif entity_type == 'customer':
+                        from tenant_apps.customers.models import Customer
+
+                        Customer.objects.get(pk=entity_pk, tenant=tenant)
+                    elif entity_type == 'plant':
+                        from tenant_apps.plants.models import Plant
+
+                        Plant.objects.get(pk=entity_pk, tenant=tenant)
+                    elif entity_type == 'location':
+                        from tenant_apps.locations.models import Location
+
+                        Location.objects.get(pk=entity_pk, tenant=tenant)
+                except Exception as exc:
+                    logger.warning(
+                        'available-forms: invalid entity context',
+                        extra={
+                            'entity_type': entity_type,
+                            'entity_id': entity_id_raw,
+                            'tenant_id': str(getattr(tenant, 'id', '')),
+                            'error': str(exc),
+                        },
+                    )
+                    return Response(
+                        {'error': 'Invalid entity context.'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
             try:
                 forms_qs = self.filter_queryset(self.get_queryset())
             except Exception as exc:
@@ -3024,7 +3025,6 @@ class AvailableFormsViewSet(viewsets.ReadOnlyModelViewSet):
             data.sort(key=lambda r: str(r.get('name') or '').lower())
             return Response(data)
         except Exception as exc:
-            # Absolute safety net: UI surfaces expect this endpoint to be resilient.
             logger.exception('available-forms: internal error; returning empty list', extra={'error': str(exc)})
             return Response([])
 

--- a/frontend/src/services/contactFormOptionsService.ts
+++ b/frontend/src/services/contactFormOptionsService.ts
@@ -112,35 +112,34 @@ export const contactFormOptionsService = {
       requestParams.protein_type = proteinTypes;
     }
 
-    const endpoints = ['/products/master/', '/master-products/'];
+    // Canonical endpoint. (Historical /products/master/ alias caused noisy 404s in some envs.)
+    const endpoint = '/master-products/';
 
-    for (const endpoint of endpoints) {
-      try {
-        const response = await businessApi.get(endpoint, { params: requestParams });
-        const payload = response.data as unknown;
-        const rows = Array.isArray(payload)
-          ? payload
-          : Array.isArray((payload as Record<string, unknown> | null)?.results)
-            ? ((payload as Record<string, unknown>).results as unknown[])
-            : [];
+    try {
+      const response = await businessApi.get(endpoint, { params: requestParams });
+      const payload = response.data as unknown;
+      const rows = Array.isArray(payload)
+        ? payload
+        : Array.isArray((payload as Record<string, unknown> | null)?.results)
+          ? ((payload as Record<string, unknown>).results as unknown[])
+          : [];
 
-        return rows
-          .map((item) => {
-            const row = item && typeof item === 'object' ? (item as Record<string, unknown>) : {};
-            const label =
-              row.display_name ??
-              row.effective_name ??
-              row.name ??
-              (row.product_code ? `${String(row.product_code)}${row.name ? ` - ${String(row.name)}` : ''}` : row.id);
-            return asOption(row.id ?? row.value ?? row.product_code ?? row.name, label);
-          })
-          .filter((item): item is ContactFormOption => Boolean(item));
-      } catch {
-        // Try fallback endpoint.
-      }
+      return rows
+        .map((item) => {
+          const row = item && typeof item === 'object' ? (item as Record<string, unknown>) : {};
+          const label =
+            row.display_name ??
+            row.effective_name ??
+            row.name ??
+            (row.product_code
+              ? `${String(row.product_code)}${row.name ? ` - ${String(row.name)}` : ''}`
+              : row.id);
+          return asOption(row.id ?? row.value ?? row.product_code ?? row.name, label);
+        })
+        .filter((item): item is ContactFormOption => Boolean(item));
+    } catch {
+      return [];
     }
-
-    return [];
   },
 };
 


### PR DESCRIPTION
### Deliverables
- Backend: make /api/v1/workflows/available-forms/ resilient (never 500)
- Backend: add regression test for serializer failure
- Frontend: stop calling deprecated /products/master/ endpoint (avoid 404 spam)

### Expected results
- Editing a Plant no longer triggers a hard crash loop when available-forms misbehaves
- Console/network noise reduced (no repeated /products/master/ 404s)

### Testing
- npm --prefix frontend run type-check
- python backend/manage.py test tenant_apps.workflows.tests.test_available_forms_never_500 tenant_apps.workflows.tests.test_available_forms_entity_context --keepdb

### Rollback
- Revert this PR; endpoint will return to previous behavior.
