### PR TITLE
WorkForms: add execution analytics dashboard

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -142,6 +142,7 @@ This file is the **append-only PR-referenceable execution log**.
 - **2026-04-28** — Docs: sync canonical root `MASTER_PLAN.md` snapshot so it reflects the shipped FlowEditor state-harmonization batches and the verified WorkForms create-time activation guard. (PR: #4722)
 - **2026-04-28** — WorkForms runtime: add tenant-scoped execution telemetry (`ExecutionEventLog`) with RLS, persist normalized audit-trail events for executions/node spans/action outcomes, and add backend regression coverage for successful and failed action events. (PR: #4723)
 - **2026-04-28** — WorkForms runtime: hydrate a persisted `runtime_state` snapshot on `TenantWorkFormExecution` from the telemetry stream so list/detail serializers can serve current node, node statuses, and errors without reparsing raw audit trails; retain fallback for legacy rows. (PR: #4724)
+- **2026-04-28** — WorkForms monitoring: add a tenant-safe execution analytics endpoint and upgrade the Monitoring page with telemetry-backed KPIs, top failed steps, slowest actions, and busiest WorkForms. (PR: TBD)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -142,7 +142,7 @@ This file is the **append-only PR-referenceable execution log**.
 - **2026-04-28** — Docs: sync canonical root `MASTER_PLAN.md` snapshot so it reflects the shipped FlowEditor state-harmonization batches and the verified WorkForms create-time activation guard. (PR: #4722)
 - **2026-04-28** — WorkForms runtime: add tenant-scoped execution telemetry (`ExecutionEventLog`) with RLS, persist normalized audit-trail events for executions/node spans/action outcomes, and add backend regression coverage for successful and failed action events. (PR: #4723)
 - **2026-04-28** — WorkForms runtime: hydrate a persisted `runtime_state` snapshot on `TenantWorkFormExecution` from the telemetry stream so list/detail serializers can serve current node, node statuses, and errors without reparsing raw audit trails; retain fallback for legacy rows. (PR: #4724)
-- **2026-04-28** — WorkForms monitoring: add a tenant-safe execution analytics endpoint and upgrade the Monitoring page with telemetry-backed KPIs, top failed steps, slowest actions, and busiest WorkForms. (PR: TBD)
+- **2026-04-28** — WorkForms monitoring: add a tenant-safe execution analytics endpoint and upgrade the Monitoring page with telemetry-backed KPIs, top failed steps, slowest actions, and busiest WorkForms. (PR: #4725)
 
 ### 2026-03-31 — Secret audit drift (manifest v5.1)
 - Command: `python config/manage_env.py audit --repo Meats-Central/ProjectMeats`

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -23,6 +23,7 @@ This file is the **canonical plan + current truth snapshot**.
   - WorkForms editor hot-path stability: derive validation/history/autosave from graph state (PR #32), move node actions out of `nodesWithHandlers` cloning and into editor context (PR #4720), and keep config-panel shadow edits local until Apply/Discard instead of rewriting the full node array on every keystroke (PR #4721).
   - WorkForms execution telemetry foundation: add a tenant-scoped `ExecutionEventLog` model with RLS, persist normalized execution/node/action events from `audit_trail`, and cover successful + failed action spans in backend tests (see `.github/MASTER_PLAN.md` for the shipped PR reference).
   - WorkForms runtime hydration: add persisted `runtime_state` snapshots on `TenantWorkFormExecution`, hydrate node status/current step/error projections from the telemetry stream, and keep execution serializers backward-compatible for legacy rows without runtime state.
+  - WorkForms analytics dashboard: expose a tenant-safe execution analytics summary from the backend and upgrade the Monitoring page to show telemetry-backed KPIs, top failing steps, slowest actions, and busiest WorkForms.
 
 ### P0 priorities (next)
 - **Core API reliability**: ✅ shipped (PR #4652). Next: expand smoke coverage for always-on endpoints (health, tenant resolution, auth bootstrap) and keep them in PR gates.
@@ -40,7 +41,7 @@ This file is the **canonical plan + current truth snapshot**.
   - Legacy workflow webhook endpoint must fail closed unless tenant context is resolvable (migrate callers to tenant-path URL).
   - Integrations OAuth callback must set tenant + RLS session vars before writing tenant-scoped rows.
   - WorkForms create must not bypass activation validation when `status=active`. ✅ shipped (runtime validation guardrails in PR #4483; verified by `apps.system.tests.test_workform_runtime_support_validation`).
-- **WorkForms runtime/observability**: editor validation/history/autosave, node action routing, local shadow-state staging, execution telemetry, and persisted runtime hydration are now hardened. Next: analytics/dashboard surfaces that consume the telemetry + runtime-state stream, then the schema upgrade command, then deterministic schema init / form "fields" model cleanup and any remaining a11y + theme-token hardening.
+- **WorkForms runtime/observability**: editor validation/history/autosave, node action routing, local shadow-state staging, execution telemetry, persisted runtime hydration, and the first operator-facing analytics dashboard are now hardened. Next: the schema upgrade command, then deterministic schema init / form "fields" model cleanup and any remaining a11y + theme-token hardening.
 - **CI guardrails (never-miss-again)**:
   - Deploy-by-digest default for UAT/Prod and digest-align the migration artifact.
   - Manifest-driven required-secret enforcement per lane (remove hardcoded lists).

--- a/backend/tenant_apps/workflows/services/workform_execution_analytics.py
+++ b/backend/tenant_apps/workflows/services/workform_execution_analytics.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from django.db.models import Avg, Count, Max, Q
+from django.utils import timezone
+
+from apps.tenants.models import Tenant
+from tenant_apps.workflows.models import ExecutionEventLog, TenantWorkFormExecution
+
+
+def _node_labels_for_workforms(workform_ids: list[str], *, tenant: Tenant) -> dict[str, dict[str, str]]:
+    from apps.system.models import TenantWorkForm
+
+    labels: dict[str, dict[str, str]] = {}
+    workforms = TenantWorkForm.objects.filter(id__in=workform_ids, tenant=tenant).only('id', 'workflow_definition')
+    for workform in workforms:
+        definition = workform.workflow_definition if isinstance(workform.workflow_definition, dict) else {}
+        nodes = definition.get('nodes', [])
+        if not isinstance(nodes, list):
+            continue
+
+        labels[str(workform.id)] = {}
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            node_id = node.get('id')
+            if not node_id:
+                continue
+            data = node.get('data') if isinstance(node.get('data'), dict) else {}
+            label = (
+                data.get('label')
+                or data.get('name')
+                or data.get('containerName')
+                or node.get('label')
+                or node.get('name')
+            )
+            if isinstance(label, str) and label.strip():
+                labels[str(workform.id)][str(node_id)] = label.strip()
+
+    return labels
+
+
+def get_workform_execution_analytics(*, tenant: Tenant, days: int = 30, limit: int = 5) -> dict[str, Any]:
+    window_days = max(int(days or 30), 1)
+    item_limit = max(int(limit or 5), 1)
+    cutoff = timezone.now() - timedelta(days=window_days)
+
+    execution_qs = TenantWorkFormExecution.objects.filter(tenant=tenant, created_on__gte=cutoff)
+    event_qs = ExecutionEventLog.objects.filter(tenant=tenant, created_on__gte=cutoff)
+
+    total_runs = execution_qs.count()
+    status_rows = execution_qs.values('status').annotate(count=Count('id')).order_by()
+    status_counts = {str(row['status']): int(row['count']) for row in status_rows}
+
+    terminal_total = sum(
+        status_counts.get(status, 0)
+        for status in ('completed', 'failed', 'cancelled', 'suspended')
+    )
+    success_rate = round((status_counts.get('completed', 0) / terminal_total) * 100, 1) if terminal_total else 0.0
+
+    duration_rows = execution_qs.exclude(started_at__isnull=True).exclude(completed_at__isnull=True).values_list(
+        'started_at',
+        'completed_at',
+    )
+    durations_ms = [
+        max(int((completed_at - started_at).total_seconds() * 1000), 0)
+        for started_at, completed_at in duration_rows
+    ]
+    avg_duration_ms = int(sum(durations_ms) / len(durations_ms)) if durations_ms else None
+
+    workform_rows = list(
+        execution_qs.values('workform_id', 'workform__name')
+        .annotate(
+            total_runs=Count('id'),
+            completed_runs=Count('id', filter=Q(status='completed')),
+            failed_runs=Count('id', filter=Q(status__in=['failed', 'cancelled', 'suspended'])),
+        )
+        .order_by('-total_runs', 'workform__name')[:item_limit]
+    )
+    for row in workform_rows:
+        total = int(row['total_runs'] or 0)
+        completed = int(row['completed_runs'] or 0)
+        row['workform_id'] = str(row.pop('workform_id'))
+        row['workform_name'] = row.pop('workform__name')
+        row['success_rate'] = round((completed / total) * 100, 1) if total else 0.0
+
+    failure_rows = list(
+        event_qs.filter(status='failed')
+        .exclude(node_id='')
+        .values('workform_id', 'workform__name', 'node_id', 'node_type')
+        .annotate(failure_count=Count('id'), last_failed_at=Max('completed_at'))
+        .order_by('-failure_count', '-last_failed_at', 'workform__name', 'node_id')[:item_limit]
+    )
+
+    slow_rows = list(
+        event_qs.filter(event_type='action_success', duration_ms__isnull=False)
+        .exclude(node_id='')
+        .values('workform_id', 'workform__name', 'node_id', 'node_type')
+        .annotate(
+            avg_duration_ms=Avg('duration_ms'),
+            max_duration_ms=Max('duration_ms'),
+            sample_count=Count('id'),
+        )
+        .order_by('-avg_duration_ms', '-max_duration_ms', 'workform__name', 'node_id')[:item_limit]
+    )
+
+    label_maps = _node_labels_for_workforms(
+        list(
+            {
+                str(row['workform_id'])
+                for row in [*failure_rows, *slow_rows]
+                if row.get('workform_id')
+            }
+        ),
+        tenant=tenant,
+    )
+
+    for row in failure_rows:
+        workform_id = str(row['workform_id'])
+        node_id = str(row['node_id'])
+        row['workform_id'] = workform_id
+        row['workform_name'] = row.pop('workform__name')
+        row['node_label'] = label_maps.get(workform_id, {}).get(node_id)
+        if row.get('last_failed_at'):
+            row['last_failed_at'] = row['last_failed_at'].isoformat()
+
+    for row in slow_rows:
+        workform_id = str(row['workform_id'])
+        node_id = str(row['node_id'])
+        row['workform_id'] = workform_id
+        row['workform_name'] = row.pop('workform__name')
+        row['node_label'] = label_maps.get(workform_id, {}).get(node_id)
+        if row.get('avg_duration_ms') is not None:
+            row['avg_duration_ms'] = int(row['avg_duration_ms'])
+        if row.get('max_duration_ms') is not None:
+            row['max_duration_ms'] = int(row['max_duration_ms'])
+
+    return {
+        'window_days': window_days,
+        'generated_at': timezone.now().isoformat(),
+        'summary': {
+            'total_runs': total_runs,
+            'active_runs': status_counts.get('pending', 0) + status_counts.get('in_progress', 0),
+            'completed_runs': status_counts.get('completed', 0),
+            'failed_runs': status_counts.get('failed', 0),
+            'suspended_runs': status_counts.get('suspended', 0),
+            'success_rate': success_rate,
+            'avg_duration_ms': avg_duration_ms,
+        },
+        'status_counts': status_counts,
+        'top_workforms': workform_rows,
+        'top_failed_nodes': failure_rows,
+        'slowest_actions': slow_rows,
+    }

--- a/backend/tenant_apps/workflows/tests/test_workform_execution_analytics_viewset.py
+++ b/backend/tenant_apps/workflows/tests/test_workform_execution_analytics_viewset.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from datetime import timedelta
+import uuid
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.system.models import TenantWorkForm
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.workflows.models import ExecutionEventLog, TenantWorkFormExecution
+from tenant_apps.workflows.views import TenantWorkFormExecutionViewSet
+
+
+class TenantWorkFormExecutionAnalyticsViewSetTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(username=f'u-{unique}', password='pw')
+
+        self.tenant_a = Tenant.objects.create(
+            name=f'Tenant A {unique}',
+            slug=f'tenant-a-{unique}',
+            contact_email=f'a-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f'Tenant B {unique}',
+            slug=f'tenant-b-{unique}',
+            contact_email=f'b-{unique}@example.com',
+            is_active=True,
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant_a, user=self.user, role='admin', is_active=True)
+        TenantUser.objects.create(tenant=self.tenant_b, user=self.user, role='admin', is_active=True)
+
+        definition = {
+            'nodes': [
+                {'id': 'a1', 'type': 'actionEmail', 'data': {'label': 'Send Email'}},
+                {'id': 'a2', 'type': 'actionNotify', 'data': {'label': 'Notify Buyer'}},
+            ],
+            'edges': [],
+        }
+
+        self.workform_a = TenantWorkForm.objects.create(
+            tenant=self.tenant_a,
+            name='WF A',
+            workflow_definition=definition,
+            status='active',
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        self.workform_b = TenantWorkForm.objects.create(
+            tenant=self.tenant_b,
+            name='WF B',
+            workflow_definition=definition,
+            status='active',
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        now = timezone.now()
+
+        self.exec_a_completed = TenantWorkFormExecution.objects.create(
+            tenant=self.tenant_a,
+            workform=self.workform_a,
+            status='completed',
+            started_by=self.user,
+            started_at=now - timedelta(seconds=8),
+            completed_at=now - timedelta(seconds=5),
+        )
+        self.exec_a_failed = TenantWorkFormExecution.objects.create(
+            tenant=self.tenant_a,
+            workform=self.workform_a,
+            status='failed',
+            started_by=self.user,
+            started_at=now - timedelta(seconds=4),
+            completed_at=now - timedelta(seconds=2),
+        )
+        self.exec_b_completed = TenantWorkFormExecution.objects.create(
+            tenant=self.tenant_b,
+            workform=self.workform_b,
+            status='completed',
+            started_by=self.user,
+            started_at=now - timedelta(seconds=6),
+            completed_at=now - timedelta(seconds=1),
+        )
+
+        ExecutionEventLog.objects.create(
+            tenant=self.tenant_a,
+            workform=self.workform_a,
+            workform_execution=self.exec_a_completed,
+            sequence=0,
+            event_type='action_success',
+            status='success',
+            node_id='a1',
+            node_type='actionEmail',
+            started_at=now - timedelta(seconds=8),
+            completed_at=now - timedelta(seconds=7),
+            duration_ms=1000,
+        )
+        ExecutionEventLog.objects.create(
+            tenant=self.tenant_a,
+            workform=self.workform_a,
+            workform_execution=self.exec_a_failed,
+            sequence=0,
+            event_type='action_error',
+            status='failed',
+            node_id='a2',
+            node_type='actionNotify',
+            started_at=now - timedelta(seconds=4),
+            completed_at=now - timedelta(seconds=3),
+            duration_ms=1000,
+            payload={'error': 'SMTP offline'},
+        )
+        ExecutionEventLog.objects.create(
+            tenant=self.tenant_b,
+            workform=self.workform_b,
+            workform_execution=self.exec_b_completed,
+            sequence=0,
+            event_type='action_success',
+            status='success',
+            node_id='a1',
+            node_type='actionEmail',
+            started_at=now - timedelta(seconds=6),
+            completed_at=now - timedelta(seconds=4),
+            duration_ms=2000,
+        )
+
+    def _get(self, path: str, tenant):
+        request = self.factory.get(path)
+        force_authenticate(request, user=self.user)
+        request.tenant = tenant
+        return request
+
+    def test_analytics_action_is_tenant_scoped(self):
+        request = self._get('/api/v1/workflows/workform-executions/analytics/?days=30&limit=5', self.tenant_a)
+        response = TenantWorkFormExecutionViewSet.as_view({'get': 'analytics'})(request)
+        self.assertEqual(response.status_code, 200)
+
+        data = response.data
+        self.assertEqual(data['summary']['total_runs'], 2)
+        self.assertEqual(data['summary']['completed_runs'], 1)
+        self.assertEqual(data['summary']['failed_runs'], 1)
+        self.assertEqual(data['summary']['active_runs'], 0)
+        self.assertEqual(data['summary']['success_rate'], 50.0)
+
+        self.assertEqual(len(data['top_workforms']), 1)
+        self.assertEqual(data['top_workforms'][0]['workform_name'], 'WF A')
+        self.assertEqual(data['top_failed_nodes'][0]['node_id'], 'a2')
+        self.assertEqual(data['top_failed_nodes'][0]['node_label'], 'Notify Buyer')
+        self.assertEqual(data['slowest_actions'][0]['workform_name'], 'WF A')
+        self.assertNotIn('WF B', {row['workform_name'] for row in data['top_workforms']})
+
+    def test_analytics_action_fails_closed_without_tenant(self):
+        request = self._get('/api/v1/workflows/workform-executions/analytics/', None)
+        response = TenantWorkFormExecutionViewSet.as_view({'get': 'analytics'})(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['summary']['total_runs'], 0)
+        self.assertEqual(response.data['top_failed_nodes'], [])

--- a/backend/tenant_apps/workflows/views.py
+++ b/backend/tenant_apps/workflows/views.py
@@ -2277,6 +2277,45 @@ class TenantWorkFormExecutionViewSet(viewsets.ReadOnlyModelViewSet):
 
         return qs.order_by('-created_on')
 
+    @action(detail=False, methods=['get'], url_path='analytics')
+    def analytics(self, request):
+        try:
+            days = max(int(request.query_params.get('days', 30) or 30), 1)
+        except (TypeError, ValueError):
+            days = 30
+
+        try:
+            limit = max(int(request.query_params.get('limit', 5) or 5), 1)
+        except (TypeError, ValueError):
+            limit = 5
+
+        tenant = getattr(request, 'tenant', None)
+        if not tenant:
+            return Response(
+                {
+                    'window_days': days,
+                    'generated_at': timezone.now().isoformat(),
+                    'summary': {
+                        'total_runs': 0,
+                        'active_runs': 0,
+                        'completed_runs': 0,
+                        'failed_runs': 0,
+                        'suspended_runs': 0,
+                        'success_rate': 0.0,
+                        'avg_duration_ms': None,
+                    },
+                    'status_counts': {},
+                    'top_workforms': [],
+                    'top_failed_nodes': [],
+                    'slowest_actions': [],
+                }
+            )
+
+        from .services.workform_execution_analytics import get_workform_execution_analytics
+
+        analytics = get_workform_execution_analytics(tenant=tenant, days=days, limit=limit)
+        return Response(analytics)
+
 
 class FormSubmissionViewSet(viewsets.ModelViewSet):
     """

--- a/frontend/src/pages/WorkForms/Monitoring.tsx
+++ b/frontend/src/pages/WorkForms/Monitoring.tsx
@@ -21,7 +21,19 @@ import { PageContainer } from '@/components/ui/PageContainer';
 import { workformExecutionService } from '@/services/workformExecutionService';
 import ProcessMonitor from '../Cockpit/ProcessMonitor';
 
+const formatDuration = (value: number | null | undefined) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  if (value < 1000) return `${value} ms`;
+  return `${(value / 1000).toFixed(1)} s`;
+};
+
 export const Monitoring: React.FC = () => {
+  const analyticsQuery = useQuery({
+    queryKey: ['workform-executions', 'analytics'],
+    queryFn: async () => workformExecutionService.getAnalytics({ days: 30, limit: 5 }),
+    refetchInterval: 15000,
+  });
+
   const activeExecutionsQuery = useQuery({
     queryKey: ['workform-executions', 'active'],
     queryFn: async () => workformExecutionService.getExecutions({ status: 'pending,in_progress', page_size: 25 }),
@@ -29,11 +41,149 @@ export const Monitoring: React.FC = () => {
   });
 
   const active = activeExecutionsQuery.data?.results ?? [];
+  const summary = analyticsQuery.data?.summary;
+  const topWorkforms = analyticsQuery.data?.top_workforms ?? [];
+  const topFailedNodes = analyticsQuery.data?.top_failed_nodes ?? [];
+  const slowestActions = analyticsQuery.data?.slowest_actions ?? [];
 
   return (
     <ErrorBoundary>
       <PageContainer title="Monitoring">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <Card padding="lg">
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+              <div>
+                <div style={{ fontWeight: 700 }}>Execution Analytics</div>
+                <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 14, marginTop: 4 }}>
+                  Telemetry-backed summary for the last 30 days.
+                </div>
+              </div>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  void analyticsQuery.refetch();
+                  void activeExecutionsQuery.refetch();
+                }}
+                disabled={analyticsQuery.isFetching || activeExecutionsQuery.isFetching}
+              >
+                Refresh
+              </Button>
+            </div>
+
+            {analyticsQuery.isLoading ? (
+              <div style={{ marginTop: 12 }}>Loading analytics…</div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 16, marginTop: 12 }}>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+                    gap: 12,
+                  }}
+                >
+                  {[
+                    { label: 'Total runs', value: String(summary?.total_runs ?? 0) },
+                    { label: 'Active runs', value: String(summary?.active_runs ?? 0) },
+                    { label: 'Completed', value: String(summary?.completed_runs ?? 0) },
+                    { label: 'Failed', value: String(summary?.failed_runs ?? 0) },
+                    { label: 'Success rate', value: `${summary?.success_rate ?? 0}%` },
+                    { label: 'Avg duration', value: formatDuration(summary?.avg_duration_ms) },
+                  ].map((item) => (
+                    <div
+                      key={item.label}
+                      style={{
+                        border: '1px solid rgb(var(--color-border))',
+                        borderRadius: 12,
+                        padding: 12,
+                        background: 'rgb(var(--color-surface))',
+                      }}
+                    >
+                      <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 12 }}>{item.label}</div>
+                      <div style={{ fontSize: 24, fontWeight: 700, marginTop: 6 }}>{item.value}</div>
+                    </div>
+                  ))}
+                </div>
+
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+                    gap: 12,
+                  }}
+                >
+                  <div
+                    style={{
+                      border: '1px solid rgb(var(--color-border))',
+                      borderRadius: 12,
+                      padding: 12,
+                    }}
+                  >
+                    <div style={{ fontWeight: 600, marginBottom: 8 }}>Top WorkForms</div>
+                    {topWorkforms.length === 0 ? (
+                      <div style={{ color: 'rgb(var(--color-text-secondary))' }}>No runs in the selected window.</div>
+                    ) : (
+                      <ul style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        {topWorkforms.map((row) => (
+                          <li key={row.workform_id}>
+                            <strong>{row.workform_name}</strong> — {row.total_runs} runs, {row.success_rate}% success
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+
+                  <div
+                    style={{
+                      border: '1px solid rgb(var(--color-border))',
+                      borderRadius: 12,
+                      padding: 12,
+                    }}
+                  >
+                    <div style={{ fontWeight: 600, marginBottom: 8 }}>Top failed steps</div>
+                    {topFailedNodes.length === 0 ? (
+                      <div style={{ color: 'rgb(var(--color-text-secondary))' }}>No failed steps recorded.</div>
+                    ) : (
+                      <ul style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        {topFailedNodes.map((row) => (
+                          <li key={`${row.workform_id}:${row.node_id}:failed`}>
+                            <strong>{row.node_label ?? row.node_id}</strong> — {row.failure_count} failures
+                            <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 12 }}>
+                              {row.workform_name}
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+
+                  <div
+                    style={{
+                      border: '1px solid rgb(var(--color-border))',
+                      borderRadius: 12,
+                      padding: 12,
+                    }}
+                  >
+                    <div style={{ fontWeight: 600, marginBottom: 8 }}>Slowest actions</div>
+                    {slowestActions.length === 0 ? (
+                      <div style={{ color: 'rgb(var(--color-text-secondary))' }}>No completed action timings yet.</div>
+                    ) : (
+                      <ul style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        {slowestActions.map((row) => (
+                          <li key={`${row.workform_id}:${row.node_id}:slow`}>
+                            <strong>{row.node_label ?? row.node_id}</strong> — {formatDuration(row.avg_duration_ms)}
+                            <div style={{ color: 'rgb(var(--color-text-secondary))', fontSize: 12 }}>
+                              {row.workform_name} • {row.sample_count} sample(s)
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+          </Card>
+
           <Card padding="lg">
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
               <div style={{ fontWeight: 700 }}>Active WorkForm Executions</div>

--- a/frontend/src/services/workformExecutionService.ts
+++ b/frontend/src/services/workformExecutionService.ts
@@ -64,6 +64,48 @@ export interface WorkFormExecutionListResponse {
   results: WorkFormExecution[];
 }
 
+export interface WorkFormExecutionAnalyticsSummary {
+  total_runs: number;
+  active_runs: number;
+  completed_runs: number;
+  failed_runs: number;
+  suspended_runs: number;
+  success_rate: number;
+  avg_duration_ms: number | null;
+}
+
+export interface WorkFormExecutionAnalyticsNodeRow {
+  workform_id: string;
+  workform_name: string;
+  node_id: string;
+  node_type: string;
+  node_label?: string | null;
+  failure_count?: number;
+  last_failed_at?: string | null;
+  avg_duration_ms?: number | null;
+  max_duration_ms?: number | null;
+  sample_count?: number;
+}
+
+export interface WorkFormExecutionAnalyticsWorkformRow {
+  workform_id: string;
+  workform_name: string;
+  total_runs: number;
+  completed_runs: number;
+  failed_runs: number;
+  success_rate: number;
+}
+
+export interface WorkFormExecutionAnalyticsResponse {
+  window_days: number;
+  generated_at: string;
+  summary: WorkFormExecutionAnalyticsSummary;
+  status_counts: Record<string, number>;
+  top_workforms: WorkFormExecutionAnalyticsWorkformRow[];
+  top_failed_nodes: WorkFormExecutionAnalyticsNodeRow[];
+  slowest_actions: WorkFormExecutionAnalyticsNodeRow[];
+}
+
 export class WorkFormExecutionService {
   private baseUrl = '/workflows/workform-executions/';
 
@@ -97,6 +139,11 @@ export class WorkFormExecutionService {
 
   async getExecution(id: string): Promise<WorkFormExecution> {
     const response = await businessApi.get(`${this.baseUrl}${id}/`);
+    return response.data;
+  }
+
+  async getAnalytics(params?: { days?: number; limit?: number }): Promise<WorkFormExecutionAnalyticsResponse> {
+    const response = await businessApi.get(`${this.baseUrl}analytics/`, { params });
     return response.data;
   }
 }


### PR DESCRIPTION
## Summary\n- add a tenant-safe execution analytics endpoint for WorkForms telemetry\n- surface KPIs, busiest WorkForms, failed steps, and slowest actions on the Monitoring page\n- cover analytics filtering in backend tests and keep frontend integration type-safe\n\n## Testing\n- cd backend && python manage.py makemigrations --check\n- cd backend && python manage.py test tenant_apps.workflows.tests.test_workform_execution_viewset_filters tenant_apps.workflows.tests.test_workform_execution_analytics_viewset --keepdb --verbosity=2\n- cd frontend && npm run type-check