### PR TITLE
fix(forms): stop Plant edit render loop

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -120,6 +120,8 @@ This file is the **append-only PR-referenceable execution log**.
 
 - **2026-04-27** — Entities: fixed UniversalEntityForm React infinite loop (#185) in Plant create/edit by stabilizing initialValues and sanitizing array-like defaults; restored AI Overview on canonical Supplier/Customer record pages; renamed Suppliers/Customers list create buttons to "New Supplier"/"New Customer" and aligned Customer form titles to "New Customer"/"Customer". (PR: #4711)
 
+- **2026-04-27** — Forms: fixed Plant edit/create crash (minified React error #185) by stabilizing cascading option fetch (no more setState loop when dependencies are empty) and adding a short-lived cache for missing `/system/choices/?list=...` slugs to prevent repeated 404 spam. (PR: #4713)
+
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`
 - Stale/Zombie secrets found in GitHub but NOT in `manifests/env.manifest.json` (or legacy `DEV_`/`UAT_`/`PROD_` prefixed):

--- a/frontend/src/features/system/DynamicFormEngine.tsx
+++ b/frontend/src/features/system/DynamicFormEngine.tsx
@@ -734,11 +734,27 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     dependencyValue?: unknown;
   }> = ({ field, showRequired, errorMessage, options, cascading = false, dependencyValue }) => {
     const currentValue = useWatch({ control, name: field.key }) as string[] | undefined;
-    const dependencyItems = Array.isArray(dependencyValue)
-      ? dependencyValue.map((item) => String(item || '').trim()).filter(Boolean)
+
+    const dependencySignature = Array.isArray(dependencyValue)
+      ? dependencyValue
+          .map((item) => String(item ?? '').trim())
+          .filter(Boolean)
+          .join('\u0001')
       : typeof dependencyValue === 'string'
-        ? [String(dependencyValue).trim()].filter(Boolean)
-        : [];
+        ? String(dependencyValue).trim()
+        : '';
+
+    const dependencyItems = useMemo(() => {
+      if (Array.isArray(dependencyValue)) {
+        return dependencyValue.map((item) => String(item ?? '').trim()).filter(Boolean);
+      }
+
+      if (typeof dependencyValue === 'string') {
+        return [String(dependencyValue).trim()].filter(Boolean);
+      }
+
+      return [] as string[];
+    }, [dependencySignature]);
 
     const hasDependencies = (field.dependencies || []).length > 0;
 

--- a/frontend/src/hooks/useCascadingField.ts
+++ b/frontend/src/hooks/useCascadingField.ts
@@ -4,7 +4,7 @@
  * Handles dependent field filtering based on parent field selections.
  * Example: Selecting "Beef" in protein type automatically filters product cuts to beef-only.
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { businessApi } from '@/services/businessApi';
 
 export interface CascadingFieldOption {
@@ -85,9 +85,37 @@ export const useCascadingField = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const parentSignature = useMemo(() => {
+    if (Array.isArray(parentValue)) {
+      return parentValue
+        .map((item) => String(item ?? '').trim())
+        .filter(Boolean)
+        .join('\u0001');
+    }
+
+    if (parentValue == null) return '';
+    if (typeof parentValue === 'string') return parentValue.trim();
+    return String(parentValue);
+  }, [parentValue]);
+
+  const normalizedParentValue = useMemo(() => {
+    if (Array.isArray(parentValue)) {
+      return parentValue.map((item) => String(item ?? '').trim()).filter(Boolean);
+    }
+
+    if (typeof parentValue === 'string') return parentValue.trim();
+    return parentValue;
+  }, [parentSignature]);
+
+  const hasParentValue = Array.isArray(normalizedParentValue)
+    ? normalizedParentValue.length > 0
+    : Boolean(normalizedParentValue);
+
   const fetchOptions = useCallback(async () => {
-    if (!enabled || !parentValue || !fieldId) {
-      setOptions([]);
+    if (!enabled || !hasParentValue || !fieldId) {
+      setError(null);
+      setLoading(false);
+      setOptions((prev) => (prev.length ? [] : prev));
       return;
     }
 
@@ -96,35 +124,35 @@ export const useCascadingField = ({
 
     try {
       if (customFetchOptions) {
-        const nextOptions = await customFetchOptions(parentValue);
+        const nextOptions = await customFetchOptions(normalizedParentValue);
         setOptions(Array.isArray(nextOptions) ? nextOptions : []);
         return;
       }
 
       const response = await businessApi.get(`/form-fields/${fieldId}/cascade-options/`, {
-        params: { parent_value: parentValue },
+        params: { parent_value: normalizedParentValue },
       });
 
-      setOptions(response.data || []);
+      setOptions(Array.isArray(response.data) ? response.data : []);
     } catch (err: any) {
       const errorMsg = err.response?.data?.error || 'Failed to fetch cascaded options';
       setError(errorMsg);
       console.error('[useCascadingField] Error fetching options:', err);
-      setOptions([]);
+      setOptions((prev) => (prev.length ? [] : prev));
     } finally {
       setLoading(false);
     }
-  }, [customFetchOptions, fieldId, parentValue, enabled]);
+  }, [customFetchOptions, enabled, fieldId, hasParentValue, normalizedParentValue]);
 
   useEffect(() => {
-    fetchOptions();
+    void fetchOptions();
   }, [fetchOptions]);
 
   return {
     options,
     loading,
     error,
-    refresh: fetchOptions
+    refresh: fetchOptions,
   };
 };
 

--- a/frontend/src/services/contactFormOptionsService.ts
+++ b/frontend/src/services/contactFormOptionsService.ts
@@ -59,9 +59,30 @@ const slugVariants = (slug: string): string[] => {
   return Array.from(variants);
 };
 
+const MISSING_CHOICE_LIST_TTL_MS = 5 * 60 * 1000;
+const missingChoiceLists = new Map<string, number>();
+
+const isKnownMissingChoiceList = (key: string): boolean => {
+  const ts = missingChoiceLists.get(key);
+  if (!ts) return false;
+  if (Date.now() - ts > MISSING_CHOICE_LIST_TTL_MS) {
+    missingChoiceLists.delete(key);
+    return false;
+  }
+  return true;
+};
+
 export const contactFormOptionsService = {
   async getSystemChoiceOptions(listSlug: string): Promise<ContactFormOption[]> {
-    const candidates = slugVariants(listSlug);
+    const key = String(listSlug || '').trim().toLowerCase();
+    if (!key) return [];
+
+    if (isKnownMissingChoiceList(key)) {
+      return [];
+    }
+
+    const candidates = slugVariants(key);
+    let sawNotFound = false;
 
     for (const candidate of candidates) {
       try {
@@ -70,8 +91,12 @@ export const contactFormOptionsService = {
         });
 
         const options = normalizeChoicePayload(response.data);
-        if (options.length > 0) return options;
-      } catch {
+        if (options.length > 0) {
+          missingChoiceLists.delete(key);
+          return options;
+        }
+      } catch (err: any) {
+        if (err?.response?.status === 404) sawNotFound = true;
         // Fall through to the next candidate / fallback.
       }
     }
@@ -80,6 +105,7 @@ export const contactFormOptionsService = {
       try {
         const options = await configService.getChoiceOptions(candidate);
         if (Array.isArray(options) && options.length > 0) {
+          missingChoiceLists.delete(key);
           return options
             .map((item) => asOption(item.value, item.label))
             .filter((item): item is ContactFormOption => Boolean(item));
@@ -87,6 +113,10 @@ export const contactFormOptionsService = {
       } catch {
         // Ignore fallback failures until all variants are exhausted.
       }
+    }
+
+    if (sawNotFound) {
+      missingChoiceLists.set(key, Date.now());
     }
 
     return [];


### PR DESCRIPTION
## Deliverables\n- Fix React max-update-depth loop when opening Plant edit/create in UniversalEntityForm/DynamicFormEngine\n- Stabilize cascading option fetch so it only runs when parent values *change*\n- Add short-lived cache for missing choice-list slugs to prevent repeated 404 spam during a single form session\n\n## Expected result\n- Clicking **Edit Plant** no longer crashes (minified React error #185)\n- Network tab no longer floods /api/v1/system/choices/?list=protein_types requests\n\n## Testing\n- npm --prefix frontend run type-check\n- npm --prefix frontend run test:ci\n\n## Risk\n- Low: changes are additive and isolated to option-loading/cascading hooks\n\n## Rollback\n- Revert this PR to restore prior behavior.