### PR TITLE
WorkForms: localize FlowEditor shadow state

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -138,6 +138,7 @@ This file is the **append-only PR-referenceable execution log**.
 - **2026-04-28** — WorkForms editor: FlowEditor overlays backend node registry metadata (aliases/labels) via `/api/v1/system/workforms/metadata/` while preserving local schema fallback. (PR: #29)
 - **2026-04-28** — WorkForms editor: derive validation from graph state, stabilize history snapshots with graph signatures, restore debounced `onChange`, and limit draft autosave to persisted draft workflows with dirty-state awareness. (PR: #32)
 - **2026-04-28** — WorkForms editor: remove `nodesWithHandlers` canvas cloning by routing edit/delete/save/reorder/title actions through a dedicated FlowEditor node-actions context; keep collapsed-edge virtualization on raw nodes and add context regression coverage. (PR: #4720)
+- **2026-04-28** — WorkForms editor: keep config-panel shadow edits local until Apply/Discard so FlowEditor no longer rewrites the full node array on every keystroke; preserve sanitized commit/discard behavior and add regression coverage for pre-commit stability and dirty-state reconciliation. (PR: #4721)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/frontend/src/components/FlowEditor/hooks/__tests__/useNodeShadowState.sanitization.test.ts
+++ b/frontend/src/components/FlowEditor/hooks/__tests__/useNodeShadowState.sanitization.test.ts
@@ -43,6 +43,10 @@ describe('useNodeShadowState (sanitization)', () => {
       } as any);
     });
 
+    const beforeCommit = result.current.nodes.find((n) => n.id === 'n1')!;
+    expect((beforeCommit.data as any).subject).toBe('old');
+    expect((beforeCommit.data as any).shadowConfig).toEqual({ subject: 'wip', configStatus: 'dirty' });
+
     act(() => {
       result.current.api.commitShadow();
     });
@@ -58,5 +62,54 @@ describe('useNodeShadowState (sanitization)', () => {
 
     // Config snapshot should be sanitized too
     expect((committed.data as any).config).toEqual({ subject: 'new', nodeType: 'actionEmail' });
+  });
+
+  it('clears dirty state when committed node data catches up to the local shadow', () => {
+    const initialNodes: Node[] = [
+      {
+        id: 'n1',
+        type: 'actionEmail',
+        position: { x: 0, y: 0 },
+        data: {
+          nodeType: 'actionEmail',
+          subject: 'old',
+          config: { subject: 'old' },
+        },
+      } as any,
+    ];
+
+    const { result } = renderHook(() => {
+      const [nodes, setNodes] = React.useState<Node[]>(initialNodes);
+      const api = useNodeShadowState('n1', nodes, setNodes);
+      return { nodes, setNodes, api };
+    });
+
+    act(() => {
+      result.current.api.updateShadow({ subject: 'new' });
+    });
+
+    expect(result.current.api.isDirty).toBe(true);
+
+    act(() => {
+      result.current.setNodes((nds) =>
+        nds.map((node) =>
+          node.id === 'n1'
+            ? {
+                ...node,
+                data: {
+                  ...(node.data as any),
+                  subject: 'new',
+                  config: { subject: 'new', nodeType: 'actionEmail' },
+                  shadowConfig: undefined,
+                  configStatus: 'pristine',
+                },
+              }
+            : node
+        )
+      );
+    });
+
+    expect(result.current.api.isDirty).toBe(false);
+    expect(result.current.api.configStatus).toBe('pristine');
   });
 });

--- a/frontend/src/components/FlowEditor/hooks/useNodeShadowState.ts
+++ b/frontend/src/components/FlowEditor/hooks/useNodeShadowState.ts
@@ -19,7 +19,7 @@
  * Created: 2026-02-12 - Phase 2 Shadow State Implementation
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Node } from '@xyflow/react';
 
 import { sanitizeNodeConfigForPersistence } from '../utils/nodeDataSanitization';
@@ -54,6 +54,18 @@ export interface UseNodeShadowStateReturn {
   discardShadow: () => void;
 }
 
+function sanitizeConfig(value: Record<string, any> | undefined): Record<string, any> {
+  return (sanitizeNodeConfigForPersistence(value) as Record<string, any>) || {};
+}
+
+function configsDiffer(left: Record<string, any>, right: Record<string, any>): boolean {
+  try {
+    return JSON.stringify(left) !== JSON.stringify(right);
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Hook for managing node shadow state
  * 
@@ -73,103 +85,82 @@ export function useNodeShadowState(
     if (!nodeId) return null;
     return nodes.find(n => n.id === nodeId);
   }, [nodeId, nodes]);
+  const nodeData = node?.data as NodeDataWithShadow | undefined;
 
-  // Extract shadow config and status
-  const shadowConfig = useMemo(() => {
+  const committedConfig = useMemo(() => {
     if (!node) return {};
-    const data = node.data as NodeDataWithShadow;
-
-    // If shadow config exists, use it (editing in progress)
-    if (data.shadowConfig) {
-      return (sanitizeNodeConfigForPersistence(data.shadowConfig) as Record<string, any>) || {};
-    }
-
-    // Otherwise, return the committed config baseline.
+    const data = nodeData;
+    if (!data) return {};
     const { config, shadowConfig, configStatus, ...rest } = data;
-    return (
-      sanitizeNodeConfigForPersistence({
-        ...rest,
-        ...(config || {}),
-      }) as Record<string, any>
-    ) || {};
-  }, [node]);
-
-  const configStatus = useMemo(() => {
-    if (!node) return 'pristine';
-    const data = node.data as NodeDataWithShadow;
-    return data.configStatus || 'pristine';
-  }, [node]);
-
-  // Derive dirty state from the actual presence/diff of shadowConfig.
-  // This is more reliable than trusting configStatus alone (which can be missed
-  // if some panels update shadowConfig but forget to update configStatus).
-  const isDirty = useMemo(() => {
-    if (!node) return false;
-    const data = node.data as NodeDataWithShadow;
-    if (!data.shadowConfig) return false;
-
-    const { config, shadowConfig, configStatus, ...rest } = data;
-
-    const committedConfig = sanitizeNodeConfigForPersistence({
+    return sanitizeConfig({
       ...rest,
       ...(config || {}),
     });
+  }, [node, nodeData]);
 
-    const shadow = sanitizeNodeConfigForPersistence(shadowConfig);
+  const initialShadowConfig = useMemo(() => {
+    if (!node) return {};
+    const data = nodeData;
+    if (!data) return committedConfig;
+    return data.shadowConfig ? sanitizeConfig(data.shadowConfig) : committedConfig;
+  }, [committedConfig, node, nodeData]);
 
-    try {
-      return JSON.stringify(shadow) !== JSON.stringify(committedConfig);
-    } catch {
-      // If serialization fails, fall back to showing Apply/Discard when shadowConfig exists.
-      return true;
+  const [localShadowConfig, setLocalShadowConfig] = useState<Record<string, any>>(initialShadowConfig);
+  const [localStatus, setLocalStatus] = useState<'pristine' | 'editing' | 'dirty'>(() =>
+    configsDiffer(initialShadowConfig, committedConfig) ? 'dirty' : 'pristine'
+  );
+  const previousNodeIdRef = useRef<string | null>(nodeId);
+
+  useEffect(() => {
+    if (!nodeId || !node) {
+      previousNodeIdRef.current = nodeId;
+      setLocalShadowConfig({});
+      setLocalStatus('pristine');
+      return;
     }
-  }, [node]);
 
-  /**
-   * Update shadow config without affecting committed config
-   * Sets status to 'editing' on first change, 'dirty' if different from committed
-   */
+    const nodeChanged = previousNodeIdRef.current !== nodeId;
+    previousNodeIdRef.current = nodeId;
+    const nextStatus = configsDiffer(initialShadowConfig, committedConfig) ? 'dirty' : 'pristine';
+
+    if (nodeChanged) {
+      setLocalShadowConfig(initialShadowConfig);
+      setLocalStatus(nextStatus);
+      return;
+    }
+
+    setLocalShadowConfig((current) => {
+      if (configsDiffer(current, committedConfig)) {
+        return current;
+      }
+      return configsDiffer(current, initialShadowConfig) ? initialShadowConfig : current;
+    });
+
+    setLocalStatus(configsDiffer(localShadowConfig, committedConfig) ? 'dirty' : nextStatus);
+  }, [committedConfig, initialShadowConfig, localShadowConfig, node, nodeId]);
+
+  const shadowConfig = localShadowConfig;
+
+  const isDirty = useMemo(() => configsDiffer(localShadowConfig, committedConfig), [committedConfig, localShadowConfig]);
+
+  const configStatus = useMemo(() => {
+    if (isDirty) return 'dirty';
+    return localStatus;
+  }, [isDirty, localStatus]);
+
+  // Stage shadow config locally so the canvas node array is untouched until Apply.
   const updateShadow = useCallback((changes: Partial<Record<string, any>>) => {
     if (!nodeId) return;
 
-    setNodes((nds) =>
-      nds.map((n) => {
-        if (n.id !== nodeId) return n;
-
-        const currentData = n.data as NodeDataWithShadow;
-        const { config, shadowConfig, configStatus, ...rest } = currentData;
-
-        const committedConfig = (sanitizeNodeConfigForPersistence({
-          ...rest,
-          ...(config || {}),
-        }) || {}) as Record<string, any>;
-
-        const currentShadow = (sanitizeNodeConfigForPersistence(
-          shadowConfig || committedConfig,
-        ) || committedConfig) as Record<string, any>;
-
-        // Merge changes into shadow config
-        const newShadow = {
-          ...currentShadow,
-          ...changes,
-        };
-
-        const sanitizedShadow = (sanitizeNodeConfigForPersistence(newShadow) || {}) as Record<string, any>;
-
-        // Check if shadow differs from committed
-        const isDifferent = JSON.stringify(sanitizedShadow) !== JSON.stringify(committedConfig);
-
-        return {
-          ...n,
-          data: {
-            ...currentData,
-            shadowConfig: sanitizedShadow,
-            configStatus: isDifferent ? ('dirty' as const) : ('pristine' as const),
-          },
-        };
-      })
-    );
-  }, [nodeId, setNodes]);
+    setLocalShadowConfig((currentShadow) => {
+      const newShadow = sanitizeConfig({
+        ...currentShadow,
+        ...changes,
+      });
+      setLocalStatus(configsDiffer(newShadow, committedConfig) ? 'dirty' : 'pristine');
+      return newShadow;
+    });
+  }, [committedConfig, nodeId]);
 
   /**
    * Commit shadow config to main config
@@ -178,30 +169,25 @@ export function useNodeShadowState(
   const commitShadow = useCallback(() => {
     if (!nodeId) return;
 
+    const sanitizedShadow = sanitizeConfig(localShadowConfig);
+
     setNodes((nds) =>
       nds.map((n) => {
         if (n.id !== nodeId) return n;
 
         const currentData = n.data as NodeDataWithShadow;
-        const shadow = currentData.shadowConfig;
-
-        if (!shadow) return n; // Nothing to commit
-
         const { config, shadowConfig, configStatus, ...rest } = currentData;
 
-        const committedBase = (sanitizeNodeConfigForPersistence({
+        const committedBase = sanitizeConfig({
           ...rest,
           ...(config || {}),
-        }) || {}) as Record<string, any>;
+        });
 
-        const sanitizedShadow = (sanitizeNodeConfigForPersistence(shadow) || {}) as Record<string, any>;
         const committed = {
           ...committedBase,
           ...sanitizedShadow,
         };
 
-        // Merge shadow into main data and clear shadow.
-        // Keep top-level keys for compatibility, but never persist UI-only bookkeeping.
         return {
           ...n,
           data: {
@@ -213,7 +199,10 @@ export function useNodeShadowState(
         };
       })
     );
-  }, [nodeId, setNodes]);
+
+    setLocalShadowConfig(sanitizedShadow);
+    setLocalStatus('pristine');
+  }, [localShadowConfig, nodeId, setNodes]);
 
   /**
    * Discard shadow config (revert to last committed)
@@ -221,13 +210,19 @@ export function useNodeShadowState(
   const discardShadow = useCallback(() => {
     if (!nodeId) return;
 
+    setLocalShadowConfig(committedConfig);
+    setLocalStatus('pristine');
+
     setNodes((nds) =>
       nds.map((n) => {
         if (n.id !== nodeId) return n;
 
         const currentData = n.data as NodeDataWithShadow;
 
-        // Clear shadow and reset status
+        if (!currentData.shadowConfig && currentData.configStatus === 'pristine') {
+          return n;
+        }
+
         return {
           ...n,
           data: {
@@ -238,7 +233,7 @@ export function useNodeShadowState(
         };
       })
     );
-  }, [nodeId, setNodes]);
+  }, [committedConfig, nodeId, setNodes]);
 
   return {
     shadowConfig,


### PR DESCRIPTION
Summary
- keep FlowEditor config-panel shadow edits local until Apply or Discard instead of rewriting the React Flow node array on every keystroke
- preserve commit and discard sanitization while clearing dirty state when committed node data catches up
- extend shadow-state regression coverage to prove the node array stays untouched before commit and dirty state clears on external commit

Validation
- npm -C frontend run test:ci -- src/components/FlowEditor/hooks/__tests__/useNodeShadowState.sanitization.test.ts
- npm -C frontend run type-check

Risks / Rollback
- Risk is limited to config-panel draft editing; revert this branch to restore node-backed shadow state if needed.
