### PR TITLE
Hotfix: harden system choices contract and stop React #185 loop

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -121,7 +121,7 @@ This file is the **append-only PR-referenceable execution log**.
 - **2026-04-27** — Entities: fixed UniversalEntityForm React infinite loop (#185) in Plant create/edit by stabilizing initialValues and sanitizing array-like defaults; restored AI Overview on canonical Supplier/Customer record pages; renamed Suppliers/Customers list create buttons to "New Supplier"/"New Customer" and aligned Customer form titles to "New Customer"/"Customer". (PR: #4711)
 
 - **2026-04-27** — Forms: fixed Plant edit/create crash (minified React error #185) by stabilizing cascading option fetch (no more setState loop when dependencies are empty) and adding a short-lived cache for missing `/system/choices/?list=...` slugs to prevent repeated 404 spam. (PR: #4713)
-- **2026-04-28** — **[HOTFIX]** Backend choices API hardened to return `200 []` for missing/unseeded `/api/v1/system/choices/?list=...` lookups, with `_`/`-` alias normalization and a canonical `protein_types` mapping. Frontend now uses a single canonical choices request, caches stable empty-array references, and removes permutation-fetch retries to permanently stop the React #185 loop. (PR: pending)
+- **2026-04-28** — **[HOTFIX]** Backend choices API hardened to return `200 []` for missing/unseeded `/api/v1/system/choices/?list=...` lookups, with `_`/`-` alias normalization and a canonical `protein_types` mapping. Frontend now uses a single canonical choices request, caches stable empty-array references, and removes permutation-fetch retries to permanently stop the React #185 loop. (PR: #4719)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -121,6 +121,7 @@ This file is the **append-only PR-referenceable execution log**.
 - **2026-04-27** — Entities: fixed UniversalEntityForm React infinite loop (#185) in Plant create/edit by stabilizing initialValues and sanitizing array-like defaults; restored AI Overview on canonical Supplier/Customer record pages; renamed Suppliers/Customers list create buttons to "New Supplier"/"New Customer" and aligned Customer form titles to "New Customer"/"Customer". (PR: #4711)
 
 - **2026-04-27** — Forms: fixed Plant edit/create crash (minified React error #185) by stabilizing cascading option fetch (no more setState loop when dependencies are empty) and adding a short-lived cache for missing `/system/choices/?list=...` slugs to prevent repeated 404 spam. (PR: #4713)
+- **2026-04-28** — **[HOTFIX]** Backend choices API hardened to return `200 []` for missing/unseeded `/api/v1/system/choices/?list=...` lookups, with `_`/`-` alias normalization and a canonical `protein_types` mapping. Frontend now uses a single canonical choices request, caches stable empty-array references, and removes permutation-fetch retries to permanently stop the React #185 loop. (PR: pending)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/backend/apps/system/tests/test_system_choices_api.py
+++ b/backend/apps/system/tests/test_system_choices_api.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.system.models import SystemChoiceItem, SystemChoiceList
+from apps.tenants.models import Tenant, TenantDomain, TenantUser
+
+
+User = get_user_model()
+
+
+@override_settings(ALLOWED_HOSTS=['*'])
+class SystemChoicesApiTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.user = User.objects.create_user(username=f'user-{unique}', password='pw')
+        self.client.force_authenticate(self.user)
+
+        self.tenant = Tenant.objects.create(
+            name=f'Tenant {unique}',
+            slug=f'tenant-{unique}',
+            contact_email=f'{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        self.domain = TenantDomain.objects.create(
+            tenant=self.tenant,
+            domain=f'{self.tenant.slug}.example.com',
+            is_primary=True,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='admin', is_active=True)
+
+        self.choice_list, _ = SystemChoiceList.objects.get_or_create(
+            slug='protein_type',
+            defaults={
+                'name': 'Protein Type',
+                'description': 'Protein choices',
+                'is_extensible': True,
+                'is_reorderable': True,
+                'created_by': self.user,
+            },
+        )
+        self.system_item = (
+            SystemChoiceItem.objects.filter(choice_list=self.choice_list, tenant__isnull=True)
+            .order_by('order', 'label')
+            .first()
+        )
+        if self.system_item is None:
+            self.system_item = SystemChoiceItem.objects.create(
+                choice_list=self.choice_list,
+                tenant=None,
+                value='BEEF',
+                label='Beef',
+                order=1,
+                is_active=True,
+            )
+
+        self.tenant_item = SystemChoiceItem.objects.create(
+            choice_list=self.choice_list,
+            tenant=self.tenant,
+            value=f'WAGYU_{unique.upper()}',
+            label='Wagyu',
+            order=2,
+            is_active=True,
+        )
+
+        self.tenant_headers = {
+            'HTTP_X_TENANT_ID': str(self.tenant.id),
+            'HTTP_HOST': self.domain.domain,
+        }
+
+    def test_missing_list_returns_200_with_empty_array(self):
+        response = self.client.get('/api/v1/system/choices/', {'list': 'does-not-exist'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])
+
+    def test_protein_type_aliases_resolve_in_single_endpoint(self):
+        response = self.client.get(
+            '/api/v1/system/choices/',
+            {'list': 'protein-types'},
+            **self.tenant_headers,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        values = [item['value'] for item in response.json()]
+
+        self.assertIn(self.system_item.value, values)
+        self.assertIn(self.tenant_item.value, values)
+
+    def test_without_tenant_context_only_system_items_are_returned(self):
+        response = self.client.get('/api/v1/system/choices/', {'list': 'protein_types'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        values = [item['value'] for item in response.json()]
+
+        self.assertIn(self.system_item.value, values)
+        self.assertNotIn(self.tenant_item.value, values)

--- a/backend/apps/system/urls.py
+++ b/backend/apps/system/urls.py
@@ -24,6 +24,7 @@ from apps.system.views import (
     EntityIntrospectionViewSet,
     SystemProductViewSet,
     TenantProductPreferenceViewSet,
+    SystemChoicesAPIView,
 )
 from apps.system.views.search_viewset import RankedSearchViewSet
 from apps.system.views.entity_viewset import EntityViewSet
@@ -51,6 +52,7 @@ router.register(r'product-preferences', TenantProductPreferenceViewSet, basename
 router.register(r'search/ranked', RankedSearchViewSet, basename='ranked-search')
 
 urlpatterns = [
+    path('choices/', SystemChoicesAPIView.as_view(), name='system-choices'),
     # IMPORTANT: include router first so Schema Bridge routes work:
     # - /api/v1/system/entities/<entity_id>/fields/
     # - /api/v1/system/entities/<entity_id>/display-fields/

--- a/backend/apps/system/views/__init__.py
+++ b/backend/apps/system/views/__init__.py
@@ -9,6 +9,7 @@ from apps.system.views.choice_viewsets import (
     ConfigResolverView,
     ConfigAuditLogViewSet,
     EntityIntrospectionViewSet,
+    SystemChoicesAPIView,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     'ConfigResolverView',
     'ConfigAuditLogViewSet',
     'EntityIntrospectionViewSet',
+    'SystemChoicesAPIView',
 ]

--- a/backend/apps/system/views/choice_viewsets.py
+++ b/backend/apps/system/views/choice_viewsets.py
@@ -8,10 +8,13 @@ Provides DRF ViewSets for:
 - TenantConfig (tenant admins can manage their configs)
 - ConfigAuditLog (read-only audit trail)
 """
-from rest_framework import viewsets, permissions, status
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404
+from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter, OrderingFilter
@@ -52,6 +55,48 @@ def _get_client_ip(request):
     if x_forwarded_for:
         return x_forwarded_for.split(',')[0].strip()
     return request.META.get('REMOTE_ADDR')
+
+
+CHOICE_LIST_ALIASES = {
+    'protein_type': ('protein_types', 'protein_type'),
+    'protein_types': ('protein_types', 'protein_type'),
+}
+
+
+def _normalize_choice_list_slug(raw_slug):
+    return str(raw_slug or '').strip().lower().replace('-', '_')
+
+
+def _iter_choice_list_slugs(raw_slug):
+    normalized = _normalize_choice_list_slug(raw_slug)
+    if not normalized:
+        return []
+
+    candidates = CHOICE_LIST_ALIASES.get(normalized, (normalized,))
+    seen = set()
+    ordered = []
+
+    for candidate in candidates:
+        normalized_candidate = _normalize_choice_list_slug(candidate)
+        if not normalized_candidate or normalized_candidate in seen:
+            continue
+        ordered.append(normalized_candidate)
+        seen.add(normalized_candidate)
+
+    return ordered
+
+
+def _resolve_choices_for_slug(resolver, raw_slug):
+    for candidate in _iter_choice_list_slugs(raw_slug):
+        try:
+            choices = resolver.get_choices(candidate)
+        except (ObjectDoesNotExist, Http404):
+            continue
+
+        if choices:
+            return choices
+
+    return []
 
 
 class SystemChoiceItemsPagination(PageNumberPagination):
@@ -748,15 +793,7 @@ class ConfigResolverView(viewsets.ViewSet):
         """Get choice items for a dropdown field."""
         tenant = getattr(request, 'tenant', None)
         resolver = ConfigResolver(tenant=tenant)
-        
-        try:
-            choices = resolver.get_choices(slug)
-            return Response(choices)
-        except Exception as e:
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_404_NOT_FOUND
-            )
+        return Response(_resolve_choices_for_slug(resolver, slug))
     
     @action(detail=False, methods=['get'], url_path='field-schema/(?P<field_path>.+)')
     def field_schema(self, request, field_path=None):
@@ -946,3 +983,31 @@ class EntityIntrospectionViewSet(viewsets.ViewSet):
             'entity_id': pk,
             'display_fields': display_fields
         })
+
+
+class SystemChoicesAPIView(APIView):
+    """
+    Canonical system choice-list endpoint used by schema-driven forms.
+
+    This endpoint never returns 404 for a missing or unseeded list. A missing list
+    degrades to an empty array so frontend callers can safely cache the result
+    without triggering retry/error loops.
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        list_slug = (
+            request.query_params.get('list')
+            or request.query_params.get('slug')
+            or request.query_params.get('choice_type')
+        )
+        if not list_slug:
+            return Response(
+                {'error': 'list parameter required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        tenant = getattr(request, 'tenant', None)
+        resolver = ConfigResolver(tenant=tenant)
+        return Response(_resolve_choices_for_slug(resolver, list_slug), status=status.HTTP_200_OK)

--- a/frontend/src/features/system/DynamicFormEngine.tsx
+++ b/frontend/src/features/system/DynamicFormEngine.tsx
@@ -19,6 +19,7 @@ import { CountrySelect } from '../../components/ui';
 import { DEFAULT_COUNTRY } from '../../utils/constants/countries';
 import { useCascadingField } from '../../hooks/useCascadingField';
 import { contactFormOptionsService } from '../../services/contactFormOptionsService';
+import { EMPTY_CHOICES } from '../../services/choiceConstants';
 import { resolveConfig } from '../../services/configService';
 import { getChoicesForField, isStaticChoiceField } from '../../services/choicesService';
 import { formatUsPhone } from '../../utils/phone';
@@ -511,8 +512,8 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     a: { value: string; label: string }[] | undefined,
     b: { value: string; label: string }[] | undefined
   ): boolean => {
-    const aa = Array.isArray(a) ? a : [];
-    const bb = Array.isArray(b) ? b : [];
+    const aa = Array.isArray(a) ? a : (EMPTY_CHOICES as { value: string; label: string }[]);
+    const bb = Array.isArray(b) ? b : (EMPTY_CHOICES as { value: string; label: string }[]);
     if (aa.length !== bb.length) return false;
 
     for (let i = 0; i < aa.length; i += 1) {
@@ -632,7 +633,7 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
       return field.options.map((opt) => (typeof opt === 'string' ? { value: opt, label: opt } : opt));
     }
     // Fall back to dynamically loaded options
-    return dynamicOptions[field.key] || [];
+    return dynamicOptions[field.key] || (EMPTY_CHOICES as { value: string; label: string }[]);
   };
 
   const isStateLikeKey = (normalizedKey: string): boolean => {

--- a/frontend/src/hooks/useCascadingField.ts
+++ b/frontend/src/hooks/useCascadingField.ts
@@ -6,6 +6,7 @@
  */
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { businessApi } from '@/services/businessApi';
+import { EMPTY_CHOICES } from '@/services/choiceConstants';
 
 export interface CascadingFieldOption {
   value: string;
@@ -81,7 +82,9 @@ export const useCascadingField = ({
   enabled?: boolean;
   fetchOptions?: (parentValue: any) => Promise<CascadingFieldOption[]>;
 }) => {
-  const [options, setOptions] = useState<CascadingFieldOption[]>([]);
+  const [options, setOptions] = useState<CascadingFieldOption[]>(
+    () => EMPTY_CHOICES as CascadingFieldOption[]
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -115,7 +118,7 @@ export const useCascadingField = ({
     if (!enabled || !hasParentValue || !fieldId) {
       setError(null);
       setLoading(false);
-      setOptions((prev) => (prev.length ? [] : prev));
+      setOptions((prev) => (prev.length ? (EMPTY_CHOICES as CascadingFieldOption[]) : prev));
       return;
     }
 
@@ -125,7 +128,11 @@ export const useCascadingField = ({
     try {
       if (customFetchOptions) {
         const nextOptions = await customFetchOptions(normalizedParentValue);
-        setOptions(Array.isArray(nextOptions) ? nextOptions : []);
+        setOptions(
+          Array.isArray(nextOptions) && nextOptions.length > 0
+            ? nextOptions
+            : (EMPTY_CHOICES as CascadingFieldOption[])
+        );
         return;
       }
 
@@ -133,12 +140,16 @@ export const useCascadingField = ({
         params: { parent_value: normalizedParentValue },
       });
 
-      setOptions(Array.isArray(response.data) ? response.data : []);
+      setOptions(
+        Array.isArray(response.data) && response.data.length > 0
+          ? response.data
+          : (EMPTY_CHOICES as CascadingFieldOption[])
+      );
     } catch (err: any) {
       const errorMsg = err.response?.data?.error || 'Failed to fetch cascaded options';
       setError(errorMsg);
       console.error('[useCascadingField] Error fetching options:', err);
-      setOptions((prev) => (prev.length ? [] : prev));
+      setOptions((prev) => (prev.length ? (EMPTY_CHOICES as CascadingFieldOption[]) : prev));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/services/choiceConstants.ts
+++ b/frontend/src/services/choiceConstants.ts
@@ -1,0 +1,6 @@
+export interface ChoiceOptionShape {
+  value: string;
+  label: string;
+}
+
+export const EMPTY_CHOICES: readonly ChoiceOptionShape[] = Object.freeze([]);

--- a/frontend/src/services/contactFormOptionsService.test.ts
+++ b/frontend/src/services/contactFormOptionsService.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EMPTY_CHOICES } from './choiceConstants';
+
+vi.mock('./businessApi', () => ({
+  businessApi: {
+    get: vi.fn(),
+  },
+}));
+
+import { businessApi } from './businessApi';
+import { contactFormOptionsService } from './contactFormOptionsService';
+
+describe('contactFormOptionsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contactFormOptionsService.clearCache();
+  });
+
+  it('uses one canonical slug and caches the stable empty choices reference', async () => {
+    vi.mocked(businessApi.get).mockResolvedValue({ data: [] });
+
+    const first = await contactFormOptionsService.getSystemChoiceOptions('protein-type');
+    const second = await contactFormOptionsService.getSystemChoiceOptions('protein_type');
+
+    expect(businessApi.get).toHaveBeenCalledTimes(1);
+    expect(businessApi.get).toHaveBeenCalledWith('/system/choices/', {
+      params: { list: 'protein_types' },
+    });
+    expect(first).toBe(EMPTY_CHOICES);
+    expect(second).toBe(EMPTY_CHOICES);
+  });
+});

--- a/frontend/src/services/contactFormOptionsService.ts
+++ b/frontend/src/services/contactFormOptionsService.ts
@@ -1,10 +1,28 @@
 import { businessApi } from './businessApi';
-import { configService } from './configService';
+import { EMPTY_CHOICES } from './choiceConstants';
 
 export interface ContactFormOption {
   value: string;
   label: string;
 }
+
+const CANONICAL_CHOICE_LIST_ALIASES: Record<string, string> = {
+  'protein-type': 'protein_types',
+  'protein_type': 'protein_types',
+  'protein_types': 'protein_types',
+};
+
+const systemChoiceCache = new Map<string, ContactFormOption[]>();
+const pendingSystemChoiceRequests = new Map<string, Promise<ContactFormOption[]>>();
+
+const normalizeChoiceListSlug = (slug: string): string => {
+  const normalized = String(slug || '').trim().toLowerCase();
+  if (!normalized) return '';
+
+  return CANONICAL_CHOICE_LIST_ALIASES[normalized] || normalized.replace(/-/g, '_');
+};
+
+const emptyChoices = (): ContactFormOption[] => EMPTY_CHOICES as ContactFormOption[];
 
 const asOption = (value: unknown, label?: unknown): ContactFormOption | null => {
   const normalizedValue = value == null ? '' : String(value).trim();
@@ -20,12 +38,14 @@ const asOption = (value: unknown, label?: unknown): ContactFormOption | null => 
 
 const normalizeChoicePayload = (payload: unknown): ContactFormOption[] => {
   if (Array.isArray(payload)) {
-    return payload
+    const options = payload
       .map((item) => {
         const row = item && typeof item === 'object' ? (item as Record<string, unknown>) : {};
         return asOption(row.value ?? row.id ?? row.key, row.label ?? row.name ?? row.display_name);
       })
       .filter((item): item is ContactFormOption => Boolean(item));
+
+    return options.length > 0 ? options : emptyChoices();
   }
 
   const obj = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null;
@@ -40,86 +60,44 @@ const normalizeChoicePayload = (payload: unknown): ContactFormOption[] => {
   return normalizeChoicePayload(results);
 };
 
-const slugVariants = (slug: string): string[] => {
-  const normalized = String(slug || '').trim();
-  if (!normalized) return [];
-
-  const variants = new Set<string>([
-    normalized,
-    normalized.replace(/-/g, '_'),
-    normalized.replace(/_/g, '-'),
-  ]);
-
-  if (normalized.endsWith('s')) {
-    variants.add(normalized.slice(0, -1));
-  } else {
-    variants.add(`${normalized}s`);
-  }
-
-  return Array.from(variants);
-};
-
-const MISSING_CHOICE_LIST_TTL_MS = 5 * 60 * 1000;
-const missingChoiceLists = new Map<string, number>();
-
-const isKnownMissingChoiceList = (key: string): boolean => {
-  const ts = missingChoiceLists.get(key);
-  if (!ts) return false;
-  if (Date.now() - ts > MISSING_CHOICE_LIST_TTL_MS) {
-    missingChoiceLists.delete(key);
-    return false;
-  }
-  return true;
-};
-
 export const contactFormOptionsService = {
   async getSystemChoiceOptions(listSlug: string): Promise<ContactFormOption[]> {
-    const key = String(listSlug || '').trim().toLowerCase();
-    if (!key) return [];
-
-    if (isKnownMissingChoiceList(key)) {
-      return [];
+    const key = normalizeChoiceListSlug(listSlug);
+    if (!key) {
+      return emptyChoices();
     }
 
-    const candidates = slugVariants(key);
-    let sawNotFound = false;
+    const cached = systemChoiceCache.get(key);
+    if (cached) {
+      return cached;
+    }
 
-    for (const candidate of candidates) {
-      try {
-        const response = await businessApi.get('/system/choices/', {
-          params: { list: candidate },
-        });
+    const pending = pendingSystemChoiceRequests.get(key);
+    if (pending) {
+      return pending;
+    }
 
+    const request = businessApi
+      .get('/system/choices/', {
+        params: { list: key },
+      })
+      .then((response) => {
         const options = normalizeChoicePayload(response.data);
-        if (options.length > 0) {
-          missingChoiceLists.delete(key);
-          return options;
-        }
-      } catch (err: any) {
-        if (err?.response?.status === 404) sawNotFound = true;
-        // Fall through to the next candidate / fallback.
-      }
-    }
+        const stableOptions = options.length > 0 ? options : emptyChoices();
+        systemChoiceCache.set(key, stableOptions);
+        return stableOptions;
+      })
+      .catch(() => {
+        const stableEmpty = emptyChoices();
+        systemChoiceCache.set(key, stableEmpty);
+        return stableEmpty;
+      })
+      .finally(() => {
+        pendingSystemChoiceRequests.delete(key);
+      });
 
-    for (const candidate of candidates) {
-      try {
-        const options = await configService.getChoiceOptions(candidate);
-        if (Array.isArray(options) && options.length > 0) {
-          missingChoiceLists.delete(key);
-          return options
-            .map((item) => asOption(item.value, item.label))
-            .filter((item): item is ContactFormOption => Boolean(item));
-        }
-      } catch {
-        // Ignore fallback failures until all variants are exhausted.
-      }
-    }
-
-    if (sawNotFound) {
-      missingChoiceLists.set(key, Date.now());
-    }
-
-    return [];
+    pendingSystemChoiceRequests.set(key, request);
+    return request;
   },
 
   async getMasterProductOptions(params?: {
@@ -154,7 +132,7 @@ export const contactFormOptionsService = {
           ? ((payload as Record<string, unknown>).results as unknown[])
           : [];
 
-      return rows
+      const options = rows
         .map((item) => {
           const row = item && typeof item === 'object' ? (item as Record<string, unknown>) : {};
           const label =
@@ -167,9 +145,16 @@ export const contactFormOptionsService = {
           return asOption(row.id ?? row.value ?? row.product_code ?? row.name, label);
         })
         .filter((item): item is ContactFormOption => Boolean(item));
+
+      return options.length > 0 ? options : emptyChoices();
     } catch {
-      return [];
+      return emptyChoices();
     }
+  },
+
+  clearCache(): void {
+    systemChoiceCache.clear();
+    pendingSystemChoiceRequests.clear();
   },
 };
 


### PR DESCRIPTION
## Deliverables
- Add canonical GET /api/v1/system/choices/?list=... endpoint that always returns 200 OK with an array, even when the list is missing or unseeded
- Normalize protein_types / protein_type and _ / - variants server-side in one request
- Remove frontend slug-permutation retries and cache stable empty-choice references
- Add backend and frontend regression coverage
- Append the hotfix entry to .github/MASTER_PLAN.md

## Expected results
- /api/v1/system/choices/?list=protein_types no longer 404s
- Missing or unseeded lists resolve to [] without triggering Axios error handling
- DynamicFormEngine and cascading fields no longer receive fresh empty-array references that can restart React #185 loops
- Plant edit and create stop retrying protein_types / protein-types / protein_type permutations from the frontend

## Acceptance criteria
- Unknown /api/v1/system/choices/?list=... returns 200 with []
- protein-types and protein_type resolve through the same backend contract
- Frontend makes one canonical system choices request for protein choices
- Targeted backend and frontend regression tests pass
- Frontend type-check passes

## Dependencies
- Existing shared-schema tenant resolution via TenantMiddleware
- Existing ConfigResolver.get_choices behavior for tenant-aware choice retrieval
- Existing frontend DynamicFormEngine regression test harness

## Risk register
- Risk: alias normalization could return the wrong list if mappings are too broad
  - Mitigation: aliasing is intentionally narrow (protein_types/protein_type only) and hyphen normalization is deterministic
- Risk: shared empty-array references could be mutated later
  - Mitigation: EMPTY_CHOICES is frozen and reused intentionally
- Risk: tenant-scoped custom items could leak
  - Mitigation: backend tests cover tenant and no-tenant behavior on the new endpoint

## Testing strategy
- cd backend && python manage.py makemigrations --check
- cd backend && python manage.py test apps.system.tests.test_system_choices_api --verbosity=2
- cd frontend && npm test -- contactFormOptionsService.test.ts DynamicFormEngine.stability.test.tsx --run
- cd frontend && npm run type-check

## Rollback
- Revert this PR to restore the prior contract and frontend behavior. No migrations are involved, so rollback is code-only.
