### PR TITLE
Hotfix: stop 401 cascade + UniversalEntityForm loop

### DIFF
--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -14,6 +14,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuthState } from '@/contexts/AuthContext';
 import { Button, Modal, Spin, message, Select, Skeleton } from 'antd';
 import styled from 'styled-components';
 import { businessApi } from '../../services/businessApi';
@@ -877,7 +878,11 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   keyFields,
   allowModeSwitch,
 }) => {
+  const { isAuthenticated, loading: authLoading } = useAuthState();
+  const stableEmptyInitialValues = useMemo(() => ({} as Record<string, unknown>), []);
+
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<unknown | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [schema, setSchema] = useState<BackendSchema | null>(null);
   const [recordValues, setRecordValues] = useState<Record<string, unknown> | null>(null);
@@ -1020,15 +1025,22 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
         setFkValues(sanitized);
       } catch (err: unknown) {
         if (!mounted) return;
+        setLoadError(err);
         setSchema(null);
         setRecordValues(null);
         setResolvedInitialValues(initialSnapshot);
+
+        const status = (err as any)?.response?.status;
         const errorMessage =
           typeof (err as { response?: { data?: { error?: string } } })?.response?.data?.error ===
           'string'
             ? (err as { response?: { data?: { error?: string } } }).response?.data?.error
             : 'Failed to load form';
-        message.error(errorMessage);
+
+        // Avoid toast spam for auth failures; the global interceptor will redirect.
+        if (status !== 401 && status !== 403) {
+          message.error(errorMessage);
+        }
       } finally {
         if (mounted) setLoading(false);
       }
@@ -1039,7 +1051,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     return () => {
       mounted = false;
     };
-  }, [endpoint, entityId, inferredMode, isOpen, loadSchema, schemaEntityKey]);
+  }, [authLoading, endpoint, entityId, inferredMode, isAuthenticated, isOpen, loadSchema, schemaEntityKey, stableEmptyInitialValues]);
 
   // Load basic FK option lists (best-effort) for non-product references.
   useEffect(() => {
@@ -1757,6 +1769,12 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
       {loading ? (
         <div style={{ padding: 16 }}>
           <Skeleton active paragraph={{ rows: 6 }} />
+        </div>
+      ) : loadError ? (
+        <div style={{ padding: 12, color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>
+          {(loadError as any)?.response?.status === 401 || (loadError as any)?.response?.status === 403
+            ? 'Authentication required. Redirecting to login…'
+            : 'Unable to load form.'}
         </div>
       ) : !schema ? (
         <div style={{ padding: 12, color: 'rgb(var(--color-text-secondary))', fontSize: 13 }}>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -176,3 +176,27 @@ export const useAuth = (): AuthContextType => {
   }
   return context;
 };
+
+/**
+ * Minimal auth state hook that does NOT require AuthProvider.
+ *
+ * Used for providers/hooks that can be mounted in isolation (tests, storybook, etc.)
+ * but still need to avoid firing authenticated queries when no credentials exist.
+ */
+export const useAuthState = (): { isAuthenticated: boolean; loading: boolean } => {
+  const context = useContext(AuthContext);
+  if (context !== undefined) {
+    return { isAuthenticated: context.isAuthenticated, loading: context.loading };
+  }
+
+  const hasStorageAuth =
+    typeof window !== 'undefined' &&
+    Boolean(
+      localStorage.getItem('accessToken') ||
+        localStorage.getItem('refreshToken') ||
+        localStorage.getItem('authToken') ||
+        localStorage.getItem('user')
+    );
+
+  return { isAuthenticated: hasStorageAuth, loading: false };
+};

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -185,18 +185,23 @@ export const useAuth = (): AuthContextType => {
  */
 export const useAuthState = (): { isAuthenticated: boolean; loading: boolean } => {
   const context = useContext(AuthContext);
-  if (context !== undefined) {
-    return { isAuthenticated: context.isAuthenticated, loading: context.loading };
-  }
 
-  const hasStorageAuth =
+  // Treat cached user objects as *non-authoritative* for API gating.
+  // We only consider the session authenticated for network calls when token credentials exist.
+  const hasTokenCredentials =
     typeof window !== 'undefined' &&
     Boolean(
       localStorage.getItem('accessToken') ||
         localStorage.getItem('refreshToken') ||
-        localStorage.getItem('authToken') ||
-        localStorage.getItem('user')
+        localStorage.getItem('authToken')
     );
 
-  return { isAuthenticated: hasStorageAuth, loading: false };
+  if (context !== undefined) {
+    return {
+      isAuthenticated: context.isAuthenticated && hasTokenCredentials,
+      loading: context.loading,
+    };
+  }
+
+  return { isAuthenticated: hasTokenCredentials, loading: false };
 };

--- a/frontend/src/contexts/QuickActionsContext.test.tsx
+++ b/frontend/src/contexts/QuickActionsContext.test.tsx
@@ -207,7 +207,10 @@ describe('QuickActionsContext', () => {
 
     it('should treat 401/403 as logged-out state (no error)', async () => {
       localStorageMock = {
-        // No JWT or legacy token (cookie-auth may still exist in real app)
+        // No JWT or legacy token (cookie-auth may still exist in real app).
+        // In the real app, AuthProvider would mark the user as authenticated via /auth/user/.
+        // For this isolated provider test, use a stored user to simulate an authenticated session.
+        user: JSON.stringify({ id: 1, username: 'tester', email: 'tester@example.com' }),
         tenantId: '11111111-1111-4111-8111-111111111111',
       };
 

--- a/frontend/src/contexts/QuickActionsContext.test.tsx
+++ b/frontend/src/contexts/QuickActionsContext.test.tsx
@@ -207,10 +207,8 @@ describe('QuickActionsContext', () => {
 
     it('should treat 401/403 as logged-out state (no error)', async () => {
       localStorageMock = {
-        // No JWT or legacy token (cookie-auth may still exist in real app).
-        // In the real app, AuthProvider would mark the user as authenticated via /auth/user/.
-        // For this isolated provider test, use a stored user to simulate an authenticated session.
-        user: JSON.stringify({ id: 1, username: 'tester', email: 'tester@example.com' }),
+        // Simulate an authenticated session (API gating requires token credentials).
+        authToken: 'legacy-token',
         tenantId: '11111111-1111-4111-8111-111111111111',
       };
 

--- a/frontend/src/contexts/QuickActionsContext.tsx
+++ b/frontend/src/contexts/QuickActionsContext.tsx
@@ -5,6 +5,7 @@
  * Handles loading, caching, and updating user's quick actions.
  */
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { useAuthState } from '@/contexts/AuthContext';
 import { getAvailableWorkForms } from '@/services/workformsApi';
 import { showAlert } from '@/utils/uiDialogs';
 import { logger } from '@/utils/logger';
@@ -64,6 +65,8 @@ interface QuickActionsProviderProps {
 }
 
 export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ children }) => {
+  const { isAuthenticated, loading: authLoading } = useAuthState();
+
   const [quickActions, setQuickActions] = useState<QuickActionItem[]>([]);
   const [availableForms, setAvailableForms] = useState<AvailableForm[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -75,8 +78,18 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
 
   const warnedMissingTenantRef = React.useRef(false);
 
-  // Load quick actions on mount
+  // Load quick actions when authenticated (and tenant is available)
   const refreshQuickActions = useCallback(async () => {
+    // Prevent noisy 401 spam during app bootstrap.
+    if (authLoading) return;
+    if (!isAuthenticated) {
+      setQuickActions([]);
+      setAvailableForms([]);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
     const isAuthError = (err: any) => {
       const status = err?.response?.status;
       return status === 401 || status === 403;
@@ -200,17 +213,27 @@ export const QuickActionsProvider: React.FC<QuickActionsProviderProps> = ({ chil
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [authLoading, isAuthenticated]);
 
-  const didInitialFetchRef = React.useRef(false);
+  const didFetchForAuthRef = React.useRef(false);
 
   useEffect(() => {
-    // Always attempt to load: supports cookie-auth sessions (no localStorage token).
-    // Guard against effect re-run (e.g., React dev strict-mode double-invoke) to avoid retry loops.
-    if (didInitialFetchRef.current) return;
-    didInitialFetchRef.current = true;
-    refreshQuickActions();
-  }, [refreshQuickActions]);
+    if (authLoading) return;
+
+    if (!isAuthenticated) {
+      // Allow a fresh load after the next successful login.
+      didFetchForAuthRef.current = false;
+      setQuickActions([]);
+      setAvailableForms([]);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    if (didFetchForAuthRef.current) return;
+    didFetchForAuthRef.current = true;
+    void refreshQuickActions();
+  }, [authLoading, isAuthenticated, refreshQuickActions]);
 
   const updateQuickActions = useCallback(async (items: QuickActionItem[]) => {
     try {

--- a/frontend/src/hooks/useAdminPermissions.ts
+++ b/frontend/src/hooks/useAdminPermissions.ts
@@ -15,6 +15,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { useAuthState } from '@/contexts/AuthContext';
 import { apiClient } from '../services/apiService';
 
 export interface AdminPermissions {
@@ -39,6 +40,7 @@ export interface AdminPermissions {
  * Hook to fetch and manage admin permissions for the current user.
  */
 export function useAdminPermissions() {
+  const { isAuthenticated, loading: authLoading } = useAuthState();
   const tenantId = typeof window !== 'undefined' ? localStorage.getItem('tenantId') : null;
 
   const query = useQuery<AdminPermissions>({
@@ -96,6 +98,7 @@ export function useAdminPermissions() {
         return getDefaultPermissions();
       }
     },
+    enabled: !authLoading && isAuthenticated,
     staleTime: 5 * 60 * 1000, // 5 minutes - permissions don't change often
     retry: (failureCount, error: any) => {
       if (error?.response?.status === 401) {

--- a/frontend/src/services/apiService.refreshQueue.test.ts
+++ b/frontend/src/services/apiService.refreshQueue.test.ts
@@ -101,8 +101,12 @@ describe('apiService JWT refresh queue', () => {
   let apiClient: any;
   let rejected: (err: any) => Promise<any>;
   let resetState: (() => void) | undefined;
+  let mockClearTokens: any;
 
   beforeAll(async () => {
+    const jwt = (await import('./jwtService')) as any;
+    mockClearTokens = jwt.clearTokens;
+
     const mod = (await import('./apiService')) as any;
     apiClient = mod.apiClient;
     resetState = mod.__resetAuthRefreshStateForTests;
@@ -118,6 +122,7 @@ describe('apiService JWT refresh queue', () => {
     resetState?.();
     mockRefreshAccessToken.mockReset();
     mockTriggerGlobalSessionExpired.mockReset();
+    mockClearTokens?.mockClear?.();
     apiClient.mockClear();
   });
 
@@ -163,6 +168,6 @@ describe('apiService JWT refresh queue', () => {
     await expect(p2).rejects.toBe(err);
 
     expect(apiClient).toHaveBeenCalledTimes(0);
-    expect(mockTriggerGlobalSessionExpired).toHaveBeenCalledTimes(1);
+    expect(mockClearTokens).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -7,7 +7,7 @@
  * - Uses Bearer tokens for JWT authentication
  * - Falls back to Token auth for legacy compatibility
  * - Automatic token refresh on 401 responses
- * - Session expired modal instead of hard redirects
+ * - Global 401 handling: clears local auth + hard-redirects to /login when refresh fails/missing
  */
 import axios, { AxiosError as AxiosErrorType, InternalAxiosRequestConfig } from 'axios';
 import * as Sentry from '@sentry/react';
@@ -21,7 +21,6 @@ import {
   clearTokens,
   isUsingJwt,
 } from './jwtService';
-import { triggerGlobalSessionExpired } from '../contexts/SessionManagerContext';
 import { ApiServiceError, createCircuitBreakerError } from './apiErrors';
 
 // API Configuration
@@ -52,6 +51,57 @@ const processQueue = (error: unknown | null) => {
     }
   });
   failedQueue = [];
+};
+
+const isAuthEndpointRequest = (url?: string | null): boolean => {
+  const u = String(url || '');
+  return (
+    u.includes('/auth/token/refresh/') ||
+    u.includes('/auth/token/verify/') ||
+    u.includes('/auth/token/') ||
+    u.includes('/auth/login/') ||
+    u.includes('/auth/guest-login/') ||
+    u.includes('/auth/signup')
+  );
+};
+
+const redirectToLogin = () => {
+  if (typeof window === 'undefined') return;
+
+  const currentPath = `${window.location.pathname}${window.location.search}`;
+
+  // Avoid redirect loops (and allow the login page to handle invalid credentials normally).
+  if (currentPath.startsWith('/login')) return;
+
+  try {
+    localStorage.setItem('redirectAfterLogin', currentPath);
+  } catch {
+    // best-effort
+  }
+
+  try {
+    window.location.assign('/login');
+  } catch {
+    // JSDOM (tests) and some restricted browser contexts may throw on navigation.
+    // Auth state is already cleared, so swallow and let the app router handle it.
+  }
+};
+
+const forceLogoutAndRedirect = () => {
+  try {
+    clearTokens();
+  } catch {
+    // best-effort
+  }
+
+  try {
+    localStorage.removeItem('user');
+  } catch {
+    // best-effort
+  }
+
+  // KEEP tenant context for re-login - user should see same tenant after re-auth.
+  redirectToLogin();
 };
 
 const stripJsonContentTypeForFormData = (config: InternalAxiosRequestConfig) => {
@@ -281,24 +331,20 @@ apiClient.interceptors.response.use(
     }
     
     // Handle 401 Unauthorized
+    // Never auto-logout/redirect for auth endpoints themselves (login failures should be handled by the caller).
+    if (status === 401 && originalRequest && isAuthEndpointRequest(originalRequest.url)) {
+      return Promise.reject(error);
+    }
+
     if (status === 401 && originalRequest && !originalRequest._retry) {
       // Prevent infinite retry loops
       const retryCount = (originalRequest._retryCount || 0) + 1;
       if (retryCount > 2) {
-        logger.error('[API] Max retry attempts reached, showing session expired modal');
-        clearTokens();
-        localStorage.removeItem('user');
-        // KEEP tenant context for re-login - user should see same tenant after re-auth
-        // This prevents unexpected tenant switching mid-session
-        // localStorage.removeItem('tenantId');
-        // localStorage.removeItem('tenantName');
-        // localStorage.removeItem('tenantSlug');
-        
-        // Show session expired modal instead of hard redirect
-        triggerGlobalSessionExpired('Your session has expired after multiple authentication attempts.');
+        logger.error('[API] Max retry attempts reached, forcing logout + redirect');
+        forceLogoutAndRedirect();
         return Promise.reject(error);
       }
-      
+
       // If using JWT and we have a refresh token, try to refresh
       if (isUsingJwt()) {
         if (isRefreshing) {
@@ -307,51 +353,43 @@ apiClient.interceptors.response.use(
             failedQueue.push({ resolve, reject, config: originalRequest });
           }).then((config) => apiClient(config as InternalAxiosRequestConfig));
         }
-        
+
         originalRequest._retry = true;
         originalRequest._retryCount = retryCount;
         isRefreshing = true;
-        
+
         try {
           const newToken = await refreshAccessToken();
-          
+
           if (newToken) {
             // Retry original request with new token
             originalRequest.headers.Authorization = `Bearer ${newToken}`;
             processQueue(null);
             logger.debug('[API] Retrying request with refreshed token');
             return apiClient(originalRequest);
-          } else {
-            // Refresh returned null - tokens are invalid
-            throw new Error('Token refresh returned null');
           }
+
+          // Refresh returned null - tokens are invalid
+          throw new Error('Token refresh returned null');
         } catch (refreshError) {
           logger.error('[API] Token refresh failed:', refreshError);
           processQueue(refreshError);
-          // Refresh failed, show session expired modal
-          clearTokens();
-          localStorage.removeItem('user');
-          // KEEP tenant context for re-login - user should see same tenant after re-auth
-          // This prevents unexpected tenant switching mid-session
-          // localStorage.removeItem('tenantId');
-          // localStorage.removeItem('tenantName');
-          // localStorage.removeItem('tenantSlug');
-          
-          triggerGlobalSessionExpired('Your session could not be refreshed. Please log in again.');
+
+          // Refresh failed: clear local auth immediately and hard-redirect to login.
+          forceLogoutAndRedirect();
           return Promise.reject(refreshError);
         } finally {
           // CRITICAL: Always reset isRefreshing flag
           isRefreshing = false;
         }
       }
-      
-      // No JWT or refresh failed, clear auth and show modal
-      logger.warn('[API] No JWT auth available, showing session expired modal');
-      clearTokens();
-      localStorage.removeItem('user');
-      triggerGlobalSessionExpired('Your session has expired. Please log in to continue.');
+
+      // No JWT or refresh token available: clear auth and hard-redirect to login.
+      logger.warn('[API] No JWT auth available, forcing logout + redirect');
+      forceLogoutAndRedirect();
+      return Promise.reject(error);
     }
-    
+
     return Promise.reject(error);
   }
 );
@@ -404,35 +442,37 @@ adminClient.interceptors.response.use(
       });
     }
     
-    if (error.response?.status === 401 && originalRequest && !originalRequest._retry) {
+    // Never auto-logout/redirect for auth endpoints themselves (login failures should be handled by the caller).
+    if (status === 401 && originalRequest && isAuthEndpointRequest(originalRequest.url)) {
+      return Promise.reject(error);
+    }
+
+    if (status === 401 && originalRequest && !originalRequest._retry) {
       // Prevent infinite retry loops
       const retryCount = (originalRequest._retryCount || 0) + 1;
       if (retryCount > 2) {
-        logger.error('[Admin API] Max retry attempts reached, showing session expired modal');
-        clearTokens();
-        localStorage.removeItem('user');
-        triggerGlobalSessionExpired('Your session has expired.');
+        logger.error('[Admin API] Max retry attempts reached, forcing logout + redirect');
+        forceLogoutAndRedirect();
         return Promise.reject(error);
       }
-      
+
       if (isUsingJwt()) {
         originalRequest._retry = true;
         originalRequest._retryCount = retryCount;
         const newToken = await refreshAccessToken();
-        
+
         if (newToken) {
           originalRequest.headers.Authorization = `Bearer ${newToken}`;
           logger.debug('[Admin API] Retrying request with refreshed token');
           return adminClient(originalRequest);
         }
       }
-      
-      logger.warn('[Admin API] No JWT auth available, showing session expired modal');
-      clearTokens();
-      localStorage.removeItem('user');
-      triggerGlobalSessionExpired('Your session has expired. Please log in to continue.');
+
+      logger.warn('[Admin API] No JWT auth available, forcing logout + redirect');
+      forceLogoutAndRedirect();
+      return Promise.reject(error);
     }
-    
+
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
## What\n- Axios interceptors: on 401 where refresh is missing/fails, clear local auth and hard-redirect to /login; always reject promises.\n- UniversalEntityForm: guard when auth is missing + track load error to prevent infinite update loops when record fetch returns 401.\n- QuickActionsContext + useAdminPermissions: gate initial calls until token credentials exist to prevent 401 spam.\n\n## Why\nPrevents 401 cascade and React #185 infinite loop when tokens are missing/cleared.\n\n## Testing\n- frontend: type-check\n- frontend: vitest (targeted suites): apiService.refreshQueue + QuickActionsContext\n\n## Manual\nDelete accessToken/authToken in Local Storage then click Edit Plant: should redirect to /login (no crash).\n