### PR TITLE
fix: stabilize universal entity form loads

### DIFF
--- a/frontend/src/components/Shared/UniversalEntityForm.stability.test.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.stability.test.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useState } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const businessApiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  options: vi.fn(),
+}));
+
+const capturedDynamicFormProps = vi.hoisted(
+  () => [] as Array<{ schema: unknown; initialValues: unknown }>
+);
+
+vi.mock('../../services/businessApi', () => ({
+  businessApi: businessApiMock,
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthState: () => ({ isAuthenticated: true, loading: false }),
+}));
+
+vi.mock('../../features/system/DynamicFormEngine', () => ({
+  default: (props: { schema: unknown; initialValues: unknown }) => {
+    capturedDynamicFormProps.push({
+      schema: props.schema,
+      initialValues: props.initialValues,
+    });
+
+    return <div data-testid="dynamic-form-engine" />;
+  },
+}));
+
+import { UniversalEntityForm } from './UniversalEntityForm';
+
+describe('UniversalEntityForm stability', () => {
+  beforeEach(() => {
+    businessApiMock.get.mockReset();
+    businessApiMock.options.mockReset();
+    capturedDynamicFormProps.length = 0;
+  });
+
+  it('dedupes plant edit loads when parent rebuilds initialValues objects', async () => {
+    businessApiMock.get.mockImplementation((url: string) => {
+      if (url === '/system/forms/schema/') {
+        return Promise.resolve({
+          data: {
+            name: 'Plant',
+            description: 'Plant schema',
+            fields: [
+              { key: 'name', label: 'Plant Name', type: 'text', required: true },
+              { key: 'export_approved', label: 'Export Approved', type: 'checkbox' },
+            ],
+          },
+        });
+      }
+
+      if (url === 'plants/2769/') {
+        return Promise.resolve({
+          data: {
+            id: 2769,
+            name: 'North Plant',
+            export_approved: false,
+          },
+        });
+      }
+
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+
+    const Parent: React.FC = () => {
+      const [tick, setTick] = useState(0);
+
+      useEffect(() => {
+        if (tick >= 6) return;
+        setTick((prev) => prev + 1);
+      }, [tick]);
+
+      return (
+        <UniversalEntityForm
+          entityType="plant"
+          entityId="2769"
+          mode="edit"
+          variant="inline"
+          isOpen
+          onClose={() => {}}
+          initialValues={{ export_approved: false }}
+        />
+      );
+    };
+
+    render(<Parent />);
+
+    await waitFor(() => {
+      expect(capturedDynamicFormProps.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(businessApiMock.get).toHaveBeenCalledTimes(2);
+    });
+
+    expect(businessApiMock.get).toHaveBeenCalledWith('/system/forms/schema/', {
+      params: { entity_type: 'plant' },
+    });
+    expect(businessApiMock.get).toHaveBeenCalledWith('plants/2769/');
+
+    const latest = capturedDynamicFormProps.at(-1);
+    expect(latest?.initialValues).toMatchObject({
+      name: 'North Plant',
+      export_approved: false,
+    });
+  });
+
+  it('loads once when the form opens from a closed state', async () => {
+    businessApiMock.get.mockImplementation((url: string) => {
+      if (url === '/system/forms/schema/') {
+        return Promise.resolve({
+          data: {
+            name: 'Plant',
+            description: 'Plant schema',
+            fields: [{ key: 'name', label: 'Plant Name', type: 'text', required: true }],
+          },
+        });
+      }
+
+      if (url === 'plants/2769/') {
+        return Promise.resolve({
+          data: {
+            id: 2769,
+            name: 'North Plant',
+          },
+        });
+      }
+
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+
+    const Parent: React.FC = () => {
+      const [isOpen, setIsOpen] = useState(false);
+
+      useEffect(() => {
+        setIsOpen(true);
+      }, []);
+
+      return (
+        <UniversalEntityForm
+          entityType="plant"
+          entityId="2769"
+          mode="edit"
+          variant="inline"
+          isOpen={isOpen}
+          onClose={() => {}}
+          initialValues={{}}
+        />
+      );
+    };
+
+    render(<Parent />);
+
+    await waitFor(() => {
+      expect(capturedDynamicFormProps.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(businessApiMock.get).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/components/Shared/UniversalEntityForm.tsx
+++ b/frontend/src/components/Shared/UniversalEntityForm.tsx
@@ -98,6 +98,14 @@ function useDeepStableValue<T>(value: T): T {
   return ref.current;
 }
 
+const getStableSignature = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
 const isArrayLikeField = (field: BackendField): boolean => {
   const t = String(field.type ?? '').toLowerCase();
   const ui = field.ui && typeof field.ui === 'object' ? (field.ui as Record<string, unknown>) : null;
@@ -893,6 +901,10 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
 }) => {
   const { isAuthenticated, loading: authLoading } = useAuthState();
   const stableInitialValues = useDeepStableValue(initialValues);
+  const stableInitialValuesSignature = useMemo(
+    () => getStableSignature(stableInitialValues ?? EMPTY_FORM_VALUES),
+    [stableInitialValues]
+  );
 
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<unknown | null>(null);
@@ -902,11 +914,20 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
 
   const initialValuesRef = useRef<Record<string, unknown> | undefined>(stableInitialValues);
   const [resolvedInitialValues, setResolvedInitialValues] = useState<Record<string, unknown>>({});
+  const lastLoadSignatureRef = useRef<string | null>(null);
+  const lastFkSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
     initialValuesRef.current = stableInitialValues;
   }, [isOpen, stableInitialValues]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      lastLoadSignatureRef.current = null;
+      lastFkSignatureRef.current = null;
+    }
+  }, [isOpen]);
 
   const inferredMode: UniversalEntityFormMode = useMemo(() => {
     const hasId = entityId != null && String(entityId).trim().length > 0;
@@ -1019,6 +1040,18 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     }
   }, [endpoint, entityType, schemaEntityKey]);
 
+  const loadSignature = useMemo(
+    () =>
+      getStableSignature({
+        endpoint,
+        entityId: entityId == null ? '' : String(entityId),
+        inferredMode,
+        schemaEntityKey,
+        initialValues: stableInitialValuesSignature,
+      }),
+    [endpoint, entityId, inferredMode, schemaEntityKey, stableInitialValuesSignature]
+  );
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -1065,6 +1098,12 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
 
       return;
     }
+
+    if (lastLoadSignatureRef.current === loadSignature) {
+      return;
+    }
+
+    lastLoadSignatureRef.current = loadSignature;
 
     let mounted = true;
 
@@ -1126,6 +1165,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     inferredMode,
     isAuthenticated,
     isOpen,
+    loadSignature,
     loadSchema,
     schemaEntityKey,
     setFkValuesIfChanged,
@@ -1134,9 +1174,26 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     setSchemaIfChanged,
   ]);
 
+  const fkLoadSignature = useMemo(() => {
+    const fkFields = (schema?.fields ?? [])
+      .filter((field) => !shouldSkipField(field.key) && Boolean(field.related_entity))
+      .map((field) => ({
+        key: field.key,
+        related_entity: field.related_entity,
+      }));
+
+    return getStableSignature(fkFields);
+  }, [schema?.fields]);
+
   // Load basic FK option lists (best-effort) for non-product references.
   useEffect(() => {
     if (!isOpen || !schema?.fields?.length) return;
+
+    if (lastFkSignatureRef.current === fkLoadSignature) {
+      return;
+    }
+
+    lastFkSignatureRef.current = fkLoadSignature;
 
     const fkFields = schema.fields.filter(
       (f) => !shouldSkipField(f.key) && Boolean(f.related_entity)
@@ -1189,7 +1246,13 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
           });
 
           if (cancelled) return;
-          setFkOptions((prev) => ({ ...prev, [f.key]: options }));
+          setFkOptions((prev) => {
+            if (isEqual(prev[f.key], options)) {
+              return prev;
+            }
+
+            return { ...prev, [f.key]: options };
+          });
         } catch {
           // ignore
         }
@@ -1201,7 +1264,7 @@ export const UniversalEntityForm: React.FC<UniversalEntityFormProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, schema?.fields]);
+  }, [fkLoadSignature, isOpen, schema?.fields]);
 
   const preferredKeys = useMemo(() => {
     const normalized = schemaEntityKey.toLowerCase();

--- a/frontend/src/features/system/DynamicFormEngine.tsx
+++ b/frontend/src/features/system/DynamicFormEngine.tsx
@@ -121,6 +121,14 @@ function useDeepStableValue<T>(value: T): T {
   return ref.current;
 }
 
+const getStableSignature = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
 const FormContainer = styled.form`
   width: 100%;
   max-width: 800px;
@@ -608,6 +616,10 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     }
     return next;
   }, [stableInitialValues, stableFields]);
+  const defaultValuesSignature = useMemo(
+    () => getStableSignature(defaultValues),
+    [defaultValues]
+  );
 
   const {
     register,
@@ -622,16 +634,16 @@ export const DynamicFormEngine: React.FC<DynamicFormEngineProps> = ({
     mode: formConfig.validateOnChange ? 'onChange' : 'onSubmit',
   });
 
-  const previousDefaultValuesRef = useRef(defaultValues);
+  const previousDefaultValuesSignatureRef = useRef(defaultValuesSignature);
 
   useEffect(() => {
-    if (isEqual(previousDefaultValuesRef.current, defaultValues)) {
+    if (previousDefaultValuesSignatureRef.current === defaultValuesSignature) {
       return;
     }
 
-    previousDefaultValuesRef.current = defaultValues;
+    previousDefaultValuesSignatureRef.current = defaultValuesSignature;
     reset(defaultValues);
-  }, [defaultValues, reset]);
+  }, [defaultValues, defaultValuesSignature, reset]);
 
   const watchedValues = useWatch({ control });
   


### PR DESCRIPTION
## Summary
- dedupe UniversalEntityForm schema/entity reloads using stable request signatures
- keep FK option state stable and switch DynamicFormEngine reset guarding to a primitive signature
- add plant edit regressions for both mount-open and closed-to-open flows

## Testing
- cd frontend && npx vitest run src/components/Shared/UniversalEntityForm.stability.test.tsx src/components/Shared/UniversalEntityForm.unauth.test.tsx src/features/system/DynamicFormEngine.stability.test.tsx src/features/system/DynamicFormEngine.visibleWhenClear.test.tsx
- cd frontend && npm run type-check

## Notes
- no MASTER_PLAN update for this targeted hotfix