### PR TITLE
Test: prevent DynamicFormEngine update loop

### DIFF
--- a/frontend/src/features/system/DynamicFormEngine.stability.test.tsx
+++ b/frontend/src/features/system/DynamicFormEngine.stability.test.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import DynamicFormEngine from './DynamicFormEngine';
+
+vi.mock('../../services/configService', () => ({
+  resolveConfig: vi.fn(async (_key: string, fallback: unknown) => ({ value: fallback })),
+}));
+
+describe('DynamicFormEngine stability', () => {
+  it('does not hit maximum update depth when schema/initialValues objects are rebuilt', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    const Parent: React.FC = () => {
+      const [tick, setTick] = useState(0);
+
+      useEffect(() => {
+        if (tick >= 10) return;
+        setTick((prev) => prev + 1);
+      }, [tick]);
+
+      // Recreate objects each render to simulate parent rebuilds.
+      const schema = {
+        step_index: 0,
+        name: 'Plant Profile',
+        fields: [
+          {
+            key: 'export_approved',
+            label: 'Export Approved',
+            type: 'checkbox',
+            required: false,
+          },
+          {
+            key: 'export_documents_handled',
+            label: 'Export Documents Handled',
+            type: 'text',
+            required: false,
+            ui: {
+              visible_when: {
+                field: 'export_approved',
+                equals: true,
+              },
+            },
+          },
+        ],
+      };
+
+      const initialValues = {
+        export_approved: false,
+        export_documents_handled: 'LOG (Letter of Guarantee)',
+      };
+
+      return <DynamicFormEngine schema={schema as any} initialValues={initialValues} onSubmit={onSubmit} />;
+    };
+
+    render(<Parent />);
+
+    // Ensure the form is interactive and can be submitted.
+    expect(screen.getByRole('checkbox', { name: 'Export Approved' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /submit|save/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      export_approved: false,
+      export_documents_handled: '',
+    });
+  });
+});


### PR DESCRIPTION
Adds a regression test to ensure DynamicFormEngine does not hit React maximum update depth when parents rebuild schema and initialValues objects each render.

Testing:
- frontend npm test -- DynamicFormEngine.stability.test.tsx --run

Rollback:
- Removing the test only affects CI coverage (no runtime change).