### PR TITLE
fix: support tabular AI document uploads

### DIFF
--- a/.github/MASTER_PLAN.md
+++ b/.github/MASTER_PLAN.md
@@ -1778,3 +1778,4 @@ Deliverables:
 
 - **2026-04-27** — WorkForms UI: a11y hardening — keyboard-operable Catalog/In Progress cards and accessible TemplateSelector modal (dialog semantics, Escape close, focus trap + restore focus) with automated tests. (PR: #4703)
 - **2026-04-28** — [COMPLETED] Hardened AI Swarm execution against tool-loop exhaustion and upgraded Microsoft Graph email search to support flexible folder/read/attachment querying with structured tool errors and regression coverage.
+- **2026-04-28** — [COMPLETED] Enhanced AI Chat Widget and Swarm ingestion pipeline to support CSV/XLS/XLSX tabular data parsing with markdown conversion, 500-row truncation safeguards, and upload validation for spreadsheet MIME types.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -47,6 +47,8 @@ whitenoise==6.12.0
 python-decouple==3.8
 Pillow>=10.2.0  # For ImageField support if needed - 10.2.0+ supports Python 3.13
 psutil>=5.9.0  # For system health monitoring
+openpyxl>=3.1.5  # XLSX parsing for bounded AI tabular document ingestion
+xlrd>=2.0.1  # Legacy XLS parsing for bounded AI tabular document ingestion
 
 # HTTP requests
 requests>=2.31.0  # For GitHub API integration in bug reports

--- a/backend/tenant_apps/ai_assistant/models.py
+++ b/backend/tenant_apps/ai_assistant/models.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 
 
 from apps.core.models import OwnedModel, StatusModel, TenantAwareModel
+from tenant_apps.ai_assistant.services.document_parser import AI_DOCUMENT_ALLOWED_EXTENSIONS
 
 
 class ChatSessionStatusChoices(models.TextChoices):
@@ -367,7 +368,7 @@ class AIDocument(TenantAwareModel):
         upload_to=aidocument_upload_to,
         validators=[
             FileExtensionValidator(
-                allowed_extensions=['pdf', 'txt', 'csv', 'jpg', 'jpeg', 'png', 'doc', 'docx', 'xls', 'xlsx']
+                allowed_extensions=list(AI_DOCUMENT_ALLOWED_EXTENSIONS)
             )
         ],
     )

--- a/backend/tenant_apps/ai_assistant/serializers.py
+++ b/backend/tenant_apps/ai_assistant/serializers.py
@@ -2,7 +2,9 @@
 Serializers for AI Assistant functionality.
 """
 from rest_framework import serializers
+
 from .models import AIDocument, AIFeedbackLog, AIConfiguration, ChatMessage, ChatSession
+from .services.document_parser import validate_ai_document_upload
 
 
 
@@ -153,6 +155,16 @@ class AIDocumentSerializer(serializers.ModelSerializer):
     def get_document_type(self, obj) -> str:
         # Classification may happen asynchronously; keep this additive and deterministic.
         return 'unknown'
+
+    def validate_file(self, value):
+        try:
+            validate_ai_document_upload(
+                filename=getattr(value, 'name', ''),
+                content_type=getattr(value, 'content_type', ''),
+            )
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc)) from exc
+        return value
 
     class Meta:
         model = AIDocument

--- a/backend/tenant_apps/ai_assistant/services/document_parser.py
+++ b/backend/tenant_apps/ai_assistant/services/document_parser.py
@@ -1,0 +1,286 @@
+"""Helpers for validating and parsing AI assistant document uploads."""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+from dataclasses import dataclass
+from typing import IO, Any
+
+
+AI_DOCUMENT_ALLOWED_EXTENSIONS = (
+    'pdf',
+    'txt',
+    'csv',
+    'jpg',
+    'jpeg',
+    'png',
+    'doc',
+    'docx',
+    'xls',
+    'xlsx',
+)
+
+AI_DOCUMENT_ALLOWED_CONTENT_TYPES = frozenset(
+    {
+        'application/msword',
+        'application/octet-stream',
+        'application/pdf',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'image/jpeg',
+        'image/png',
+        'text/csv',
+        'text/plain',
+    }
+)
+
+TABULAR_DOCUMENT_EXTENSIONS = frozenset({'csv', 'xls', 'xlsx'})
+GENERIC_CONTENT_TYPES = frozenset({'', 'application/octet-stream'})
+
+MAX_TABULAR_ROWS = 500
+MAX_TABULAR_TEXT_CHARS = 40000
+
+ROW_TRUNCATION_WARNING = '[WARNING: Data truncated at 500 rows to preserve context window]'
+TEXT_TRUNCATION_WARNING = '[WARNING: Markdown output truncated to preserve context window]'
+
+
+@dataclass(frozen=True)
+class TabularParseResult:
+    text: str
+    rows_included: int
+    sheet_count: int
+    truncated: bool
+    warnings: tuple[str, ...]
+    preview: tuple[dict[str, Any], ...]
+
+
+def get_document_extension(filename: str | None) -> str:
+    return os.path.splitext(str(filename or ''))[1].lower().lstrip('.')
+
+
+def is_tabular_document(*, filename: str | None, content_type: str | None) -> bool:
+    extension = get_document_extension(filename)
+    if extension in TABULAR_DOCUMENT_EXTENSIONS:
+        return True
+
+    normalized_content_type = str(content_type or '').strip().lower()
+    return normalized_content_type in {
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'text/csv',
+    }
+
+
+def validate_ai_document_upload(*, filename: str | None, content_type: str | None) -> None:
+    extension = get_document_extension(filename)
+    if not extension or extension not in AI_DOCUMENT_ALLOWED_EXTENSIONS:
+        allowed = ', '.join(AI_DOCUMENT_ALLOWED_EXTENSIONS)
+        raise ValueError(f'Unsupported file extension. Allowed extensions: {allowed}.')
+
+    normalized_content_type = str(content_type or '').strip().lower()
+    if normalized_content_type in GENERIC_CONTENT_TYPES:
+        return
+
+    if normalized_content_type not in AI_DOCUMENT_ALLOWED_CONTENT_TYPES:
+        raise ValueError(
+            'Unsupported file content type. Allowed uploads include PDF, image, text, Word, CSV, and Excel files.'
+        )
+
+
+def parse_tabular_document(file_obj: IO[bytes], *, filename: str, content_type: str | None = None) -> TabularParseResult:
+    extension = get_document_extension(filename)
+    if extension not in TABULAR_DOCUMENT_EXTENSIONS:
+        raise ValueError(f'Tabular parser does not support .{extension or "unknown"} files.')
+
+    file_obj.seek(0)
+
+    if extension == 'csv':
+        sheets, total_rows, truncated = _parse_csv_sheets(file_obj)
+    elif extension == 'xlsx':
+        sheets, total_rows, truncated = _parse_xlsx_sheets(file_obj)
+    else:
+        sheets, total_rows, truncated = _parse_xls_sheets(file_obj)
+
+    markdown_sections: list[str] = []
+    preview_rows: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    for sheet in sheets:
+        if sheet['sheet_name']:
+            markdown_sections.append(f"## Sheet: {sheet['sheet_name']}")
+        markdown_sections.append(sheet['markdown'])
+        preview_rows.append(
+            {
+                'type': 'table',
+                'sheet': sheet['sheet_name'],
+                'rows_included': sheet['rows_included'],
+                'columns': sheet['columns'],
+            }
+        )
+
+    if truncated:
+        warnings.append(ROW_TRUNCATION_WARNING)
+
+    text = '\n\n'.join(section for section in markdown_sections if section).strip()
+    if warnings:
+        text = f'{text}\n\n' + '\n'.join(warnings)
+
+    if len(text) > MAX_TABULAR_TEXT_CHARS:
+        cut = text[:MAX_TABULAR_TEXT_CHARS]
+        cut = cut.rsplit('\n', 1)[0] or cut
+        warnings.append(TEXT_TRUNCATION_WARNING)
+        text = f'{cut}\n\n{TEXT_TRUNCATION_WARNING}'
+        truncated = True
+
+    return TabularParseResult(
+        text=text,
+        rows_included=total_rows,
+        sheet_count=len(sheets),
+        truncated=truncated,
+        warnings=tuple(dict.fromkeys(warnings)),
+        preview=tuple(preview_rows[:10]),
+    )
+
+
+def _parse_csv_sheets(file_obj: IO[bytes]) -> tuple[list[dict[str, Any]], int, bool]:
+    raw_bytes = file_obj.read()
+    try:
+        decoded = raw_bytes.decode('utf-8-sig')
+    except UnicodeDecodeError:
+        decoded = raw_bytes.decode('latin-1')
+
+    reader = csv.reader(io.StringIO(decoded))
+    rows = [list(row) for row in reader]
+    sheet, rows_included, truncated = _sheet_from_rows('CSV', rows, MAX_TABULAR_ROWS)
+    return ([sheet] if sheet else []), rows_included, truncated
+
+
+def _parse_xlsx_sheets(file_obj: IO[bytes]) -> tuple[list[dict[str, Any]], int, bool]:
+    from openpyxl import load_workbook
+
+    workbook = load_workbook(file_obj, read_only=True, data_only=True)
+    sheets: list[dict[str, Any]] = []
+    remaining_rows = MAX_TABULAR_ROWS
+    total_rows = 0
+    truncated = False
+
+    try:
+        for worksheet in workbook.worksheets:
+            rows = [list(row) for row in worksheet.iter_rows(values_only=True)]
+            sheet, rows_included, sheet_truncated = _sheet_from_rows(worksheet.title, rows, remaining_rows)
+            if sheet:
+                sheets.append(sheet)
+                total_rows += rows_included
+                remaining_rows = max(0, remaining_rows - rows_included)
+            if sheet_truncated:
+                truncated = True
+                break
+            if remaining_rows <= 0:
+                truncated = True
+                break
+    finally:
+        workbook.close()
+
+    return sheets, total_rows, truncated
+
+
+def _parse_xls_sheets(file_obj: IO[bytes]) -> tuple[list[dict[str, Any]], int, bool]:
+    import xlrd
+
+    workbook = xlrd.open_workbook(file_contents=file_obj.read(), on_demand=True)
+    sheets: list[dict[str, Any]] = []
+    remaining_rows = MAX_TABULAR_ROWS
+    total_rows = 0
+    truncated = False
+
+    try:
+        for sheet_ref in workbook.sheets():
+            rows = [sheet_ref.row_values(row_index) for row_index in range(sheet_ref.nrows)]
+            sheet, rows_included, sheet_truncated = _sheet_from_rows(sheet_ref.name, rows, remaining_rows)
+            if sheet:
+                sheets.append(sheet)
+                total_rows += rows_included
+                remaining_rows = max(0, remaining_rows - rows_included)
+            if sheet_truncated:
+                truncated = True
+                break
+            if remaining_rows <= 0:
+                truncated = True
+                break
+    finally:
+        workbook.release_resources()
+
+    return sheets, total_rows, truncated
+
+
+def _sheet_from_rows(
+    sheet_name: str,
+    rows: list[list[Any]],
+    row_budget: int,
+) -> tuple[dict[str, Any] | None, int, bool]:
+    if not rows:
+        return None, 0, False
+
+    normalized_rows = [_normalize_row(row) for row in rows]
+    header = normalized_rows[0]
+    data_rows = normalized_rows[1:]
+
+    if row_budget < len(data_rows):
+        data_rows = data_rows[:row_budget]
+        truncated = True
+    else:
+        truncated = False
+
+    if not any(header):
+        column_count = max((len(row) for row in data_rows), default=1)
+        header = [f'Column {index + 1}' for index in range(column_count)]
+
+    column_count = max(len(header), *(len(row) for row in data_rows), 0)
+    header = _pad_row(header, column_count)
+    padded_rows = [_pad_row(row, column_count) for row in data_rows]
+
+    markdown = _rows_to_markdown(header, padded_rows)
+    return (
+        {
+            'sheet_name': sheet_name,
+            'rows_included': len(padded_rows),
+            'columns': header,
+            'markdown': markdown,
+        },
+        len(padded_rows),
+        truncated,
+    )
+
+
+def _normalize_row(row: list[Any]) -> list[str]:
+    return [_normalize_cell(value) for value in row]
+
+
+def _normalize_cell(value: Any) -> str:
+    if value is None:
+        return ''
+    if isinstance(value, float) and value.is_integer():
+        value = int(value)
+    text = str(value).replace('\r', ' ').replace('\n', ' ').strip()
+    text = text.replace('|', '\\|')
+    return text
+
+
+def _pad_row(row: list[str], column_count: int) -> list[str]:
+    if len(row) >= column_count:
+        return row[:column_count]
+    return row + [''] * (column_count - len(row))
+
+
+def _rows_to_markdown(header: list[str], rows: list[list[str]]) -> str:
+    divider = ['---'] * len(header)
+    lines = [
+        f"| {' | '.join(header)} |",
+        f"| {' | '.join(divider)} |",
+    ]
+    for row in rows:
+        lines.append(f"| {' | '.join(row)} |")
+    return '\n'.join(lines)

--- a/backend/tenant_apps/ai_assistant/swarm/executor.py
+++ b/backend/tenant_apps/ai_assistant/swarm/executor.py
@@ -946,6 +946,48 @@ class ToolExecutor:
                     'parse_document requires an uploaded document_id (UUID or integer). URL fetch is disabled for SSRF safety.'
                 ) from e
 
+        from tenant_apps.ai_assistant.models import AIDocument
+        from tenant_apps.ai_assistant.services.document_parser import is_tabular_document, parse_tabular_document
+
+        doc = AIDocument.objects.filter(id=(document_int or document_uuid), tenant=tenant, owner=user).first()
+        if not doc:
+            raise ValueError('Document not found for this tenant/user')
+
+        if not doc.file:
+            raise ValueError('Document record has no file attached')
+
+        filename = doc.original_filename or 'document'
+        content_type = doc.content_type or 'application/octet-stream'
+
+        if is_tabular_document(filename=filename, content_type=content_type):
+            from tenant_apps.ai_assistant.swarm.tools.microsoft_graph import ToolExecutionError
+
+            try:
+                with doc.file.open('rb') as f:
+                    parsed = parse_tabular_document(
+                        f,
+                        filename=filename,
+                        content_type=content_type,
+                    )
+            except Exception as exc:
+                raise ToolExecutionError(
+                    error_code='DOCUMENT_PARSE_FAILED',
+                    message='The spreadsheet file could not be parsed.',
+                    hint='Upload a valid CSV or Excel file, or resave the spreadsheet and try again.',
+                    retryable=False,
+                    details=f'{type(exc).__name__}: {exc}',
+                ) from exc
+            return {
+                'document_id': str(doc.id),
+                'filename': filename,
+                'content_type': content_type,
+                'text': parsed.text,
+                'elements_preview': list(parsed.preview),
+                'parser': 'tabular_markdown',
+                'truncated': parsed.truncated,
+                'warnings': list(parsed.warnings),
+            }
+
         from django.conf import settings
 
         base_url = (getattr(settings, 'UNSTRUCTURED_API_URL', '') or '').strip()
@@ -958,18 +1000,6 @@ class ToolExecutor:
         endpoint = base_url.rstrip('/')
         if '/general/' not in endpoint and not endpoint.endswith('/general/v0/general'):
             endpoint = f"{endpoint}/general/v0/general"
-
-        from tenant_apps.ai_assistant.models import AIDocument
-
-        doc = AIDocument.objects.filter(id=(document_int or document_uuid), tenant=tenant, owner=user).first()
-        if not doc:
-            raise ValueError('Document not found for this tenant/user')
-
-        if not doc.file:
-            raise ValueError('Document record has no file attached')
-
-        filename = doc.original_filename or 'document'
-        content_type = doc.content_type or 'application/octet-stream'
 
         import requests
 

--- a/backend/tenant_apps/ai_assistant/test_tabular_document_parsing.py
+++ b/backend/tenant_apps/ai_assistant/test_tabular_document_parsing.py
@@ -1,0 +1,135 @@
+import json
+import io
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+if 'tenant_apps.ai_assistant' not in settings.INSTALLED_APPS:
+    raise unittest.SkipTest('tenant_apps.ai_assistant is excluded from INSTALLED_APPS in test settings')
+
+from apps.tenants.models import Tenant, TenantUser
+from tenant_apps.ai_assistant.models import AIDocument
+from tenant_apps.ai_assistant.swarm.executor import ToolExecutor
+
+
+class TabularDocumentParsingTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='tabular-user', password='testpass123')
+        self.tenant = Tenant.objects.create(
+            name='Tabular Tenant',
+            slug='tabular-tenant',
+            contact_email='tabular@example.com',
+            created_by=self.user,
+        )
+        TenantUser.objects.create(tenant=self.tenant, user=self.user, role='owner', is_active=True)
+        self.executor = ToolExecutor()
+
+    def _create_document(self, *, name: str, content: bytes, content_type: str) -> AIDocument:
+        upload = SimpleUploadedFile(name, content, content_type=content_type)
+        return AIDocument.objects.create(
+            tenant=self.tenant,
+            owner=self.user,
+            file=upload,
+            original_filename=name,
+            content_type=content_type,
+            file_size=len(content),
+        )
+
+    def test_parse_document_converts_csv_to_markdown(self):
+        document = self._create_document(
+            name='parts.csv',
+            content=(
+                b'Part,Status,Cost\n'
+                b'Chuck,Backordered,10.50\n'
+                b'Ribeye,Available,21.00\n'
+            ),
+            content_type='text/csv',
+        )
+
+        parsed = self.executor._parse_document(
+            {'file_id_or_url': str(document.id)},
+            self.tenant,
+            user=self.user,
+        )
+
+        self.assertEqual(parsed['parser'], 'tabular_markdown')
+        self.assertEqual(parsed['content_type'], 'text/csv')
+        self.assertIn('| Part | Status | Cost |', parsed['text'])
+        self.assertIn('| Chuck | Backordered | 10.50 |', parsed['text'])
+        self.assertFalse(parsed['truncated'])
+
+    def test_parse_document_truncates_csv_after_500_rows(self):
+        rows = ['Part,Status,Cost']
+        rows.extend([f'Item {index},Backordered,{index}.00' for index in range(1, 503)])
+        document = self._create_document(
+            name='large-parts.csv',
+            content='\n'.join(rows).encode('utf-8'),
+            content_type='text/csv',
+        )
+
+        parsed = self.executor._parse_document(
+            {'file_id_or_url': str(document.id)},
+            self.tenant,
+            user=self.user,
+        )
+
+        self.assertTrue(parsed['truncated'])
+        self.assertIn('[WARNING: Data truncated at 500 rows to preserve context window]', parsed['text'])
+        self.assertIn('| Item 500 | Backordered | 500.00 |', parsed['text'])
+        self.assertNotIn('| Item 501 | Backordered | 501.00 |', parsed['text'])
+
+    def test_parse_document_converts_xlsx_to_markdown(self):
+        from openpyxl import Workbook
+
+        workbook = Workbook()
+        worksheet = workbook.active
+        worksheet.title = 'Backorders'
+        worksheet.append(['Part', 'Status', 'Cost'])
+        worksheet.append(['Tenderloin', 'Backordered', 55.25])
+        worksheet.append(['Brisket', 'Available', 14.00])
+
+        buffer = io.BytesIO()
+        workbook.save(buffer)
+        workbook.close()
+
+        document = self._create_document(
+            name='parts.xlsx',
+            content=buffer.getvalue(),
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+
+        parsed = self.executor._parse_document(
+            {'file_id_or_url': str(document.id)},
+            self.tenant,
+            user=self.user,
+        )
+
+        self.assertEqual(parsed['parser'], 'tabular_markdown')
+        self.assertIn('## Sheet: Backorders', parsed['text'])
+        self.assertIn('| Tenderloin | Backordered | 55.25 |', parsed['text'])
+
+    @patch('tenant_apps.ai_assistant.swarm.executor.set_current_tenant', return_value=SimpleNamespace(ok=True, error=None))
+    def test_execute_returns_structured_error_for_corrupt_spreadsheet(self, _mock_rls):
+        document = self._create_document(
+            name='broken.xlsx',
+            content=b'not-a-real-xlsx',
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+
+        payload = json.loads(
+            self.executor.execute(
+                'parse_document',
+                {'file_id_or_url': str(document.id)},
+                self.tenant,
+                user=self.user,
+            )
+        )
+
+        self.assertFalse(payload['ok'])
+        self.assertEqual(payload['tool'], 'parse_document')
+        self.assertEqual(payload['error']['code'], 'DOCUMENT_PARSE_FAILED')

--- a/backend/tenant_apps/ai_assistant/tests_document_upload.py
+++ b/backend/tenant_apps/ai_assistant/tests_document_upload.py
@@ -39,8 +39,8 @@ class AIDocumentUploadTests(APITestCase):
         # TenantMiddleware intentionally ignores X-Tenant-ID for anonymous requests.
         self.client.force_login(self.user)
 
-    def _upload(self):
-        file = SimpleUploadedFile('test.pdf', b'%PDF-1.4\n% test\n', content_type='application/pdf')
+    def _upload(self, *, filename='test.pdf', content=b'%PDF-1.4\n% test\n', content_type='application/pdf'):
+        file = SimpleUploadedFile(filename, content, content_type=content_type)
         return self.client.post(
             '/api/v1/ai-assistant/ai-documents/',
             data={'file': file},
@@ -52,6 +52,22 @@ class AIDocumentUploadTests(APITestCase):
         resp = self._upload()
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         self.assertIn('id', resp.data)
+
+    def test_csv_upload_returns_201(self):
+        resp = self._upload(
+            filename='inventory.csv',
+            content=b'part,status\nribeye,Backordered\n',
+            content_type='text/csv',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    def test_xlsx_upload_returns_201(self):
+        resp = self._upload(
+            filename='inventory.xlsx',
+            content=b'not-a-real-xlsx-but-validation-only',
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
     @patch('tenant_apps.ai_assistant.serializers.AIDocumentSerializer.save')
     def test_storage_errors_return_400(self, mock_save):

--- a/frontend/src/components/AIAssistant/AIAgentWidget.tsx
+++ b/frontend/src/components/AIAssistant/AIAgentWidget.tsx
@@ -17,6 +17,7 @@ import { useCockpitNavigation } from '@/contexts/CockpitNavigationContext';
 import { buildAIPageContext } from '@/services/aiContext';
 import {
   FileText,
+  FileSpreadsheet,
   GitBranch,
   History,
   LoaderCircle,
@@ -33,6 +34,11 @@ import { useToast } from '../../hooks/useToast';
 import { businessApi } from '../../services/businessApi';
 import { useHealth } from '@/hooks/useHealth';
 import { HITLReviewCard } from './HITLReviewCard';
+import {
+  CHAT_UPLOAD_ACCEPT_ATTR,
+  CHAT_UPLOAD_SUPPORTED_EXTENSIONS,
+  getChatUploadFileKind,
+} from '@/components/ChatInterface/fileUploadConfig';
 
 type AgentState = 'idle' | 'thinking' | 'action_required';
 
@@ -83,9 +89,28 @@ type UploadedAttachment = {
   content_type?: string;
 };
 
-const SUPPORTED_EXTENSIONS = ['pdf', 'jpg', 'jpeg', 'png'];
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const LOCAL_STORAGE_SESSION_KEY = 'pm.ai.widget.sessionId';
+
+const getMetadataString = (
+  metadata: Record<string, unknown> | undefined,
+  key: string
+): string | undefined => {
+  const value = metadata?.[key];
+  return typeof value === 'string' ? value : undefined;
+};
+
+const renderAttachmentIcon = (
+  filename?: string,
+  contentType?: string,
+  size = 14
+) => {
+  return getChatUploadFileKind(filename, contentType) === 'spreadsheet' ? (
+    <FileSpreadsheet size={size} />
+  ) : (
+    <FileText size={size} />
+  );
+};
 
 const calmPulse = keyframes`
   0%, 100% { transform: translateY(0); box-shadow: 0 10px 28px rgb(var(--color-text-primary) / 0.10); }
@@ -726,8 +751,13 @@ export const AIAgentWidget: React.FC = () => {
       return `File size too large. Max ${(MAX_FILE_SIZE / (1024 * 1024)).toFixed(1)}MB.`;
     }
     const ext = file.name.split('.').pop()?.toLowerCase();
-    if (!ext || !SUPPORTED_EXTENSIONS.includes(ext)) {
-      return `Unsupported file type. Supported: ${SUPPORTED_EXTENSIONS.join(', ')}`;
+    if (
+      !ext ||
+      !CHAT_UPLOAD_SUPPORTED_EXTENSIONS.includes(
+        ext as (typeof CHAT_UPLOAD_SUPPORTED_EXTENSIONS)[number]
+      )
+    ) {
+      return `Unsupported file type. Supported: ${CHAT_UPLOAD_SUPPORTED_EXTENSIONS.join(', ')}`;
     }
     return null;
   };
@@ -1395,19 +1425,18 @@ export const AIAgentWidget: React.FC = () => {
                   <Bubble key={m.id} $role={m.role}>
                     {m.role === 'document' ? (
                       <DocumentRow>
-                        <FileText size={16} />
+                        {renderAttachmentIcon(
+                          getMetadataString(m.metadata, 'original_filename') ?? m.content,
+                          getMetadataString(m.metadata, 'content_type'),
+                          16
+                        )}
                         <DocumentMeta>
                           {(() => {
-                            const fileUrl =
-                              m.metadata && typeof m.metadata === 'object' && typeof (m.metadata as any).file_url === 'string'
-                                ? ((m.metadata as any).file_url as string)
-                                : undefined;
-                            const originalFilename =
-                              m.metadata &&
-                              typeof m.metadata === 'object' &&
-                              typeof (m.metadata as any).original_filename === 'string'
-                                ? ((m.metadata as any).original_filename as string)
-                                : undefined;
+                            const fileUrl = getMetadataString(m.metadata, 'file_url');
+                            const originalFilename = getMetadataString(
+                              m.metadata,
+                              'original_filename'
+                            );
 
                             const label = originalFilename ?? m.content;
 
@@ -1421,10 +1450,10 @@ export const AIAgentWidget: React.FC = () => {
                           })()}
                           <div>
                             {(() => {
-                              const ct =
-                                m.metadata && typeof m.metadata === 'object' && typeof (m.metadata as any).content_type === 'string'
-                                  ? ((m.metadata as any).content_type as string)
-                                  : undefined;
+                              const ct = getMetadataString(
+                                m.metadata,
+                                'content_type'
+                              );
                               return ct ?? 'Document';
                             })()}
                           </div>
@@ -1462,15 +1491,15 @@ export const AIAgentWidget: React.FC = () => {
                 void handleSend();
               }}
             >
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                accept={SUPPORTED_EXTENSIONS.map((x) => `.${x}`).join(',')}
-                style={{ display: 'none' }}
-                onChange={(e) => {
-                  const list = e.target.files ? Array.from(e.target.files) : [];
-                  if (list.length) void addAttachments(list);
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  accept={CHAT_UPLOAD_ACCEPT_ATTR}
+                  style={{ display: 'none' }}
+                  onChange={(e) => {
+                    const list = e.target.files ? Array.from(e.target.files) : [];
+                    if (list.length) void addAttachments(list);
                   e.target.value = '';
                 }}
               />
@@ -1479,7 +1508,7 @@ export const AIAgentWidget: React.FC = () => {
                 <AttachmentsBar>
                   {attachments.map((a, idx) => (
                     <AttachmentChip key={`${a.id}-${idx}`}>
-                      <FileText size={14} />
+                      {renderAttachmentIcon(a.original_filename, a.content_type)}
                       <span>{a.original_filename}</span>
                       <ChipRemove
                         type="button"

--- a/frontend/src/components/ChatInterface/MessageInput.tsx
+++ b/frontend/src/components/ChatInterface/MessageInput.tsx
@@ -10,6 +10,12 @@
 import React, { useState, useRef, useEffect, KeyboardEvent, useCallback } from 'react';
 import styled from 'styled-components';
 
+import {
+  CHAT_UPLOAD_ACCEPT_ATTR,
+  CHAT_UPLOAD_SUPPORTED_EXTENSIONS,
+  getChatUploadEmoji,
+} from './fileUploadConfig';
+
 interface MessageInputProps {
   onSendMessage: (message: string) => void;
   onFileUpload?: (file: File) => Promise<{ id: string; status: string }>;
@@ -19,7 +25,6 @@ interface MessageInputProps {
 }
 
 // Supported file extensions and constraints
-const SUPPORTED_EXTENSIONS = ['pdf', 'jpg', 'jpeg', 'png', 'txt', 'doc', 'docx', 'xls', 'xlsx'];
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 const MessageInput: React.FC<MessageInputProps> = ({
@@ -56,8 +61,8 @@ const MessageInput: React.FC<MessageInputProps> = ({
 
     // Check file type
     const fileExtension = file.name.split('.').pop()?.toLowerCase();
-    if (!fileExtension || !SUPPORTED_EXTENSIONS.includes(fileExtension)) {
-      return `File type not supported. Supported types: ${SUPPORTED_EXTENSIONS.join(', ')}`;
+    if (!fileExtension || !CHAT_UPLOAD_SUPPORTED_EXTENSIONS.includes(fileExtension as (typeof CHAT_UPLOAD_SUPPORTED_EXTENSIONS)[number])) {
+      return `File type not supported. Supported types: ${CHAT_UPLOAD_SUPPORTED_EXTENSIONS.join(', ')}`;
     }
 
     return null;
@@ -85,7 +90,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
         await onFileUpload(file);
 
         // Add a message about the uploaded file
-        const fileMessage = `📄 I've uploaded "${file.name}" for processing.`;
+        const fileMessage = `${getChatUploadEmoji(file.name, file.type)} I've uploaded "${file.name}" for processing.`;
         setMessage(fileMessage);
         textareaRef.current?.focus();
       } catch (err) {
@@ -226,13 +231,13 @@ const MessageInput: React.FC<MessageInputProps> = ({
       $isDragOver={isDragOver}
     >
       {/* Hidden file input */}
-      <HiddenFileInput
-        ref={fileInputRef}
-        type="file"
-        accept={SUPPORTED_EXTENSIONS.map((ext) => `.${ext}`).join(',')}
-        onChange={handleFileInputChange}
-        disabled={disabled || uploading}
-      />
+        <HiddenFileInput
+          ref={fileInputRef}
+          type="file"
+          accept={CHAT_UPLOAD_ACCEPT_ATTR}
+          onChange={handleFileInputChange}
+          disabled={disabled || uploading}
+        />
 
       {/* Error display */}
       {error && (

--- a/frontend/src/components/ChatInterface/fileUploadConfig.test.ts
+++ b/frontend/src/components/ChatInterface/fileUploadConfig.test.ts
@@ -1,0 +1,41 @@
+import {
+  CHAT_UPLOAD_ACCEPT_ATTR,
+  CHAT_UPLOAD_SUPPORTED_EXTENSIONS,
+  getChatUploadEmoji,
+  getChatUploadFileKind,
+} from './fileUploadConfig';
+
+describe('fileUploadConfig', () => {
+  it('includes spreadsheet mime types and extensions in the accept attribute', () => {
+    expect(CHAT_UPLOAD_SUPPORTED_EXTENSIONS).toContain('csv');
+    expect(CHAT_UPLOAD_SUPPORTED_EXTENSIONS).toContain('xls');
+    expect(CHAT_UPLOAD_SUPPORTED_EXTENSIONS).toContain('xlsx');
+
+    expect(CHAT_UPLOAD_ACCEPT_ATTR).toContain('text/csv');
+    expect(CHAT_UPLOAD_ACCEPT_ATTR).toContain(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    expect(CHAT_UPLOAD_ACCEPT_ATTR).toContain('application/vnd.ms-excel');
+    expect(CHAT_UPLOAD_ACCEPT_ATTR).toContain('.csv');
+    expect(CHAT_UPLOAD_ACCEPT_ATTR).toContain('.xls');
+    expect(CHAT_UPLOAD_ACCEPT_ATTR).toContain('.xlsx');
+  });
+
+  it('detects spreadsheet uploads from filenames and content types', () => {
+    expect(getChatUploadFileKind('parts-list.xlsx')).toBe('spreadsheet');
+    expect(getChatUploadFileKind('parts-list.csv', 'text/csv')).toBe(
+      'spreadsheet'
+    );
+    expect(
+      getChatUploadFileKind('parts-list', 'application/vnd.ms-excel')
+    ).toBe('spreadsheet');
+    expect(getChatUploadFileKind('quote.pdf', 'application/pdf')).toBe(
+      'document'
+    );
+  });
+
+  it('returns a spreadsheet emoji for tabular files', () => {
+    expect(getChatUploadEmoji('inventory.xlsx')).toBe('📊');
+    expect(getChatUploadEmoji('notes.pdf')).toBe('📄');
+  });
+});

--- a/frontend/src/components/ChatInterface/fileUploadConfig.ts
+++ b/frontend/src/components/ChatInterface/fileUploadConfig.ts
@@ -1,0 +1,62 @@
+export type ChatUploadFileKind = 'document' | 'spreadsheet';
+
+export const CHAT_UPLOAD_SUPPORTED_EXTENSIONS = [
+  'pdf',
+  'jpg',
+  'jpeg',
+  'png',
+  'txt',
+  'doc',
+  'docx',
+  'csv',
+  'xls',
+  'xlsx',
+] as const;
+
+export const CHAT_UPLOAD_ACCEPTED_MIME_TYPES = [
+  'application/pdf',
+  'application/msword',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'image/jpeg',
+  'image/png',
+  'text/csv',
+  'text/plain',
+] as const;
+
+export const CHAT_UPLOAD_ACCEPT_ATTR = [
+  ...CHAT_UPLOAD_ACCEPTED_MIME_TYPES,
+  ...CHAT_UPLOAD_SUPPORTED_EXTENSIONS.map((extension) => `.${extension}`),
+].join(',');
+
+const spreadsheetExtensions = new Set(['csv', 'xls', 'xlsx']);
+
+export const getChatUploadFileKind = (
+  filename?: string,
+  contentType?: string
+): ChatUploadFileKind => {
+  const extension = filename?.split('.').pop()?.toLowerCase() ?? '';
+  const normalizedContentType = contentType?.toLowerCase() ?? '';
+
+  if (
+    spreadsheetExtensions.has(extension) ||
+    normalizedContentType === 'text/csv' ||
+    normalizedContentType ===
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
+    normalizedContentType === 'application/vnd.ms-excel'
+  ) {
+    return 'spreadsheet';
+  }
+
+  return 'document';
+};
+
+export const getChatUploadEmoji = (
+  filename?: string,
+  contentType?: string
+): string => {
+  return getChatUploadFileKind(filename, contentType) === 'spreadsheet'
+    ? '📊'
+    : '📄';
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ backend = [
     "Pillow>=10.2.0",
     "psutil>=5.9.0",
     "requests>=2.31.0",
+    "openpyxl>=3.1.5",
+    "xlrd>=2.0.1",
 ]
 
 dev = [


### PR DESCRIPTION
## Summary
- add a bounded tabular document parser for AI uploads that converts CSV/XLS/XLSX data into markdown tables instead of sending raw spreadsheet bytes through Unstructured
- expand the AI chat upload surfaces to accept spreadsheet MIME types/extensions and render spreadsheet-specific staged/document icons
- validate AI document uploads for spreadsheet MIME types, add corrupt-file error handling, and record the shipment in `.github/MASTER_PLAN.md`
- add backend/frontend regression coverage for spreadsheet acceptance, markdown conversion, 500-row truncation, and corrupt spreadsheet handling

## Expected results
- the AI widget and chat message input both accept `.csv`, `.xls`, and `.xlsx` uploads
- spreadsheet uploads are parsed into readable markdown table context for Swarm tools
- oversized tabular datasets truncate safely at 500 rows with an explicit warning instead of flooding the model context
- malformed spreadsheets return a structured parse error instead of opaque tool failures

## Acceptance criteria
- chat upload `accept` attributes include `text/csv`, `application/vnd.ms-excel`, and `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` alongside the matching extensions
- `parse_document` handles CSV/XLS/XLSX locally and preserves the existing Unstructured path for non-tabular documents
- uploaded spreadsheet files produce markdown-table text with a 500-row truncation warning when needed
- upload validation allows spreadsheet content types/extensions without regressing existing PDF/image/text/Word uploads

## Testing
- `cd backend && python manage.py test tenant_apps.ai_assistant.tests tenant_apps.ai_assistant.tests_document_upload tenant_apps.ai_assistant.test_tabular_document_parsing --verbosity=2 --noinput`
- `cd backend && pytest tenant_apps/ai_assistant/tests/test_po_extraction.py -q`
- `cd backend && python manage.py makemigrations --check --dry-run`
- `cd frontend && npx vitest run src/components/ChatInterface/fileUploadConfig.test.ts`
- `cd frontend && npm run type-check`

## Risks
- legacy `.xls` parsing depends on `xlrd`, so corrupt files are now surfaced as structured `DOCUMENT_PARSE_FAILED` tool errors instead of generic failures
- wide spreadsheets can still be large, so the parser also applies a markdown text budget after the 500-row cap to preserve the context window

## Rollback
- revert commit `0aa5d79c` to remove spreadsheet upload support and restore the prior non-tabular-only AI document path