### PR TITLE
fix: harden AI email search loop handling

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1777,3 +1777,4 @@ Deliverables:
 - **2026-04-27** — WorkForms editor: polish trigger preview/test/debug UX — persist Dry Run Debugger mock inputs with Reset Input, and make Smart Auto-Map suggestions disappear on accept/reject; add unit coverage for schedule cron helpers + auto-map immutability. (PR: #4702)
 
 - **2026-04-27** — WorkForms UI: a11y hardening — keyboard-operable Catalog/In Progress cards and accessible TemplateSelector modal (dialog semantics, Escape close, focus trap + restore focus) with automated tests. (PR: #4703)
+- **2026-04-28** — [COMPLETED] Hardened AI Swarm execution against tool-loop exhaustion and upgraded Microsoft Graph email search to support flexible folder/read/attachment querying with structured tool errors and regression coverage.

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -25,9 +25,38 @@ DEFAULT_OPENAI_TOOLS = [
     {
         'type': 'function',
         'function': {
-            'name': 'check_unread_emails',
-            'description': "Checks the user's connected Microsoft Outlook inbox for unread emails and document attachments.",
-            'parameters': {'type': 'object', 'properties': {}},
+            'name': 'fetch_emails',
+            'description': (
+                "Search the user's connected Microsoft Outlook mailbox with explicit folder/read/"
+                'attachment/search filters. Defaults to inbox when folder is omitted.'
+            ),
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'folder': {
+                        'type': 'string',
+                        'enum': ['inbox', 'sentitems', 'archive'],
+                        'description': 'Mailbox folder to search. Defaults to inbox.',
+                    },
+                    'is_read': {
+                        'type': 'boolean',
+                        'description': 'Optional read-status filter. Omit to search both read and unread mail.',
+                    },
+                    'has_attachments': {
+                        'type': 'boolean',
+                        'description': 'Optional attachment filter. Omit to include both messages with and without attachments.',
+                    },
+                    'search_query': {
+                        'type': 'string',
+                        'description': 'Optional keyword query for Graph search, e.g. "invoice".',
+                    },
+                    'limit': {
+                        'type': 'integer',
+                        'description': 'Max results to return (default 10, maximum 25).',
+                    },
+                },
+                'additionalProperties': False,
+            },
         },
     },
     {
@@ -434,6 +463,7 @@ class ToolExecutor:
 
     def __init__(self):
         self._tools: Dict[str, Callable[[Dict[str, Any], Any, Any], Any]] = {
+            'fetch_emails': self._fetch_emails,
             'check_unread_emails': self._check_unread_emails,
             'draft_outlook_email': self._draft_outlook_email,
             'get_record_detail': self._get_record_detail,
@@ -471,6 +501,8 @@ class ToolExecutor:
         Returns:
             JSON string containing success data or an error payload.
         """
+        from tenant_apps.ai_assistant.swarm.tools.microsoft_graph import error_payload_from_exception
+
         try:
             fn = self._tools.get(tool_name)
             if not fn:
@@ -516,59 +548,49 @@ class ToolExecutor:
             tenant_id = str(getattr(tenant, 'id', '') or '')
             logger.warning('Tool execution failed tool=%s tenant=%s: %s', tool_name, tenant_id, str(e), exc_info=True)
             return json.dumps(
-                {
-                    'ok': False,
-                    'tool': tool_name,
-                    'tenant_id': tenant_id or None,
-                    'error': (
-                        f"Tool '{tool_name}' failed for tenant {tenant_id or 'UNKNOWN'}. "
-                        'This may be due to missing data, invalid arguments, or RLS constraints. '
-                        f"Details: {type(e).__name__}: {e}"
-                    ),
-                },
+                error_payload_from_exception(
+                    tool_name=tool_name,
+                    tenant_id=tenant_id or None,
+                    exc=e,
+                ),
                 default=str,
             )
 
-    def _check_unread_emails(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
-        from apps.integrations.models import ExternalAuthProvider
-        from tenant_apps.ai_assistant.swarm.tools.microsoft_graph import decryption_failed_payload
+    def _fetch_emails(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
         from tenant_apps.integrations.services.email_ingestion import EmailIngestionService
 
         tenant_id = getattr(tenant, 'id', None)
         if not tenant_id:
             raise ValueError('Tenant not resolved; cannot access email tools')
 
-        provider = (
-            ExternalAuthProvider.objects.filter(
-                tenant=tenant,
-                provider_type='microsoft',
-                is_active=True,
-            )
-            .select_related('tenant')
-            .first()
+        folder = arguments.get('folder') or 'inbox'
+        is_read = arguments.get('is_read') if 'is_read' in arguments else None
+        has_attachments = arguments.get('has_attachments') if 'has_attachments' in arguments else None
+        search_query = arguments.get('search_query')
+        limit = arguments.get('limit')
+
+        return EmailIngestionService(tenant).fetch_emails_for_ai(
+            folder=folder,
+            is_read=is_read,
+            has_attachments=has_attachments,
+            search_query=search_query,
+            limit=limit,
         )
-        if not provider:
-            raise ValueError('Outlook not connected. Connect it in Settings → Email Integrations.')
-        if provider.is_token_expired():
-            raise ValueError('Outlook connection expired. Reconnect in Settings → Email Integrations.')
 
-        # Decryption errors can occur when OAUTH_ENCRYPTION_KEY has changed.
-        # In that case, return a stable payload so the AI can instruct the user to reconnect.
-        try:
-            return EmailIngestionService(tenant).fetch_unread_actionable_emails()
-        except Exception as e:
-            # EmailIngestionService uses ExternalAuthProvider.get_decrypted_token under the hood.
-            # When the underlying Fernet decrypt fails, the model raises InvalidToken.
-            from cryptography.fernet import InvalidToken
-
-            if isinstance(e, InvalidToken):
-                return decryption_failed_payload()
-            raise
+    def _check_unread_emails(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
+        alias_arguments = {
+            'folder': 'inbox',
+            'is_read': False,
+            'has_attachments': True,
+            'limit': arguments.get('limit') if 'limit' in arguments else 10,
+        }
+        return self._fetch_emails(alias_arguments, tenant, user)
 
     def _draft_outlook_email(self, arguments: Dict[str, Any], tenant: Any, user: Any = None) -> Any:
         """Send an email using the tenant's Microsoft Graph connection."""
         from apps.integrations.models import ExternalAuthProvider
         from apps.integrations.providers.microsoft import MicrosoftGraphProvider
+        from tenant_apps.ai_assistant.swarm.tools.microsoft_graph import ToolExecutionError
 
         tenant_id = getattr(tenant, 'id', None)
         if not tenant_id:
@@ -606,7 +628,12 @@ class ToolExecutor:
 
         access_token, err = decrypt_token_or_error(provider_row=provider_row, token_type='access')
         if err:
-            return err
+            raise ToolExecutionError(
+                error_code=err.get('error_code') or 'DECRYPTION_FAILED',
+                message=err.get('message') or 'Your Outlook connection needs to be refreshed for security reasons.',
+                hint='Reconnect Outlook in Settings → Email Integrations.',
+                retryable=False,
+            )
 
         graph = MicrosoftGraphProvider(tenant.id)
 

--- a/backend/tenant_apps/ai_assistant/swarm/router.py
+++ b/backend/tenant_apps/ai_assistant/swarm/router.py
@@ -60,6 +60,7 @@ def build_swarm_system_prompt(
         "- create_task(title, message[, entity_type, entity_id]) to create an in-app task notification for the current user. "
         "- create_in_app_notification(title, message[, ...]) to notify other users (owners/admins only). "
         "- get_recent_errors() to fetch the most recent Sentry issues for the active tenant. "
+        "- fetch_emails([folder, is_read, has_attachments, search_query, limit]) to search Inbox, Sent Items, or Archive mail. "
         "\n\nTENANT MEMORY PROTOCOL (MANDATORY): "
         "If the user provides a standing rule or preference (e.g., 'Always route Acme through Chicago'), call save_memory(key, memory_text[, memory_json, tags]). "
         "When answering, apply the injected Tenant Memory block when relevant. "
@@ -81,6 +82,13 @@ def build_swarm_system_prompt(
         "\n\nEXTERNAL COMMS BROKER (DRAFT-ONLY): "
         "If the user wants to contact a supplier/customer (invoice mismatch, PO discrepancy, booking change), propose drafting an email. "
         "Use draft_vendor_email(vendor_id, context[, vendor_type]) to store a Draft and return the subject/body for human approval. "
+        "\n\nOUTLOOK EMAIL SEARCH PROTOCOL (MANDATORY): "
+        "You have full access to search the user's Inbox, Sent Items, and Archive. "
+        "You can search both read and unread emails. "
+        "When calling fetch_emails, you MUST map the user's request to the correct folder/is_read/has_attachments/search_query parameters. "
+        "If the user asks for sent emails, set folder to 'sentitems'. "
+        "If a tool returns a structured error or loop warning, do NOT repeat the exact same tool call. "
+        "Instead, simplify the query or ask the user for clarification."
     )
 
     if lessons_block:
@@ -98,6 +106,36 @@ def build_swarm_system_prompt(
         return base + "Outlook: CONNECTED but EXPIRED. Do not claim you can read email; instruct user to reconnect."
 
     return base + "Outlook: NOT CONNECTED. Do not claim you can read email; instruct user to connect Outlook."
+
+
+def _tool_call_signature(tool_name: str, raw_args: Any) -> str:
+    def _normalize(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: _normalize(item)
+                for key, item in value.items()
+                if item is not None
+            }
+        if isinstance(value, list):
+            return [_normalize(item) for item in value]
+        return value
+
+    if isinstance(raw_args, str):
+        try:
+            parsed = json.loads(raw_args)
+        except Exception:
+            parsed = raw_args
+    else:
+        parsed = raw_args or {}
+
+    parsed = _normalize(parsed)
+
+    try:
+        normalized_args = json.dumps(parsed, sort_keys=True, separators=(',', ':'), default=str)
+    except Exception:
+        normalized_args = str(parsed)
+
+    return f'{tool_name}:{normalized_args}'
 
 
 @dataclass(frozen=True)
@@ -302,7 +340,7 @@ class SwarmOrchestrator:
         outlook_connected = bool(provider and not outlook_expired)
 
         # Always allow safe internal tools; only advertise Outlook tools when connected.
-        email_tools = {'check_unread_emails', 'draft_outlook_email'}
+        email_tools = {'fetch_emails', 'check_unread_emails', 'draft_outlook_email'}
         if outlook_connected:
             tools = DEFAULT_OPENAI_TOOLS
         else:
@@ -338,6 +376,8 @@ class SwarmOrchestrator:
 
         max_rounds = int(getattr(settings, 'SWARM_TOOL_MAX_ROUNDS', 3) or 3)
         rounds = 0
+        tool_signatures: List[str] = []
+        loop_warning_injected = False
 
         while True:
             rounds += 1
@@ -388,7 +428,40 @@ class SwarmOrchestrator:
                 except Exception:
                     args = {}
 
-                result = executor.execute(tool_name, args, tenant, user)
+                signature = _tool_call_signature(tool_name, raw_args)
+                repeated_signature = (
+                    len(tool_signatures) >= 2
+                    and tool_signatures[-1] == signature
+                    and tool_signatures[-2] == signature
+                )
+
+                if repeated_signature:
+                    result = json.dumps(
+                        {
+                            'ok': False,
+                            'tool': tool_name,
+                            'tenant_id': str(getattr(tenant, 'id', '') or ''),
+                            'error': {
+                                'code': 'TOOL_LOOP_DETECTED',
+                                'message': 'You are stuck calling the same tool with the same parameters.',
+                                'hint': 'Stop retrying this tool and ask the user for clarification or adjust the query.',
+                                'retryable': False,
+                            },
+                        }
+                    )
+                    messages.append(
+                        {
+                            'role': 'system',
+                            'content': 'System: You are stuck in a loop. Stop calling this tool and ask the user for clarification.',
+                        }
+                    )
+                    if not loop_warning_injected:
+                        max_rounds += 1
+                        loop_warning_injected = True
+                else:
+                    result = executor.execute(tool_name, args, tenant, user)
+                    tool_signatures.append(signature)
+
                 messages.append(
                     {
                         'role': 'tool',

--- a/backend/tenant_apps/ai_assistant/swarm/tools/microsoft_graph.py
+++ b/backend/tenant_apps/ai_assistant/swarm/tools/microsoft_graph.py
@@ -1,6 +1,7 @@
 """Microsoft Graph tool helpers for PM-AS.
 
-Centralizes structured error responses so the LLM can react deterministically.
+Centralizes structured error responses, query construction, and payload shaping so
+the LLM can react deterministically.
 
 This module is the canonical place to catch decryption failures and translate them
 into stable, user-facing error payloads.
@@ -8,10 +9,44 @@ into stable, user-facing error payloads.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any
+
 from cryptography.fernet import InvalidToken
 
 
-def decryption_failed_payload() -> dict:
+DEFAULT_MAIL_FOLDER = 'inbox'
+DEFAULT_MAIL_LIMIT = 10
+MAX_MAIL_LIMIT = 25
+
+SUPPORTED_MAIL_FOLDERS = {
+    'archive': 'archive',
+    'inbox': 'inbox',
+    'sent': 'sentitems',
+    'sentitems': 'sentitems',
+}
+
+GRAPH_MAIL_SELECT_FIELDS = (
+    'id,subject,from,toRecipients,ccRecipients,receivedDateTime,bodyPreview,'
+    'hasAttachments,conversationId,isRead,webLink'
+)
+
+
+@dataclass(frozen=True)
+class ToolExecutionError(Exception):
+    """Structured tool failure that the router/LLM can reason about."""
+
+    error_code: str
+    message: str
+    hint: str | None = None
+    retryable: bool = False
+    details: str | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def decryption_failed_payload() -> dict[str, str]:
     return {
         'status': 'error',
         'error_code': 'DECRYPTION_FAILED',
@@ -19,7 +54,7 @@ def decryption_failed_payload() -> dict:
     }
 
 
-def decrypt_token_or_error(*, provider_row, token_type: str) -> tuple[str | None, dict | None]:
+def decrypt_token_or_error(*, provider_row, token_type: str) -> tuple[str | None, dict[str, str] | None]:
     """Return (token, error_payload). Never raises InvalidToken."""
 
     try:
@@ -27,3 +62,206 @@ def decrypt_token_or_error(*, provider_row, token_type: str) -> tuple[str | None
         return token, None
     except InvalidToken:
         return None, decryption_failed_payload()
+
+
+def build_tool_error_payload(
+    *,
+    tool_name: str,
+    tenant_id: str | None = None,
+    error_code: str,
+    message: str,
+    hint: str | None = None,
+    retryable: bool = False,
+    details: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        'ok': False,
+        'tool': tool_name,
+        'tenant_id': tenant_id,
+        'error': {
+            'code': error_code,
+            'message': message,
+            'retryable': retryable,
+        },
+    }
+    if hint:
+        payload['error']['hint'] = hint
+    if details:
+        payload['error']['details'] = details
+    return payload
+
+
+def error_payload_from_exception(
+    *,
+    tool_name: str,
+    tenant_id: str | None = None,
+    exc: Exception,
+) -> dict[str, Any]:
+    if isinstance(exc, ToolExecutionError):
+        return build_tool_error_payload(
+            tool_name=tool_name,
+            tenant_id=tenant_id,
+            error_code=exc.error_code,
+            message=exc.message,
+            hint=exc.hint,
+            retryable=exc.retryable,
+            details=exc.details,
+        )
+
+    if isinstance(exc, ValueError):
+        return build_tool_error_payload(
+            tool_name=tool_name,
+            tenant_id=tenant_id,
+            error_code='INVALID_TOOL_ARGUMENTS',
+            message=str(exc) or 'Tool arguments were invalid.',
+            hint='Adjust the request parameters and try again.',
+            retryable=False,
+        )
+
+    return build_tool_error_payload(
+        tool_name=tool_name,
+        tenant_id=tenant_id,
+        error_code='TOOL_EXECUTION_FAILED',
+        message='The tool failed before it could complete the request.',
+        hint='Do not repeat the exact same tool call. Simplify the request or ask the user for clarification.',
+        retryable=False,
+        details=f'{type(exc).__name__}: {exc}',
+    )
+
+
+def normalize_mail_folder(folder: str | None) -> str:
+    raw = str(folder or DEFAULT_MAIL_FOLDER).strip().lower()
+    normalized = SUPPORTED_MAIL_FOLDERS.get(raw)
+    if not normalized:
+        supported = ', '.join(sorted(set(SUPPORTED_MAIL_FOLDERS)))
+        raise ToolExecutionError(
+            error_code='UNSUPPORTED_MAIL_FOLDER',
+            message=f"Unsupported mail folder '{folder}'.",
+            hint=f'Use one of: {supported}.',
+            retryable=False,
+        )
+    return normalized
+
+
+def normalize_mail_limit(limit: Any) -> int:
+    if limit in (None, ''):
+        return DEFAULT_MAIL_LIMIT
+
+    try:
+        parsed = int(limit)
+    except (TypeError, ValueError) as exc:
+        raise ToolExecutionError(
+            error_code='INVALID_MAIL_LIMIT',
+            message='Email result limit must be an integer.',
+            hint=f'Use a number between 1 and {MAX_MAIL_LIMIT}.',
+            retryable=False,
+        ) from exc
+
+    if parsed < 1 or parsed > MAX_MAIL_LIMIT:
+        raise ToolExecutionError(
+            error_code='INVALID_MAIL_LIMIT',
+            message=f'Email result limit must be between 1 and {MAX_MAIL_LIMIT}.',
+            hint='Reduce the number of requested emails and try again.',
+            retryable=False,
+        )
+
+    return parsed
+
+
+def build_mail_request(
+    *,
+    folder: str | None = None,
+    is_read: bool | None = None,
+    has_attachments: bool | None = None,
+    search_query: str | None = None,
+    limit: Any = None,
+) -> dict[str, Any]:
+    """Build a safe Microsoft Graph mail request descriptor."""
+
+    folder_id = normalize_mail_folder(folder)
+    top = normalize_mail_limit(limit)
+    trimmed_query = str(search_query or '').strip()
+
+    params: dict[str, Any] = {
+        '$select': GRAPH_MAIL_SELECT_FIELDS,
+        '$top': top,
+    }
+    headers: dict[str, str] = {}
+
+    filter_parts: list[str] = []
+    if is_read is not None:
+        filter_parts.append(f"isRead eq {'true' if bool(is_read) else 'false'}")
+    if has_attachments is not None:
+        filter_parts.append(f"hasAttachments eq {'true' if bool(has_attachments) else 'false'}")
+    if filter_parts:
+        params['$filter'] = ' and '.join(filter_parts)
+
+    if trimmed_query:
+        escaped = trimmed_query.replace('"', '\\"')
+        params['$search'] = f'"{escaped}"'
+        headers['ConsistencyLevel'] = 'eventual'
+    else:
+        params['$orderby'] = 'receivedDateTime desc'
+
+    return {
+        'folder': folder_id,
+        'limit': top,
+        'url_path': f'/me/mailFolders/{folder_id}/messages',
+        'params': params,
+        'headers': headers,
+        'requires_filter_fallback': bool(trimmed_query and filter_parts),
+    }
+
+
+def post_filter_messages(
+    messages: list[dict[str, Any]],
+    *,
+    is_read: bool | None = None,
+    has_attachments: bool | None = None,
+) -> list[dict[str, Any]]:
+    filtered: list[dict[str, Any]] = []
+    for message in messages:
+        if is_read is not None and bool(message.get('isRead')) is not bool(is_read):
+            continue
+        if has_attachments is not None and bool(message.get('hasAttachments')) is not bool(has_attachments):
+            continue
+        filtered.append(message)
+    return filtered
+
+
+def serialize_graph_message(message: dict[str, Any], *, folder: str) -> dict[str, Any]:
+    from_data = ((message.get('from') or {}).get('emailAddress') or {}) if isinstance(message.get('from'), dict) else {}
+
+    def _recipient_list(key: str) -> list[dict[str, str]]:
+        rows = message.get(key) or []
+        if not isinstance(rows, list):
+            return []
+        recipients: list[dict[str, str]] = []
+        for row in rows[:10]:
+            email = ((row or {}).get('emailAddress') or {}) if isinstance(row, dict) else {}
+            address = str(email.get('address') or '').strip()
+            name = str(email.get('name') or '').strip()
+            if not address and not name:
+                continue
+            recipients.append({'name': name, 'address': address})
+        return recipients
+
+    preview = str(message.get('bodyPreview') or '').strip()
+
+    return {
+        'id': message.get('id'),
+        'folder': folder,
+        'subject': message.get('subject') or '(No Subject)',
+        'received_at': message.get('receivedDateTime'),
+        'is_read': bool(message.get('isRead')),
+        'has_attachments': bool(message.get('hasAttachments')),
+        'from': {
+            'name': str(from_data.get('name') or '').strip(),
+            'address': str(from_data.get('address') or '').strip(),
+        },
+        'to': _recipient_list('toRecipients'),
+        'cc': _recipient_list('ccRecipients'),
+        'preview': preview[:500],
+        'web_link': message.get('webLink'),
+        'conversation_id': message.get('conversationId'),
+    }

--- a/backend/tenant_apps/ai_assistant/test_swarm_email_tools.py
+++ b/backend/tenant_apps/ai_assistant/test_swarm_email_tools.py
@@ -1,0 +1,303 @@
+import json
+import uuid
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import requests
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase, override_settings
+from django.utils import timezone
+
+from apps.integrations.models import ExternalAuthProvider
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.ai_assistant.swarm.executor import ToolExecutor
+from tenant_apps.ai_assistant.swarm.router import SwarmOrchestrator, _tool_call_signature
+from tenant_apps.ai_assistant.swarm.tools.microsoft_graph import (
+    ToolExecutionError,
+    build_mail_request,
+)
+from tenant_apps.integrations.services.email_ingestion import EmailIngestionService
+
+
+class MicrosoftGraphToolHelperTests(SimpleTestCase):
+    def test_build_mail_request_supports_folder_filters_and_search(self):
+        request_spec = build_mail_request(
+            folder='sentitems',
+            is_read=None,
+            has_attachments=True,
+            search_query='invoice',
+            limit=12,
+        )
+
+        self.assertEqual(request_spec['folder'], 'sentitems')
+        self.assertEqual(request_spec['url_path'], '/me/mailFolders/sentitems/messages')
+        self.assertEqual(request_spec['params']['$filter'], 'hasAttachments eq true')
+        self.assertEqual(request_spec['params']['$search'], '"invoice"')
+        self.assertEqual(request_spec['params']['$top'], 12)
+        self.assertEqual(request_spec['headers']['ConsistencyLevel'], 'eventual')
+        self.assertTrue(request_spec['requires_filter_fallback'])
+
+    def test_tool_call_signature_ignores_null_optional_arguments(self):
+        signature_without_null = _tool_call_signature(
+            'fetch_emails',
+            {'folder': 'inbox', 'limit': 10},
+        )
+        signature_with_null = _tool_call_signature(
+            'fetch_emails',
+            {'folder': 'inbox', 'limit': 10, 'is_read': None},
+        )
+
+        self.assertEqual(signature_without_null, signature_with_null)
+
+
+class EmailIngestionServiceEmailFetchTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username=f'email-tools-{unique}',
+            email=f'email-tools-{unique}@example.com',
+            password='pw',
+        )
+        self.tenant = Tenant.objects.create(
+            name=f'Email Tenant {unique}',
+            slug=f'email-tenant-{unique}',
+            contact_email=f'tenant-{unique}@example.com',
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner')
+
+        self.provider = ExternalAuthProvider.objects.create(
+            tenant=self.tenant,
+            provider_type='microsoft',
+            access_token='placeholder',
+            token_expiry=timezone.now() + timedelta(days=1),
+            is_active=True,
+            connected_email='planner@example.com',
+        )
+        self.provider.set_encrypted_token('access', 'access-token')
+        self.provider.save()
+
+    def _response(self, *, status: int = 200, payload: dict | None = None, text: str = '') -> Mock:
+        response = Mock()
+        response.status_code = status
+        response.json.return_value = payload or {}
+        response.text = text
+        if status >= 400:
+            response.raise_for_status.side_effect = requests.HTTPError(response=response)
+        else:
+            response.raise_for_status.return_value = None
+        return response
+
+    @patch('apps.integrations.providers.MicrosoftGraphProvider')
+    @patch('requests.get')
+    def test_fetch_emails_falls_back_to_search_only_when_graph_rejects_search_and_filter_combo(
+        self,
+        mock_get,
+        mock_graph_provider,
+    ):
+        mock_graph_provider.return_value = SimpleNamespace(
+            GRAPH_API_BASE='https://graph.microsoft.com/v1.0'
+        )
+        mock_get.side_effect = [
+            self._response(status=400, text='Bad Request'),
+            self._response(
+                payload={
+                    'value': [
+                        {
+                            'id': 'sent-2',
+                            'subject': 'Invoice attached',
+                            'receivedDateTime': '2026-04-28T11:00:00Z',
+                            'bodyPreview': 'Newest invoice preview',
+                            'hasAttachments': True,
+                            'isRead': True,
+                            'from': {'emailAddress': {'address': 'seller@example.com', 'name': 'Seller'}},
+                            'toRecipients': [{'emailAddress': {'address': 'buyer@example.com', 'name': 'Buyer'}}],
+                        },
+                        {
+                            'id': 'sent-1',
+                            'subject': 'Invoice without attachment',
+                            'receivedDateTime': '2026-04-27T11:00:00Z',
+                            'bodyPreview': 'Older invoice preview',
+                            'hasAttachments': False,
+                            'isRead': True,
+                            'from': {'emailAddress': {'address': 'seller@example.com', 'name': 'Seller'}},
+                            'toRecipients': [{'emailAddress': {'address': 'buyer@example.com', 'name': 'Buyer'}}],
+                        },
+                    ]
+                }
+            ),
+        ]
+
+        result = EmailIngestionService(self.tenant).fetch_emails_for_ai(
+            folder='sentitems',
+            has_attachments=True,
+            search_query='invoice',
+            limit=10,
+        )
+
+        self.assertEqual(result['folder'], 'sentitems')
+        self.assertEqual(result['count'], 1)
+        self.assertEqual(result['messages'][0]['id'], 'sent-2')
+
+        first_call = mock_get.call_args_list[0]
+        self.assertIn('/me/mailFolders/sentitems/messages', first_call.args[0])
+        self.assertEqual(first_call.kwargs['params']['$filter'], 'hasAttachments eq true')
+        self.assertEqual(first_call.kwargs['params']['$search'], '"invoice"')
+        self.assertEqual(first_call.kwargs['headers']['ConsistencyLevel'], 'eventual')
+
+        second_call = mock_get.call_args_list[1]
+        self.assertNotIn('$filter', second_call.kwargs['params'])
+        self.assertEqual(second_call.kwargs['params']['$top'], 25)
+
+
+class ToolExecutorEmailToolTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username=f'executor-email-{unique}',
+            email=f'executor-email-{unique}@example.com',
+            password='pw',
+        )
+        self.tenant = Tenant.objects.create(
+            name=f'Executor Email Tenant {unique}',
+            slug=f'executor-email-tenant-{unique}',
+            contact_email=f'executor-{unique}@example.com',
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner')
+
+    @patch('tenant_apps.ai_assistant.swarm.executor.set_current_tenant', return_value=SimpleNamespace(ok=True, error=None))
+    @patch('tenant_apps.integrations.services.email_ingestion.EmailIngestionService.fetch_emails_for_ai')
+    def test_execute_returns_structured_graph_error_payload(self, mock_fetch, _mock_rls):
+        mock_fetch.side_effect = ToolExecutionError(
+            error_code='GRAPH_QUERY_REJECTED',
+            message='Microsoft Graph rejected the email search query format.',
+            hint='Try simplifying your search terms.',
+            retryable=False,
+        )
+
+        payload = json.loads(
+            ToolExecutor().execute(
+                'fetch_emails',
+                {'folder': 'sentitems', 'has_attachments': True, 'search_query': 'invoice'},
+                self.tenant,
+            )
+        )
+
+        self.assertFalse(payload['ok'])
+        self.assertEqual(payload['tool'], 'fetch_emails')
+        self.assertEqual(payload['error']['code'], 'GRAPH_QUERY_REJECTED')
+        self.assertEqual(payload['error']['hint'], 'Try simplifying your search terms.')
+
+
+class SwarmRouterLoopDetectionTests(TestCase):
+    def setUp(self):
+        unique = uuid.uuid4().hex[:8]
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username=f'loop-router-{unique}',
+            email=f'loop-router-{unique}@example.com',
+            password='pw',
+        )
+        self.tenant = Tenant.objects.create(
+            name=f'Loop Router Tenant {unique}',
+            slug=f'loop-router-tenant-{unique}',
+            contact_email=f'loop-router-{unique}@example.com',
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner')
+
+        provider = ExternalAuthProvider.objects.create(
+            tenant=self.tenant,
+            provider_type='microsoft',
+            access_token='placeholder',
+            token_expiry=timezone.now() + timedelta(days=1),
+            is_active=True,
+            connected_email='planner@example.com',
+        )
+        provider.set_encrypted_token('access', 'access-token')
+        provider.save()
+
+    @staticmethod
+    def _completion_with_tool_call(arguments: str):
+        tool_call = SimpleNamespace(
+            id='tc-1',
+            type='function',
+            function=SimpleNamespace(name='fetch_emails', arguments=arguments),
+        )
+        message = SimpleNamespace(content='', tool_calls=[tool_call])
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    @staticmethod
+    def _completion_with_text(content: str):
+        message = SimpleNamespace(content=content, tool_calls=None)
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    @override_settings(OPENAI_API_KEY='test-key', SWARM_TOOL_MAX_ROUNDS=3)
+    @patch('tenant_apps.ai_assistant.services.memory_service.get_relevant_lessons', return_value=[])
+    @patch('tenant_apps.ai_assistant.services.memory_service.format_lessons_block', return_value='')
+    @patch('tenant_apps.ai_assistant.services.tenant_memory_service.get_relevant_memories', return_value=[])
+    @patch('tenant_apps.ai_assistant.services.tenant_memory_service.format_memory_block', return_value='')
+    @patch('apps.system.services.ai_model_resolver.get_active_openai_model_id', return_value='gpt-4o-mini')
+    @patch('tenant_apps.ai_assistant.swarm.router.ToolExecutor.execute')
+    @patch('openai.OpenAI')
+    def test_run_tool_loop_injects_loop_warning_before_max_rounds_exhaust(
+        self,
+        mock_openai,
+        mock_execute,
+        _mock_model,
+        _mock_format_memory,
+        _mock_memories,
+        _mock_format_lessons,
+        _mock_lessons,
+    ):
+        repeated_args = json.dumps(
+            {
+                'folder': 'sentitems',
+                'has_attachments': True,
+                'search_query': 'invoice',
+            }
+        )
+
+        mock_execute.return_value = json.dumps(
+            {
+                'ok': True,
+                'tool': 'fetch_emails',
+                'data': {'messages': []},
+            }
+        )
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=Mock(
+                        side_effect=[
+                            self._completion_with_tool_call(repeated_args),
+                            self._completion_with_tool_call(repeated_args),
+                            self._completion_with_tool_call(repeated_args),
+                            self._completion_with_text('I am stuck on the same email query and need clarification.'),
+                        ]
+                    )
+                )
+            )
+        )
+        mock_openai.return_value = fake_client
+
+        result = SwarmOrchestrator(tenant_id=str(self.tenant.id)).run_tool_loop(
+            user_message='Please grab the last sent invoice emails with attachments.',
+            tenant=self.tenant,
+            user=self.user,
+        )
+
+        self.assertEqual(result['response'], 'I am stuck on the same email query and need clarification.')
+        self.assertEqual(mock_execute.call_count, 2)
+        self.assertTrue(
+            any(
+                message.get('role') == 'system'
+                and 'You are stuck in a loop' in str(message.get('content') or '')
+                for message in result['messages']
+            )
+        )

--- a/backend/tenant_apps/ai_assistant/views.py
+++ b/backend/tenant_apps/ai_assistant/views.py
@@ -560,7 +560,7 @@ class SwarmToolsOpenAPIView(APIView):
         except Exception:
             logger.warning('tools/openapi: failed to load outlook connection status', exc_info=True)
 
-        email_tools = {'check_unread_emails', 'draft_outlook_email'}
+        email_tools = {'fetch_emails', 'check_unread_emails', 'draft_outlook_email'}
 
         if outlook['connected']:
             tools = DEFAULT_OPENAI_TOOLS
@@ -840,7 +840,7 @@ class ToolsOpenAPIView(APIView):
         except Exception:
             outlook_connected = False
 
-        email_tools = {'check_unread_emails', 'draft_outlook_email'}
+        email_tools = {'fetch_emails', 'check_unread_emails', 'draft_outlook_email'}
 
         if outlook_connected:
             tools = DEFAULT_OPENAI_TOOLS

--- a/backend/tenant_apps/integrations/services/email_ingestion.py
+++ b/backend/tenant_apps/integrations/services/email_ingestion.py
@@ -5,11 +5,23 @@ Polls inboxes for order-related emails and creates EmailLog entries for AI proce
 """
 import logging
 from datetime import timedelta
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
+import requests
 from django.utils import timezone
 from django.db import transaction
+
 from apps.integrations.models import ExternalAuthProvider, EmailLog
 from apps.tenants.models import Tenant
+from tenant_apps.ai_assistant.swarm.tools.microsoft_graph import (
+    MAX_MAIL_LIMIT,
+    ToolExecutionError,
+    build_mail_request,
+    decrypt_token_or_error,
+    decryption_failed_payload,
+    post_filter_messages,
+    serialize_graph_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -524,6 +536,106 @@ class EmailIngestionService:
 
         return results
 
+    def fetch_emails_for_ai(
+        self,
+        *,
+        folder: str | None = None,
+        is_read: bool | None = None,
+        has_attachments: bool | None = None,
+        search_query: str | None = None,
+        limit: int | None = None,
+    ) -> Dict[str, Any]:
+        """Fetch a bounded, LLM-safe mail slice for the active tenant."""
+        if not self.tenant:
+            raise ToolExecutionError(
+                error_code='TENANT_CONTEXT_MISSING',
+                message='Tenant context is required before searching Outlook email.',
+                hint='Retry from a tenant-scoped ProjectMeats session.',
+                retryable=False,
+            )
+
+        provider = (
+            ExternalAuthProvider.objects.filter(
+                tenant=self.tenant,
+                provider_type='microsoft',
+                is_active=True,
+            )
+            .select_related('tenant')
+            .first()
+        )
+        if not provider:
+            raise ToolExecutionError(
+                error_code='OUTLOOK_NOT_CONNECTED',
+                message='Outlook is not connected for this tenant.',
+                hint='Connect Outlook in Settings → Email Integrations before searching email.',
+                retryable=False,
+            )
+
+        try:
+            provider.refresh_if_needed()
+        except Exception:
+            logger.warning(
+                'Token refresh failed for AI email search tenant=%s provider_id=%s',
+                self.tenant.id,
+                provider.id,
+                exc_info=True,
+            )
+
+        if provider.is_token_expired():
+            raise ToolExecutionError(
+                error_code='OUTLOOK_CONNECTION_EXPIRED',
+                message='Your Outlook connection has expired.',
+                hint='Reconnect Outlook in Settings → Email Integrations.',
+                retryable=False,
+            )
+
+        access_token, err = decrypt_token_or_error(provider_row=provider, token_type='access')
+        if err:
+            raise ToolExecutionError(
+                error_code=err.get('error_code') or 'DECRYPTION_FAILED',
+                message=err.get('message') or decryption_failed_payload()['message'],
+                hint='Reconnect Outlook in Settings → Email Integrations.',
+                retryable=False,
+            )
+        if not access_token:
+            raise ToolExecutionError(
+                error_code='OUTLOOK_ACCESS_TOKEN_MISSING',
+                message='No Outlook access token is available for this tenant.',
+                hint='Reconnect Outlook in Settings → Email Integrations.',
+                retryable=False,
+            )
+
+        request_spec = build_mail_request(
+            folder=folder,
+            is_read=is_read,
+            has_attachments=has_attachments,
+            search_query=search_query,
+            limit=limit,
+        )
+
+        from apps.integrations.providers import MicrosoftGraphProvider
+
+        graph_provider = MicrosoftGraphProvider(self.tenant.id)
+        results = self._fetch_graph_messages_for_ai(
+            graph_provider=graph_provider,
+            access_token=access_token,
+            request_spec=request_spec,
+            is_read=is_read,
+            has_attachments=has_attachments,
+        )
+
+        return {
+            'folder': request_spec['folder'],
+            'limit': request_spec['limit'],
+            'count': len(results),
+            'filters': {
+                'is_read': is_read,
+                'has_attachments': has_attachments,
+                'search_query': (str(search_query or '').strip() or None),
+            },
+            'messages': results,
+        }
+
     def fetch_unread_emails(self, tenant: Tenant) -> List[Dict[str, Any]]:
         """Fetch unread emails (and attachments) for a tenant via Microsoft Graph.
 
@@ -592,6 +704,143 @@ class EmailIngestionService:
             results.append({'message': msg, 'attachments': attachments})
 
         return results
+
+    def _fetch_graph_messages_for_ai(
+        self,
+        *,
+        graph_provider,
+        access_token: str,
+        request_spec: Dict[str, Any],
+        is_read: bool | None,
+        has_attachments: bool | None,
+    ) -> List[Dict[str, Any]]:
+        url = f"{graph_provider.GRAPH_API_BASE}{request_spec['url_path']}"
+        headers = {
+            'Authorization': f'Bearer {access_token}',
+            'Accept': 'application/json',
+            **request_spec.get('headers', {}),
+        }
+        max_pages = 1
+
+        try:
+            messages = self._collect_graph_messages(
+                url=url,
+                headers=headers,
+                params=request_spec['params'],
+                limit=request_spec['limit'],
+                max_pages=max_pages,
+            )
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code == 400 and request_spec.get('requires_filter_fallback'):
+                fallback_params = {
+                    key: value for key, value in request_spec['params'].items() if key != '$filter'
+                }
+                fallback_params['$top'] = 25
+                messages = self._collect_graph_messages(
+                    url=url,
+                    headers=headers,
+                    params=fallback_params,
+                    limit=MAX_MAIL_LIMIT,
+                    max_pages=max_pages,
+                )
+                messages = post_filter_messages(
+                    messages,
+                    is_read=is_read,
+                    has_attachments=has_attachments,
+                )
+            else:
+                raise self._map_graph_exception(exc) from exc
+        except requests.RequestException as exc:
+            raise self._map_graph_exception(exc) from exc
+
+        messages = sorted(
+            messages,
+            key=lambda row: str(row.get('receivedDateTime') or ''),
+            reverse=True,
+        )
+
+        return [
+            serialize_graph_message(message, folder=request_spec['folder'])
+            for message in messages[: request_spec['limit']]
+        ]
+
+    def _collect_graph_messages(
+        self,
+        *,
+        url: str,
+        headers: Dict[str, str],
+        params: Dict[str, Any] | None,
+        limit: int,
+        max_pages: int,
+    ) -> List[Dict[str, Any]]:
+        all_messages: List[Dict[str, Any]] = []
+        next_url = url
+        next_params = params
+        page = 0
+
+        while next_url and page < max_pages and len(all_messages) < limit:
+            response = requests.get(next_url, headers=headers, params=next_params, timeout=30)
+            response.raise_for_status()
+            data = response.json() or {}
+
+            batch = data.get('value', []) or []
+            all_messages.extend(batch)
+
+            next_url = data.get('@odata.nextLink')
+            next_params = None
+            page += 1
+
+        return all_messages[:limit]
+
+    def _map_graph_exception(self, exc: requests.RequestException) -> ToolExecutionError:
+        if isinstance(exc, requests.Timeout):
+            return ToolExecutionError(
+                error_code='GRAPH_TIMEOUT',
+                message='Microsoft Graph timed out while searching email.',
+                hint='Try a smaller search query or a narrower folder.',
+                retryable=True,
+            )
+
+        if isinstance(exc, requests.HTTPError):
+            response = exc.response
+            status_code = response.status_code if response is not None else None
+            response_text = ''
+            if response is not None:
+                response_text = (response.text or '').strip()[:400]
+
+            if status_code == 400:
+                return ToolExecutionError(
+                    error_code='GRAPH_QUERY_REJECTED',
+                    message='Microsoft Graph rejected the email search query format.',
+                    hint='Try simplifying your search terms or reducing the number of filters.',
+                    retryable=False,
+                    details=response_text or None,
+                )
+            if status_code in {401, 403}:
+                return ToolExecutionError(
+                    error_code='GRAPH_AUTH_FAILED',
+                    message='Microsoft Graph rejected the current Outlook credentials.',
+                    hint='Reconnect Outlook in Settings → Email Integrations.',
+                    retryable=False,
+                    details=response_text or None,
+                )
+
+            return ToolExecutionError(
+                error_code='GRAPH_HTTP_ERROR',
+                message='Microsoft Graph returned an unexpected email search error.',
+                hint='Try simplifying the email request or ask the user for clarification.',
+                retryable=False,
+                details=response_text or None,
+            )
+
+        return ToolExecutionError(
+            error_code='GRAPH_REQUEST_FAILED',
+            message='Microsoft Graph email search failed before returning results.',
+            hint='Try a simpler request or ask the user to reconnect Outlook if the problem persists.',
+            retryable=False,
+            details=str(exc),
+        )
 
     def _download_attachments(self, graph_provider, access_token: str, message_id: str | None) -> List[Dict[str, Any]]:
         """Download attachments for a Graph message.


### PR DESCRIPTION
## Summary
- add a canonical `fetch_emails` Outlook tool with explicit folder/read/attachment/search parameters while preserving `check_unread_emails` as a compatibility alias
- harden Graph email ingestion with structured tool errors, bounded payload shaping, sent/inbox/archive folder mapping, and `$search + $filter` fallback behavior
- stop blind Swarm retries by teaching the router how to detect repeated identical tool calls and inject a loop-breaker warning to the model
- add regression coverage for request building, Graph fallback, structured tool error payloads, and loop-signature normalization
- append the PR execution log entry in `.github/MASTER_PLAN.md`

## Expected results
- prompts like "please grab the last 10 sent invoice related emails that have attachments" can target `sentitems` instead of inbox-only unread mail
- Graph query failures return a structured JSON tool error the model can react to instead of opaque retry loops
- the Swarm stops after repeated identical tool calls and asks for clarification instead of exhausting rounds

## Acceptance criteria
- `fetch_emails` supports `folder`, `is_read`, `has_attachments`, `search_query`, and `limit`
- Graph email search returns bounded, lightweight payloads and degrades safely on unsupported `$search`/`$filter` combinations
- repeated identical tool calls are detected even when optional null args are omitted in one call and sent as `null` in another
- Outlook tools are only advertised when a Microsoft provider is connected

## Testing
- `cd backend && python manage.py test tenant_apps.ai_assistant.tests tenant_apps.ai_assistant.test_swarm_email_tools --verbosity=2 --noinput`
- `cd backend && pytest tenant_apps/ai_assistant/tests/test_po_extraction.py -q`
- `cd backend && python manage.py makemigrations --check --dry-run`

## Risks
- Microsoft Graph search ordering can still depend on Graph search semantics when keyword search is used; we mitigate by sorting returned messages by `receivedDateTime` before serializing and by bounding payload sizes
- loop detection is scoped to repeated consecutive identical tool calls, which is intentional to avoid blocking legitimate revised queries

## Rollback
- revert commit `13bce256` to remove the new `fetch_emails` tool path and restore previous Outlook/tool-loop behavior