### PR TITLE
fix: restore superadmin invites and tenantlist drift

### DIFF
--- a/backend/apps/tenants/admin.py
+++ b/backend/apps/tenants/admin.py
@@ -524,47 +524,49 @@ class TenantInvitationAdmin(TenantFilteredAdmin):
         
         if request.method == 'POST':
             form = InviteUserForm(request.POST)
+            selected_tenant_id = request.POST.get('tenant', '')
             if form.is_valid():
                 email = form.cleaned_data['email']
                 role = form.cleaned_data['role']
                 message = form.cleaned_data['message']
                 
-                # Get tenant from form or use default
-                tenant_id = request.POST.get('tenant')
+                tenant = None
+                tenant_id = selected_tenant_id
                 if tenant_id:
-                    tenant = Tenant.objects.get(id=tenant_id)
+                    tenant = tenants.filter(id=tenant_id).first()
+                    if tenant is None:
+                        form.add_error(None, "Please select a valid tenant.")
                 elif default_tenant:
                     tenant = default_tenant
                 else:
-                    messages.error(request, "Please select a tenant.")
-                    return redirect('.')
-                
-                # Create invitation
-                invitation = TenantInvitation.objects.create(
-                    tenant=tenant,
-                    email=email,
-                    role=role,
-                    invited_by=request.user,
-                    is_reusable=False,
-                    status='pending',
-                    message=message
-                )
-                
-                # Generate invite link
-                base_url = getattr(settings, 'FRONTEND_URL', 'https://meatscentral.com')
-                link = f"{base_url}/signup?token={invitation.token}"
-                
-                messages.success(
-                    request,
-                    format_html(
-                        '✅ Invitation sent to <strong>{}</strong> as <strong>{}</strong> for <strong>{}</strong><br>'
-                        'Invite link: <input type="text" value="{}" style="width: 100%; padding: 8px; margin-top: 8px;" readonly onclick="this.select();">',
-                        email, role, tenant.name, link
+                    form.add_error(None, "Please select a tenant.")
+
+                if tenant and not form.errors:
+                    invitation = TenantInvitation.objects.create(
+                        tenant=tenant,
+                        email=email,
+                        role=role,
+                        invited_by=request.user,
+                        is_reusable=False,
+                        status='pending',
+                        message=message
                     )
-                )
-                return redirect('..')
+
+                    base_url = getattr(settings, 'FRONTEND_URL', 'https://meatscentral.com')
+                    link = f"{base_url}/signup?token={invitation.token}"
+
+                    messages.success(
+                        request,
+                        format_html(
+                            '✅ Invitation sent to <strong>{}</strong> as <strong>{}</strong> for <strong>{}</strong><br>'
+                            'Invite link: <input type="text" value="{}" style="width: 100%; padding: 8px; margin-top: 8px;" readonly onclick="this.select();">',
+                            email, role, tenant.name, link
+                        )
+                    )
+                    return redirect('..')
         else:
             form = InviteUserForm()
+            selected_tenant_id = str(default_tenant.id) if default_tenant else ''
         
         context = {
             'title': '🚀 Invite New User',
@@ -576,6 +578,7 @@ class TenantInvitationAdmin(TenantFilteredAdmin):
             'tenants': tenants,
             'default_tenant': default_tenant,
             'is_superuser': request.user.is_superuser,
+            'selected_tenant_id': selected_tenant_id,
         }
         
         return render(request, 'admin/tenants/invite_user.html', context)

--- a/backend/apps/tenants/invitation_views.py
+++ b/backend/apps/tenants/invitation_views.py
@@ -43,6 +43,12 @@ class TenantInvitationViewSet(viewsets.ModelViewSet):
         Regular users see only their own invitations (if any).
         """
         user = self.request.user
+        tenant = getattr(self.request, 'tenant', None)
+
+        if user.is_superuser:
+            if tenant:
+                return TenantInvitation.objects.filter(tenant=tenant)
+            return TenantInvitation.objects.none()
         
         # Get user's tenants where they are admin or owner
         admin_tenants = TenantUser.objects.filter(
@@ -100,16 +106,13 @@ class TenantInvitationViewSet(viewsets.ModelViewSet):
                 {'error': 'Tenant context is required to invite users (X-Tenant-ID header or tenant domain).'},
                 status=status.HTTP_403_FORBIDDEN
             )
-        
-        # Verify user is admin/owner of this tenant
-        tenant_user = TenantUser.objects.filter(
+
+        if not request.user.is_superuser and not TenantUser.objects.filter(
             tenant=tenant,
             user=request.user,
             role__in=['admin', 'owner'],
-            is_active=True
-        ).first()
-        
-        if not tenant_user:
+            is_active=True,
+        ).exists():
             return Response(
                 {'error': 'You do not have permission to invite users to this tenant'},
                 status=status.HTTP_403_FORBIDDEN

--- a/backend/apps/tenants/test_admin_invite_view.py
+++ b/backend/apps/tenants/test_admin_invite_view.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.tenants.models import Tenant, TenantInvitation
+
+
+User = get_user_model()
+
+
+class AdminInviteViewTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.superuser = User.objects.create_superuser(
+            username=f"admin-{unique}",
+            email=f"admin-{unique}@example.com",
+            password="pw",
+        )
+        self.tenant = Tenant.objects.create(
+            name=f"Tenant {unique}",
+            slug=f"tenant-{unique}",
+            contact_email=f"tenant-{unique}@example.com",
+            is_active=True,
+            created_by=self.superuser,
+        )
+        self.client.force_login(self.superuser)
+        self.url = reverse("meatscentral_admin:tenants_tenantinvitation_invite")
+
+    def test_superuser_tenant_selector_renders_inside_form(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        form_start = html.index('<form method="post">')
+        tenant_select = html.index('name="tenant"')
+        form_end = html.index("</form>")
+
+        self.assertLess(form_start, tenant_select)
+        self.assertLess(tenant_select, form_end)
+
+    def test_superuser_can_submit_selected_tenant(self):
+        response = self.client.post(
+            self.url,
+            {
+                "tenant": str(self.tenant.id),
+                "email": "new-admin@example.com",
+                "role": "admin",
+                "message": "Welcome",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        invitation = TenantInvitation.objects.get(email="new-admin@example.com")
+        self.assertEqual(invitation.tenant, self.tenant)
+        self.assertEqual(invitation.invited_by, self.superuser)

--- a/backend/apps/tenants/test_superuser_invitation_api.py
+++ b/backend/apps/tenants/test_superuser_invitation_api.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.tenants.models import Tenant, TenantInvitation
+
+
+User = get_user_model()
+
+
+class SuperuserInvitationApiTests(APITestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+
+        self.superuser = User.objects.create_superuser(
+            username=f"super-{unique}",
+            email=f"super-{unique}@example.com",
+            password="pw",
+        )
+        self.tenant_a = Tenant.objects.create(
+            name=f"Tenant A {unique}",
+            slug=f"tenant-a-{unique}",
+            contact_email=f"a-{unique}@example.com",
+            is_active=True,
+            created_by=self.superuser,
+        )
+        self.tenant_b = Tenant.objects.create(
+            name=f"Tenant B {unique}",
+            slug=f"tenant-b-{unique}",
+            contact_email=f"b-{unique}@example.com",
+            is_active=True,
+            created_by=self.superuser,
+        )
+
+        self.client.force_login(self.superuser)
+
+    def test_superuser_can_create_invitation_for_selected_tenant(self):
+        response = self.client.post(
+            "/api/v1/invitations/",
+            {
+                "email": "invitee@example.com",
+                "role": "user",
+                "message": "Welcome aboard",
+            },
+            format="json",
+            HTTP_X_TENANT_ID=str(self.tenant_a.id),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        invitation = TenantInvitation.objects.get(email="invitee@example.com")
+        self.assertEqual(invitation.tenant, self.tenant_a)
+        self.assertEqual(invitation.invited_by, self.superuser)
+
+    def test_superuser_invitation_list_scopes_to_selected_tenant(self):
+        invitation_a = TenantInvitation.objects.create(
+            tenant=self.tenant_a,
+            invited_by=self.superuser,
+            email="tenant-a@example.com",
+            role="user",
+        )
+        TenantInvitation.objects.create(
+            tenant=self.tenant_b,
+            invited_by=self.superuser,
+            email="tenant-b@example.com",
+            role="user",
+        )
+
+        response = self.client.get(
+            "/api/v1/invitations/",
+            HTTP_X_TENANT_ID=str(self.tenant_a.id),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.data.get("results", response.data) if hasattr(response.data, "get") else response.data
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(str(payload[0]["id"]), str(invitation_a.id))

--- a/backend/templates/admin/tenants/invite_user.html
+++ b/backend/templates/admin/tenants/invite_user.html
@@ -120,32 +120,37 @@
 <div class="invite-form-container">
     <h2>🚀 Invite New User</h2>
     <p class="subtitle">Send an invitation to join your organization on ProjectMeats</p>
-    
-    {% if default_tenant %}
-    <div class="tenant-info">
-        <strong>Inviting to:</strong> {{ default_tenant.name }}
-    </div>
-    {% elif is_superuser %}
-    <div class="form-group">
-        <label for="id_tenant">Organization *</label>
-        <select name="tenant" id="id_tenant" required style="width: 100%; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; font-size: 14px;">
-            <option value="">Select an organization...</option>
-            {% for tenant in tenants %}
-                <option value="{{ tenant.id }}">{{ tenant.name }}</option>
-            {% endfor %}
-        </select>
-        <p style="color: #6B7280; font-size: 12px; margin-top: 5px;">
-            Select which organization to send the invitation for
-        </p>
-    </div>
-    {% elif tenants.count > 1 %}
-    <div class="tenant-info">
-        <strong>Note:</strong> You have access to multiple tenants. The invitation will be sent for your primary tenant.
-    </div>
-    {% endif %}
-    
     <form method="post">
         {% csrf_token %}
+
+        {% if form.non_field_errors %}
+            {% for error in form.non_field_errors %}
+                <p style="color: #DC2626; font-size: 13px; margin-bottom: 16px;">{{ error }}</p>
+            {% endfor %}
+        {% endif %}
+
+        {% if default_tenant %}
+        <div class="tenant-info">
+            <strong>Inviting to:</strong> {{ default_tenant.name }}
+        </div>
+        {% elif is_superuser %}
+        <div class="form-group">
+            <label for="id_tenant">Organization *</label>
+            <select name="tenant" id="id_tenant" required style="width: 100%; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; font-size: 14px;">
+                <option value="">Select an organization...</option>
+                {% for tenant in tenants %}
+                    <option value="{{ tenant.id }}" {% if tenant.id|stringformat:"s" == selected_tenant_id %}selected{% endif %}>{{ tenant.name }}</option>
+                {% endfor %}
+            </select>
+            <p style="color: #6B7280; font-size: 12px; margin-top: 5px;">
+                Select which organization to send the invitation for
+            </p>
+        </div>
+        {% elif tenants.count > 1 %}
+        <div class="tenant-info">
+            <strong>Note:</strong> You have access to multiple tenants. The invitation will be sent for your primary tenant.
+        </div>
+        {% endif %}
         
         <div class="form-group">
             <label for="id_email">Email Address *</label>

--- a/backend/tenant_apps/workflows/migrations/0036_ensure_workflow_custom_data_columns.py
+++ b/backend/tenant_apps/workflows/migrations/0036_ensure_workflow_custom_data_columns.py
@@ -1,0 +1,89 @@
+"""workflows 0036 hotfix: ensure legacy workflow tables have custom_data.
+
+Production drift was observed where workflows_tenantlist was missing the
+TenantAwareModel custom_data column, causing ORM queries and admin delete
+collection to fail with ProgrammingError.
+
+This migration is intentionally idempotent and additive:
+- adds custom_data only when the table/column is missing
+- backfills NULL values to {}
+- preserves existing data
+
+Reverse is a no-op because removing the column would be unsafe on live tenants.
+"""
+
+from django.db import migrations
+
+
+_ADD_COLUMNS_SQL = """
+ALTER TABLE IF EXISTS workflows_tenantlist
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantform
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantformentity
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantformfield
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantformrule
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantworkflow
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantworkflowcondition
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantworkflowaction
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_workflowexecutionlog
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantformversion
+    ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+"""
+
+_BACKFILL_SQL = """
+UPDATE workflows_tenantlist SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_tenantform SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_tenantformentity SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_tenantformfield SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_tenantformrule SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_tenantworkflow SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_tenantworkflowcondition SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_tenantworkflowaction SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_workflowexecutionlog SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+UPDATE workflows_tenantformversion SET custom_data = '{}'::jsonb WHERE custom_data IS NULL;
+"""
+
+_SET_NOT_NULL_SQL = """
+ALTER TABLE IF EXISTS workflows_tenantlist ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantlist ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_tenantform ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantform ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_tenantformentity ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantformentity ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_tenantformfield ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantformfield ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_tenantformrule ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantformrule ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_tenantworkflow ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantworkflow ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_tenantworkflowcondition ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantworkflowcondition ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_tenantworkflowaction ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantworkflowaction ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_workflowexecutionlog ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_workflowexecutionlog ALTER COLUMN custom_data SET NOT NULL;
+ALTER TABLE IF EXISTS workflows_tenantformversion ALTER COLUMN custom_data SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS workflows_tenantformversion ALTER COLUMN custom_data SET NOT NULL;
+"""
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("workflows", "0035_tenantworkformexecution_runtime_state"),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=_ADD_COLUMNS_SQL, reverse_sql=migrations.RunSQL.noop),
+        migrations.RunSQL(sql=_BACKFILL_SQL, reverse_sql=migrations.RunSQL.noop),
+        migrations.RunSQL(sql=_SET_NOT_NULL_SQL, reverse_sql=migrations.RunSQL.noop),
+    ]

--- a/backend/tenant_apps/workflows/test_schema_columns.py
+++ b/backend/tenant_apps/workflows/test_schema_columns.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from django.db import connection
+from django.test import TestCase
+
+
+class WorkflowSchemaColumnTests(TestCase):
+    def _column_names(self, table_name: str) -> set[str]:
+        with connection.cursor() as cursor:
+            return {
+                column.name
+                for column in connection.introspection.get_table_description(cursor, table_name)
+            }
+
+    def test_tenantlist_has_tenantaware_columns(self):
+        columns = self._column_names("workflows_tenantlist")
+
+        self.assertIn("created_on", columns)
+        self.assertIn("modified_on", columns)
+        self.assertIn("custom_data", columns)


### PR DESCRIPTION
## Summary
- move the Django admin superuser tenant selector inside the invite form and preserve the selected tenant on validation errors
- allow superusers to create and list invitations for the explicitly selected tenant in the API without requiring TenantUser membership
- add an idempotent workflows migration to repair missing custom_data columns on drifted tenant-aware workflow tables

## Testing
- cd backend && python manage.py test apps.tenants.test_admin_invite_view apps.tenants.test_superuser_invitation_api apps.tenants.test_invitations_flow apps.tenants.test_current_tenant_failclosed tenant_apps.workflows.test_schema_columns --verbosity=2
- cd backend && python manage.py makemigrations --check
- cd backend && python manage.py migrate --plan