### PR TITLE
Hotfix: prevent UniversalEntityForm auth loop

### DIFF
--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -879,7 +879,6 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   allowModeSwitch,
 }) => {
   const { isAuthenticated, loading: authLoading } = useAuthState();
-  const stableEmptyInitialValues = useMemo(() => ({} as Record<string, unknown>), []);
 
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<unknown | null>(null);
@@ -992,12 +991,49 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
   useEffect(() => {
     if (!isOpen) return;
 
+    setLoadError(null);
     setShowAdvanced(false);
     setActiveMode(inferredMode);
     setRecordValues(null);
 
     const initialSnapshot = (initialValuesRef.current || {}) as Record<string, unknown>;
     setResolvedInitialValues(initialSnapshot);
+    setFkValues(initialSnapshot);
+
+    // Wait for auth initialization to settle before attempting any protected calls.
+    if (authLoading) {
+      setLoading(true);
+      return;
+    }
+
+    // If no token credentials exist, do NOT attempt network calls. This prevents
+    // a 401→state update→re-render→retry loop that can trigger React error #185.
+    if (!isAuthenticated) {
+      setSchema(null);
+      setRecordValues(null);
+      setLoading(false);
+      setLoadError({ response: { status: 401 } });
+
+      // Best-effort redirect matching the global interceptor behavior.
+      if (typeof window !== 'undefined') {
+        const currentPath = `${window.location.pathname}${window.location.search}`;
+        if (!currentPath.startsWith('/login')) {
+          try {
+            localStorage.setItem('redirectAfterLogin', currentPath);
+          } catch {
+            // best-effort
+          }
+
+          try {
+            window.location.assign('/login');
+          } catch {
+            // JSDOM/tests may throw on navigation.
+          }
+        }
+      }
+
+      return;
+    }
 
     let mounted = true;
 
@@ -1029,6 +1065,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
         setSchema(null);
         setRecordValues(null);
         setResolvedInitialValues(initialSnapshot);
+        setFkValues(initialSnapshot);
 
         const status = (err as any)?.response?.status;
         const errorMessage =
@@ -1051,7 +1088,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     return () => {
       mounted = false;
     };
-  }, [authLoading, endpoint, entityId, inferredMode, isAuthenticated, isOpen, loadSchema, schemaEntityKey, stableEmptyInitialValues]);
+  }, [authLoading, endpoint, entityId, inferredMode, isAuthenticated, isOpen, loadSchema, schemaEntityKey]);
 
   // Load basic FK option lists (best-effort) for non-product references.
   useEffect(() => {

--- a/frontend/src/components/Shared/UniversalEntityForm.unauth.test.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.unauth.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const businessApiMock = vi.hoisted(() => {
+  return {
+    get: vi.fn(),
+    options: vi.fn(),
+  };
+});
+
+vi.mock('../../services/businessApi', () => {
+  return {
+    businessApi: businessApiMock,
+  };
+});
+
+vi.mock('@/contexts/AuthContext', () => {
+  return {
+    useAuthState: () => ({ isAuthenticated: false, loading: false }),
+  };
+});
+
+vi.mock('../../features/system/DynamicFormEngine', () => {
+  return {
+    default: () => <div data-testid="dynamic-form-engine" />,
+  };
+});
+
+import { UniversalEntityForm } from './UniversalEntityForm';
+
+describe('UniversalEntityForm (unauthenticated)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    businessApiMock.get.mockReset();
+    businessApiMock.options.mockReset();
+  });
+
+  it('does not call businessApi when unauthenticated', async () => {
+    render(
+      <UniversalEntityForm
+        entityType="plant"
+        entityId="2769"
+        mode="edit"
+        variant="inline"
+        isOpen
+        onClose={() => {}}
+      />
+    );
+
+    expect(await screen.findByText(/Authentication required/i)).toBeInTheDocument();
+    expect(businessApiMock.get).not.toHaveBeenCalled();
+    expect(businessApiMock.options).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Prevents React #185 (max update depth) by skipping protected loads when unauthenticated and redirecting to /login. Adds a regression test ensuring UniversalEntityForm does not call businessApi when unauthenticated.